### PR TITLE
Add sequence deconstruction to `Tokens`

### DIFF
--- a/scalameta/src/main/scala/scala/meta/syntactic/Tokens.scala
+++ b/scalameta/src/main/scala/scala/meta/syntactic/Tokens.scala
@@ -33,6 +33,7 @@ object Tokens {
     if ((tokens: Seq[Token]).isInstanceOf[Tokens]) tokens.asInstanceOf[Tokens]
     else new Tokens(tokens: _*)
   }
+  def unapplySeq(tokens: Tokens): Some[Seq[Token]] = Some(tokens)
 
   class Projected[A](repr: A*)
   extends AbstractSeq[A]


### PR DESCRIPTION
I think it makes sense to allow deconstruction of `Tokens` just like other `Seq`s (after all, it is a `Seq`).

```scala
tokens match { case Tokens(first, second, rest @ _*) => ??? }
```
