### PR TITLE
introduces Mod.Ffi

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ For instance, let's dig into the List that we obtained and get its member method
 
 ```
 scala> res8.defs("apply")
-res10: scala.meta.Member.Term = override def apply[A](xs: A*): List[A] = jvmMethod("Lscala/collection/immutable/List$;", "apply", "(Lscala/collection/Seq;)Lscala/collection/immutable/List;").invoke(this, xs)
+res10: scala.meta.Member.Term = override def apply[A](xs: A*): List[A] = ???
 ```
 
 Note that in addition to signatures, members also carry their bodies. In fact, a `Member` obtained via `Ref.defn`
@@ -200,8 +200,7 @@ and a `Member` obtained by parsing and typechecking corresponding source code ar
 because of the overarching principle of scala.meta - everything should be represented and operated on via concrete syntax.
 This is going to be somewhat tricky to implement, but with the help of the recent initiative of persisting
 typed syntax trees we will get there. In the meanwhile, `Ref.defns` is going to include full bodies only
-for members declared in the currently processed compilation run, and otherwise scala.meta will operate
-in compatibility mode as demonstrated in the printout above.
+for members declared in the currently processed compilation run.
 
 ### Hygiene
 

--- a/scalameta/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/src/main/scala/scala/meta/Trees.scala
@@ -458,6 +458,7 @@ package scala.meta.internal.ast {
     // and that has proven to be very clunky (e.g. such XXX.Param type has to be a supertype for Term.Param)
     @ast class ValParam() extends Mod
     @ast class VarParam() extends Mod
+    @ast class Ffi(signature: String) extends Mod
   }
 
   @branch trait Enumerator extends api.Enumerator with Tree

--- a/scalameta/src/main/scala/scala/meta/semantic/Api.scala
+++ b/scalameta/src/main/scala/scala/meta/semantic/Api.scala
@@ -260,6 +260,7 @@ private[meta] trait Api {
     @hosted def isVarargParam: Boolean = tree match { case impl.Term.Param(_, _, Some(impl.Type.Arg.Repeated(_)), _) => true; case _ => false }
     @hosted def isValParam: Boolean = tree.mods.exists(_.isInstanceOf[impl.Mod.ValParam])
     @hosted def isVarParam: Boolean = tree.mods.exists(_.isInstanceOf[impl.Mod.VarParam])
+    @hosted def ffi: Option[String] = tree.mods.collectFirst { case impl.Mod.Ffi(signature) => signature }
   }
 
   implicit class XtensionSemanticMember(member: Member) extends XtensionSemanticMemberLike {

--- a/scalameta/src/main/scala/scala/meta/ui/ShowCode.scala
+++ b/scalameta/src/main/scala/scala/meta/ui/ShowCode.scala
@@ -29,7 +29,8 @@ object Code {
   @root trait Style
   object Style {
     @leaf object Lazy extends Style
-    @leaf implicit object Unabridged extends Style
+    @leaf implicit object Eager extends Style
+    @leaf object WithFfi extends Style
   }
 
   // NOTE: these groups closely follow non-terminals in the grammar spec from SLS, except for:
@@ -440,6 +441,7 @@ object Code {
     case _: Mod.Lazy                     => kw("lazy")
     case _: Mod.ValParam                 => kw("val")
     case _: Mod.VarParam                 => kw("var")
+    case Mod.Ffi(signature)              => s(kw("@"), "ffi(", s(enquote(signature, if (signature.contains(EOL)) TripleQuotes else DoubleQuotes)), ")")
 
     // Enumerator
     case t: Enumerator.Val           => s(p(Pattern1, t.pat), " = ", p(Expr, t.rhs))
@@ -480,7 +482,8 @@ object Code {
     s("(", r(pats, ", "), ")")
   }
   private implicit def codeMods(implicit dialect: Dialect, style: Style): Code[Seq[Mod]] = Code { mods =>
-    if (mods.nonEmpty) r(mods, " ") else s()
+    val filteredMods = mods.filter(mod => style == Style.WithFfi || !mod.isInstanceOf[Mod.Ffi])
+    if (filteredMods.nonEmpty) r(filteredMods, " ") else s()
   }
   private implicit def codeAnnots(implicit dialect: Dialect, style: Style): Code[Seq[Mod.Annot]] = Code { annots =>
     if (annots.nonEmpty) r(annots, " ") else s()

--- a/tests/src/test/scala/adt/ReflectionSuite.scala
+++ b/tests/src/test/scala/adt/ReflectionSuite.scala
@@ -13,7 +13,7 @@ class ReflectionSuite extends AdtSuite {
   test("root") {
     assert(symbolOf[Tree].isRoot)
     assert(symbolOf[Tree].asRoot.allBranches.length === 64)
-    assert(symbolOf[Tree].asRoot.allLeafs.length === 130)
+    assert(symbolOf[Tree].asRoot.allLeafs.length === 131)
   }
 
   test("If") {


### PR DESCRIPTION
I can't say I like this idea very much, but we need an immediate solution,
so that scalahost can represent abstract methods that originate from bytecode.
In the case of concrete methods, we could replace their bodies with stubs that carry
all the necessary info, but with abstract methods there's not much that we can do.
We will need to revise this decision later on when the dust settles.