### PR TITLE
Fix #399

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -20,7 +20,8 @@ object build extends Build {
     packagedArtifacts := Map.empty,
     unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject,
     aggregate in test := false,
-    test := (test in scalameta in Test).value
+    test := (test in scalameta in Test).value,
+    console := (console in scalameta in Compile).value
   ) aggregate (
     common,
     dialects,
@@ -136,7 +137,7 @@ object build extends Build {
     exposePaths("scalameta", Test): _*
   ) dependsOn (common, dialects, parsers, quasiquotes, tokenizers, transversers, trees)
 
-  lazy val sharedSettings = Defaults.defaultSettings ++ crossVersionSharedSources ++ Seq(
+  lazy val sharedSettings = crossVersionSharedSources ++ Seq(
     scalaVersion := ScalaVersions.max,
     crossScalaVersions := ScalaVersions,
     crossVersion := CrossVersion.binary,

--- a/scalameta/common/src/main/scala/scala/meta/internal/transversers/transformer.scala
+++ b/scalameta/common/src/main/scala/scala/meta/internal/transversers/transformer.scala
@@ -26,8 +26,12 @@ class TransformerMacros(val c: Context) extends TransverserMacros {
           val $to = apply($from)
           $to match {
             case $to: ${hygienicRef(tpe.typeSymbol)} =>
-              if ($from ne $to) same = false
-              $to
+              if ($from ne $to) {
+                same = false
+                $to.withOrigin(_root_.scala.meta.internal.ast.Origin.Transformed($from))
+              } else {
+                $to
+              }
             case $to =>
               this.fail(${f.owner.prefix + "." + f.name}, $from, $to)
           }

--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/transversers/TransverserSuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/transversers/TransverserSuite.scala
@@ -6,6 +6,7 @@ import scala.compat.Platform.EOL
 import scala.meta._
 import scala.meta.internal.semantic._
 import scala.meta.internal.prettyprinters._
+import scala.meta.internal.ast.Origin
 
 class TransverserSuite extends FunSuite {
   test("Traverser Ok") {
@@ -150,4 +151,15 @@ class TransverserSuite extends FunSuite {
     val result1 = tree0.collect { case Term.Name(s) => s }
     assert(result1.toString == "List(x, +, y)")
   }
+
+  test("origin preserving transforms") {
+    val tree0 = "{ /* hello */ def foo(bar: Int) = bar }".parse[Term].get
+    val result1 = tree0 transform { case q"bar" => q"baz" }
+    assert(tree0.pos eq result1.pos)
+    result1.origin match {
+      case Origin.Transformed(tree) => assert(tree.origin eq tree0.origin)
+      case _ => assert(false)
+
+    }
+  }   
 }

--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/transversers/TransverserSuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/transversers/TransverserSuite.scala
@@ -152,12 +152,14 @@ class TransverserSuite extends FunSuite {
     assert(result1.toString == "List(x, +, y)")
   }
 
-  test("origin preserving transforms") {
+  test("Origin preserving transforms") {
     val tree0 = "{ /* hello */ def foo(bar: Int) = bar }".parse[Term].get
     val result1 = tree0 transform { case q"bar" => q"baz" }
-    assert(tree0.pos eq result1.pos)
     result1.origin match {
-      case Origin.Transformed(tree) => assert(tree.origin eq tree0.origin)
+      case Origin.Transformed(tree) =>
+        assert(tree0 eq tree)
+        assert(tree.origin eq tree0.origin)
+        assert(tree0.children.map(_.origin) == tree.children.map(_.origin))
       case _ => assert(false)
 
     }

--- a/scalameta/trees/src/main/scala/scala/meta/internal/ast/InternalTrees.scala
+++ b/scalameta/trees/src/main/scala/scala/meta/internal/ast/InternalTrees.scala
@@ -66,7 +66,10 @@ trait InternalTree {
   }
 
   def pos: Position = {
-    origin match { case Origin.Parsed(_, _, pos) => pos; case _ => Position.None }
+    origin match {
+      case Origin.Parsed(_, _, pos) => pos
+      case _ => Position.None
+    }
   }
 
   def tokens(implicit dialect: Dialect): Tokens = {

--- a/scalameta/trees/src/main/scala/scala/meta/internal/ast/Origin.scala
+++ b/scalameta/trees/src/main/scala/scala/meta/internal/ast/Origin.scala
@@ -10,4 +10,5 @@ import scala.meta.inputs._
 object Origin {
   @adt.none object None extends Origin
   @adt.leaf class Parsed(input: Input, dialect: Dialect, pos: Position) extends Origin
+  @adt.leaf class Transformed(tree: Tree) extends Origin
 }

--- a/scalameta/trees/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -18,6 +18,8 @@ import org.scalameta.collections._
 import org.scalameta.invariants._
 import org.scalameta.{unreachable, debug}
 import scala.compat.Platform.EOL
+import scala.meta.prettyprinters.Syntax.Options.Lazy
+import scala.meta.dialects.{Scala211}
 
 object TreeSyntax {
   def apply[T <: Tree](dialect: Dialect, options: Options): Syntax[T] = {
@@ -548,6 +550,8 @@ object TreeSyntax {
         // case Origin.Parsed(originalInput, originalDialect, pos) if dialect == originalDialect && options == Options.Eager =>
         case Origin.Parsed(originalInput, originalDialect, pos) if dialect == originalDialect =>
           s(new String(originalInput.chars, pos.start.offset, pos.end.offset - pos.start.offset))
+        case Origin.Transformed(tree) =>
+          s("Trying to print transformed tree (???)")
         case _ =>
           syntaxInstances.syntaxTree[T].apply(x)
       }

--- a/scalameta/trees/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -248,18 +248,18 @@ object TreeSyntax {
         case t: Term.Tuple           => m(SimpleExpr1, s("(", r(t.elements, ", "), ")"))
         case t: Term.Block           =>
           import Term.{Block, Function}
-          def pstats(s: Seq[Stat]) = r(s.map(i(_)), "")
+          def pstats(s: Seq[Stat]) = r(s, "")
           t match {
             case Block(Function(Term.Param(mods, name: Term.Name, tptopt, _) :: Nil, Block(stats)) :: Nil) if mods.exists(_.is[Mod.Implicit]) =>
-              m(SimpleExpr, s("{ ", kw("implicit"), " ", name, tptopt.map(s(kw(":"), " ", _)).getOrElse(s()), " ", kw("=>"), " ", pstats(stats), n("}")))
+              m(SimpleExpr, s("{ ", kw("implicit"), " ", name, tptopt.map(s(kw(":"), " ", _)).getOrElse(s()), " ", kw("=>"), " ", pstats(stats), " }"))
             case Block(Function(Term.Param(mods, name: Term.Name, None, _) :: Nil, Block(stats)) :: Nil) =>
-              m(SimpleExpr, s("{ ", name, " ", kw("=>"), " ", pstats(stats), n("}")))
+              m(SimpleExpr, s("{ ", name, " ", kw("=>"), " ", pstats(stats), " }"))
             case Block(Function(Term.Param(_, _: Name.Anonymous, _, _) :: Nil, Block(stats)) :: Nil) =>
-              m(SimpleExpr, s("{ ", kw("_"), " ", kw("=>"), " ", pstats(stats), n("}")))
+              m(SimpleExpr, s("{ ", kw("_"), " ", kw("=>"), " ", pstats(stats), " }"))
             case Block(Function(params, Block(stats)) :: Nil) =>
-              m(SimpleExpr, s("{ (", r(params, ", "), ") => ", pstats(stats), n("}")))
+              m(SimpleExpr, s("{ (", r(params, ", "), ") => ", pstats(stats), " }"))
             case _ =>
-              m(SimpleExpr, if (t.stats.isEmpty) s("{}") else s("{", pstats(t.stats), n("}")))
+              m(SimpleExpr, if (t.stats.isEmpty) s("{}") else s("{ ", pstats(t.stats), " }"))
           }
         case t: Term.If              => m(Expr1, s(kw("if"), " (", t.cond, ") ", p(Expr, t.thenp), if (guessHasElsep(t)) s(" ", kw("else"), " ", p(Expr, t.elsep)) else s()))
         case t: Term.Match           => m(Expr1, s(p(PostfixExpr, t.scrut), " ", kw("match"), " {", r(t.cases.map(i(_)), ""), n("}")))
@@ -549,7 +549,7 @@ object TreeSyntax {
         // because if we've parsed a tree, it's not gonna contain lazy seqs anyway.
         // case Origin.Parsed(originalInput, originalDialect, pos) if dialect == originalDialect && options == Options.Eager =>
         case Origin.Parsed(originalInput, originalDialect, pos) if dialect == originalDialect =>
-          s(new String(originalInput.chars, pos.start.offset, pos.end.offset - pos.start.offset))        
+          s(new String(originalInput.chars, pos.start.offset, pos.end.offset - pos.start.offset))
         case _ =>
           syntaxInstances.syntaxTree[T].apply(x)
       }

--- a/scalameta/trees/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -549,9 +549,7 @@ object TreeSyntax {
         // because if we've parsed a tree, it's not gonna contain lazy seqs anyway.
         // case Origin.Parsed(originalInput, originalDialect, pos) if dialect == originalDialect && options == Options.Eager =>
         case Origin.Parsed(originalInput, originalDialect, pos) if dialect == originalDialect =>
-          s(new String(originalInput.chars, pos.start.offset, pos.end.offset - pos.start.offset))
-        case Origin.Transformed(tree) =>
-          s("Trying to print transformed tree (???)")
+          s(new String(originalInput.chars, pos.start.offset, pos.end.offset - pos.start.offset))        
         case _ =>
           syntaxInstances.syntaxTree[T].apply(x)
       }

--- a/scalameta/trees/src/main/scala/scala/meta/internal/prettyprinters/TreeToString.scala
+++ b/scalameta/trees/src/main/scala/scala/meta/internal/prettyprinters/TreeToString.scala
@@ -9,6 +9,7 @@ import scala.meta.prettyprinters.Syntax.Options.Lazy
 object TreeToString {
   def apply(tree: Tree) = {
     val dialect = tree.origin match {
+      case Origin.Transformed(tree) => Scala211
       case Origin.Parsed(_, dialect, _) => dialect
       case Origin.None if tree.isInstanceOf[Quasi] => QuasiquoteTerm(Scala211, multiline = true)
       case Origin.None => Scala211 // this dialect is as good as any as a default


### PR DESCRIPTION
This PR is for review purposes. There's a few more features (i.e. pretty printing transformed trees) and tests to add before merging.

Currently, there's a clean mapping between transformed trees and original trees, and each transformed tree knows where it came from. This positional information can be used to retain formatting, preserve comments, etc, but once again this needs to fully be investigated before merging. 