### PR TITLE
fixes prettyprinting for internal Quasi trees

### DIFF
--- a/scalameta/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/src/main/scala/scala/meta/Trees.scala
@@ -498,8 +498,19 @@ package scala.meta.internal.ast {
     require(stats.forall(_.isTopLevelStat))
   }
 
-  // TODO: after we bootstrap, Quasi.tree will become scala.meta.Tree
-  // however, for now, we will keep it at Any in order to also support scala.reflect trees
+  // NOTE: Quasi is a base trait for a whole bunch of classes.
+  // Every root, branch and ast trait/class among scala.meta trees (except for quasis themselves)
+  // has a corresponding quasi, e.g. Term.Quasi or Type.Arg.Quasi.
+  //
+  // Here's how quasis represent quasiquotes:
+  // * q"$x" => Term.Quasi(<scala.reflect tree representing x>, 0)
+  // * q"..$xs" => Term.Quasi(Term.Quasi(<scala.reflect tree representing xs>, 0), 1)
+  // * q"..{$fs($args)}" => Term.Quasi(Term.Apply(Term.Quasi(<fs>, 0), List(Term.Quasi(<args>, 0))), 1)
+  // * q"...$xss" => not sure, because we don't support ... yet
+  //
+  // TODO: After we bootstrap, Quasi.tree will become scala.meta.Tree.
+  // However, for now, we will keep it at Any in order implement quasiquotes via scala.reflect macros
+  // (because in that case, Quasi.tree has to store scala.reflect trees).
   @branch trait Quasi extends Tree {
     def tree: Any
     def rank: Int

--- a/tests/src/test/scala/show/QuasiSuite.scala
+++ b/tests/src/test/scala/show/QuasiSuite.scala
@@ -1,0 +1,16 @@
+package scala.meta
+
+import org.scalatest._
+import scala.reflect.runtime.universe._
+import scala.meta.internal.ast._
+import scala.meta.dialects.Scala211
+
+class QuasiSuite extends FunSuite {
+  val XtensionQuasiquoteTerm = "shadow scala.metq quasiquotes"
+  test("$x") {
+    assert(Term.Quasi(q"x", 0).show[Code] === "${x @ Term}")
+  }
+  test("..$xs") {
+    assert(Term.Quasi(Term.Quasi(q"xs", 0), 1).show[Code] === "..${xs @ Term}")
+  }
+}


### PR DESCRIPTION
These trees are used as an intermediate representation that only exists
in implementation of quasiquotes. Therefore, the bug wasn't that bad and
was only found recently.