### PR TITLE
fix #462

### DIFF
--- a/scalameta/parsers/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -970,7 +970,12 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
           else {
             next()
             accept[KwType]
-            Type.Singleton(ref)
+            val refOrQuasi = ref match {
+              case quasi: Term.Name.Quasi =>
+                quasi.become[Term.Ref.Quasi]
+              case ref => ref
+            }
+            Type.Singleton(refOrQuasi)
           }
       }))
     }
@@ -1298,7 +1303,7 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
     val name = termName() match {
       case quasi: Term.Name.Quasi =>
         quasi.become[Term.Ref.Quasi]
-      case ref@_ => ref
+      case ref => ref
     }
     if (token.isNot[Dot]) name
     else {
@@ -2430,7 +2435,12 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
           case _        => Nil
         }
         (token, sid) match {
-          case (LeftParen(), _)                     => Pat.Extract(sid, targs, checkNoTripleDots(argumentPatterns()))
+          case (LeftParen(), _)                     =>
+            val quasiOrSid = sid match {
+              case quasi: Term.Name.Quasi => quasi.become[Term.Ref.Quasi]
+              case path => path
+            }
+            Pat.Extract(quasiOrSid, targs, checkNoTripleDots(argumentPatterns()))
           case (_, _) if targs.nonEmpty             => syntaxError("pattern must be a value", at = token)
           case (_, name: Term.Name.Quasi)           => name.become[Pat.Quasi]
           case (_, name: Term.Name) if isVarPattern => Pat.Var.Term(name)
@@ -2809,7 +2819,10 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
    *  }}}
    */
   def importer(): Importer = autoPos {
-    val sid = stableId()
+    val sid = stableId() match {
+      case quasi: Term.Name.Quasi => quasi.become[Term.Ref.Quasi]
+      case path => path
+    }
     def dotselectors = { accept[Dot]; Importer(sid, importees()) }
     sid match {
       case Term.Select(sid: Term.Ref, name: Term.Name) if sid.isStableId =>

--- a/scalameta/parsers/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1295,10 +1295,6 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
   *   }}}
   */
   def qualId(): Term.Ref = {
-    /*
-      Issue #472
-      If name is an unquote (Quasi) return the Term.Ref.Quasi type
-     */
     val name = termName() match {
       case quasi: Term.Name.Quasi =>
         quasi.become[Term.Ref.Quasi]

--- a/scalameta/parsers/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1295,7 +1295,15 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
   *   }}}
   */
   def qualId(): Term.Ref = {
-    val name = termName()
+    /*
+      Issue #472
+      If name is an unquote (Quasi) return the Term.Ref.Quasi type
+     */
+    val name = termName() match {
+      case quasi: Term.Name.Quasi =>
+        quasi.become[Term.Ref.Quasi]
+      case ref@_ => ref
+    }
     if (token.isNot[Dot]) name
     else {
       next()

--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -775,6 +775,13 @@ class SuccessSuite extends FunSuite {
     val ref = q"X"
     assert(t"$ref.type".show[Structure] === "Type.Singleton(Term.Name(\"X\"))")
   }
+  /*
+   Issue #462
+   */
+  test("3 t\"$ref.type\"") {
+    val ref = q"X.a"
+    assert(t"$ref.type".show[Structure] === "Type.Singleton(Term.Select(Term.Name(\"X\"), Term.Name(\"a\")))")
+  }
 
   test("1 t\"$tpe[..$tpes]") {
     val t"$tpe[..$tpes]" = t"X[Y, Z]"
@@ -1026,6 +1033,16 @@ class SuccessSuite extends FunSuite {
     val tpes = List(t"`A`", t"B")
     val apats = List(p"`Q`", q"W")
     assert(p"$ref[..$tpes](..$apats)".show[Structure] === "Pat.Extract(Term.Name(\"x\"), Seq(Type.Name(\"A\"), Type.Name(\"B\")), Seq(Term.Name(\"Q\"), Term.Name(\"W\")))")
+  }
+
+  /*
+   Issue #462
+   */
+  test("5 p\"$ref[..$tpes](..$apats)\"") {
+    val ref = q"x.a"
+    val tpes = List(t"A", t"B")
+    val apats = List(q"Q", q"W")
+    assert(p"$ref[..$tpes](..$apats)".show[Structure] === "Pat.Extract(Term.Select(Term.Name(\"x\"), Term.Name(\"a\")), Seq(Type.Name(\"A\"), Type.Name(\"B\")), Seq(Term.Name(\"Q\"), Term.Name(\"W\")))")
   }
 
   test("1 p\"$pat $name (..$apats)\"") {
@@ -2036,6 +2053,15 @@ class SuccessSuite extends FunSuite {
     assert(importees.length == 2)
     assert(importees(0).show[Syntax] === "baz")
     assert(importees(1).show[Syntax] === "_")
+  }
+
+  /*
+   Issue #462
+   */
+  test("3 importer\"$ref.{..$importees}\"") {
+    val ref = q"bar.a"
+    val importees = List(importee"baz", importee"_")
+    assert(importer"$ref.{..$importees}".show[Syntax] === "bar.a.{ baz, _ }")
   }
 
   test("1 importee\"$iname\"") {

--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -1683,6 +1683,15 @@ class SuccessSuite extends FunSuite {
     assert(q"package $ref { ..$stats }".show[Structure] === "Pkg(Term.Name(\"p\"), Seq(Defn.Class(Nil, Type.Name(\"A\"), Nil, Ctor.Primary(Nil, Ctor.Ref.Name(\"this\"), Nil), Template(Nil, Nil, Term.Param(Nil, Name.Anonymous(), None, None), None)), Defn.Object(Nil, Term.Name(\"B\"), Template(Nil, Nil, Term.Param(Nil, Name.Anonymous(), None, None), None))))")
   }
 
+  /*
+   Issue #472
+   */
+  test("3 q\"package $ref { ..$stats }\"") {
+    val ref = q"p.a"
+    val stats = List(q"class A", q"object B")
+    assert(q"package $ref { ..$stats }".show[Structure] === """Pkg(Term.Select(Term.Name("p"), Term.Name("a")), Seq(Defn.Class(Nil, Type.Name("A"), Nil, Ctor.Primary(Nil, Ctor.Ref.Name("this"), Nil), Template(Nil, Nil, Term.Param(Nil, Name.Anonymous(), None, None), None)), Defn.Object(Nil, Term.Name("B"), Template(Nil, Nil, Term.Param(Nil, Name.Anonymous(), None, None), None))))""")
+  }
+
   test("1 q\"..$mods def this(...$paramss)\"") {
     val q"..$mods def this(...$paramss)" = q"private def this(x: X, y: Y)"
     assert(mods.toString === "List(private)")

--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -1684,7 +1684,7 @@ class SuccessSuite extends FunSuite {
   }
 
   /*
-   Issue #472
+   Issue #462
    */
   test("3 q\"package $ref { ..$stats }\"") {
     val ref = q"p.a"

--- a/scalameta/trees/src/main/scala/scala/meta/internal/ast/Helpers.scala
+++ b/scalameta/trees/src/main/scala/scala/meta/internal/ast/Helpers.scala
@@ -123,6 +123,7 @@ object Helpers {
   implicit class XtensionTermRefOps(tree: Term.Ref) {
     def isPath: Boolean = tree.isStableId || tree.is[Term.This]
     def isQualId: Boolean = tree match {
+      case _: Term.Ref.Quasi              => true
       case _: Term.Name                   => true
       case Term.Select(qual: Term.Ref, _) => qual.isQualId
       case _                              => false

--- a/scalameta/trees/src/main/scala/scala/meta/internal/ast/Helpers.scala
+++ b/scalameta/trees/src/main/scala/scala/meta/internal/ast/Helpers.scala
@@ -129,6 +129,7 @@ object Helpers {
       case _                              => false
     }
     def isStableId: Boolean = tree match {
+      case _: Term.Ref.Quasi              => true
       case _: Term.Name | Term.Select(_: Term.Super, _) => true
       case Term.Select(qual: Term.Quasi, _)             => true
       case Term.Select(qual: Term.Ref, _)               => qual.isPath


### PR DESCRIPTION
In Issue #462  unquoting a Term.Select results in a compiler error. 
The ScalametaParser creates a Quasi of the wrong type  when unquoting the ref attribute of the Pkg tree. This occurs when the variable that is unquoted is a Term.Select.

The following call sequence results in the creation of the Pkg.ref Quasi tree
  ```scala
    def packageDef(): Pkg
       def qualId(): Term.Ref
          def termName(advance: Boolean = true) Term.Name
              def name[T <: Tree : AllowedName : AstInfo](ctor: String => T, advance: Boolean): T 
                 def unquote[T](advance)
```
This previously always returned a  Term.Name.Quasi.
This value is appropriate if the variable unquoted  is a Term.Name,  However if it is a Term.Select,
the error in #462 results.
We fix this in  qualId( which is presently only called in regard to creating a Pkg tree) 
by converting the Term.Name.Quasi to a Term.Ref.Quasi.
Note that this issue may potentially arise in other cases where termName or name is being called in which the result could potentially be a Quasi, and where Term.Ref is allowable. 
I have added a test to confirm the fix 
