### PR TITLE
workaround for a scanner bug

### DIFF
--- a/scalameta/src/main/scala/scala/meta/syntactic/parsers/Parsers.scala
+++ b/scalameta/src/main/scala/scala/meta/syntactic/parsers/Parsers.scala
@@ -165,13 +165,13 @@ class Parser(val origin: Origin)(implicit val dialect: Dialect) extends Abstract
         if (curr.is[`(`]) sepRegions = ')' :: sepRegions
         else if (curr.is[`[`]) sepRegions = ']' :: sepRegions
         else if (curr.is[`{`]) sepRegions = '}' :: sepRegions
-        else if (curr.is[`case`] && !next.is[`class `] && !next.is[`object`]) sepRegions = '⇒' :: sepRegions
+        else if (curr.is[`case`] && !next.is[`class `] && !next.is[`object`]) sepRegions = '\u21d2' :: sepRegions
         else if (curr.is[`}`]) {
           while (!sepRegions.isEmpty && sepRegions.head != '}') sepRegions = sepRegions.tail
           if (!sepRegions.isEmpty) sepRegions = sepRegions.tail
         } else if (curr.is[`]`]) { if (!sepRegions.isEmpty && sepRegions.head == ']') sepRegions = sepRegions.tail }
         else if (curr.is[`)`]) { if (!sepRegions.isEmpty && sepRegions.head == ')') sepRegions = sepRegions.tail }
-        else if (curr.is[`=>`]) { if (!sepRegions.isEmpty && sepRegions.head == '⇒') sepRegions = sepRegions.tail }
+        else if (curr.is[`=>`]) { if (!sepRegions.isEmpty && sepRegions.head == '\u21d2') sepRegions = sepRegions.tail }
         else () // do nothing for other tokens
         tokenPos = pos
         token = curr


### PR DESCRIPTION
If we use a unicode character instead of a unicode escape to represent
the rightward double arrow in Parsers.scala, then our scanner refuses
to tokenize the file, which fails our tests. I've no time to debug this,
so I'm just working around.