### PR TITLE
Adding token positions in token sequence to Origin

### DIFF
--- a/scalameta/src/main/scala/scala/meta/Origin.scala
+++ b/scalameta/src/main/scala/scala/meta/Origin.scala
@@ -10,6 +10,8 @@ import org.scalameta.invariants._
   def dialect: Dialect
   def start: Int
   def end: Int
+  def startTokenPos: Int
+  def endTokenPos: Int
   def startLine: Int
   def endLine: Int
   def tokens: Seq[Token]
@@ -21,6 +23,8 @@ object Origin {
     val dialect = scala.meta.dialects.Scala211
     val start = 0
     val end = -1
+    val startTokenPos = 0
+    val endTokenPos = -1
     val startLine = 0
     val endLine = -1
     def tokens = Nil
@@ -57,6 +61,8 @@ object Origin {
     def dialect = tree.origin.dialect
     def start = tree.origin.start
     def end = tree.origin.end
+    def startTokenPos = tree.origin.startTokenPos
+    def endTokenPos = tree.origin.endTokenPos
     def startLine = tree.origin.startLine
     def endLine = tree.origin.endLine
     def tokens = tree.origin.tokens


### PR DESCRIPTION
Storing the corresponding position of trees in the vector of tokens will be useful to let Obey know the exact mapping between a position in the token sequence and a modified part of tree. This allow to modify small parts of the token stream while keeping surrounding layout. A dummy example would be:

```scala
class C {
    /*  represent xyz */ case class ImmutableCaseClass() /* This is a case class which could be a case object */
}
```

```scala
class C {
    /*  represent xyz */  case object ImmutableCaseClass /* This is a case class which could be a case object */
}
```

i.e. only `case class ImmutableCaseClass()` is replace, the surrounding is kept as is.

This is [where it will be used](https://github.com/mdemarne/Obey/blob/rewriting/model/src/main/scala/scala/obey/formatter/Merge.scala#L28). This is a draft only accounting for layout surrounding modified subparts of the tree - and only one modification at a time. The next step will be to check the modified tree to preserve or adapt its inner layout.

The token position was available for `Parsed` origins, but not `Transformed`. This makes it available.