### PR TITLE
work around #448

### DIFF
--- a/scalameta/quasiquotes/src/main/scala/scala/meta/quasiquotes/QuasiquoteParsers.scala
+++ b/scalameta/quasiquotes/src/main/scala/scala/meta/quasiquotes/QuasiquoteParsers.scala
@@ -13,5 +13,6 @@ private[meta] trait QuasiquoteParsers extends scala.meta.parsers.Api {
   implicit lazy val parseQuasiquotePat: Parse[Pat] = toParse(_.parseQuasiquotePat())
   implicit lazy val parseQuasiquotePatArg: Parse[Pat.Arg] = toParse(_.parseQuasiquotePatArg())
   implicit lazy val parseQuasiquotePatType: Parse[Pat.Type] = toParse(_.parseQuasiquotePatType())
+  implicit lazy val parseQuasiquoteTemplate: Parse[Template] = toParse(_.parseQuasiquoteTemplate())
   implicit lazy val parseQuasiquoteMod: Parse[Mod] = toParse(_.parseQuasiquoteMod())
 }

--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/quasiquotes/ErrorSuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/quasiquotes/ErrorSuite.scala
@@ -834,4 +834,21 @@ class ErrorSuite extends FunSuite {
       |               ^
     """.trim.stripMargin)
   }
+
+  test("#448") {
+    assert(typecheckError("""
+      import scala.meta._
+      val notReallyAParent = t"_root_.scala.AnyVal"
+      q"class C extends $notReallyAParent"
+    """) === """
+      |<macro>:4: type mismatch when unquoting;
+      | found   : scala.meta.Type.Select
+      | required: scala.meta.Template
+      |Note: This shape of a quasiquote tells scala.meta that you're unquoting a template.
+      |If you'd like to unquote a parent reference, add {} immediately after the unquote.
+      |For more details, see https://github.com/scalameta/scalameta/issues/223.
+      |      q"class C extends $notReallyAParent"
+      |                        ^
+    """.trim.stripMargin)
+  }
 }

--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -2158,4 +2158,13 @@ class SuccessSuite extends FunSuite {
     val q"class $tname2 ..$mods2" = q"class C private"
     assert(q"class $tname2 ..$mods2".syntax === "class C private")
   }
+
+  test("#448") {
+    val parent = ctor"_root_.scala.AnyVal"
+    val template = template"$parent"
+    assert(q"class C extends $template".syntax === "class C extends _root_.scala.AnyVal")
+    assert(q"class C extends $parent with $parent".syntax === "class C extends _root_.scala.AnyVal with _root_.scala.AnyVal")
+    assert(q"class C extends $parent(arg)".syntax === "class C extends _root_.scala.AnyVal(arg)")
+    assert(q"class C extends $parent[targ]".syntax === "class C extends _root_.scala.AnyVal[targ]")
+  }
 }


### PR DESCRIPTION
We can't fully fix #448 at the moment because of the syntactic ambiguity
described in #223.

When the user writes q"class C extends $foo", we can't really know whether
they meant to insert/extract a constructor or a template.

Therefore, what we expect people to do now is to write q"class C extends $foo {}",
in which case they unambiguously point out that they want to work with a parent.
It turns out that this didn't work before, and now I fixed that.
I also improved the error message to clearly explain what needs to be done.

I hope that in the future we'll be able to do better here.