### PR TITLE
final touches before 0.0.4

### DIFF
--- a/scalameta/trees/src/main/scala/scala/meta/parsers/common/Api.scala
+++ b/scalameta/trees/src/main/scala/scala/meta/parsers/common/Api.scala
@@ -7,7 +7,7 @@ import scala.meta.inputs._
 
 private[meta] trait Api {
   implicit class XtensionParseInputLike[T](inputLike: T) {
-    def parse[U](implicit convert: Convert[T, Input], dialect: Dialect, parse: Parse[U]): U = {
+    def parse[U](implicit convert: Convert[T, Input], parse: Parse[U]): U = {
       parse(convert(inputLike))
     }
   }


### PR DESCRIPTION
The `dialect` parameter to `parse[U]` was only necessary because we wanted
to display better error messages if a dialect was not in scope
(not `no Parse[U] found`, but `no dialect found).

Now that there's a fallback implicit dialect in Dialect, this parameter
is no longer useful.