### PR TITLE
makes everything Serializable

### DIFF
--- a/foundation/src/main/scala/org/scalameta/adt/Adt.scala
+++ b/foundation/src/main/scala/org/scalameta/adt/Adt.scala
@@ -40,7 +40,7 @@ class AdtMacros(val c: Context) {
       stats1 += q"def internalTag: _root_.scala.Int"
       mstats1 += q"$Internal.hierarchyCheck[$name]"
       val anns1 = anns :+ q"new $Internal.root"
-      val parents1 = parents :+ tq"$Internal.Adt"
+      val parents1 = parents :+ tq"$Internal.Adt" :+ tq"_root_.scala.Product" :+ tq"_root_.scala.Serializable"
 
       val cdef1 = ClassDef(Modifiers(flags1, privateWithin, anns1), name, tparams, Template(parents1, self, stats1.toList))
       val mdef1 = ModuleDef(mmods, mname, Template(mparents, mself, mstats1.toList))

--- a/foundation/src/main/scala/org/scalameta/ast/root.scala
+++ b/foundation/src/main/scala/org/scalameta/ast/root.scala
@@ -35,7 +35,7 @@ class RootMacros(val c: Context) {
       stats1 += q"def internalTag: _root_.scala.Int"
       mstats1 += q"$AstInternal.hierarchyCheck[$name]"
       val anns1 = anns :+ q"new $AdtInternal.root" :+ q"new $AstInternal.root"
-      val parents1 = parents :+ tq"$AstInternal.Ast"
+      val parents1 = parents :+ tq"$AstInternal.Ast" :+ tq"_root_.scala.Product" :+ tq"_root_.scala.Serializable"
 
       // TODO: think of better ways to abstract this away from the public API
       val q"..$boilerplate" = q"""

--- a/foundation/src/main/scala/org/scalameta/tokens/root.scala
+++ b/foundation/src/main/scala/org/scalameta/tokens/root.scala
@@ -13,11 +13,12 @@ class RootMacros(val c: Context) {
   import Flag._
   def impl(annottees: Tree*): Tree = {
     def transform(cdef: ClassDef): ClassDef = {
-      val ClassDef(mods @ Modifiers(flags, privateWithin, anns), name, tparams, templ) = cdef
+      val ClassDef(mods @ Modifiers(flags, privateWithin, anns), name, tparams, Template(parents, self, stats)) = cdef
       val Adt = q"_root_.org.scalameta.adt"
       val TokenInternal = q"_root_.org.scalameta.tokens.internal"
       val anns1 = q"new $TokenInternal.root" +: q"new $Adt.root" +: anns
-      ClassDef(Modifiers(flags, privateWithin, anns1), name, tparams, templ)
+      val parents1 = parents :+ tq"$TokenInternal.Token" :+ tq"_root_.scala.Product" :+ tq"_root_.scala.Serializable"
+      ClassDef(Modifiers(flags, privateWithin, anns1), name, tparams, Template(parents1, self, stats))
     }
     val expanded = annottees match {
       case (cdef @ ClassDef(mods, _, _, _)) :: rest if mods.hasFlag(TRAIT) => transform(cdef) :: rest

--- a/scalameta/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/src/main/scala/scala/meta/Trees.scala
@@ -4,7 +4,7 @@ import org.scalameta.ast._
 import scala.{meta => api}
 
 package scala.meta {
-  @root trait Tree extends Product {
+  @root trait Tree extends Product with Serializable {
     type ThisType <: Tree
     def parent: Option[Tree]
     def tokens: Tokens

--- a/scalameta/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/src/main/scala/scala/meta/dialects/package.scala
@@ -7,7 +7,7 @@ import scala.annotation.implicitNotFound
 // because then implicit scope for Dialect lookups will contain members of the package object
 // i.e. both Scala211 and Dotty, which is definitely not what we want
 @implicitNotFound("don't know what dialect to use here (to fix this, import something from scala.dialects, e.g. scala.meta.dialects.Scala211)")
-trait Dialect {
+trait Dialect extends Serializable {
   // The sequence of characters that's used to express a bind
   // to a sequence wildcard pattern.
   def bindToSeqWildcardDesignator: String

--- a/scalameta/src/main/scala/scala/meta/syntactic/Input.scala
+++ b/scalameta/src/main/scala/scala/meta/syntactic/Input.scala
@@ -19,6 +19,8 @@ object Input {
   }
   final case class File(f: java.io.File, charset: Charset) extends Content {
     lazy val chars = scala.io.Source.fromFile(f)(scala.io.Codec(charset)).mkString.toArray
+    private def writeObject(out: java.io.ObjectOutputStream) = { out.writeObject(f); out.writeObject(charset.name) }
+    private def readObject(in: java.io.ObjectInputStream) = { File(in.readObject.asInstanceOf[java.io.File], Charset.forName(in.readObject.asInstanceOf[Predef.String])) }
   }
   object File {
     def apply(path: Predef.String): Input.File = Input.File(new java.io.File(path))

--- a/scalameta/src/main/scala/scala/meta/syntactic/Token.scala
+++ b/scalameta/src/main/scala/scala/meta/syntactic/Token.scala
@@ -7,7 +7,7 @@ import org.scalameta.default._
 import org.scalameta.default.Param._
 import scala.reflect.ClassTag
 
-@root trait Token extends org.scalameta.tokens.internal.Token {
+@root trait Token {
   def input: Content = content
   def content: Content
   def dialect: Dialect

--- a/tests/src/test/scala/ast/SerializationSuite.scala
+++ b/tests/src/test/scala/ast/SerializationSuite.scala
@@ -1,0 +1,29 @@
+import org.scalatest._
+import java.io._
+import scala.meta._
+import scala.meta.dialects.Scala211
+
+class SerializationSuite extends FunSuite {
+  private def trySerialize(x: Any): Unit = {
+    val baos = new ByteArrayOutputStream();
+    val oos = new ObjectOutputStream(baos);
+    oos.writeObject(x);
+    oos.close();
+    baos.close();
+  }
+
+  test("Input.String-based trees are serializable") {
+    val source = "class C".parse[Source]
+    trySerialize(source)
+  }
+
+  test("Input.File-based trees are serializable") {
+    val file = File.createTempFile("dummy", ".scala")
+    file.deleteOnExit()
+    val writer = new BufferedWriter(new FileWriter(file))
+    writer.write("class C")
+    writer.close()
+    val source = file.parse[Source]
+    trySerialize(source)
+  }
+}


### PR DESCRIPTION
Using Java serialization is, of course, quite low-tech, but it's dead simple and works as a partial proof that our trees are now platform-independent. Now I'd like to do the same to converted trees in scalahost. Fixes https://github.com/scalameta/scalameta/issues/73.