### PR TITLE
introduces Denotation.Multi

### DIFF
--- a/scalameta/src/main/scala/scala/meta/internal/semantic/Denotation.scala
+++ b/scalameta/src/main/scala/scala/meta/internal/semantic/Denotation.scala
@@ -50,10 +50,11 @@ object Prefix {
 // Also, hopefully, it's only necessary to define denotations for all names in a tree
 // to guarantee hygienic comparisons and name lookups.
 
-@root trait Denotation { def prefix: Prefix; def symbol: Symbol }
+@root trait Denotation { def prefix: Prefix; def symbols: List[Symbol] }
 object Denotation {
-  @leaf object Zero extends Denotation { def prefix = Prefix.Zero; def symbol = Symbol.Zero; }
-  @leaf class Single(prefix: Prefix, symbol: Symbol) extends Denotation
+  @leaf object Zero extends Denotation { def prefix = Prefix.Zero; def symbols = Nil; }
+  @leaf class Single(prefix: Prefix, symbol: Symbol) extends Denotation { def symbols = List(symbol) }
+  @leaf class Multi(prefix: Prefix, symbols: List[Symbol]) extends Denotation { require(symbols.length > 1) }
 }
 
 // TODO: This unrelated code is here because of the limitation of knownDirectSubclasses.

--- a/scalameta/src/main/scala/scala/meta/ui/ShowSemantics.scala
+++ b/scalameta/src/main/scala/scala/meta/ui/ShowSemantics.scala
@@ -66,7 +66,8 @@ object Semantics {
               if (result != "_root_") result = result.stripPrefix("_root_.")
               result
             }
-            prettyprintPrefix(denot.prefix) + "::" + prettyprintSymbol(denot.symbol)
+            val symbol = denot.require[Denotation.Single].symbol
+            prettyprintPrefix(denot.prefix) + "::" + prettyprintSymbol(symbol)
           }
         }
         implicit def typingFootnote(typing: Typing): Footnote = new Footnote {
@@ -133,8 +134,12 @@ object Semantics {
         val denotPart = x match {
           case x: Name =>
             x.denot match {
-              case Denotation.Zero => ""
-              case denot @ Denotation.Single(prefix, symbol) => s"[${footnotes.insert(denot)}]"
+              case Denotation.Zero =>
+                ""
+              case denot @ Denotation.Single(prefix, symbol) =>
+                s"[${footnotes.insert(denot)}]"
+              case denot @ Denotation.Multi(prefix, symbols) =>
+                s"[${symbols.map(symbol => footnotes.insert(Denotation.Single(prefix, symbol))).mkString(", ")}]"
             }
           case _ =>
             ""


### PR DESCRIPTION
Not sure whether it's better to merge Denotation.Single and Multi or
to keep them separate, so let's go for the route that doesn't break
pre-existing code that already uses denotations (e.g. Intellij).