### PR TITLE
fixes #175

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -177,6 +177,7 @@ object build extends Build {
     libraryDependencies <+= (scalaVersion)("org.scala-lang" % "scala-reflect" % _),
     libraryDependencies += "org.scalatest" %% "scalatest" % "2.1.3" % "test",
     libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.11.3" % "test",
+    scalacOptions += "-Xfatal-warnings",
     packagedArtifacts := Map.empty,
     sourceDirectory in Test := {
       val defaultValue = (sourceDirectory in Test).value

--- a/scalameta/src/main/scala/scala/meta/internal/quasiquotes/ast/ReificationMacros.scala
+++ b/scalameta/src/main/scala/scala/meta/internal/quasiquotes/ast/ReificationMacros.scala
@@ -528,16 +528,11 @@ private[meta] class ReificationMacros(val c: Context) extends AstReflection with
             (thenp, q"_root_.scala.None")
           }
         }
-        val internalResult = q"""
-          new {
-            def unapply(input: _root_.scala.meta.Tree) = {
-              input match {
-                case $pattern => $thenp
-                case _ => $elsep
-              }
-            }
-          }.unapply($dummy)
-        """
+        val matchp = pattern match {
+          case Bind(_, Ident(termNames.WILDCARD)) => q"input match { case $pattern => $thenp }"
+          case _ => q"input match { case $pattern => $thenp; case _ => $elsep }"
+        }
+        val internalResult = q"new { def unapply(input: _root_.scala.meta.Tree) = $matchp }.unapply($dummy)"
         if (sys.props("quasiquote.debug") != null) {
           println(internalResult)
           // println(showRaw(internalResult))

--- a/tests/src/test/scala/quasiquotes/QuasiquoteSuite.scala
+++ b/tests/src/test/scala/quasiquotes/QuasiquoteSuite.scala
@@ -79,4 +79,9 @@ class QuasiquoteSuite extends FunSuite {
       |}
     """.trim.stripMargin)
   }
+
+  test("val q\"$x\" = ...") {
+    val q"$x" = q"42"
+    assert(x.show[Code] === "42")
+  }
 }


### PR DESCRIPTION
Apparently the pattern matcher is unhappy if we generate code that looks like:
`... match { case <freshname> => Some(...); case _ => None }`, therefore I had to tune
the reification macro to avoid such codegen in rare edge cases.