### PR TITLE
introduces meta.Pat.Type

### DIFF
--- a/docs/quasiquotes.md
+++ b/docs/quasiquotes.md
@@ -107,6 +107,26 @@
  Sequence Wildcard | `p"_*"`
  Pattern           | `p"$pat"`
 
+## Type Patterns (meta.Pat.Type)
+
+                   | Quasiquote
+-------------------|------------------------------
+ Wildcard          | `pt"_"`
+ Var               | `pt"name"`
+ Name              | `pt"`name`"`
+ Selection         | `pt"$ref.$tname"`
+ Projection        | `pt"$ptpe#$tname"`
+ Singleton         | `pt"$ref.type"`
+ Application       | `pt"$ptpe[..$ptpes]`
+ Infix Application | `pt"$ptpe $tname $ptpe"`
+ Function          | `pt"(..$ptpes) => $ptpe"`
+ Tuple             | `pt"(..$ptpes)"`
+ Compound          | `pt"..$ptpes { ..$stats }"`
+ Existential       | `pt"$ptpe forSome { ..$stats }"`
+ Annotate          | `pt"$ptpe ..@$expr"`
+ Placeholder       | `pt"_ >: $tpeopt <: tpeopt"`
+ Literal           | `pt"$lit"`
+
 ## Statements (meta.Stat)
 
             | Quasiquote
@@ -237,6 +257,7 @@
  meta.Mod            | `$mod`        | `mod`
  meta.Pat            | `$pat`        | `p`
  meta.Pat.Arg        | `$apat`       | `p`
+ meta.Pat.Type       | `$ptpe`       | `pt`
  meta.Importee       | `$importee`   | `importee`
  meta.Stat           | `$stat`       | `q`
  meta.Template       | `$template`   | `template`

--- a/foundation/src/main/scala/org/scalameta/ast/ast.scala
+++ b/foundation/src/main/scala/org/scalameta/ast/ast.scala
@@ -65,7 +65,8 @@ class AstMacros(val c: Context) {
             fullName == "scala.meta.internal.ast.Mod.PrivateThis" ||
             fullName == "scala.meta.internal.ast.Mod.PrivateWithin" ||
             fullName == "scala.meta.internal.ast.Mod.ProtectedThis" ||
-            fullName == "scala.meta.internal.ast.Mod.ProtectedWithin") {
+            fullName == "scala.meta.internal.ast.Mod.ProtectedWithin" ||
+            fullName == "scala.meta.internal.ast.Pat.Type.Name") {
           (rawparamss.head ++ List(denotParam, sigmaParam)) +: rawparamss.tail
         } else {
           rawparamss

--- a/scalameta/src/main/scala/scala/meta/internal/hygiene/Equality.scala
+++ b/scalameta/src/main/scala/scala/meta/internal/hygiene/Equality.scala
@@ -14,9 +14,10 @@ import impl._
 // 2) some structurally equal refs may compare unequal when they refer to different defns
 
 // Now let's go through all of our refs and see how we should compare them.
-// At the moment, we have 20 different AST nodes that are subtype of Ref:
+// At the moment, we have 21 different AST nodes that are subtype of Ref:
 // Term.This, Term.Super, Term.Name, Term.Select,
 // Type.Name, Type.Select, Type.Project, Type.Singleton,
+// Pat.Type.Project,
 // Ctor.Ref.Name, Ctor.Ref.Select, Ctor.Ref.Project, Ctor.Ref.Function,
 // Selector.Wildcard, Selector.Name, Selector.Rename, Selector.Unimport,
 // Mod.PrivateThis, Mod.PrivateWithin, Mod.ProtectedThis, Mod.ProtectedWithin.

--- a/tests/src/test/scala/parser/DeclSuite.scala
+++ b/tests/src/test/scala/parser/DeclSuite.scala
@@ -3,22 +3,22 @@ import scala.meta.dialects.Scala211
 
 class DeclSuite extends ParseSuite {
   test("val x: Int") {
-    val Decl.Val(Nil, List(Pat.Var(Term.Name("x"))), Type.Name("Int")) = templStat("val x: Int")
+    val Decl.Val(Nil, List(Pat.Var.Term(Term.Name("x"))), Type.Name("Int")) = templStat("val x: Int")
   }
 
   test("var x: Int") {
-    val Decl.Var(Nil, List(Pat.Var(Term.Name("x"))), Type.Name("Int")) = templStat("var x: Int")
+    val Decl.Var(Nil, List(Pat.Var.Term(Term.Name("x"))), Type.Name("Int")) = templStat("var x: Int")
   }
 
   test("val x, y: Int") {
-    val Decl.Val(Nil, List(Pat.Var(Term.Name("x")), Pat.Var(Term.Name("y"))), Type.Name("Int")) =
+    val Decl.Val(Nil, List(Pat.Var.Term(Term.Name("x")), Pat.Var.Term(Term.Name("y"))), Type.Name("Int")) =
       templStat("val x, y: Int")
-    val Decl.Var(Nil, List(Pat.Var(Term.Name("x")), Pat.Var(Term.Name("y"))), Type.Name("Int")) =
+    val Decl.Var(Nil, List(Pat.Var.Term(Term.Name("x")), Pat.Var.Term(Term.Name("y"))), Type.Name("Int")) =
       templStat("var x, y: Int")
   }
 
   test("var x, y: Int") {
-    val Decl.Var(Nil, List(Pat.Var(Term.Name("x")), Pat.Var(Term.Name("y"))), Type.Name("Int")) =
+    val Decl.Var(Nil, List(Pat.Var.Term(Term.Name("x")), Pat.Var.Term(Term.Name("y"))), Type.Name("Int")) =
       templStat("var x, y: Int")
   }
 

--- a/tests/src/test/scala/parser/DefnSuite.scala
+++ b/tests/src/test/scala/parser/DefnSuite.scala
@@ -3,35 +3,35 @@ import scala.meta.dialects.Scala211
 
 class DefnSuite extends ParseSuite {
   test("val x = 2") {
-    val Defn.Val(Nil, Pat.Var(Term.Name("x")) :: Nil, None, Lit.Int(2)) = templStat("val x = 2")
+    val Defn.Val(Nil, Pat.Var.Term(Term.Name("x")) :: Nil, None, Lit.Int(2)) = templStat("val x = 2")
   }
 
   test("var x = 2") {
-    val Defn.Var(Nil, Pat.Var(Term.Name("x")) :: Nil, None, Some(Lit.Int(2))) = templStat("var x = 2")
+    val Defn.Var(Nil, Pat.Var.Term(Term.Name("x")) :: Nil, None, Some(Lit.Int(2))) = templStat("var x = 2")
   }
 
   test("val x, y = 2") {
-    val Defn.Val(Nil, Pat.Var(Term.Name("x")) :: Pat.Var(Term.Name("y")) :: Nil,
+    val Defn.Val(Nil, Pat.Var.Term(Term.Name("x")) :: Pat.Var.Term(Term.Name("y")) :: Nil,
                  None, Lit.Int(2)) = templStat("val x, y = 2")
   }
 
   test("val x: Int = 2") {
-    val Defn.Val(Nil, Pat.Var(Term.Name("x")) :: Nil,
+    val Defn.Val(Nil, Pat.Var.Term(Term.Name("x")) :: Nil,
                  Some(Type.Name("Int")), Lit.Int(2)) = templStat("val x: Int = 2")
   }
 
   test("val `x`: Int = 2") {
-    val Defn.Val(Nil, Pat.Var(Term.Name("x")) :: Nil,
+    val Defn.Val(Nil, Pat.Var.Term(Term.Name("x")) :: Nil,
                  Some(Type.Name("Int")), Lit.Int(2)) = templStat("val `x`: Int = 2")
   }
 
   test("var x: Int = _") {
-    val Defn.Var(Nil, Pat.Var(Term.Name("x")) :: Nil,
+    val Defn.Var(Nil, Pat.Var.Term(Term.Name("x")) :: Nil,
                  Some(Type.Name("Int")), None) = templStat("var x: Int = _")
   }
 
   test("val (x: Int) = 2") {
-    val Defn.Val(Nil, Pat.Typed(Pat.Var(Term.Name("x")), Type.Name("Int")) :: Nil,
+    val Defn.Val(Nil, Pat.Typed(Pat.Var.Term(Term.Name("x")), Type.Name("Int")) :: Nil,
                  None, Lit.Int(2)) = templStat("val (x: Int) = 2")
   }
 

--- a/tests/src/test/scala/parser/PatSuite.scala
+++ b/tests/src/test/scala/parser/PatSuite.scala
@@ -1,4 +1,4 @@
-import scala.meta.internal.ast._, Pat._, Term.Name
+import scala.meta.internal.ast._, Pat.{Type => _, _}
 import scala.meta.dialects.Scala211
 
 class PatSuite extends ParseSuite {
@@ -7,43 +7,55 @@ class PatSuite extends ParseSuite {
   }
 
   test("a @ _") {
-    val Bind(Var(Name("a")), Wildcard()) = pat("a @ _")
+    val Bind(Var.Term(Term.Name("a")), Wildcard()) = pat("a @ _")
   }
 
   test("a") {
-    val Var(Name("a")) = pat("a")
+    val Var.Term(Term.Name("a")) = pat("a")
   }
 
   test("`a`") {
-    val Name("a") = pat("`a`")
+    val Term.Name("a") = pat("`a`")
   }
 
   test("a: Int") {
-    val Typed(Var(Name("a")), Type.Name("Int")) = pat("a: Int")
+    val Typed(Var.Term(Term.Name("a")), Type.Name("Int")) = pat("a: Int")
   }
 
   test("_: Int") {
     val Typed(Wildcard(), Type.Name("Int")) = pat("_: Int")
   }
 
+  test("_: t") {
+    val Typed(Wildcard(), Type.Name("t")) = pat("_: t")
+  }
+
   test("_: F[t]") {
-    val Typed(Wildcard(), Type.Apply(Type.Name("F"), Type.Name("t") :: Nil)) = pat("_: F[t]")
+    val Typed(Wildcard(), Pat.Type.Apply(Type.Name("F"), Var.Type(Type.Name("t")) :: Nil)) = pat("_: F[t]")
+  }
+
+  test("_: F[_]") {
+    val Typed(Wildcard(), Pat.Type.Apply(Type.Name("F"), Pat.Type.Wildcard() :: Nil)) = pat("_: F[_]")
+  }
+
+  test("_: (t Map u)") {
+    val Typed(Wildcard(), Pat.Type.ApplyInfix(Type.Name("t"), Type.Name("Map"), Type.Name("u"))) = pat("_: (t Map u)")
   }
 
   test("foo(x)") {
-    val Extract(Name("foo"), Nil, Var(Name("x")) :: Nil) = pat("foo(x)")
+    val Extract(Term.Name("foo"), Nil, Var.Term(Term.Name("x")) :: Nil) = pat("foo(x)")
   }
 
   test("foo(_*)") {
-    val Extract(Name("foo"), Nil, Arg.SeqWildcard() :: Nil) = pat("foo(_*)")
+    val Extract(Term.Name("foo"), Nil, Arg.SeqWildcard() :: Nil) = pat("foo(_*)")
   }
 
   test("foo(x @ _*)") {
-    val Extract(Name("foo"), Nil, Bind(Var(Name("x")), Arg.SeqWildcard()) :: Nil) = pat("foo(x @ _*)")
+    val Extract(Term.Name("foo"), Nil, Bind(Var.Term(Term.Name("x")), Arg.SeqWildcard()) :: Nil) = pat("foo(x @ _*)")
   }
 
   test("a :: b") {
-    val ExtractInfix(Var(Name("a")), Name("::"), Var(Name("b")) :: Nil) = pat("a :: b")
+    val ExtractInfix(Var.Term(Term.Name("a")), Term.Name("::"), Var.Term(Term.Name("b")) :: Nil) = pat("a :: b")
   }
 
   test("1 | 2 | 3") {
@@ -56,14 +68,14 @@ class PatSuite extends ParseSuite {
   }
 
   test("foo\"bar\"") {
-    val Interpolate(Name("foo"), Lit.String("bar") :: Nil, Nil) = pat("foo\"bar\"")
+    val Interpolate(Term.Name("foo"), Lit.String("bar") :: Nil, Nil) = pat("foo\"bar\"")
   }
 
   test("foo\"a $b c\"") {
-    val Interpolate(Name("foo"), Lit.String("a ") :: Lit.String(" c") :: Nil, Var(Name("b")) :: Nil) = pat("foo\"a $b c\"")
+    val Interpolate(Term.Name("foo"), Lit.String("a ") :: Lit.String(" c") :: Nil, Var.Term(Term.Name("b")) :: Nil) = pat("foo\"a $b c\"")
   }
 
   test("foo\"${b @ foo()}\"") {
-    val Interpolate(Name("foo"), Lit.String("") :: Lit.String("") :: Nil, Bind(Var(Name("b")), Extract(Name("foo"), Nil, Nil)) :: Nil) = pat("foo\"${b @ foo()}\"")
+    val Interpolate(Term.Name("foo"), Lit.String("") :: Lit.String("") :: Nil, Bind(Var.Term(Term.Name("b")), Extract(Term.Name("foo"), Nil, Nil)) :: Nil) = pat("foo\"${b @ foo()}\"")
   }
 }

--- a/tests/src/test/scala/parser/TemplateSuite.scala
+++ b/tests/src/test/scala/parser/TemplateSuite.scala
@@ -29,7 +29,7 @@ class TemplateSuite extends ParseSuite {
 
   test("trait A extends { val x: Int } with B") {
     val Trait(Nil, Type.Name("A"), Nil, EmptyCtor(),
-              Template(Defn.Val(Nil, List(Pat.Var(Term.Name("x"))), Some(Type.Name("Int")), Lit.Int(2)) :: Nil,
+              Template(Defn.Val(Nil, List(Pat.Var.Term(Term.Name("x"))), Some(Type.Name("Int")), Lit.Int(2)) :: Nil,
                        Ctor.Name("B") :: Nil, EmptySelf(), None)) =
       templStat("trait A extends { val x: Int = 2 } with B")
   }
@@ -66,7 +66,7 @@ class TemplateSuite extends ParseSuite {
 
   test("class A extends { val x: Int } with B") {
     val Class(Nil, Type.Name("A"), Nil, EmptyCtor(),
-              Template(Defn.Val(Nil, List(Pat.Var(Term.Name("x"))), Some(Type.Name("Int")), Lit.Int(2)) :: Nil,
+              Template(Defn.Val(Nil, List(Pat.Var.Term(Term.Name("x"))), Some(Type.Name("Int")), Lit.Int(2)) :: Nil,
                        Ctor.Name("B") :: Nil, EmptySelf(), None)) =
       templStat("class A extends { val x: Int = 2 } with B")
   }
@@ -153,7 +153,7 @@ class TemplateSuite extends ParseSuite {
 
   test("object A extends { val x: Int } with B") {
     val Object(Nil, Term.Name("A"), EmptyCtor(),
-              Template(Defn.Val(Nil, List(Pat.Var(Term.Name("x"))), Some(Type.Name("Int")), Lit.Int(2)) :: Nil,
+              Template(Defn.Val(Nil, List(Pat.Var.Term(Term.Name("x"))), Some(Type.Name("Int")), Lit.Int(2)) :: Nil,
                        Ctor.Name("B") :: Nil, EmptySelf(), None)) =
       templStat("object A extends { val x: Int = 2 } with B")
   }

--- a/tests/src/test/scala/parser/TermSuite.scala
+++ b/tests/src/test/scala/parser/TermSuite.scala
@@ -224,16 +224,16 @@ class TermSuite extends ParseSuite {
   }
 
   test("for (a <- b; if c; x = a) x") {
-    val For(List(Enumerator.Generator(Pat.Var(TermName("a")), TermName("b")),
+    val For(List(Enumerator.Generator(Pat.Var.Term(TermName("a")), TermName("b")),
                  Enumerator.Guard(TermName("c")),
-                 Enumerator.Val(Pat.Var(TermName("x")), TermName("a"))),
+                 Enumerator.Val(Pat.Var.Term(TermName("x")), TermName("a"))),
             TermName("x")) = term("for (a <- b; if c; x = a) x")
 
   }
   test("for (a <- b; if c; x = a) yield x") {
-    val ForYield(List(Enumerator.Generator(Pat.Var(TermName("a")), TermName("b")),
+    val ForYield(List(Enumerator.Generator(Pat.Var.Term(TermName("a")), TermName("b")),
                       Enumerator.Guard(TermName("c")),
-                      Enumerator.Val(Pat.Var(TermName("x")), TermName("a"))),
+                      Enumerator.Val(Pat.Var.Term(TermName("x")), TermName("a"))),
                  TermName("x")) = term("for (a <- b; if c; x = a) yield x")
   }
 
@@ -279,7 +279,7 @@ class TermSuite extends ParseSuite {
   }
 
   test("new { val x: Int = 1 } with A") {
-    val New(Template(Defn.Val(Nil, List(Pat.Var(TermName("x"))), Some(TypeName("Int")), Lit.Int(1)) :: Nil,
+    val New(Template(Defn.Val(Nil, List(Pat.Var.Term(TermName("x"))), Some(TypeName("Int")), Lit.Int(1)) :: Nil,
                      Ctor.Name("A") :: Nil, EmptySelf(), None)) =
       term("new { val x: Int = 1 } with A")
   }

--- a/tests/src/test/scala/parser/TypeSuite.scala
+++ b/tests/src/test/scala/parser/TypeSuite.scala
@@ -72,7 +72,7 @@ class TypeSuite extends ParseSuite {
     val Compound(TypeName("A") :: Nil,
                  Decl.Def(Nil, TermName("x"),
                           Nil, Nil, TypeName("Int")) ::
-                 Decl.Val(Nil, List(Pat.Var(TermName("y"))), TypeName("B")) ::
+                 Decl.Val(Nil, List(Pat.Var.Term(TermName("y"))), TypeName("B")) ::
                  Decl.Type(Nil, TypeName("C"), Nil, Type.Bounds(None, None)) :: Nil) =
       tpe("A { def x: Int; val y: B; type C }")
   }
@@ -108,7 +108,7 @@ class TypeSuite extends ParseSuite {
 
   test("a.T forSome { val a: A }") {
     val Existential(Select(TermName("a"), TypeName("T")),
-                    Decl.Val(Nil, Pat.Var(TermName("a")) :: Nil, TypeName("A")) :: Nil) =
+                    Decl.Val(Nil, Pat.Var.Term(TermName("a")) :: Nil, TypeName("A")) :: Nil) =
       tpe("a.T forSome { val a: A }")
   }
 }

--- a/tests/src/test/scala/quasiquotes/JoinSuite.scala
+++ b/tests/src/test/scala/quasiquotes/JoinSuite.scala
@@ -21,16 +21,16 @@ class JoinSuite extends FunSuite {
       q"val $f = $ref.$f"
     }
     assert(vals.length === 2)
-    val Defn.Val(Nil, List(Pat.Var(Term.Name("x"))), None, Term.Select(Term.Name("xtemp"), Term.Name("x"))) = vals(0)
-    val Defn.Val(Nil, List(Pat.Var(Term.Name("y"))), None, Term.Select(Term.Name("ytemp"), Term.Name("y"))) = vals(1)
+    val Defn.Val(Nil, List(Pat.Var.Term(Term.Name("x"))), None, Term.Select(Term.Name("xtemp"), Term.Name("x"))) = vals(0)
+    val Defn.Val(Nil, List(Pat.Var.Term(Term.Name("y"))), None, Term.Select(Term.Name("ytemp"), Term.Name("y"))) = vals(1)
   }
 
   test("result") {
     val x = Term.Name("x")
     val y = Term.Name("y")
     val valsin = List(
-      Defn.Val(Nil, List(Pat.Var(Term.Name("x"))), None, Term.Select(Term.Name("xtemp"), Term.Name("x"))),
-      Defn.Val(Nil, List(Pat.Var(Term.Name("y"))), None, Term.Select(Term.Name("ytemp"), Term.Name("y"))))
+      Defn.Val(Nil, List(Pat.Var.Term(Term.Name("x"))), None, Term.Select(Term.Name("xtemp"), Term.Name("x"))),
+      Defn.Val(Nil, List(Pat.Var.Term(Term.Name("y"))), None, Term.Select(Term.Name("ytemp"), Term.Name("y"))))
     val result = {
       import scala.meta._
       q"""
@@ -41,8 +41,8 @@ class JoinSuite extends FunSuite {
     }
     val Term.Block(stats) = result
     assert(stats.length === 3)
-    val Defn.Val(Nil, List(Pat.Var(Term.Name("xtemp"))), None, Term.Name("x")) = stats(0)
-    val Defn.Val(Nil, List(Pat.Var(Term.Name("ytemp"))), None, Term.Name("y")) = stats(1)
+    val Defn.Val(Nil, List(Pat.Var.Term(Term.Name("xtemp"))), None, Term.Name("x")) = stats(0)
+    val Defn.Val(Nil, List(Pat.Var.Term(Term.Name("ytemp"))), None, Term.Name("y")) = stats(1)
     val Term.New(Template(Nil, Nil, Term.Param(Nil, Name.Anonymous(), None, None), Some(valsout))) = stats(2)
     // TODO: FIXME
     // assert(valsout.length === 2)

--- a/tests/src/test/scala/show/DottySuite.scala
+++ b/tests/src/test/scala/show/DottySuite.scala
@@ -5,7 +5,7 @@ import scala.meta.dialects.Dotty
 class DottySuite extends ParseSuite {
   test("case List(xs: _*)") {
     val tree = pat("List(xs: _*)")
-    assert(tree.show[Raw] === "Pat.Extract(Term.Name(\"List\"), Nil, List(Pat.Bind(Pat.Var(Term.Name(\"xs\")), Pat.Arg.SeqWildcard())))")
+    assert(tree.show[Raw] === "Pat.Extract(Term.Name(\"List\"), Nil, List(Pat.Bind(Pat.Var.Term(Term.Name(\"xs\")), Pat.Arg.SeqWildcard())))")
     assert(tree.show[Code] === "List(xs: _*)")
   }
 }

--- a/tests/src/test/scala/show/ScalaSuite.scala
+++ b/tests/src/test/scala/show/ScalaSuite.scala
@@ -5,7 +5,7 @@ import scala.meta.dialects.Scala211
 class ScalaSuite extends ParseSuite {
   test("val x: Int (raw)") {
     val tree = templStat("val x: Int")
-    assert(tree.show[Raw] === "Decl.Val(Nil, List(Pat.Var(Term.Name(\"x\"))), Type.Name(\"Int\"))")
+    assert(tree.show[Raw] === "Decl.Val(Nil, List(Pat.Var.Term(Term.Name(\"x\"))), Type.Name(\"Int\"))")
   }
 
   test("val x: Int (code)") {
@@ -35,7 +35,7 @@ class ScalaSuite extends ParseSuite {
       QQQ
       val y = "\""
     }""".replace("QQQ", "\"\"\""))
-    assert(tree.show[Raw] === """Term.Block(List(Defn.Val(Nil, List(Pat.Var(Term.Name("x"))), None, Lit.String("%n        x%n      ")), Defn.Val(Nil, List(Pat.Var(Term.Name("y"))), None, Lit.String("\""))))""".replace("%n", escapedEOL))
+    assert(tree.show[Raw] === """Term.Block(List(Defn.Val(Nil, List(Pat.Var.Term(Term.Name("x"))), None, Lit.String("%n        x%n      ")), Defn.Val(Nil, List(Pat.Var.Term(Term.Name("y"))), None, Lit.String("\""))))""".replace("%n", escapedEOL))
     assert(tree.show[Code] === """
     |{
     |  val x = QQQ
@@ -55,7 +55,7 @@ class ScalaSuite extends ParseSuite {
         ..$z
       QQQ
     }""".replace("QQQ", "\"\"\""))
-    assert(tree.show[Raw] === """Term.Block(List(Defn.Val(Nil, List(Pat.Var(Term.Name("x"))), None, Term.Interpolate(Term.Name("q"), List(Lit.String("123 + "), Lit.String(" + "), Lit.String(" + 456")), List(Term.Name("x"), Term.Apply(Term.Name("foo"), List(Lit.Int(123)))))), Defn.Val(Nil, List(Pat.Var(Term.Name("y"))), None, Lit.String("%n        $x%n        $y%n        ..$z%n      "))))""".replace("%n", escapedEOL))
+    assert(tree.show[Raw] === """Term.Block(List(Defn.Val(Nil, List(Pat.Var.Term(Term.Name("x"))), None, Term.Interpolate(Term.Name("q"), List(Lit.String("123 + "), Lit.String(" + "), Lit.String(" + 456")), List(Term.Name("x"), Term.Apply(Term.Name("foo"), List(Lit.Int(123)))))), Defn.Val(Nil, List(Pat.Var.Term(Term.Name("y"))), None, Lit.String("%n        $x%n        $y%n        ..$z%n      "))))""".replace("%n", escapedEOL))
     assert(tree.show[Code] === """
     |{
     |  val x = q"123 + $x + ${foo(123)} + 456"
@@ -298,7 +298,7 @@ class ScalaSuite extends ParseSuite {
 
   test("case List(xs @ _*)") {
     val tree = pat("List(xs @ _*)")
-    assert(tree.show[Raw] === "Pat.Extract(Term.Name(\"List\"), Nil, List(Pat.Bind(Pat.Var(Term.Name(\"xs\")), Pat.Arg.SeqWildcard())))")
+    assert(tree.show[Raw] === "Pat.Extract(Term.Name(\"List\"), Nil, List(Pat.Bind(Pat.Var.Term(Term.Name(\"xs\")), Pat.Arg.SeqWildcard())))")
     assert(tree.show[Code] === "List(xs @ _*)")
   }
 


### PR DESCRIPTION
Now I remember why we didn't introduce Pat.Var a year ago.

Because it would require a symmetric change to express type variable patterns,
and that would make it impossible to use meta.Type types for type patterns.
That was deemed too inconvenient and rejected.

Now I think that we should've followed that through, because pattern types
seem to form a distinct syntactic group, with their own peculiarities.
An argument that types and pattern types look the same syntactically
is compelling and seductive, but Term.Apply and Pat.Extract also look
the same, and we didn't unify them, so I think that there is more to
tree unification that just syntactic likeness.

Even though this change creates an inconvenience (it's no longer possible
to use Type and Pat.Type interchangeably), that inconvenience is arguably minor,
because one could always imagine having a bidirectional conversion, with
the Type => Pat.Type direction being always successful (+ a Liftable)
and Pat.Type => Type being potentially fallible.