### PR TITLE
h.Signature needs to distinguish term/type members and term/type parameters

### DIFF
--- a/scalameta/src/main/scala/scala/meta/internal/hygiene/Denotation.scala
+++ b/scalameta/src/main/scala/scala/meta/internal/hygiene/Denotation.scala
@@ -18,6 +18,8 @@ object Signature {
   @leaf object Type extends Signature
   @leaf object Term extends Signature
   @leaf class Method(jvmSignature: String) extends Signature
+  @leaf object TypeParameter extends Signature
+  @leaf object TermParameter extends Signature
 }
 
 @root trait Symbol

--- a/scalameta/src/main/scala/scala/meta/semantic/Api.scala
+++ b/scalameta/src/main/scala/scala/meta/semantic/Api.scala
@@ -110,7 +110,7 @@ trait Api {
       }
       val prefixlessName = tree.name match {
         case name: impl.Name.Anonymous => name
-        case name: impl.Term.Name => name.copy(denot = stripPrefix(name.denot))
+        case name: impl.Term.Name if name.isBinder => name.copy(denot = stripPrefix(name.denot))
         case name: impl.Type.Name => name.copy(denot = stripPrefix(name.denot))
         case name: impl.Ctor.Name => name.copy(denot = stripPrefix(name.denot))
         case name: impl.Term.This => name.copy(denot = stripPrefix(name.denot))
@@ -125,7 +125,7 @@ trait Api {
     @hosted def owner: Scope = ???
     @hosted def name: Name = {
       tree.require[impl.Member] match {
-        case tree: impl.Term.Name => tree
+        case tree: impl.Term.Name if tree.isBinder => tree
         case tree: impl.Decl.Def => tree.name
         case tree: impl.Decl.Type => tree.name
         case tree: impl.Defn.Def => tree.name
@@ -168,7 +168,7 @@ trait Api {
     }
     @hosted def mods: Seq[Mod] = {
       tree.require[impl.Member] match {
-        case tree: impl.Term.Name => firstNonPatParent(tree).collect{case member: Member => member}.map(_.mods).getOrElse(Nil)
+        case tree: impl.Term.Name if name.isBinder => firstNonPatParent(tree).collect{case member: Member => member}.map(_.mods).getOrElse(Nil)
         case tree: impl.Decl.Def => tree.mods
         case tree: impl.Decl.Type => tree.mods
         case tree: impl.Defn.Def => tree.mods

--- a/scalameta/src/main/scala/scala/meta/ui/ShowSemantics.scala
+++ b/scalameta/src/main/scala/scala/meta/ui/ShowSemantics.scala
@@ -68,6 +68,8 @@ object Semantics {
           case Symbol.Global(owner, name, Signature.Type) => loop(owner) + "#" + name
           case Symbol.Global(owner, name, Signature.Term) => loop(owner) + "." + name
           case Symbol.Global(owner, name, Signature.Method(jvmSignature)) => loop(owner) + "." + name + jvmSignature
+          case Symbol.Global(owner, name, Signature.TypeParameter) => loop(owner) + "[" + name + "]"
+          case Symbol.Global(owner, name, Signature.TermParameter) => loop(owner) + "(" + name + ")"
           case Symbol.Local(id) => "local#" + id
         }
         var result = loop(sym)


### PR DESCRIPTION
An owner can have term/type members and term/type parameters with the same name,
so just Type/Term/Method distinction doesn't cut it.