### PR TITLE
fix #462

### DIFF
--- a/scalameta/parsers/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1295,7 +1295,15 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
   *   }}}
   */
   def qualId(): Term.Ref = {
-    val name = termName()
+    /*
+      Issue #472
+      If name is an unquote (Quasi) return the Term.Ref.Quasi type
+     */
+    val name = termName() match {
+      case quasi: Term.Name.Quasi =>
+        quasi.become[Term.Ref.Quasi]
+      case ref@_ => ref
+    }
     if (token.isNot[Dot]) name
     else {
       next()

--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -1683,6 +1683,15 @@ class SuccessSuite extends FunSuite {
     assert(q"package $ref { ..$stats }".show[Structure] === "Pkg(Term.Name(\"p\"), Seq(Defn.Class(Nil, Type.Name(\"A\"), Nil, Ctor.Primary(Nil, Ctor.Ref.Name(\"this\"), Nil), Template(Nil, Nil, Term.Param(Nil, Name.Anonymous(), None, None), None)), Defn.Object(Nil, Term.Name(\"B\"), Template(Nil, Nil, Term.Param(Nil, Name.Anonymous(), None, None), None))))")
   }
 
+  /*
+   Issue #472
+   */
+  test("3 q\"package $ref { ..$stats }\"") {
+    val ref = q"p.a"
+    val stats = List(q"class A", q"object B")
+    assert(q"package $ref { ..$stats }".show[Structure] === """Pkg(Term.Select(Term.Name("p"), Term.Name("a")), Seq(Defn.Class(Nil, Type.Name("A"), Nil, Ctor.Primary(Nil, Ctor.Ref.Name("this"), Nil), Template(Nil, Nil, Term.Param(Nil, Name.Anonymous(), None, None), None)), Defn.Object(Nil, Term.Name("B"), Template(Nil, Nil, Term.Param(Nil, Name.Anonymous(), None, None), None))))""")
+  }
+
   test("1 q\"..$mods def this(...$paramss)\"") {
     val q"..$mods def this(...$paramss)" = q"private def this(x: X, y: Y)"
     assert(mods.toString === "List(private)")

--- a/scalameta/trees/src/main/scala/scala/meta/internal/ast/Helpers.scala
+++ b/scalameta/trees/src/main/scala/scala/meta/internal/ast/Helpers.scala
@@ -123,6 +123,7 @@ object Helpers {
   implicit class XtensionTermRefOps(tree: Term.Ref) {
     def isPath: Boolean = tree.isStableId || tree.is[Term.This]
     def isQualId: Boolean = tree match {
+      case _: Term.Ref.Quasi              => true
       case _: Term.Name                   => true
       case Term.Select(qual: Term.Ref, _) => qual.isQualId
       case _                              => false


### PR DESCRIPTION
In Issue #462  unquoting a Term.Select results in a compiler error. 
The ScalametaParser creates a Quasi of the wrong type  when unquoting the ref attribute of the Pkg tree. This occurs when the variable that is unquoted is a Term.Select.

The following call sequence results in the creation of the Pkg.ref Quasi tree
  ```scala
    def packageDef(): Pkg
       def qualId(): Term.Ref
          def termName(advance: Boolean = true) Term.Name
              def name[T <: Tree : AllowedName : AstInfo](ctor: String => T, advance: Boolean): T 
                 def unquote[T](advance)
```
This previously always returned a  Term.Name.Quasi.
This value is appropriate if the variable unquoted  is a Term.Name,  However if it is a Term.Select,
the error in #462 results.
We fix this in  qualId( which is presently only called in regard to creating a Pkg tree) 
by converting the Term.Name.Quasi to a Term.Ref.Quasi.
Note that this issue may potentially arise in other cases where termName or name is being called in which the result could potentially be a Quasi, and where Term.Ref is allowable. 
I have added a test to confirm the fix 