### PR TITLE
better error messages for parse errors

### DIFF
--- a/scalameta/inputs/src/main/scala/scala/meta/inputs/Content.scala
+++ b/scalameta/inputs/src/main/scala/scala/meta/inputs/Content.scala
@@ -6,6 +6,56 @@ import org.scalameta.convert._
 
 trait Content extends Input {
   def chars: Array[Char]
+
+  // TODO: It's regrettable that we need to taint the pure abstraction of Content.
+  // However, as #334 shows, we just can't redo offset -> line conversions over and over again.
+  // This means that we gotta cache, and this instance is really the only place versatile enough.
+  private lazy val lineIndices: Array[Int] = {
+    val chars = this.chars
+    val buf = new scala.collection.mutable.ArrayBuffer[Int]
+    buf += 0
+    var i = 0
+    while (i < chars.length) {
+      if (chars(i) == '\n') buf += (i + 1)
+      i += 1
+    }
+    if (buf.last != chars.length) buf += chars.length // sentinel value used for binary search
+    buf.toArray
+  }
+
+  private[meta] def lineToOffset(line: Int): Int = {
+    // NOTE: The length-1 part is not a typo, it's to accommodate the sentinel value.
+    if (!(0 <= line && line <= lineIndices.length - 1)) {
+      val message = s"$line is not a valid line number, allowed 0..${lineIndices.length - 1}"
+      throw new IllegalArgumentException(message)
+    }
+    lineIndices(line)
+  }
+
+  private[meta] def offsetToLine(offset: Int): Int = {
+    val chars = this.chars
+    val a = lineIndices
+    // NOTE: We allow chars.length, because it's a valid value for an offset.
+    if (!(0 <= offset && offset <= chars.length)) {
+      val message = s"$offset is not a valid offset, allowed 0..${chars.length}"
+      throw new IllegalArgumentException(message)
+    }
+    // NOTE: chars.length requires a really ugly special case.
+    // If the file doesn't end with \n, then it's simply last_line:last_col+1.
+    // But if the file does end with \n, then it's last_line+1:0.
+    if (offset == chars.length && (0 < chars.length && chars(offset - 1) == '\n')) {
+      return a.length - 1
+    }
+    var lo = 0
+    var hi = a.length - 1
+    while (hi - lo > 1) {
+      val mid = (hi + lo) / 2
+      if (offset < a(mid)) hi = mid
+      else if (a(mid) == offset) return mid
+      else /* if (a(mid) < offset */ lo = mid
+    }
+    return lo
+  }
 }
 
 object Content {

--- a/scalameta/inputs/src/main/scala/scala/meta/inputs/Position.scala
+++ b/scalameta/inputs/src/main/scala/scala/meta/inputs/Position.scala
@@ -17,6 +17,10 @@ object Position {
   }
 }
 
+// NOTE: All numbers here are zero-based, namely:
+// * Offset 0 is the first character in the content.
+// * Line 0 is the first line in the content.
+// * Column 0 is the first character in the line.
 @root trait Point {
   def content: Content
   def offset: Int
@@ -40,7 +44,7 @@ object Point {
       (eolCount, eolPos)
     }
     def line: Int = eolCount
-    def column: Int = offset - eolPos + 1
+    def column: Int = offset - eolPos
     override def toString = s"$offset in $content"
   }
 }

--- a/scalameta/inputs/src/main/scala/scala/meta/inputs/Position.scala
+++ b/scalameta/inputs/src/main/scala/scala/meta/inputs/Position.scala
@@ -4,6 +4,9 @@ package inputs
 import org.scalameta.adt._
 import org.scalameta.invariants._
 
+// NOTE: `start` and `end` are String.substring-style,
+// i.e. `start` is inclusive and `end` is not.
+// Therefore Position.end can point to the last character plus one.
 @root trait Position {
   def content: Content
   def start: Point

--- a/scalameta/inputs/src/main/scala/scala/meta/internal/inputs/package.scala
+++ b/scalameta/inputs/src/main/scala/scala/meta/internal/inputs/package.scala
@@ -1,0 +1,28 @@
+package scala.meta
+package internal
+
+import scala.compat.Platform.EOL
+import scala.meta.inputs._
+
+package object inputs {
+  implicit class XtensionPositionFormatMessage(position: Position) {
+    def formatMessage(severity: String, message: String): String = {
+      position.point.formatMessage(severity, message)
+    }
+  }
+
+  implicit class XtensionPointFormatMessage(point: Point) {
+    def formatMessage(severity: String, message: String): String = {
+      val content = point.content
+      val shortContent = content match { case Input.File(file, _) => file.getName; case _ => "<content>" }
+      val header = s"$shortContent:${point.line + 1}: $severity: $message"
+      val line = {
+        val start = content.lineToOffset(point.line)
+        val end = if (start < content.chars.length) content.lineToOffset(point.line + 1) else start
+        new String(content.chars, start, end - start).trim
+      }
+      var caret = " " * point.column + "^"
+      header + EOL + line + EOL + caret
+    }
+  }
+}

--- a/scalameta/parsers/src/main/scala/scala/meta/parsers/Errors.scala
+++ b/scalameta/parsers/src/main/scala/scala/meta/parsers/Errors.scala
@@ -4,6 +4,8 @@ package parsers
 import org.scalameta.adt._
 import org.scalameta.data._
 import scala.meta.inputs._
+import scala.meta.internal.inputs._
+import scala.compat.Platform.EOL
 
 @root trait Parsed[+T] {
   def get: T = this match {
@@ -23,11 +25,12 @@ import scala.meta.inputs._
 object Parsed {
   @leaf class Success[+T](tree: T) extends Parsed[T]
   @leaf class Error(pos: Position, message: String, details: ParseException) extends Parsed[Nothing] {
-    override def toString = s"Error($details)"
+    override def toString = s"Error(${details.getMessage})"
   }
 }
 
-@data class ParseException(pos: Position, message: String)
-extends Exception(s"$message at ${pos.start.offset}..${pos.end.offset}") {
-  override def toString = super.toString
+@data class ParseException(pos: Position, shortMessage: String)
+extends Exception(pos.formatMessage("error", shortMessage)) {
+  def fullMessage = getMessage
+  override def toString = fullMessage
 }

--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/inputs/FormatMessageSuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/inputs/FormatMessageSuite.scala
@@ -1,0 +1,95 @@
+package scala.meta.tests
+package inputs
+
+import org.scalatest._
+import scala.compat.Platform.EOL
+import scala.meta._
+import scala.meta.internal.inputs._
+
+class FormatMessageSuite extends FunSuite {
+  private def test(s: String)(expected: String): Unit = {
+    val testName = (if (s != "") s.replace("\n", "\\n") else "empty string")
+    super.test(testName) {
+      val content = Input.String(s)
+      val points = 0.to(content.chars.length).map(i => Point.Offset(content, i))
+      val actual = points.map(p => s"${p.formatMessage("error", "foo")}").mkString(EOL)
+      if (actual != expected) Console.err.println(actual)
+      assert(actual === expected)
+    }
+  }
+
+  test("")("""
+    |<content>:1: error: foo
+    |
+    |^
+  """.trim.stripMargin)
+
+  test("\n")("""
+    |<content>:1: error: foo
+    |
+    |^
+    |<content>:2: error: foo
+    |
+    |^
+  """.trim.stripMargin)
+
+  test("foo")("""
+    |<content>:1: error: foo
+    |foo
+    |^
+    |<content>:1: error: foo
+    |foo
+    | ^
+    |<content>:1: error: foo
+    |foo
+    |  ^
+    |<content>:1: error: foo
+    |foo
+    |   ^
+  """.trim.stripMargin)
+
+  test("foo\n")("""
+    |<content>:1: error: foo
+    |foo
+    |^
+    |<content>:1: error: foo
+    |foo
+    | ^
+    |<content>:1: error: foo
+    |foo
+    |  ^
+    |<content>:1: error: foo
+    |foo
+    |   ^
+    |<content>:2: error: foo
+    |
+    |^
+  """.trim.stripMargin)
+
+  test("foo\nbar")("""
+    |<content>:1: error: foo
+    |foo
+    |^
+    |<content>:1: error: foo
+    |foo
+    | ^
+    |<content>:1: error: foo
+    |foo
+    |  ^
+    |<content>:1: error: foo
+    |foo
+    |   ^
+    |<content>:2: error: foo
+    |bar
+    |^
+    |<content>:2: error: foo
+    |bar
+    | ^
+    |<content>:2: error: foo
+    |bar
+    |  ^
+    |<content>:2: error: foo
+    |bar
+    |   ^
+  """.trim.stripMargin)
+}

--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/inputs/OffsetLineColumnSuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/inputs/OffsetLineColumnSuite.scala
@@ -5,9 +5,9 @@ import org.scalatest._
 import scala.compat.Platform.EOL
 import scala.meta._
 
-class PositionSuite extends FunSuite {
-  private def testOffsets(s: String)(expected: String): Unit = {
-    val testName = "offsets for " + (if (s != "") s.replace("\n", "\\n") else "empty string")
+class OffsetLineColumnSuite extends FunSuite {
+  private def test(s: String)(expected: String): Unit = {
+    val testName = (if (s != "") s.replace("\n", "\\n") else "empty string")
     super.test(testName) {
       val content = Input.String(s)
       val points = 0.to(content.chars.length).map(i => Point.Offset(content, i))
@@ -19,23 +19,23 @@ class PositionSuite extends FunSuite {
     }
   }
 
-  testOffsets("")("""
+  test("")("""
     |0 0 0
   """.trim.stripMargin)
 
-  testOffsets("\n")("""
+  test("\n")("""
     |0 0 0
     |1 1 0
   """.trim.stripMargin)
 
-  testOffsets("foo")("""
+  test("foo")("""
     |0 0 0
     |1 0 1
     |2 0 2
     |3 0 3
   """.trim.stripMargin)
 
-  testOffsets("foo\n")("""
+  test("foo\n")("""
     |0 0 0
     |1 0 1
     |2 0 2
@@ -43,7 +43,7 @@ class PositionSuite extends FunSuite {
     |4 1 0
   """.trim.stripMargin)
 
-  testOffsets("foo\nbar")("""
+  test("foo\nbar")("""
     |0 0 0
     |1 0 1
     |2 0 2

--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/inputs/PositionSuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/inputs/PositionSuite.scala
@@ -1,0 +1,56 @@
+package scala.meta.tests
+package inputs
+
+import org.scalatest._
+import scala.compat.Platform.EOL
+import scala.meta._
+
+class PositionSuite extends FunSuite {
+  private def testOffsets(s: String)(expected: String): Unit = {
+    val testName = "offsets for " + (if (s != "") s.replace("\n", "\\n") else "empty string")
+    super.test(testName) {
+      val content = Input.String(s)
+      val points = 0.to(content.chars.length).map(i => Point.Offset(content, i))
+      intercept[IllegalArgumentException](Point.Offset(content, -1))
+      intercept[IllegalArgumentException](Point.Offset(content, content.chars.length + 1))
+      val actual = points.map(p => s"${p.offset} ${p.line} ${p.column}").mkString(EOL)
+      if (actual != expected) Console.err.println(actual)
+      assert(actual === expected)
+    }
+  }
+
+  testOffsets("")("""
+    |0 0 0
+  """.trim.stripMargin)
+
+  testOffsets("\n")("""
+    |0 0 0
+    |1 1 0
+  """.trim.stripMargin)
+
+  testOffsets("foo")("""
+    |0 0 0
+    |1 0 1
+    |2 0 2
+    |3 0 3
+  """.trim.stripMargin)
+
+  testOffsets("foo\n")("""
+    |0 0 0
+    |1 0 1
+    |2 0 2
+    |3 0 3
+    |4 1 0
+  """.trim.stripMargin)
+
+  testOffsets("foo\nbar")("""
+    |0 0 0
+    |1 0 1
+    |2 0 2
+    |3 0 3
+    |4 1 0
+    |5 1 1
+    |6 1 2
+    |7 1 3
+  """.trim.stripMargin)
+}

--- a/scalameta/tokenizers/src/main/scala/scala/meta/tokenizers/Errors.scala
+++ b/scalameta/tokenizers/src/main/scala/scala/meta/tokenizers/Errors.scala
@@ -5,6 +5,8 @@ import org.scalameta.adt._
 import org.scalameta.data._
 import scala.meta.tokens._
 import scala.meta.inputs._
+import scala.meta.internal.inputs._
+import scala.compat.Platform.EOL
 
 @root trait Tokenized {
   def get: Tokens = this match {
@@ -24,11 +26,12 @@ import scala.meta.inputs._
 object Tokenized {
   @leaf class Success(tokens: Tokens) extends Tokenized
   @leaf class Error(pos: Position, message: String, details: TokenizeException) extends Tokenized {
-    override def toString = s"Error($details)"
+    override def toString = s"Error(${details.getMessage})"
   }
 }
 
-@data class TokenizeException(pos: Position, message: String)
-extends Exception(s"$message at ${pos.start.offset}..${pos.end.offset}") {
+@data class TokenizeException(pos: Position, shortMessage: String)
+extends Exception(pos.formatMessage("error", shortMessage)) {
+  def fullMessage = getMessage
   override def toString = super.toString
 }


### PR DESCRIPTION
Reproduces error messages emitted by the Scala compiler - including an offending line and a caret. Some examples can be found below:

```
16:14 ~/Projects/core/sandbox1 (master)$ parse 'foo + class'
// Scala source: /var/folders/n4/39sn1y_d1hn3qjx6h1z3jk8m0000gn/T/tmpyyRWlx
tmpyyRWlx:1: error: ; expected but class found
foo + class
      ^
	at scala.meta.internal.parsers.Reporter$class.syntaxError(Reporter.scala:17)
	at scala.meta.internal.parsers.Reporter$$anon$1.syntaxError(Reporter.scala:23)
	at scala.meta.internal.parsers.Reporter$class.syntaxError(Reporter.scala:18)
	at scala.meta.internal.parsers.Reporter$$anon$1.syntaxError(Reporter.scala:23)
	at scala.meta.internal.parsers.ScalametaParser.syntaxErrorExpected(ScalametaParser.scala:504)
        ...
```

```
16:16 ~/Projects/core/sandbox1 (master)$ scala
Welcome to Scala 2.11.8-20160304-115712-1706a37eb8 (Java HotSpot(TM) 64-Bit Server VM, Java 1.7.0_79).
Type in expressions for evaluation. Or try :help.

scala> "foo + class".parse[Term]
res0: scala.meta.parsers.Parsed[scala.meta.Term] =
<content>:1: error: end of file expected but class found
foo + class
      ^
```

More examples at https://github.com/scalameta/scalameta/blob/4a3ce3851388a4fb15f97325f6c24726e6195559/scalameta/scalameta/src/test/scala/scala/meta/tests/inputs/FormatMessageSuite.scala.