### PR TITLE
TQL: bug fix in TraverserBuilder

### DIFF
--- a/scalameta/src/main/scala/scala/meta/internal/tql/TraverserHelper.scala
+++ b/scalameta/src/main/scala/scala/meta/internal/tql/TraverserHelper.scala
@@ -46,6 +46,15 @@ object TraverserHelper {
     Some((if (hasChanged) collection.immutable.Seq(buffer: _*) else seq, acc))
   }
 
+
+  def traverseOptionalSeq[U, T <: U with AnyRef: ClassTag, A: Monoid](
+              f: Traverser[U]#Matcher[A],
+              a: Option[Seq[T]]): Option[(Option[Seq[T]], A)] = Some(
+    a.flatMap (traverseSeq(f, _))
+    .collect{case (x: Seq[T], y) => (Some(x), y)}
+    .getOrElse(None, implicitly[Monoid[A]].zero))
+
+
   def optional[U, T <: U with AnyRef : ClassTag, A: Monoid](
               f:  Traverser[U]#Matcher[A],
               a: Option[T]): Option[(Option[T], A)] = Some(a

--- a/tests/src/test/scala/tql/ObeyRuleSuite.scala
+++ b/tests/src/test/scala/tql/ObeyRuleSuite.scala
@@ -32,11 +32,13 @@ class ObeyRuleSuite extends FunSuite {
   val listToSetBool = topDown(transform {
     case tt @ impl.Term.Apply(t @ impl.Term.Select(impl.Term.Apply(impl.Term.Name("List"), _), impl.Term.Name("toSet")), _) =>
       t andCollect tt.toString
+    case tt @ impl.Term.Name("List") =>
+      impl.Term.Name("Set") andCollect tt.toString
   })
 
   test("listToSetBool") {
-    val rewrittenTree = listToSetBool(propagandaTree)
-    val rewrittenCode = rewrittenTree.tree.get
-    assert(rewrittenCode != propagandaCode)
+    val rewrittenResult = listToSetBool(propagandaTree)
+    val rewrittenTree = rewrittenResult.tree.get
+    assert(rewrittenTree.show[Raw] != propagandaTree.show[Raw])
   }
 }


### PR DESCRIPTION
1. The TQL TraverserBuilder prevented any traversal of Templates. This was due to the way stats are setup into templates as Option[Seq[Stat]], which was not handled by the previous version of TQL. This is now corrected and the Obey test case passes as usual.

2. Correcting ObeyRuleSuite for TQL: we can't compare source code as strings directly, due to formatting differences between the source code and the prettyprinter output. The test now checks if the raw of the trees are equals. A small case was also added for testing purposes.

This is the continuation of https://github.com/begeric/TQL-scalameta/pull/2.