### PR TITLE
merging example code from github.com/scalameta/example

### DIFF
--- a/example-compiletime/src/main/org.scalameta.example/CompileTime.scala
+++ b/example-compiletime/src/main/org.scalameta.example/CompileTime.scala
@@ -1,0 +1,13 @@
+package org.scalameta.example
+
+import scala.meta.internal.ast._
+import scala.meta.Scalahost
+
+trait CompileTime {
+  val global: scala.tools.nsc.Global
+  implicit val c = Scalahost.mkGlobalContext(global)
+
+  def example(sources: List[Source]): Unit = {
+    println(sources)
+  }
+}

--- a/example-compiletime/src/main/org.scalameta.example/Plugin.scala
+++ b/example-compiletime/src/main/org.scalameta.example/Plugin.scala
@@ -1,0 +1,33 @@
+package org.scalameta.example
+
+import scala.tools.nsc.{Global, Phase, SubComponent}
+import scala.meta.internal.hosts.scalac.{PluginBase => ScalahostPlugin}
+import scala.tools.nsc.plugins.{Plugin => NscPlugin, PluginComponent => NscPluginComponent}
+import org.scalameta.reflection._
+
+class Plugin(val global: Global) extends ScalahostPlugin with CompileTime {
+  val name = "example"
+  val description = """An example of using pre-alpha scala.meta APIs.
+  For more information visit https://github.com/scalameta/example"""
+  val components = List[NscPluginComponent](ConvertComponent, ExampleComponent)
+
+  object ExampleComponent extends NscPluginComponent {
+    val global: Plugin.this.global.type = Plugin.this.global
+    import global._
+
+    override val runsAfter = List("typer")
+    override val runsRightAfter = Some("convert")
+    val phaseName = "example"
+    override def description = "an example of using pre-alpha scala.meta apis"
+
+    override def newPhase(prev: Phase): StdPhase = new StdPhase(prev) {
+      var alreadyRun = false
+      override def apply(unit: CompilationUnit) {
+        if (!alreadyRun) {
+          example(global.currentRun.units.toList.map(_.body.metadata("scalameta").asInstanceOf[scala.meta.internal.ast.Source]))
+          alreadyRun = true
+        }
+      }
+    }
+  }
+}

--- a/example-tests/src/main/scala/Hello.scala
+++ b/example-tests/src/main/scala/Hello.scala
@@ -1,0 +1,5 @@
+// object Hello {
+//   def v = 42
+// }
+
+// class A

--- a/example-tests/src/main/scala/org.example/Hello.scala
+++ b/example-tests/src/main/scala/org.example/Hello.scala
@@ -1,0 +1,7 @@
+package org.example
+
+object Hello {
+  def v = 42
+}
+
+class A


### PR DESCRIPTION
```scala
scala.meta.internal.hosts.scalac.converters.ConvertException: unexpected tree during scala.reflect -> scala.meta conversion:
ModuleDef(Modifiers(),
  org.example.Hello,
  Template(List(Select(Ident(scala), TypeName("AnyRef"))),
  noSelfType, List(DefDef(Modifiers(), termNames.CONSTRUCTOR, List(), List(List()),
  TypeTree(), Block(List(Apply(Select(Super(This(TypeName("Hello")), typeNames.EMPTY), termNames.CONSTRUCTOR),
  List())), Literal(Constant(())))), DefDef(Modifiers(), TermName("v"), List(), List(), TypeTree(), Literal(Constant(42))))))
(PackageDef) package org.example {   object Hello extends scala.AnyRef { ...
```
Is this missing `ModuleDef` ? https://github.com/scalameta/scalameta/blob/8ebdeca7b5f5259e450a29b3588c588d700cf4f7/scalahost/src/main/scala/scala/meta/internal/hosts/scalac/converters/ToMtree.scala#L38