### PR TITLE
absorbs https://github.com/begeric/TQL-scalameta

### DIFF
--- a/foundation/src/main/scala/org/scalameta/algebra/Monoid.scala
+++ b/foundation/src/main/scala/org/scalameta/algebra/Monoid.scala
@@ -1,0 +1,83 @@
+package org.scalameta.algebra
+
+import scala.language.higherKinds
+import scala.collection.generic._
+
+/**
+ * https://en.wikipedia.org/wiki/Monoid
+ * */
+// NOTE: I don't like reinventing the wheels, but I honestly don't know where to get Monoid.
+// Scalaz, spire, algebra, cats, structures, even shapeless and who knows what else defines monoids...
+trait Monoid[A] {
+  def zero : A
+  def append(a: A, b: A): A
+}
+
+/**
+ * Different base implementation of several instances of Monoids
+ * */
+object Monoid {
+  //note: http://stackoverflow.com/questions/15623585/why-is-list-a-semigroup-but-seq-is-not
+  implicit def listMonoid[A] = new Monoid[List[A]] {
+    def zero = Nil
+    def append(a: List[A], b: List[A]) = a ::: b
+  }
+
+  implicit def setMonoid[A] = new Monoid[Set[A]] {
+    def zero = Set.empty[A]
+    def append(a: Set[A], b: Set[A]) = a ++ b
+  }
+
+  implicit def traversableMonoid[A, B[A] <: Traversable[A]](implicit y: CanBuildFrom[B[A], A, B[A]]) =
+    new Monoid[B[A]] {
+      def zero = y.apply.result
+      def append(a: B[A], b: B[A]): B[A] =
+        if (a.size == 0) b
+        else if (b.size == 0) a
+        else {
+          val x = y.apply
+          x ++= a
+          x ++= b
+          x.result
+        }
+  }
+
+  implicit def mapMonoid[A, C, B[A, C] <: Traversable[(A, C)]](implicit y: CanBuildFrom[B[A, C], (A, C), B[A, C]]) =
+    new Monoid[B[A, C]] {
+      def zero = y.apply.result
+      def append(a: B[A, C], b: B[A, C]): B[A, C] = {
+        val x = y.apply
+        x ++= a
+        x ++= b
+        x.result
+      }
+  }
+
+  implicit object Void extends Monoid[Unit]{
+    def zero = ()
+    def append(a: Unit, b: Unit) = ()
+  }
+
+  implicit def tupleMonoid[A : Monoid, B : Monoid] = new Monoid[(A, B)] {
+    def zero = (implicitly[Monoid[A]].zero,  implicitly[Monoid[B]].zero)
+    def append(a: (A, B), b: (A, B)) = (a._1 + b._1, a._2 + b._2)
+  }
+
+  //State monoid, from https://hackage.haskell.org/package/monoid-transformer-0.0.2/docs/src/Data-Monoid-State.html#T
+  case class Cons[S, A](run: S => (A, S))
+
+  def pure[S, A](a: A) = Cons((s: S) => (a, s))
+  def evaluate[S, A](s: S, m: Cons[S, A]) = m.run(s)._1
+  def execute [S, A](s: S, m: Cons[S, A]) = m.run(s)._2
+  def put[S, A: Monoid](s: S) = Cons((_: S) => (implicitly[Monoid[A]].zero, s))
+  def modify[S, A: Monoid](f: S => S) = Cons((s: S) => (implicitly[Monoid[A]].zero, f(s)))
+
+  implicit def stateMonoid[S, A : Monoid] = new Monoid[Cons[S, A]] {
+    def zero = pure[S, A](implicitly[Monoid[A]].zero)
+    def append(x: Cons[S, A], y: Cons[S, A]) = Cons(s0 => {
+      val (xr, s1) = x.run(s0)
+      val (yr, s2) = y.run(s1)
+      (implicitly[Monoid[A]].append(xr, yr), s2)
+    })
+  }
+}

--- a/foundation/src/main/scala/org/scalameta/algebra/package.scala
+++ b/foundation/src/main/scala/org/scalameta/algebra/package.scala
@@ -1,0 +1,35 @@
+package org.scalameta
+
+package object algebra {
+  implicit class XtensionMonoid[A : Monoid](a: A){
+    def + (b: A) = implicitly[Monoid[A]].append(a, b)
+  }
+
+  /**
+   * Sometimes the Scala parser/compiler is not happy about Monoid 'addition' and things like
+   * a + b where a and b are monoids of type A won't work because it thinks the + is for a String addition.
+   *
+   * found   : C
+   * required: String
+   *
+   * (from what I can gather it doesn't work when there is a type parameter C >: B : Monoid and then we want to do
+   * 'addition' on two monoids of type C)
+   * Even if one defines another operator, say |+|, it stills fails with an error of that kind:
+   *  Error:(81, 45) value |+| is not a member of type parameter C
+   *
+   * Fun fact: intelliji actually parses things correctly!
+   *
+   * So this is why the weird object M exists, to 'lift' a Monoid.
+   * */
+  object M {
+    def apply[A: Monoid](a: A) = new XtensionMonoid(a)
+
+    /**
+     * Chosed because:
+     * 1) left-associative
+     * 2) higher precedence than + which is used in XtensionMonoid
+     * 3) the less ugly of all choices
+     * */
+    def %[A: Monoid](a: A) = new XtensionMonoid(a)
+  }
+}

--- a/foundation/src/main/scala/org/scalameta/tql/TraverserBuilder.scala
+++ b/foundation/src/main/scala/org/scalameta/tql/TraverserBuilder.scala
@@ -1,0 +1,135 @@
+package org.scalameta.tql
+
+import scala.reflect.macros.whitebox.Context
+import org.scalameta.adt._
+
+class TraverserBuilderMacros(val c: Context) extends AdtReflection {
+  val u: c.universe.type = c.universe
+  val mirror: u.Mirror = c.mirror
+  import c.universe._
+  val XtensionQuasiquoteTerm = "shadow scala.meta quasiquotes"
+
+  def getAllLeaves(root: Root) = root.allLeafs
+
+  def changeOrderOf(firsts: List[Symbol], allLeafs: List[Symbol]): List[Symbol] = {
+    val tmp = firsts.map(_.fullName)
+    val rest = for {leaf <- allLeafs if !(tmp contains leaf.fullName)} yield leaf
+    val leafFist = firsts.map(x => allLeafs.find(_.fullName == x.fullName).get)
+    leafFist ++ rest
+  }
+
+  def getAllLeafsOrderedInTree[T : c.WeakTypeTag](firsts: c.Tree*): List[c.Tree] = {
+    val leaves: List[Leaf] = getAllLeaves(u.symbolOf[T].asRoot)
+    //weird hack so that the types are set in each symbol and the buildImpl function doesn't fail
+    leaves.foreach(_.sym.owner.info)
+    val leafsWithOrder = changeOrderOf(firsts.map(_.symbol).toList, leaves.map(_.sym))
+    leafsWithOrder.map(x => q"${x.companion}")
+  }
+
+
+  def buildFromTopSymbolDelegate[T : c.WeakTypeTag, A : c.WeakTypeTag](f: c.Tree, firsts: c.Tree*): c.Tree = {
+    val allLeafs = getAllLeafsOrderedInTree[T](firsts: _*)
+    buildImplDelegate[T, A](f, allLeafs: _*)
+  }
+
+  //trick to make it work with the Name unapply.
+  def getParamsWithTypes(typ: c.Type): Option[(List[TermName], List[c.Type])] = {
+    val fields = typ.companion.typeSymbol.asLeaf.fields
+    if (!fields.isEmpty){
+      Some(fields.map(x => (TermName(c.freshName), x.tpe) ).unzip)
+    }
+    else
+      None
+  }
+
+  def buildImpl[T : c.WeakTypeTag, A : c.WeakTypeTag](f: c.Tree, objs: c.Tree*): c.Tree = {
+    val parameter = TermName(c.freshName)
+    val cases = buildCases[T, A](f, objs.toList, parameter)
+    buildFuncWith[T, A](cases, parameter)
+  }
+
+  def buildFuncWith[T : c.WeakTypeTag, A : c.WeakTypeTag](cases: List[c.Tree], parameter: TermName): c.Tree = {
+    q"""
+        ($parameter: ${implicitly[c.WeakTypeTag[T]]}) => $parameter match {
+          case ..$cases
+          case v => Some((v, implicitly[_root_.org.scalameta.algebra.Monoid[${implicitly[c.WeakTypeTag[A]]}]].zero))
+        }
+    """
+  }
+
+  def buildImplDelegate[T : c.WeakTypeTag, A : c.WeakTypeTag](f: c.Tree, objs: c.Tree*): c.Tree = {
+    val parameter = c.internal.enclosingOwner.asMethod.paramLists.head.head.name.toTermName //LOL
+    val cases = buildCases[T, A](f, objs.toList, parameter)
+    buildDelegateWith[T, A](cases, parameter)
+  }
+
+  def buildDelegateWith[T : c.WeakTypeTag, A : c.WeakTypeTag](cases: List[c.Tree], parameter: TermName): c.Tree = {
+    q"""
+      $parameter match {
+        case ..$cases
+        case v => Some((v, implicitly[_root_.org.scalameta.algebra.Monoid[${implicitly[c.WeakTypeTag[A]]}]].zero))
+      }
+     """
+  }
+
+  def buildCases[T : c.WeakTypeTag, A : c.WeakTypeTag]
+                (f: c.Tree, objs: List[c.Tree],
+                 parameter: TermName): List[c.Tree] =
+    for {
+      obj <- objs
+      args <- getParamsWithTypes(obj.symbol.info)
+      extractorVars = args._1.map(p => pq"$p @ _")
+      pat = pq"$obj(..${extractorVars})"
+      stat <- caseMatch[T, A](f, obj, parameter, args._1, args._2)
+    } yield cq"$pat => $stat"
+
+
+  def createEnum[T : c.WeakTypeTag, A : c.WeakTypeTag]
+                (f: c.Tree, name: TermName, typ: c.Type)/*: List[Option[(TermName, TermName, c.Tree)]] */= {
+    val aTpe = implicitly[c.WeakTypeTag[A]]
+    val newTree = TermName(c.freshName)
+    val newResult = TermName(c.freshName)
+    val lhs = pq"($newTree: $typ, $newResult @ _)"
+    val rhs = typ match {
+      case t if t <:< weakTypeOf[T] =>
+        Some(q"$f($name)")
+      case t if t <:< weakTypeOf[scala.collection.immutable.Seq[T]] =>
+        Some(q"_root_.scala.meta.internal.tql.TraverserHelper.traverseSeq($f, $name)")
+      case t if t <:< weakTypeOf[scala.collection.immutable.Seq[scala.collection.immutable.Seq[T]]] =>
+        Some(q"_root_.scala.meta.internal.tql.TraverserHelper.traverseSeqOfSeq($f, $name)")
+      case t if t <:< weakTypeOf[scala.Option[T]] =>
+        Some(q"_root_.scala.meta.internal.tql.TraverserHelper.optional($f, $name)")
+      case _ => None
+    }
+    rhs.map(r => (newTree, newResult, fq"$lhs <- $r"))
+  }
+
+
+  def caseMatch[T : c.WeakTypeTag, A : c.WeakTypeTag](f: c.Tree, constructor: c.Tree, origin: TermName,
+                                                      names: List[TermName], types: List[c.Type]): Option[c.Tree] = {
+
+    val parameters: List[(TermName, Type)] = names.zip(types)
+    val enums = parameters.map(x => createEnum[T, A](f, x._1, x._2))
+    val forEnums: List[c.Tree] = enums.flatMap(_.map(_._3))
+    val results: List[TermName] = enums.flatMap(_.map(_._2))
+
+    if (!results.isEmpty){
+      val addResults = results.tail.foldLeft[c.Tree](q"${results.head}")((a, b) => q"$a + $b")
+      val paramsWithNewParams = parameters.unzip._1.zip(enums.map(_.map(_._1)))
+      val reconstructParams = paramsWithNewParams.map(x => x._2.getOrElse(x._1))
+      val reconstruct = q"$constructor(..$reconstructParams)"
+      val eqList = paramsWithNewParams.foldLeft[c.Tree](q"true"){
+        (acc, x) => q"$acc && ${x._2.map(y => q"($y eq ${x._1})").getOrElse(q"true")}"}
+
+      val doesReconstruct = q"if ($eqList) $origin else $reconstruct"
+
+      Some(q"""
+        for (
+          ..$forEnums
+        ) yield ($doesReconstruct, $addResults)
+      """)
+    }
+    else
+      None
+  }
+}

--- a/foundation/src/main/scala/org/scalameta/typelevel/=!=.scala
+++ b/foundation/src/main/scala/org/scalameta/typelevel/=!=.scala
@@ -1,0 +1,20 @@
+package org.scalameta.typelevel
+
+/**
+ * Allows to specify that the type A must be different from type B.
+ * Use the same as with =:=
+ * */
+//thanks to http://stackoverflow.com/questions/6909053/enforce-type-difference/17047288#17047288
+@annotation.implicitNotFound(msg = "Cannot prove that ${A} =!= ${B}.")
+trait =!=[A,B]
+
+object =!= {
+  class Impl[A, B]
+  object Impl {
+    implicit def neq[A, B] : A Impl B = null
+    implicit def neqAmbig1[A] : A Impl A = null
+    implicit def neqAmbig2[A] : A Impl A = null
+  }
+
+  implicit def foo[A,B]( implicit e: A Impl B ): A =!= B = null
+}

--- a/project/build.scala
+++ b/project/build.scala
@@ -14,7 +14,7 @@ object build extends Build {
     publishArtifact in Compile := false,
     publishArtifact in Test := false,
     scalacOptions ++= Seq("-deprecation", "-feature", "-optimise", "-unchecked"),
-    scalacOptions in (Compile, doc) ++= Seq("-skip-packages", "scala.meta.internal.ast:scala.meta.internal.hygiene"),
+    scalacOptions in (Compile, doc) ++= Seq("-skip-packages", "scala.meta.internal.ast:scala.meta.internal.hygiene:scala.meta.internal.tql"),
     scalacOptions in (Compile, doc) ++= Seq("-implicits", "-implicits-hide:.,scala.meta.syntactic.Api.XtensionInputLike,scala.meta.ui.Api.XtensionShow"),
     scalacOptions in (Compile, doc) ++= Seq("-groups"),
     parallelExecution in Test := false, // hello, reflection sync!!

--- a/scalameta/src/main/scala/scala/meta/internal/tql/AllowedTransformation.scala
+++ b/scalameta/src/main/scala/scala/meta/internal/tql/AllowedTransformation.scala
@@ -1,0 +1,40 @@
+package scala.meta
+package internal
+package tql
+
+import org.scalameta.adt._
+import scala.reflect.macros.blackbox.Context
+import scala.meta.tql._
+
+private[meta] class AllowedTransformationMacros(val c: Context) extends AdtReflection {
+  val u: c.universe.type = c.universe
+  val mirror: u.Mirror = c.mirror
+  import c.universe._
+  val XtensionQuasiquoteTerm = "shadow scala.meta quasiquotes"
+
+  def materialize[T : c.WeakTypeTag, I : c.WeakTypeTag, O : c.WeakTypeTag]: c.Expr[AllowedTransformation[I, O]] = {
+    val brlhs = getBranch[I].filterNot(_.fullName == u.symbolOf[T].fullName)
+    val Tout = u.symbolOf[O].asType
+    //c.abort(c.enclosingPosition, show(Tout) + " : " + show(brlhs.filter(x => Tout.toType <:< x.info.typeSymbol.asType.toType)))
+
+    if (brlhs.exists(x => Tout.toType <:< x.info.typeSymbol.asType.toType))
+      c.Expr(q"new _root_.scala.meta.tql.AllowedTransformation[${implicitly[c.WeakTypeTag[I]]}, ${implicitly[c.WeakTypeTag[O]]}] {}")
+    else
+      c.abort(c.enclosingPosition,
+        "impossible to materialize AllowedTransformations[" +
+          show(implicitly[c.WeakTypeTag[I]].tpe) + ", " +
+          show(implicitly[c.WeakTypeTag[O]].tpe) + "]" + "\n" +
+          "because " + show(Tout.fullName) + " is not a subtype of any in " + show(brlhs) + "\n")
+  }
+
+  private def getBranch[A : c.WeakTypeTag]: List[TypeSymbol] = {
+    val Asym = u.symbolOf[A]
+    if (Asym.isBranch) List(Asym.asType)
+    else if (Asym.isLeaf)
+      Asym.asLeaf.sym.asClass.baseClasses
+        .filter(_.isBranch)
+        //.filter(_.asBranch.leafs.exists(x => x.sym.fullName == Asym.asLeaf.sym.fullName))//gotta find a better solution
+        .map(_.asType)
+    else c.abort(c.enclosingPosition, show("impossible to get branch from  "  + show(implicitly[c.WeakTypeTag[A]])))
+  }
+}

--- a/scalameta/src/main/scala/scala/meta/internal/tql/CollectionLikeUI.scala
+++ b/scalameta/src/main/scala/scala/meta/internal/tql/CollectionLikeUI.scala
@@ -1,0 +1,34 @@
+package scala.meta
+package internal
+package tql
+
+import scala.language.experimental.macros
+import scala.reflect.macros.whitebox.Context
+import scala.meta.tql._
+
+/**
+ * This class, much like CombinatorMacros, define several bundled macros used to enhance
+ * or to make less boilerplaty the CollectionLikeUI
+ * */
+private[meta] class CollectionLikeUIMacros(override val c: Context) extends CombinatorMacros(c) {
+  import c.universe._
+  override val XtensionQuasiquoteTerm = "shadow scala.meta quasiquotes"
+
+  /**
+   * See comments in parent class (CombinatorMacros).
+   * This method has to be overriden because the 'prefix' has to be added in front of the
+   * rewritten function.
+   * */
+  override def filterSugarImpl[T : c.WeakTypeTag](f: c.Tree): c.Tree = {
+    //I know it's ugly but that's the only way I found to do it.
+    val (lhs, _) =  getLUBsfromPFs[T](f)
+    q"${c.prefix}.guard[$lhs]($f)"
+  }
+
+  /**
+   * The implementation of transform is special in CollectionLikeUI because we have to make sure that several
+   * transformations can be re-written.
+   * */
+  def transformSugarImplWithTRtype[T : c.WeakTypeTag](f: c.Tree): c.Tree =
+    q"${c.prefix}.transforms(${transformSugarImpl[T](f)})"
+}

--- a/scalameta/src/main/scala/scala/meta/internal/tql/Combinators.scala
+++ b/scalameta/src/main/scala/scala/meta/internal/tql/Combinators.scala
@@ -1,0 +1,156 @@
+package scala.meta
+package internal
+package tql
+
+import scala.language.experimental.macros
+import scala.reflect.macros.whitebox.Context
+import scala.meta.tql._
+
+/**
+ * This class define several bundled macros used to enhance or to make less boilerplaty the usage
+ * of the combinators defined in Combinators.scala
+ * */
+private[meta] class CombinatorMacros(val c: Context) {
+  import c.universe._
+  val XtensionQuasiquoteTerm = "shadow scala.meta quasiquotes"
+
+  /**
+   * Transform focus*{case Term.If(a,b,c) => true} into guard[Term.If]{case Term.If(a,b,c) => true}
+   * as the compiler cannot infer the type in arguments of anonymous functions (see §8.5).
+   * * name can change.
+   * */
+  def filterSugarImpl[T : c.WeakTypeTag](f: c.Tree): c.Tree = {
+    val (lhs, _) =  getLUBsfromPFs[T](f)
+    q"guard[$lhs]($f)"
+  }
+
+  /**
+   * This allows to inline the method withResult of the CTWithResult implicit class, so as to have the power of an implicit class
+   * without the runtime performance impact.
+   * */
+  def TWithResult[T: c.WeakTypeTag, A : c.WeakTypeTag](a: c.Tree): c.Tree  = c.untypecheck(c.prefix.tree) match {
+    case q"$_.CTWithResult[$_]($t)" => q"($t, $a)"
+    case q"$_.CTWithResult[$_]($t).andCollect[$_]" => q"($t, $a)"
+    case _ => c.abort(c.enclosingPosition, "Bad form in TWithResult " + show(c.prefix.tree))
+  }
+
+  /**
+   * Inline the method andCOllect of the CTWithResult implicit class (see TWithResult macro).
+   * The second parameter is actually the implicit paramter of type Collector.
+   * */
+  def TAndCollect[T: c.WeakTypeTag, A : c.WeakTypeTag](a: c.Tree)(y: c.Tree): c.Tree =
+    TWithResult[T, List[A]](q"($y.builder += $a).result")
+
+  /**
+   * Rewrite
+   * transform {
+   *    case Lit.Int(a) => Lit.Int(a * 3) andCollect a
+   *    case Term.If(a, b, c) => Term.If(a, b, c)  andCollect 0
+   * }
+   * into
+   *
+   * transformWithResult[Lit, Lit, List[Int] ]({case Lit.Int(a) => Lit.Int(a * 3) andCollect a} |
+   * transformWithResult[Term, Term, List[Int] ]({case Term.If(a, b, c) => Term.If(a, b, c)  andCollect 0} |
+   *
+   *Here's the kind of error you get if you try to do something like that:
+   *
+   * transform {
+   *    case Lit.Int(a) => Lit.Int(a * 3) andCollect a
+   *    case Term.If(a, b, c) => Term.If(a, b, c)  //no result here.
+   * }.down
+   *
+   * [error] D:\[..]\scala\meta\tql\Example.scala:44: could not find implicit
+   * value for evidence parameter of type tql.Monoid[Any]
+   * */
+  def transformSugarImpl[T : c.WeakTypeTag](f: c.Tree): c.Tree = {
+    val Ttpe = implicitly[c.WeakTypeTag[T]].tpe
+
+    def setTuplesForEveryOne(clauses: List[CaseDef]): List[CaseDef] = {
+      def setTupleTo(rhs: c.Tree) = rhs.tpe match {
+        case TypeRef(_, sym, _) if sym.fullName != "scala.Tuple2" => q"($rhs, _root_.org.scalameta.algebra.Monoid.Void)"
+        case _ => rhs
+      }
+      clauses.map{_ match {
+        case cq"${lhs: c.Tree} => ${rhs:  c.Tree}" => cq"$lhs => ${setTupleTo(rhs)}"
+        case cq"${lhs: c.Tree} if $cond => ${rhs:  c.Tree}" => cq"$lhs if $cond => ${setTupleTo(rhs)}"
+        case x => x
+      }}
+    }
+
+    def getTypesFromTuple2(rhss: List[c.Type]): List[(c.Type, c.Type)] = rhss.map{
+      /*It's not like I have a choice..
+      http://stackoverflow.com/questions/18735295/how-to-match-a-universetype-via-quasiquotes-or-deconstructors*/
+      case TypeRef(_, sym, List(a, b)) if sym.fullName == "scala.Tuple2" => (a, b)
+      case x if x <:< Ttpe => (x, typeOf[Unit])
+      case _ => c.abort(c.enclosingPosition, "There should be a Tuple2 or a " + show(Ttpe) + " here")
+    }
+
+    def normalizeCases(pf: c.Tree) = pf match {
+      case q"{case ..$cases}" => setTuplesForEveryOne(cases).map(betterUntypecheck(_))
+    }
+
+    val cases = normalizeCases(f)
+    val (lhss, rhss) = getTypesFromPFS[T](f).unzip
+    val (trhs, ress) = getTypesFromTuple2(rhss).unzip
+
+    val transforms = cases.zip(lhss).zip(trhs).zip(ress).map{
+      case (((cas, lhs), rhs), res) =>
+       q"${c.prefix}.transformWithResult[$lhs, $rhs, $res]({case $cas})"
+    }
+
+    if (transforms.size < 1)
+      c.abort(c.enclosingPosition, "No cases found in " + show(f))
+
+    val res = betterUntypecheck(transforms.reduceRight[c.Tree]((c, acc) => q"$c | $acc"))
+    res
+  }
+
+
+
+  protected def getLUBsfromPFs[T : c.WeakTypeTag](f: c.Tree): (c.Type, c.Type) = {
+    val tpes = getTypesFromPFS[T](f)
+    if (tpes.size > 1) {
+      val (lhs, rhs) = tpes.unzip
+      (c.universe.lub(lhs), c.universe.lub(rhs))
+    }
+    else
+      tpes.head //TODO guarenteed to have size > 0?
+  }
+
+  protected def getTypesFromPFS[T : c.WeakTypeTag](f: c.Tree): List[(c.Type, c.Type)] = {
+    f match {
+      case q"{case ..$cases}" =>
+        cases.map(getTypesFromCase(_))
+      case func if func.tpe <:< weakTypeOf[PartialFunction[_, _]] =>
+        val lhs :: rhs :: Nil = func.tpe.typeArgs
+        List((implicitly[c.WeakTypeTag[T]].tpe, rhs))
+      case _ => c.abort(c.enclosingPosition, "Expecting a partial function here")
+    }
+  }
+
+  protected def getTypesFromCase(cas: c.Tree): (c.Type, c.Type) = {
+    import c.universe._
+    cas match {
+      case cq"${lhs: c.Tree} => ${rhs:  c.Tree}" => (lhs.tpe, rhs.tpe)
+      case cq"${lhs: c.Tree} if $_ => ${rhs:  c.Tree}" => (lhs.tpe, rhs.tpe)
+      case p => c.abort(c.enclosingPosition, "Bad format in partial function at: " + show(p))
+    }
+  }
+
+  /**
+   * When type checking a partial function an <unapply-selector> thing gets added in the AST of the pattern match
+   * and this thing cannot be typechecked a second time. (see : https://issues.scala-lang.org/browse/SI-5465)
+   * To solve this problem we have to remonve the <unapply-selector> ourselves, and here is the solution:
+   * thanks Eugene : https://gist.github.com/xeno-by/7fbd422c6789299140a7*/
+  protected object betterUntypecheck extends Transformer {
+    override def transform(tree: Tree): Tree = tree match {
+      case UnApply(Apply(Select(qual, TermName("unapply")), List(Ident(TermName("<unapply-selector>")))), args) =>
+        Apply(transform(qual), transformTrees(args))
+      case UnApply(Apply(TypeApply(Select(qual, TermName("unapplySeq")),List(TypeTree())), List(Ident(TermName("<unapply-selector>")))), args) =>
+        //this is funny
+        Apply(transform(qual), transformTrees(args))
+      case _ => super.transform(tree)
+    }
+    def apply(tree: Tree): Tree =  c.untypecheck(transform(tree))
+  }
+}

--- a/scalameta/src/main/scala/scala/meta/internal/tql/TraverserBuilder.scala
+++ b/scalameta/src/main/scala/scala/meta/internal/tql/TraverserBuilder.scala
@@ -1,0 +1,13 @@
+package scala.meta
+package internal
+package tql
+
+import scala.language.experimental.macros
+import org.scalameta.adt._
+import org.scalameta.tql._
+import scala.meta.tql._
+
+object TraverserBuilder {
+  def buildFromTopSymbolDelegate[T, A](f: Traverser[T]#Matcher[A], firsts: Any*): Traverser[T]#MatchResult[A] =
+    macro TraverserBuilderMacros.buildFromTopSymbolDelegate[T, A]
+}

--- a/scalameta/src/main/scala/scala/meta/internal/tql/TraverserHelper.scala
+++ b/scalameta/src/main/scala/scala/meta/internal/tql/TraverserHelper.scala
@@ -1,0 +1,55 @@
+package scala.meta
+package internal
+package tql
+
+import scala.collection.immutable.Seq
+import scala.collection.mutable.ListBuffer
+import scala.reflect._
+import org.scalameta.algebra._
+import scala.meta.tql._
+
+object TraverserHelper {
+  def traverseSeq[U, T <: U with AnyRef : ClassTag, A : Monoid](
+                 f: Traverser[U]#Matcher[A],
+                 seq: Seq[T]): Option[(Seq[T], A)] = {
+    val m = implicitly[Monoid[A]]
+    var buffer = new ListBuffer[T]()
+    var hasChanged = false
+    var acc = m.zero
+    for {t <- seq
+         (a1 : T, a2) <- f(t)
+         if classTag[T].runtimeClass.isInstance(a1)
+    } {
+        buffer.append(a1)
+        acc += a2
+        hasChanged |= !(a1 eq t)
+    }
+    hasChanged |= seq.size != buffer.size //TODO this should be an error
+    Some((if (hasChanged) collection.immutable.Seq(buffer: _*) else seq, acc))
+  }
+
+  def traverseSeqOfSeq[U, T <: U with AnyRef : ClassTag, A : Monoid](
+                      f:  Traverser[U]#Matcher[A],
+                      seq: Seq[Seq[T]]): Option[(Seq[Seq[T]], A)] = {
+    val m = implicitly[Monoid[A]]
+    var buffer = new ListBuffer[Seq[T]]()
+    var hasChanged = false
+    var acc = m.zero
+    for {t <- seq
+         (a1, a2) <- traverseSeq(f, t)
+    }{
+        buffer.append(a1)
+        acc += a2
+        hasChanged |= !(a1 eq t)
+    }
+    hasChanged |= seq.size != buffer.size //TODO this should be an error
+    Some((if (hasChanged) collection.immutable.Seq(buffer: _*) else seq, acc))
+  }
+
+  def optional[U, T <: U with AnyRef : ClassTag, A: Monoid](
+              f:  Traverser[U]#Matcher[A],
+              a: Option[T]): Option[(Option[T], A)] = Some(a
+    .flatMap(f(_))
+    .collect{case (x: T, y) if classTag[T].runtimeClass.isInstance(x) => (Some(x), y)}
+    .getOrElse((None, implicitly[Monoid[A]].zero)))
+}

--- a/scalameta/src/main/scala/scala/meta/package.scala
+++ b/scalameta/src/main/scala/scala/meta/package.scala
@@ -3,7 +3,8 @@ package scala
 import scala.meta.macros.{Api => MacroApi}
 import scala.meta.syntactic.{Api => SyntacticApi}
 import scala.meta.semantic.{Api => SemanticApi}
+import scala.meta.tql.{Api => TQLApi}
 import scala.meta.ui.{Api => UIApi}
 import scala.meta.{Quasiquotes => QuasiquoteApi}
 
-package object meta extends MacroApi with SyntacticApi with SemanticApi with UIApi with QuasiquoteApi
+package object meta extends MacroApi with SyntacticApi with SemanticApi with TQLApi with UIApi with QuasiquoteApi

--- a/scalameta/src/main/scala/scala/meta/tql/AllowedTransformation.scala
+++ b/scalameta/src/main/scala/scala/meta/tql/AllowedTransformation.scala
@@ -1,0 +1,25 @@
+package scala.meta
+package tql
+
+import scala.meta.internal.{ast => impl}
+import scala.meta.internal.tql._
+import scala.language.experimental.macros
+
+trait AllowedTransformation[I, O]
+
+object AllowedTransformation {
+  /**
+   * Create an AllowedTransformation[I, O] If :
+   *  Upper Branch* of O is a subtype of Upper Branch of I
+   *  Where I and O are both subtypes of T.
+   *  Example:
+   *  materializerAllowedTransformation[Tree, Lit.Int, Lit] would work since:
+   *  Lit.Int is a Leaf* => its upper branch is Lit and Lit is a subtype of Lit
+   *
+   *  But materialize[Tree, Lit.Int, Term.If] wouldn't work
+   *
+   *  Branch, Leaf  in the Adt scala.meta sense of the term
+   */
+  implicit def materialize[I <: Tree, O <: Tree]: AllowedTransformation[I, O] =
+    macro AllowedTransformationMacros.materialize[impl.Tree, I, O]
+}

--- a/scalameta/src/main/scala/scala/meta/tql/Api.scala
+++ b/scalameta/src/main/scala/scala/meta/tql/Api.scala
@@ -1,0 +1,13 @@
+package scala.meta
+package tql
+
+import org.scalameta.algebra._
+import scala.language.implicitConversions
+
+// TODO: The current incarnation of the traversal/transformation API is very generic (that is interesting)
+// but also contains a lot of moving parts, e.g. see things like EvaluatorMetaCollector (that is daunting).
+// We need to study how accessible this is for the users and see where to go from there.
+trait Api {
+  implicit def collectionLikeUI[V <: Tree](v: V): Evaluator[V] = new Evaluator[V](v)
+  implicit def forceResultUI[V, A : Monoid, R](x: EvaluatorAndThen[V, A]): ForceResult[V, A, R] = new ForceResult[V, A, R](x)
+}

--- a/scalameta/src/main/scala/scala/meta/tql/CollectionLikeUI.scala
+++ b/scalameta/src/main/scala/scala/meta/tql/CollectionLikeUI.scala
@@ -1,0 +1,271 @@
+package scala.meta
+package tql
+
+import scala.language.higherKinds
+import scala.language.reflectiveCalls
+import scala.language.experimental.macros
+import scala.reflect.ClassTag
+import org.scalameta.algebra._
+import org.scalameta.typelevel._
+import scala.meta.internal.tql._
+
+/**
+ * This trait allows to easily write simple traversals.
+ * Instead of writing:
+ *  t : T
+ *  val x = topDown(collect{...})
+ *  val result = x(t).result
+ * We can wirte instead
+ *  t.collect{...}
+ *
+ *  topDownBreak(focus{..} ~> topDown{transform{...}}) (t)
+ *  becomes
+ *  t.topDownBreak.focus{..}.topDown.transform{..}
+ *  Which is essentially easier to read and to write
+ *
+ *  - transform return either
+ *    - just a T => x: T = t.transform{case Lit.Int(a) => Lit.Int(a * 2)}
+ *    - a tuple (T, A) => (x: T, y: List[Int]) = t.transform{case Lit.Int(a) => Lit.Int(a * 2) andCollect a}
+ *  - it is possible to use it on
+ *    - t: T => t.transform{case Lit.Int(a) => Lit.Int(a * 2)}: T
+ *    - t: Option[T] => t.transform{case Lit.Int(a) => Lit.Int(a * 2)}: Option[T]
+ *    - t: List[T] => t.transform{case Lit.Int(a) => Lit.Int(a * 2)}: List[T]
+ *
+ *  The drawbacks:
+ *    - Every combinator have to be re-written in those 'Evaluator' classes (even macros)
+ *    - Composition is lost.
+ *
+ * /!\ Beware: this code contains a lot of implcit magic tricks
+ * */
+trait CollectionLikeUI[T] { self: Combinators[T] with Traverser[T] with SyntaxEnhancer[T] =>
+
+  /**Abstract class used to delay delay the time when the type parameter of
+    * a meta combinator is decided.
+    * Anonymous functions can't take type parameter, so this ugly stuff is required
+    * */
+  abstract class DelayedMeta{
+    def apply[A : Monoid](m: Matcher[A]): Matcher[A]
+  }
+
+  /**
+   * System needed to recover the correct type from a 'transfrom' call.
+   * 1) x.transform{case x: T => x} : T
+   * 2) x.transform{case x: T => (x, List(1))} : (T, List[Int])
+   * */
+  trait TransformResultTr[A, R]{
+    def get(t: T, x: MatchResult[A]): R
+  }
+
+  object TransformResultTr{
+    //for 1) the case where the returned type is Unit
+    implicit val unitRes = new TransformResultTr[Unit, T] {
+      def get(t: T, x: MatchResult[Unit]): T  = x.tree.getOrElse(t)
+    }
+
+    //for 2) the case where the returned type is not Unit
+    implicit def withRes[A: Monoid](implicit ev: A =!= Unit) = new TransformResultTr[A, (T, A)] {
+      def get(t: T, x: MatchResult[A]): (T, A)  = (x.tree.getOrElse(t), x.result)
+    }
+  }
+
+
+  /**
+   * Make it possible to use the collection like ui api inside different structures
+   * A := Result of the Matcher
+   * R := Some anonymous type which represents the result of a transformation on each MatchResult
+   * V := T | Option[T] | List[T]
+   * L := R | Option[R] | List[R]
+   * */
+  trait MatcherApply[A, R, V, L] {
+    def apply(value: V)(m: Matcher[A])(f: (T, MatchResult[A]) => R): L
+  }
+
+  object MatcherApply {
+    //Base case
+    implicit def direct[A, R, U <: T, L] = new MatcherApply[A, R, U, R] {
+      def apply(value: U)(m: Matcher[A])(f: (T, MatchResult[A]) => R): R = f(value, m.apply(value))
+    }
+
+    //Make generic to Monad, Functor, Applicative, Monoid.. ?
+    implicit def toOpt[A, R, U <: T, L] = new MatcherApply[A, R, Option[U], Option[R]] {
+      def apply(value: Option[U])(m: Matcher[A])(f: (T, MatchResult[A]) => R): Option[R] =
+        value.map(x => f(x, m.apply(x)))
+    }
+
+    //TODO make more generic (if needed?) to take into account, Set, Seq, Vector..
+    implicit def toList[A, R, U <: T, L] = new MatcherApply[A, R, List[U], List[R]] {
+      def apply(value: List[U])(m: Matcher[A])(f: (T, MatchResult[A]) => R): List[R] =
+        value.map(x => f(x, m.apply(x)))
+    }
+  }
+
+  /**
+   * Allows to call 'combinators' directly on T
+   * For documentation see Combinators.scala
+   * */
+  /* implicit */ class Evaluator[V](value: V) {
+
+    //combinator interfaces (see documentation for combinators)
+    def collect[C[_]] = new EvaluatorCollector[V, C](this)
+
+    def focus(f: PartialFunction[T, Boolean]): EvaluatorAndThen[V, T] = macro CollectionLikeUIMacros.filterSugarImpl[T]
+
+    def transform(f: PartialFunction[T, Any]): Any =
+      macro CollectionLikeUIMacros.transformSugarImplWithTRtype[T]
+
+    /**
+     * Allows to use other combinators which are not defined in the CollectionLikeUI framework
+     * */
+    def combine[B](x: Matcher[B]) = topDown.combine(x)
+
+    //traversal strategies
+    def topDown =
+      new EvaluatorMeta(value, new DelayedMeta{def apply[A : Monoid](x: Matcher[A]) = self.topDown(x)})
+    def topDownBreak =
+      new EvaluatorMeta(value, new DelayedMeta{def apply[A : Monoid](x: Matcher[A]) = self.topDownBreak(x)})
+    def bottomUp =
+      new EvaluatorMeta(value, new DelayedMeta{def apply[A : Monoid](x: Matcher[A]) = self.bottomUp(x)})
+    def bottomUpBreak =
+      new EvaluatorMeta(value, new DelayedMeta{def apply[A : Monoid](x: Matcher[A]) = self.bottomUpBreak(x)})
+    def children =
+      new EvaluatorMeta(value, new DelayedMeta{def apply[A : Monoid](x: Matcher[A]) = self.children(x)})
+
+    //methods required to implement the above interface
+    def guard[U <: T : ClassTag](f: PartialFunction[U, Boolean]) = topDown.guard(f)
+    /**
+     * This is required for the transform macro as it cannot access self.transformWithResult by itself
+     * */
+    def transformWithResult[I <: T : ClassTag, O <: T, A]
+                            (f: PartialFunction[I, (O, A)])
+                            (implicit x: AllowedTransformation[I, O]) = self.transformWithResult(f)
+
+    def transforms[A : Monoid, R, L]
+                  (f: Matcher[A])
+                  (implicit r: TransformResultTr[A, R],
+                  l: MatcherApply[A, R, V, L]) = topDown.transforms(f)
+
+  }
+
+  class EvaluatorCollector[V, C[_]](evaluator: Evaluator[V]) {
+    def apply[A, R, L](f: PartialFunction[T, A])
+                      (implicit x: ClassTag[T],
+                      y: Collector[C[A], A, R],
+                      z: Monoid[R],
+                      l: MatcherApply[R, R, V, L]) =
+      evaluator.topDown.collect[C](f)
+  }
+
+  /**
+   * Evaluator at which will be applied the traversal strategy defined in 'meta'
+   * */
+  class EvaluatorMeta[V](value: V, meta: DelayedMeta) {
+
+    def collect[C[_]] = new EvaluatorMetaCollector[V, C](value, meta)
+
+    def transform(f: PartialFunction[T, Any]): Any =
+      macro CollectionLikeUIMacros.transformSugarImplWithTRtype[T]
+
+    def focus(f: PartialFunction[T, Boolean]): EvaluatorAndThen[V, T] =
+      macro CollectionLikeUIMacros.filterSugarImpl[T]
+
+    /**
+     * Allows to use other combinators which are not defined in the CollectionLikeUI framework
+     * */
+    def combine[B](x: Matcher[B]) = new EvaluatorAndThen[V, B](value, x, meta)
+
+    /**
+     * This is required for the transform macro as it cannot access self.transformWithResult by itself
+     * */
+    def transformWithResult[I <: T : ClassTag, O <: T, A]
+                            (f: PartialFunction[I, (O, A)])
+                            (implicit x: AllowedTransformation[I, O]) = self.transformWithResult(f)
+
+    def transforms[A : Monoid, R, L]
+                  (f: Matcher[A])
+                  (implicit r: TransformResultTr[A, R],
+                   l: MatcherApply[A, R, V, L]) =
+                    l(value)(meta(f))((t, m) => r.get(t, m))
+
+    def guard[U <: T : ClassTag](f: PartialFunction[U, Boolean]) =
+      new EvaluatorAndThen(value, self.guard(f), meta)
+  }
+
+  class EvaluatorMetaCollector[V, C[_]](value: V, meta: DelayedMeta) {
+    def apply[A, R, L](f: PartialFunction[T, A])
+                      (implicit x: ClassTag[T],
+                       y: Collector[C[A], A, R],
+                       z: Monoid[R],
+                       l: MatcherApply[R, R, V, L]) =
+      l(value)(meta(self.collect[C](f)))((t, m) => m.result)
+  }
+
+
+  /**
+   * Evaluator at which will be applied m andThen the traversal strategy defined in 'meta'
+   * */
+  class EvaluatorAndThen[V, +A]( private[CollectionLikeUI] val value: V,
+                                 private[CollectionLikeUI] val m: Matcher[A],
+                                 private[CollectionLikeUI] val meta: DelayedMeta) {
+    def collect[C[_]] = new EvaluatorAndThenCollector[V, C](value, meta)
+
+    def focus(f: PartialFunction[T, Boolean]): EvaluatorAndThen[V, T] =
+      macro CollectionLikeUIMacros.filterSugarImpl[T]
+
+
+    def transform(f: PartialFunction[T, Any]): Any =
+      macro CollectionLikeUIMacros.transformSugarImplWithTRtype[T]
+
+    def combine[B](x: Matcher[B]) = new EvaluatorAndThen[V, B](value, m ~> x, meta)
+
+
+    def topDown =
+      new EvaluatorMeta(value, new DelayedMeta{def apply[A : Monoid](x: Matcher[A]) = meta(m ~> self.topDown(x))})
+    def topDownBreak =
+      new EvaluatorMeta(value, new DelayedMeta{def apply[A : Monoid](x: Matcher[A]) = meta(m ~> self.topDownBreak(x))})
+    def bottomUp =
+      new EvaluatorMeta(value, new DelayedMeta{def apply[A : Monoid](x: Matcher[A]) = meta(m ~> self.bottomUp(x))})
+    def bottomUpBreak =
+      new EvaluatorMeta(value, new DelayedMeta{def apply[A : Monoid](x: Matcher[A]) = meta(m ~> self.bottomUpBreak(x))})
+    def children =
+      new EvaluatorMeta(value, new DelayedMeta{def apply[A : Monoid](x: Matcher[A]) = meta(m ~> self.children(x))})
+
+
+    /**
+     * This is required for the transform macro as it cannot access self.transformWithResult by itself
+     * */
+    def transformWithResult[I <: T : ClassTag, O <: T, A]
+                          (f: PartialFunction[I, (O, A)])
+                          (implicit x: AllowedTransformation[I, O]) = self.transformWithResult(f)
+
+    def transforms[A : Monoid, R, L]
+                  (f: Matcher[A])
+                  (implicit r: TransformResultTr[A, R],
+                   l: MatcherApply[A, R, V, L]) =
+      l(value)(meta(f))((t, m) => r.get(t, m))
+
+    def guard[U <: T : ClassTag](f: PartialFunction[U, Boolean]) =
+      new EvaluatorAndThen(value, m ~> self.guard(f), meta)
+  }
+
+  class EvaluatorAndThenCollector[V, C[_]](value: V, meta: DelayedMeta) {
+    def apply[A, R, L](f: PartialFunction[T, A])
+                      (implicit x: ClassTag[T],
+                       y: Collector[C[A], A, R],
+                       z: Monoid[R],
+                       l: MatcherApply[R, R, V, L])  =
+      l(value)(meta(self.collect[C](f)))((t, m) => m.result)
+  }
+
+  /**
+   * This has to be outside of EvaluatorAndThen because of covarience stuff it is not possible to write
+   * def force(implicit x: Monoid[A]) = ...inside EvaluatorAndThen[A]
+   * We should write def force[B >: A](implicit x: Monoid[B]) but Monoid should be made contravarient in A,
+   * which is not possible (in part because it is not logical and because contravarient stuff does not work well
+   * with implicits)
+   * */
+  /* implicit */ class ForceResult[V, A : Monoid, R](x : EvaluatorAndThen[V, A]){
+    def force[L](implicit l: MatcherApply[A, MatchResult[A], V, L]) = l(x.value)(x.meta(x.m))((t, m) => m)
+    def result[L](implicit l: MatcherApply[A, A, V, L]) = l(x.value)(x.meta(x.m))((t, m) => m.result)
+    def tree[L](implicit l: MatcherApply[A, T, V, L]) = l(x.value)(x.meta(x.m))((t, m) => m.tree.getOrElse(t))
+  }
+}

--- a/scalameta/src/main/scala/scala/meta/tql/Combinators.scala
+++ b/scalameta/src/main/scala/scala/meta/tql/Combinators.scala
@@ -1,0 +1,211 @@
+package scala.meta
+package tql
+
+import scala.language.higherKinds
+import scala.language.implicitConversions
+import scala.language.experimental.macros
+import scala.collection.mutable
+import scala.reflect.ClassTag
+import scala.collection.generic.CanBuildFrom
+import org.scalameta.algebra._
+import scala.meta.internal.tql._
+
+/**
+ * This trait contains the base combinators which can be used to write powerful traversers.
+ * */
+trait Combinators[T] { self: Traverser[T] =>
+
+  /**
+   * Simple Identity combinator. a identity = a
+   * */
+  def identity[A : Monoid] = Matcher[A]{tree => Some(tree, implicitly[Monoid[A]].zero)}
+
+  /**
+   * Traverse the direct children of the tree and apply f to them.
+   * */
+  def children[A : Monoid](f: => Matcher[A]) = Matcher[A]{ tree =>
+    traverse(tree, f)
+  }
+
+  /*
+  * Is successful if at least one of the children is successful
+  * TODO currently using a var, change that when stateful transformation are working
+  * */
+  def oneOfChildren[A: Monoid](m: => Matcher[A]) = Matcher[A] { tree =>
+    var oneSuccess = false
+    def wrapper = Matcher[A] { t =>
+      m(t) match {
+        case x @ Some(_) =>
+          oneSuccess = true
+          x
+        case None => identity.apply(t)
+      }
+    }
+    val traverseChildren = children(wrapper).apply(tree)
+    if (oneSuccess)
+      traverseChildren
+    else
+      None
+  }
+
+  /**
+   * Same as TopDown, but does not sop when a transformation/traversal has succeeded
+   * */
+  def topDown[A : Monoid](m: Matcher[A]): Matcher[A] =
+    m + children(topDown[A](m))
+
+  /**
+   * Same as bottomUpBreak, but does not sop when a transformation/traversal has succeeded
+   * */
+  def bottomUp[A : Monoid](m: => Matcher[A]): Matcher[A] =
+    children(bottomUp[A](m)) + m
+
+  /**
+   * Traverse the tree in a TopDown manner, stop when a transformation/traversal has succeeded
+   * */
+  def topDownBreak[A : Monoid](m: Matcher[A]): Matcher[A] =
+    m | children(topDownBreak[A](m))
+
+  /**
+   * Traverse the tree in a BottomUp manner, stop when a transformation/traversal has succeeded
+   * */
+  def bottomUpBreak[A : Monoid](m: Matcher[A]): Matcher[A] =
+    oneOfChildren(bottomUpBreak[A](m)) | m
+
+
+  /*
+  * Traverse the structure and apply m1 until m2 matches. Then return only the result aggregated by m1
+  * */
+  def until[A : Monoid, B](m1: => Matcher[A], m2: Matcher[B]): Matcher[A] =
+    m2 |> (m1 + children(until(m1, m2)))
+
+  /*
+  * Traverse the structure and apply m1 until m2 matches. Return a tuple of the result of m1 and m2,
+  * TODO find a better name
+  * */
+  def tupledUntil[A : Monoid, B: Monoid](m1: Matcher[A], m2: Matcher[B]): Matcher[(A, B)] =
+    m2.map(x => (implicitly[Monoid[A]].zero, x)) |
+    (m1.map(x => (x, implicitly[Monoid[B]].zero)) + children(tupledUntil(m1, m2)))
+
+  /**
+   * The infamous fix point combinator
+   * */
+  def fix[A](f: Matcher[A] => Matcher[A]): Matcher[A] = Matcher[A]{ tree =>
+    f(fix(f))(tree)
+  }
+
+  /**
+   * Succeed if the partial function f applied on the tree is defined and return true
+   * */
+  def guard[U <: T : ClassTag](f: PartialFunction[U, Boolean]) = Matcher[U]{
+    case t: U if f.isDefinedAt(t) && f(t) => Some((t, t))
+    case _ => None
+  }
+
+  /**
+   * Alias for focus{case t: U => some((t,t)}
+   * */
+  def select[U <: T: ClassTag] = Matcher[U]{
+    case t: U => Some((t, t))
+    case _ => None
+  }
+
+  /**
+   * Alias for select
+   * */
+  def @@[U <: T: ClassTag] = select[U]
+
+  /**
+   *  Transform a I into a T where both I and O are subtypes of T and where a transformation from I to O is authorized
+   * */
+  def transformWithResult[I <: T : ClassTag, O <: T, A](f: PartialFunction[I, (O, A)])(implicit x: AllowedTransformation[I, O]) =
+    Matcher[A] {
+      case t: I if f.isDefinedAt(t) => Some(f(t))
+      case _ => None
+    }
+
+  /**
+   *  Traverse the data structure and return a result
+   * */
+  def visit[A](f: PartialFunction[T, A])(implicit x: ClassTag[T]) =
+    guard[T]{case t => f.isDefinedAt(t)} map(f(_))
+
+
+  /**
+   * This trait is part of the infrastructure required to make the collect combinator have a
+   * default parameter to List[_].
+   * C is the type of the collection (ex: List[Int]) given by the User (or inferred to Nothing by the compiler)
+   * A is the element inside the collection (in List[Int] it would be Int)
+   * R is the 'real' collection that will be used i.e if C = Nothing => R = List[A] else R = C
+   *
+   * Note: maybe it would be interesting to generate such boilerplaite with a macro annotation. Something like that:
+   * @default(C = List[_]) def collect[C[_] ]{..}
+   * */
+  trait Collector[C, A, R] {
+    def builder: mutable.Builder[A, R]
+  }
+  object Collector {
+    implicit def nothingToList[A](implicit y: CanBuildFrom[List[A], A, List[A]], m: Monoid[List[A]]) =
+      new Collector[Nothing, A, List[A]] {
+        def builder = {y().clear(); y()}
+      }
+
+    implicit def otherToCollect[A, C[A]](implicit y: CanBuildFrom[C[A], A, C[A]], m: Monoid[C[A]]) =
+      new Collector[C[A], A, C[A]] {
+        def builder = {y().clear(); y()}
+      }
+  }
+
+  /**
+   * This is solely use to write collect as  def collect[C[_] ] = new CollectInType[C] {..} instead of
+   * def collect[C[_] ] = new {} and so to not use reflective calls. This as not been benchmarked so I don't really know
+   * if it has a real performance impact
+   * */
+  abstract class CollectInType[C[_]] {
+    def apply[A, R](f: PartialFunction[T, A])(implicit  x: ClassTag[T], y: Collector[C[A], A, R]): Matcher[R]
+  }
+
+  /**
+   * Same as visit but puts the results into a collection (List by default)
+   * */
+  def collect[C[_]] = new CollectInType[C] {
+    def apply[A, R](f: PartialFunction[T, A])(implicit  x: ClassTag[T], y: Collector[C[A], A, R]): Matcher[R] =
+      Matcher[R] { tree =>
+        if (f.isDefinedAt(tree)) Some((tree, (y.builder += f(tree)).result))
+        else None
+      }
+  }
+
+  /**
+   * same as collect but put the results into a collection of 2 type parameter e.g a Map[K, V]
+   * */
+  def collect2[V[_, _]] = new {
+    def apply[A, B](f: PartialFunction[T, (A, B)])(implicit  x: ClassTag[T], y: CanBuildFrom[V[A, B], (A, B), V[A, B]]) =
+      guard[T]{case t => f.isDefinedAt(t)} map(t => (y() += f(t)).result)
+  }
+
+
+  /**
+   * Part of the 'transform' infrastructure.
+   * transform ca take either a T only or a (T, A).
+   * (t, a) is bit cumbersome to write and that is why CTWithResult exists.
+   * This allows to write t andCollect a instead of (t, List(a))
+   * */
+  implicit class CTWithResult[U <: T](t: U) {
+    def withResult[A](a: A): (U, A) = macro CombinatorMacros.TWithResult[U, A]//(t, a)
+    def andCollect[C[_]] = new {
+        def apply[A, R](a: A)(implicit y: Collector[C[A], A, R]): (U, R) = macro CombinatorMacros.TAndCollect[U, A]
+      }
+  }
+
+  /**
+   * Syntactic sugar for transform combinator so that one doesn't need to type the type parameter
+   * */
+  def transform(f: PartialFunction[T, Any]): Matcher[Any] = macro CombinatorMacros.transformSugarImpl[T]
+
+  /**
+   * Syntactic sugar for guard combinator so that one doesn't need to type the type parameter
+   * */
+  def focus(f: PartialFunction[T, Boolean]): Matcher[T] = macro CombinatorMacros.filterSugarImpl[T]
+}
+

--- a/scalameta/src/main/scala/scala/meta/tql/SyntaxEnhancer.scala
+++ b/scalameta/src/main/scala/scala/meta/tql/SyntaxEnhancer.scala
@@ -1,0 +1,59 @@
+package scala.meta
+package tql
+
+import scala.language.implicitConversions
+import scala.reflect.ClassTag
+import org.scalameta.algebra._
+
+trait SyntaxEnhancer[T] { self: Combinators[T] with Traverser[T] =>
+
+  implicit class TEnhancer(t: T){
+
+    def >>[A](a: Matcher[A]) = a(t)
+
+    def resultOf[A : Monoid](a: Matcher[A]) = new MatcherResultEnhancer(a(t)).result
+    def treeOf[A : Monoid](a: Matcher[A]) = new MatcherResultEnhancer(a(t)).tree
+  }
+
+  /*Required for things inside TreeMapperEnhancer*/
+  def topDownBreakAlias[A : Monoid](m: Matcher[A]) = topDownBreak(m)
+  def topDownAlias[A : Monoid](m: Matcher[A]) = topDown(m)
+  def bottomUpBreakAlias[A : Monoid](m: Matcher[A]) = bottomUpBreak(m)
+  def bottomUpAlias[A : Monoid](m: Matcher[A]) = bottomUp(m)
+  def childrenAlias[A : Monoid](m: Matcher[A]) = children(m)
+
+  implicit class TreeMapperEnhancer[A](a: Matcher[A]){
+    //def >>[B] (f: T => MatchResult[B]) = flatMap(f)
+    /*def apply[I <: T : ClassTag, O <: T]
+             (f: PartialFunction[I, O])
+             (implicit x: ClassTag[T], y: AllowedTransformation[I, O]) =
+      transformWithResult[I, O](f)  */
+
+    def collect = a.map(List(_))
+    def topDownBreak(implicit x: Monoid[A]) = topDownBreakAlias(a)
+    def topDown(implicit x: Monoid[A]) = topDownAlias(a)
+    def bottomUpBreak(implicit x: Monoid[A]) = bottomUpBreakAlias(a)
+    def bottomUp(implicit x: Monoid[A]) = bottomUpAlias(a)
+    def children(implicit x: Monoid[A]) = childrenAlias(a)
+  }
+
+
+  /**
+   * Convention : Operators ending with : are right assosiative
+   * Moreover a \: b is desugared to b.\:(a)
+   */
+  implicit class MatcherXPath[A : Monoid](a: Matcher[A]){
+    def \: (t: T) = topDownBreakAlias(a).apply(t)
+    def \\: (t: T) = topDownAlias(a).apply(t)
+    def \:[B] (b: Matcher[B]) = b andThen topDownBreakAlias(a)
+    def \\:[B] (b: Matcher[B]) = b andThen topDownAlias(a)
+  }
+
+  implicit class MatcherResultEnhancer[A](a: MatchResult[A]){
+    def result(implicit x: Monoid[A])  = a.map(_._2).getOrElse(x.zero)
+    def tree    = a.map(_._1)
+  }
+
+  implicit def MatcherResultToResult[A : Monoid](a: MatchResult[A]): A = a.result
+  implicit def MatcherResultToTree(a : MatchResult[_]): Option[T] = a.tree
+}

--- a/scalameta/src/main/scala/scala/meta/tql/Traverser.scala
+++ b/scalameta/src/main/scala/scala/meta/tql/Traverser.scala
@@ -1,0 +1,179 @@
+package scala.meta
+package tql
+
+import org.scalameta.algebra._
+
+trait Traverser[T] {
+
+  type MatchResult[A] = Option[(T, A)]
+
+  /**
+   * A Matcher is a function or 'combinator' which takes a T and return an Option of tuple of
+   * - a transformed T (or the same)
+   * - a result of type A s.t Exists Monoid[A] so that results can be combined during the traversal
+   * A transformation/traversal has succeeded if the result of the application on the Matcher is not a None
+   * */
+  abstract class Matcher[+A] extends (T => MatchResult[A]) {
+
+    /**
+     * a andThen b
+     * b is 'executed' only if a succeeded
+     * We discard the result of a
+     * */
+    def andThen[B](m: => Matcher[B]) = Matcher[B] { tree =>
+      for {
+        (t, v) <- this(tree)
+        t2 <- m(t)
+      } yield t2
+    }
+
+    /**
+     * Alias for andThen
+     * */
+    def ~>[B](m: =>  Matcher[B]) = andThen(m)
+
+    /**
+     * a andThenLeft b
+     * b is 'executed' only if a succeeded
+     * We discard the result of b and only keep the result of a
+     * */
+    def andThenLeft[B](m: => Matcher[B]) = Matcher[A] { tree =>
+     for {
+        (t, v) <- this(tree)
+        (t2, v2) <- m(t)
+     } yield (t2, v)
+    }
+
+    /**
+     * Alias for andThenLeft
+     * */
+    def <~[B : Monoid](m: =>  Matcher[B]) = andThenLeft(m)
+
+    /**
+     * Combine the result of two TreeMappers in a tuple2.
+     * The order is important, as the the second transformation is applied on the
+     * result of the first one.
+     * */
+    def tupledWith[B : Monoid, C >: A : Monoid](m: => Matcher[B]) = Matcher[(C, B)] { tree =>
+      this(tree).map {
+        case u @ (a1, a2) => m(a1)
+          .map {case (b1, b2) => (b1, (a2, b2))}
+          .getOrElse((u._1, (u._2, implicitly[Monoid[B]].zero)))
+      } orElse(m(tree).map (u => (u._1, (implicitly[Monoid[C]].zero, u._2))))
+    }
+
+    /**
+     * Alias for tupledWith
+     * */
+    def ~[B : Monoid, C >: A : Monoid](m: => Matcher[B]) = tupledWith[B, C](m)
+
+    /**
+     * a tupledResultsWith b
+     * Same as 'tupledWith' but discard the transformed trees of a and b
+     * b operates on the origin tree, not the one transformed by a
+     */
+    def tupledResultsWith[B : Monoid, C >: A : Monoid](m: => Matcher[B]) = Matcher[(C, B)] { tree =>
+      this(tree).map {
+        case u @ (_, a2) => m(tree)
+          .map {case (_, b2) => (tree, (a2, b2))}
+          .getOrElse((u._1, (u._2, implicitly[Monoid[B]].zero)))
+      } orElse(m(tree).map (u => (u._1, (implicitly[Monoid[C]].zero, u._2))))
+    }
+
+    /**
+     * a aggregate b
+     * Apply a and apply b on the result of the application of a. This means:
+     *  - b is applied on the transformed T from a
+     *  - the results of a and b are composed
+     *
+     * If a fails then b is applied
+     * If b fails then only the result of a is used
+     * */
+    def aggregate[B >: A : Monoid](m: => Matcher[B]) = Matcher[B] { tree =>
+      this(tree) map {
+        case t @ (a1, a2)  => m(a1)
+          .map{case (b1, b2) => (b1, implicitly[Monoid[B]].append(a2, b2))}
+          .getOrElse(t)
+      } orElse(m(tree))
+    }
+
+    /**
+     * Alias for aggregate
+     * */
+    def +[B >: A : Monoid](m: => Matcher[B]) = aggregate(m)
+
+    /**
+     * a aggregateResults b
+     * Same as 'aggregate' but discard the transformed trees of a and b
+     * b operates on the origin tree, not the one transformed by a
+     */
+    def aggregateResults[B >: A : Monoid](m: => Matcher[B]) = Matcher[B] { tree =>
+      this(tree) map {
+        case t @ (_, a2) => m(tree)
+          .map{case (_, b2) => (tree, implicitly[Monoid[B]].append(a2, b2))}
+          .getOrElse(t)
+      } orElse(m(tree))
+    }
+
+    /**
+     * Alias for aggregateResults
+     * */
+    def +> [B >: A : Monoid](m: => Matcher[B]) = aggregateResults[B](m)
+
+    /**
+     * Transform the result of the Matcher, will probably change
+     * */
+    def map[B](f: A => B) = Matcher[B] { tree =>
+      for {
+        (v, t) <- this(tree)
+      } yield ((v, f(t)))
+    }
+
+    /**
+     * a orElse b
+     * Apply b only if a failed
+     * */
+    def orElse[B >: A : Monoid](m: => Matcher[B]) = Matcher[B] { tree  =>
+      this(tree) orElse m(tree)
+    }
+
+    /**
+     * Alias for orElse
+     * */
+    def |[B >: A : Monoid](m: => Matcher[B]) = orElse(m)
+
+    /**
+     * a orThen b
+     * Apply b only if a failed but return a result of type b whaterver happens
+     * */
+    def orThen[B : Monoid](m: => Matcher[B]) = Matcher[B] { tree  =>
+      this(tree)
+        .map (_ => (tree, implicitly[Monoid[B]].zero))
+        .orElse(m(tree))
+    }
+
+    def either[B : Monoid, C >: A : Monoid](m2: Matcher[B]): Matcher[(C, B)] =
+      map(x => (x, implicitly[Monoid[B]].zero)).orElse(m2.map(x => (implicitly[Monoid[C]].zero, x)))
+
+    /**
+     * Alias for orThen
+     * */
+    def |>[B : Monoid](m: => Matcher[B]) = orThen(m)
+
+    /**
+     * a feed {resa => b}
+     * combinator b can use the result (resa) of a.
+     * */
+    def feed[B : Monoid](m: => A => Matcher[B]) = Matcher[B] {tree =>for {
+        (t, v) <- this(tree)
+        t2     <- m(v)(t)
+      } yield t2
+    }
+  }
+
+  def Matcher[A](f: T => MatchResult[A]): Matcher[A] = new Matcher[A] {
+    override def apply(tree: T): MatchResult[A] = f(tree)
+  }
+
+  def traverse[A : Monoid](tree: T, f: Matcher[A]): MatchResult[A]
+}

--- a/scalameta/src/main/scala/scala/meta/tql/package.scala
+++ b/scalameta/src/main/scala/scala/meta/tql/package.scala
@@ -1,0 +1,24 @@
+package scala.meta
+
+import org.scalameta.algebra._
+import scala.meta.internal.tql._
+import scala.meta.internal.{ast => impl}
+
+package object tql extends Traverser[Tree]
+                      with Combinators[Tree]
+                      with SyntaxEnhancer[Tree]
+                      with CollectionLikeUI[Tree] {
+
+  def traverse[A : Monoid](tree: Tree, f: Matcher[A]): MatchResult[A] = {
+    TraverserBuilder.buildFromTopSymbolDelegate[Tree, A](f,
+      impl.Term.Name,
+      impl.Lit.Char,
+      impl.Term.Apply,
+      impl.Lit.Int,
+      impl.Type.Name,
+      impl.Term.Param,
+      impl.Type.Apply,
+      impl.Term.ApplyInfix
+    )
+  }
+}

--- a/tests/src/test/scala/tql/CollectionLikeUISuite.scala
+++ b/tests/src/test/scala/tql/CollectionLikeUISuite.scala
@@ -1,0 +1,37 @@
+import scala.meta._
+import scala.meta.dialects.Scala211
+import scala.meta.internal.{ast => impl}
+import org.scalatest.FunSuite
+
+class CollectionLikeUISuite extends FunSuite {
+  val x = q"""
+    val a = 5
+    val c = 3
+    c = 5
+    if (3 == 17) {
+     val c = 1
+     while (a != c) println(78)
+     val x = 14
+     while (a != c) println(85)
+    } else {
+      2
+    }
+    5
+  """
+  val t1: List[Int] = x.collect{case impl.Lit.Int(a) if a > 10 => a}
+  val t2: List[Int] = x.focus({case impl.Term.If(_,_,_) => true}).topDown.collect{case impl.Lit.Int(a) => a}
+  val t3: (Tree, List[String]) = {
+    import scala.meta.tql._
+    x.transform{case impl.Defn.Val(a, b, c, d) => impl.Defn.Var(a,b,c,Some(d)) andCollect(b.toString)}
+  }
+  val t4: Tree = x.transform{case impl.Lit.Int(x) => impl.Lit.Int(x * 2)}
+  val t5: Set[String] = x.bottomUp.collect[Set]{case x: impl.Defn.Val => x.pats.head.toString}
+  val t6: List[Int] = {
+    import scala.meta.tql._
+    x.focus({case impl.Term.If(_,_,_) => true}).combine(topDown(collect{case impl.Lit.Int(a) => a})).result
+  }
+  val t7: scala.meta.Tree = x.transform {
+    case impl.Lit.Int(a) => impl.Lit.Int(a * 3)
+    case impl.Defn.Val(a, b, c, d) => impl.Defn.Var(a,b,c,Some(d))
+  }
+}

--- a/tests/src/test/scala/tql/ObeyRuleSuite.scala
+++ b/tests/src/test/scala/tql/ObeyRuleSuite.scala
@@ -1,0 +1,42 @@
+import scala.meta._
+import scala.meta.dialects.Scala211
+import scala.meta.tql._
+import scala.meta.internal.{ast => impl}
+import org.scalatest.FunSuite
+
+class ObeyRuleSuite extends FunSuite {
+  val propagandaCode = """
+    package propaganda
+    object Propaganda {
+      def main(args: Array[String]) {
+        println("Starting the Propaganda!")
+        val u = 17
+        def test {
+          val x = 1
+        }
+        def test2 {
+          val y = {
+            val z = 19
+            1
+          }
+          var yo = 2
+        }
+        var c = 3
+        val v = List(1,2,3).toSet()
+      }
+    }
+  """
+  val propagandaTree = propagandaCode.parse[Source]
+
+  //rule taken from the Obey project
+  val listToSetBool = topDown(transform {
+    case tt @ impl.Term.Apply(t @ impl.Term.Select(impl.Term.Apply(impl.Term.Name("List"), _), impl.Term.Name("toSet")), _) =>
+      t andCollect tt.toString
+  })
+
+  test("listToSetBool") {
+    val rewrittenTree = listToSetBool(propagandaTree)
+    val rewrittenCode = rewrittenTree.tree.get
+    assert(rewrittenCode != propagandaCode)
+  }
+}


### PR DESCRIPTION
Big thanks to @begeric for designing/implementing TQL during his semester
project at LAMP (https://infoscience.epfl.ch/record/204789)!

Also special thanks to @mdemarne for porting TQL based on 0.0.0-M0
to the ever-changing 0.1.0-SNAPSHOT!

This commit takes most of the code in the aforementioned github repository,
except for:
1) Things that relate to optimizations, i.e. MapOptimized.scala,
SetOptimized.scala, Fusion.scala, ScalaMetaFusionTraverser.scala,
ScalametaTraverserHelperMacros.scala.
2) Scala.reflect-like Traverser and Transformer.
3) Some tests and benchmarks.

1 looks very interesting, but for now I'd like to keep things as simple as possible.
We'll get back to 1 and 3 when the time comes to optimize scala.meta.
2 looks useful, but I'm not sure whether I'd like to have it in scalameta/scalameta.