### PR TITLE
sbt publish-signed no longer exits with an error

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -24,7 +24,16 @@ object build extends Build {
     packagedArtifacts := Map.empty,
     unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject,
     aggregate in test := false,
-    test := (test in scalameta in Test).value,
+    test := {
+      val runTests = (test in scalameta in Test).value
+      val runDocs = (run in readme in Compile).toTask(" --validate").value
+    },
+    publish := {
+      // Others projects are published automatically because we aggregate.
+      val publishDocs = (publish in readme).value
+    },
+    // TODO: The same thing for publishSigned doesn't work.
+    // SBT calls publishSigned on aggregated projects, but ignores everything else.
     console := (console in scalameta in Compile).value
   ) aggregate (
     common,
@@ -37,8 +46,7 @@ object build extends Build {
     tokenizers,
     tokens,
     transversers,
-    trees,
-    readme
+    trees
   )
 
   lazy val common = Project(


### PR DESCRIPTION
By the advice of @fommil and @lihaoyi, I've stopped aggregating readme in root.

Now I explicitly aggregate readme to include it in the most important tasks.
Naturally, I don't feel like copy/pasting code, so I'm only doing this
for `test` and `publish`, but I've already wasted too much time on SBT.