### PR TITLE
attempt to fix https://github.com/scalameta/paradise/issues/10

### DIFF
--- a/scalameta/common/src/main/scala/org/scalameta/internal/MacroHelpers.scala
+++ b/scalameta/common/src/main/scala/org/scalameta/internal/MacroHelpers.scala
@@ -55,8 +55,8 @@ trait MacroHelpers extends DebugFinder
   lazy val AnyClass = hygienicRef[scala.Any]
   lazy val AnyRefClass = hygienicRef[scala.AnyRef]
   lazy val NothingClass = tq"_root_.scala.Nothing"
-  lazy val OptionClass = hygienicRef[scala.Option[_]]
-  lazy val SomeClass = hygienicRef[scala.Some[_]]
+  lazy val OptionClass = tq"_root_.scala.Option"
+  lazy val SomeClass = tq"_root_.scala.Some"
   lazy val SomeModule = hygienicRef(Some)
   lazy val NoneModule = hygienicRef(scala.None)
   def SerialVersionUIDAnnotation(uid: Long) = q"new ${hygienicRef[SerialVersionUID]}($uid)"
@@ -68,12 +68,12 @@ trait MacroHelpers extends DebugFinder
   lazy val ScalaRunTimeModule = hygienicRef(scala.runtime.ScalaRunTime)
   lazy val UnsupportedOperationException = hygienicRef[UnsupportedOperationException]
   lazy val IndexOutOfBoundsException = hygienicRef[IndexOutOfBoundsException]
-  lazy val IteratorClass = hygienicRef[Iterator[_]]
-  lazy val SeqClass = hygienicRef[scala.collection.immutable.Seq[_]]
+  lazy val IteratorClass = tq"_root_.scala.collection.Iterator"
+  lazy val SeqClass = tq"_root_.scala.collection.immutable.Seq"
   lazy val ListBufferModule = hygienicRef(scala.collection.mutable.ListBuffer)
   lazy val UnitClass = hygienicRef[scala.Unit]
-  lazy val ClassClass = hygienicRef[java.lang.Class[_]]
-  lazy val ClassTagClass = hygienicRef[scala.reflect.ClassTag[_]]
+  lazy val ClassClass = tq"_root_.java.lang.Class"
+  lazy val ClassTagClass = tq"_root_.scala.reflect.ClassTag"
   lazy val ImplicitlyMethod = q"${hygienicRef(scala.Predef)}.implicitly"
 
   private def fqRef(fqName: String, isTerm: Boolean): Tree = {
@@ -116,8 +116,8 @@ trait MacroHelpers extends DebugFinder
       if (tpe =:= typeOf[String] ||
           tpe =:= typeOf[scala.Symbol] ||
           ScalaPrimitiveValueClasses.contains(tpe.typeSymbol)) Some(tpe)
-      else if (tpe.typeSymbol == symbolOf[Option[_]] && PrimitiveTpe.unapply(tpe.typeArgs.head).nonEmpty) Some(tpe)
-      else if (tpe.typeSymbol == symbolOf[Class[_]]) Some(tpe)
+      else if (tpe.typeSymbol == definitions.OptionClass && PrimitiveTpe.unapply(tpe.typeArgs.head).nonEmpty) Some(tpe)
+      else if (tpe.typeSymbol == definitions.ClassClass) Some(tpe)
       else None
     }
   }

--- a/scalameta/common/src/main/scala/scala/meta/internal/classifiers/Macros.scala
+++ b/scalameta/common/src/main/scala/scala/meta/internal/classifiers/Macros.scala
@@ -11,7 +11,7 @@ import scala.meta.classifiers.Classifier
 class ClassifierMacros(val c: Context) extends MacroHelpers {
   import c.universe._
 
-  lazy val ClassifierClass = hygienicRef[Classifier[_, _]]
+  lazy val ClassifierClass = tq"_root_.scala.meta.classifiers.Classifier"
 
   def classifier(annottees: Tree*): Tree = annottees.transformAnnottees(new ImplTransformer {
     override def transformTrait(cdef: ClassDef, mdef: ModuleDef): List[ImplDef] = {

--- a/scalameta/common/src/main/scala/scala/meta/internal/prettyprinters/ShowMacros.scala
+++ b/scalameta/common/src/main/scala/scala/meta/internal/prettyprinters/ShowMacros.scala
@@ -8,7 +8,7 @@ import scala.meta.prettyprinters._
 
 class ShowMacros(val c: Context) {
   import c.universe._
-  val ShowTpe = typeOf[Show[_]]
+  val ShowClass = c.mirror.staticClass("scala.meta.prettyprinters.Show")
   val ShowObj = q"_root_.scala.meta.prettyprinters.Show"
 
   private def mkResults(xs: List[c.Tree]): List[c.Tree] = {
@@ -16,7 +16,7 @@ class ShowMacros(val c: Context) {
       if (x.tpe <:< typeOf[Show.Result])
         x
       else {
-        val printer = c.inferImplicitValue(appliedType(ShowTpe, x.tpe :: Nil), silent = true)
+        val printer = c.inferImplicitValue(appliedType(ShowClass, x.tpe :: Nil), silent = true)
         if (printer.nonEmpty)
           q"$printer($x)"
         else

--- a/scalameta/quasiquotes/src/main/scala/scala/meta/internal/quasiquotes/ConversionMacros.scala
+++ b/scalameta/quasiquotes/src/main/scala/scala/meta/internal/quasiquotes/ConversionMacros.scala
@@ -30,8 +30,8 @@ class ConversionMacros(val c: Context) extends AstReflection {
   import u._
   import definitions._
 
-  val MetaLift = symbolOf[scala.meta.quasiquotes.Lift[_, _]]
-  val MetaUnlift = symbolOf[scala.meta.quasiquotes.Unlift[_, _]]
+  val MetaLift = mirror.staticClass("scala.meta.quasiquotes.Lift")
+  val MetaUnlift = mirror.staticClass("scala.meta.quasiquotes.Unlift")
 
   private def foundReqMsg(found: c.Type, req: c.Type): String = {
     val g = c.universe.asInstanceOf[scala.tools.nsc.Global]

--- a/scalameta/quasiquotes/src/main/scala/scala/meta/internal/quasiquotes/ReificationMacros.scala
+++ b/scalameta/quasiquotes/src/main/scala/scala/meta/internal/quasiquotes/ReificationMacros.scala
@@ -293,7 +293,7 @@ class ReificationMacros(val c: Context) extends AstReflection with AdtLiftables 
           pendingQuasis.push(quasi)
           if (quasi.rank == 0) {
             var inferredPt = quasi.pt.wrap(pendingQuasis.map(_.rank).sum).toTpe
-            if (optional) inferredPt = appliedType(typeOf[Option[_]], inferredPt)
+            if (optional) inferredPt = appliedType(definitions.OptionClass, inferredPt)
             val lifted = mode match {
               case Mode.Term(_, _) =>
                 q"$InternalLift[$inferredPt](${quasi.hole.arg})"

--- a/scalameta/tokens/src/main/scala/scala/meta/internal/tokens/TokenInfo.scala
+++ b/scalameta/tokens/src/main/scala/scala/meta/internal/tokens/TokenInfo.scala
@@ -27,7 +27,7 @@ class TokenInfoMacros(val c: Context) extends MacroHelpers with TokenReflection 
   lazy val mirror: u.Mirror = c.mirror
   import u._
   def materialize[T](implicit T: c.WeakTypeTag[T]): c.Tree = {
-    val TokenInfoClass = hygienicRef[scala.meta.internal.tokens.TokenInfo[_]]
+    val TokenInfoClass = tq"_root_.scala.meta.internal.tokens.TokenInfo"
     val sym = T.tpe.typeSymbol
     if (sym.isToken) {
       q"""


### PR DESCRIPTION
typeOf/symbolOf/hygienicRef for existential types have been replaced
with equivalent constructs that don't involve reification. To see why
that's necessary, refer to the aforementioned issue.

I don't like the fact that I can't test this in an automated fashion
(well, at least I can't come up with a way of doing that at the moment).