### PR TITLE
removes wishful thinking in semantic/package.scala

### DIFF
--- a/scalameta/src/main/scala/scala/meta/semantic/package.scala
+++ b/scalameta/src/main/scala/scala/meta/semantic/package.scala
@@ -289,16 +289,4 @@ package object semantic {
     @hosted def tparams(name: String): Type.Param = internalSingle[Type.Param](name, _ => true, "type parameters")
     @hosted def tparams(name: scala.Symbol): Type.Param = internalSingle[Type.Param](name.toString, _ => true, "type parameters")
   }
-
-  // ===========================
-  // PART 5: BINDINGS
-  // ===========================
-
-  @root trait Mark
-  def mark(): Mark = ???
-
-  implicit class SemanticNameOps(val tree: Name) extends AnyVal {
-    @hosted def isBinder: Boolean = ???
-    @hosted def isReference: Boolean = ???
-  }
 }


### PR DESCRIPTION
Once we have an idea how to handle bindings, I'll add stuff here
(maybe will even reinstate something).

However, for now, these stubs will just slow us down, especially given
that now when I intend to replace all ???'s in semantic/package.scala
with real implementations.