### PR TITLE
more precise modelling of pattern types

### DIFF
--- a/scalameta/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/src/main/scala/scala/meta/Trees.scala
@@ -221,7 +221,7 @@ package scala.meta.internal.ast {
       require(quants.forall(_.isExistentialStat))
     }
     @ast class Annotate(tpe: Type, annots: Seq[Mod.Annot] @nonEmpty) extends Type
-    @ast class Placeholder(bounds: Bounds) extends Type with Pat.Type
+    @ast class Placeholder(bounds: Bounds) extends Type
     @ast class Lambda(quants: Seq[Type.Param], tpe: Type) extends Type
     @ast class Bounds(lo: Option[Type], hi: Option[Type]) extends Tree
     @branch trait Arg extends api.Type.Arg with Tree
@@ -305,8 +305,12 @@ package scala.meta.internal.ast {
     object Type {
       @branch trait Ref extends api.Pat.Type.Ref with Pat.Type with impl.Ref
       @ast class Wildcard() extends Pat.Type
-      @ast class Project(qual: Pat.Type, name: impl.Type.Name) extends Pat.Type with Pat.Type.Ref
-      @ast class Apply(tpe: Pat.Type, args: Seq[Pat.Type] @nonEmpty) extends Pat.Type
+      @ast class Project(qual: Pat.Type, name: impl.Type.Name) extends Pat.Type with Pat.Type.Ref {
+        require(!qual.isInstanceOf[Pat.Var.Type] && !qual.isInstanceOf[Pat.Type.Wildcard])
+      }
+      @ast class Apply(tpe: Pat.Type, args: Seq[Pat.Type] @nonEmpty) extends Pat.Type {
+        require(!tpe.isInstanceOf[Pat.Var.Type] && !tpe.isInstanceOf[Pat.Type.Wildcard])
+      }
       @ast class ApplyInfix(lhs: Pat.Type, op: impl.Type.Name, rhs: Pat.Type) extends Pat.Type
       @ast class Function(params: Seq[Pat.Type], res: Pat.Type) extends Pat.Type
       @ast class Tuple(elements: Seq[Pat.Type]) extends Pat.Type {
@@ -316,12 +320,21 @@ package scala.meta.internal.ast {
         // TODO: revisit this once we have trivia in place
         // require(tpes.length == 1 ==> hasRefinement)
         require(refinement.forall(_.isRefineStat))
+        require(tpes.forall(tpe => !tpe.isInstanceOf[Pat.Var.Type] && !tpe.isInstanceOf[Pat.Type.Wildcard]))
       }
       @ast class Existential(tpe: Pat.Type, quants: Seq[Stat] @nonEmpty) extends Pat.Type {
+        require(!tpe.isInstanceOf[Pat.Var.Type] && !tpe.isInstanceOf[Pat.Type.Wildcard])
         require(quants.forall(_.isExistentialStat))
       }
-      @ast class Annotate(tpe: Pat.Type, annots: Seq[Mod.Annot] @nonEmpty) extends Pat.Type
-      @ast class Lambda(quants: Seq[impl.Type.Param], tpe: Pat.Type) extends Pat.Type
+      @ast class Annotate(tpe: Pat.Type, annots: Seq[Mod.Annot] @nonEmpty) extends Pat.Type {
+        require(!tpe.isInstanceOf[Pat.Var.Type] && !tpe.isInstanceOf[Pat.Type.Wildcard])
+      }
+      @ast class Placeholder(bounds: impl.Type.Bounds) extends Pat.Type {
+        require(bounds.lo.nonEmpty || bounds.hi.nonEmpty)
+      }
+      @ast class Lambda(quants: Seq[impl.Type.Param], tpe: Pat.Type) extends Pat.Type {
+        require(!tpe.isInstanceOf[Pat.Var.Type] && !tpe.isInstanceOf[Pat.Type.Wildcard])
+      }
     }
   }
 

--- a/scalameta/src/main/scala/scala/meta/internal/parsers/Parsers.scala
+++ b/scalameta/src/main/scala/scala/meta/internal/parsers/Parsers.scala
@@ -981,7 +981,7 @@ private[meta] class Parser(val input: Input)(implicit val dialect: Dialect) { pa
         case Type.Compound(tpes, refinement) => atPos(tpe, tpe)(Pat.Type.Compound(tpes.map(loop), refinement))
         case Type.Existential(underlying, quants) => atPos(tpe, tpe)(Pat.Type.Existential(loop(underlying), quants))
         case Type.Annotate(underlying, annots) => atPos(tpe, tpe)(Pat.Type.Annotate(loop(underlying), annots))
-        case tpe: Type.Placeholder => tpe
+        case Type.Placeholder(bounds) => atPos(tpe, tpe)(Pat.Type.Placeholder(bounds))
         case tpe: Lit => tpe
       }
       loop(compoundType())

--- a/scalameta/src/main/scala/scala/meta/internal/ui/InferTokens.scala
+++ b/scalameta/src/main/scala/scala/meta/internal/ui/InferTokens.scala
@@ -521,6 +521,7 @@ private[meta] object inferTokens {
         else tpes
       case t: Pat.Type.Existential => toks"${t.tpe.tks} forSome { ${t.quants.`o;o`} }"
       case t: Pat.Type.Annotate =>    toks"${t.tpe.tks} ${t.annots.`o_o`}"
+      case t: Pat.Type.Placeholder => toks"_ ${t.bounds.tks}"
       case t: Pat.Type.Lambda =>
         val params = {
           if (t.quants.isEmpty) toks"[]"

--- a/scalameta/src/main/scala/scala/meta/semantic/Api.scala
+++ b/scalameta/src/main/scala/scala/meta/semantic/Api.scala
@@ -432,7 +432,7 @@ private[meta] trait Api {
         case impl.Pat.Type.Existential(tpe, _) => membersOfPatType(tpe)
         case impl.Pat.Type.Annotate(tpe, _) => membersOfPatType(tpe)
         case impl.Pat.Type.Lambda(_, tpe) => membersOfPatType(tpe)
-        case impl.Type.Placeholder(_) => Nil
+        case impl.Pat.Type.Placeholder(_) => Nil
         case _: impl.Lit => Nil
       }
       def membersOfPat(pat: impl.Pat.Arg): Seq[impl.Member] = pat match {
@@ -637,7 +637,7 @@ private[meta] trait Api {
         case impl.Type.Compound(tpes, refinement) => impl.Pat.Type.Compound(tpes.map(loop), refinement)
         case impl.Type.Existential(tpe, quants) => impl.Pat.Type.Existential(loop(tpe), quants)
         case impl.Type.Annotate(tpe, annots) => impl.Pat.Type.Annotate(loop(tpe), annots)
-        case tpe: impl.Type.Placeholder => tpe
+        case impl.Type.Placeholder(bounds) => impl.Pat.Type.Placeholder(bounds)
         case impl.Type.Lambda(tparams, tpe) => impl.Pat.Type.Lambda(tparams, loop(tpe))
         case tpe: impl.Lit => tpe
       }
@@ -651,7 +651,6 @@ private[meta] trait Api {
         case tpe: impl.Type.Name => tpe
         case tpe: impl.Type.Select => tpe
         case tpe: impl.Type.Singleton => tpe
-        case tpe: impl.Type.Placeholder => tpe
         case tpe: impl.Pat.Var.Type => ???
         case tpe: impl.Pat.Type.Wildcard => impl.Type.Placeholder(impl.Type.Bounds(None, None))
         case impl.Pat.Type.Project(qual, name) => impl.Type.Project(loop(qual), name)
@@ -662,6 +661,7 @@ private[meta] trait Api {
         case impl.Pat.Type.Compound(tpes, refinement) => impl.Type.Compound(tpes.map(loop), refinement)
         case impl.Pat.Type.Existential(tpe, quants) => impl.Type.Existential(loop(tpe), quants)
         case impl.Pat.Type.Annotate(tpe, annots) => impl.Type.Annotate(loop(tpe), annots)
+        case impl.Pat.Type.Placeholder(bounds) => impl.Type.Placeholder(bounds)
         case impl.Pat.Type.Lambda(tparams, tpe) => impl.Type.Lambda(tparams, loop(tpe))
         case tpe: impl.Lit => tpe
       }

--- a/tests/src/test/scala/ast/ReflectionSuite.scala
+++ b/tests/src/test/scala/ast/ReflectionSuite.scala
@@ -12,7 +12,7 @@ class ReflectionSuite extends AstSuite {
   test("root") {
     assert(symbolOf[scala.meta.Tree].isRoot)
     assert(symbolOf[scala.meta.Tree].asRoot.allBranches.length === 70)
-    assert(symbolOf[scala.meta.Tree].asRoot.allLeafs.length === 334)
+    assert(symbolOf[scala.meta.Tree].asRoot.allLeafs.length === 336)
   }
 
   test("If") {
@@ -167,6 +167,7 @@ class ReflectionSuite extends AstSuite {
       |scala.meta.internal.ast.Pat.Type.Existential     => scala.meta.Pat.Type
       |scala.meta.internal.ast.Pat.Type.Function        => scala.meta.Pat.Type
       |scala.meta.internal.ast.Pat.Type.Lambda          => scala.meta.Pat.Type
+      |scala.meta.internal.ast.Pat.Type.Placeholder     => scala.meta.Pat.Type
       |scala.meta.internal.ast.Pat.Type.Project         => scala.meta.Pat.Type.Ref
       |scala.meta.internal.ast.Pat.Type.Ref             => scala.meta.Pat.Type.Ref
       |scala.meta.internal.ast.Pat.Type.Tuple           => scala.meta.Pat.Type
@@ -236,7 +237,7 @@ class ReflectionSuite extends AstSuite {
       |scala.meta.internal.ast.Type.Name                => scala.meta.Type.Name
       |scala.meta.internal.ast.Type.Param               => scala.meta.Type.Param
       |scala.meta.internal.ast.Type.Param.Name          => scala.meta.Type.Param.Name
-      |scala.meta.internal.ast.Type.Placeholder         => scala.meta.Type with scala.meta.Pat.Type
+      |scala.meta.internal.ast.Type.Placeholder         => scala.meta.Type
       |scala.meta.internal.ast.Type.Project             => scala.meta.Type.Ref
       |scala.meta.internal.ast.Type.Ref                 => scala.meta.Type.Ref
       |scala.meta.internal.ast.Type.Select              => scala.meta.Type.Ref with scala.meta.Pat.Type.Ref
@@ -339,6 +340,7 @@ class ReflectionSuite extends AstSuite {
       |
       |scala.meta.internal.ast.Type.Bounds -> scala.meta.Tree
       |field Decl.Type.bounds: scala.meta.internal.ast.Type.Bounds
+      |field Pat.Type.Placeholder.bounds: scala.meta.internal.ast.Type.Bounds
       |field Type.Param.typeBounds: scala.meta.internal.ast.Type.Bounds
       |field Type.Placeholder.bounds: scala.meta.internal.ast.Type.Bounds
       |


### PR DESCRIPTION
1) Adds Pat.Type.Placeholder, because Pat.Type.Placeholder with empty bounds
becomes Pat.Type.Wildcard (super weird pattern type rules).

2) The only place where Pat.Var.Type and Pat.Type.Wildcard are allowed
is type arguments, so we require that they appear only there.