### PR TITLE
Fix #458: Recognize quasiquotes-generated lambda functions

### DIFF
--- a/scalameta/parsers/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -726,6 +726,9 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
       Some(atPos(tree, tree)(Term.Param(Nil, name, None, None)))
     case name: Term.Placeholder =>
       Some(atPos(tree, tree)(Term.Param(Nil, atPos(name, name)(Name.Anonymous()), None, None)))
+    case Term.Ascribe(quasiName: Term.Quasi, tpt) =>
+      val name = quasiName.become[Term.Name.Quasi]
+      Some(atPos(tree, tree)(Term.Param(Nil, name, Some(tpt), None)))
     case Term.Ascribe(name: Term.Name, tpt) =>
       Some(atPos(tree, tree)(Term.Param(Nil, name, Some(tpt), None)))
     case Term.Ascribe(name: Term.Placeholder, tpt) =>
@@ -1660,6 +1663,7 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
               case Term.Quasi(0, _) => true
               case Term.Quasi(1, ParamLike()) => true
               case NameLike() => true
+              case Term.Ascribe(Term.Quasi(0, _), _) => true
               case Term.Ascribe(NameLike(), _) => true
               case _ => false
             }

--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -2234,4 +2234,17 @@ class SuccessSuite extends FunSuite {
       |}
     """.trim.stripMargin)
   }
+
+  test("#458") {
+    val name = q"x"
+    val tpe = t"T"
+    val lambda = q"($name: $tpe) => ???"
+    assert(lambda.syntax === "(x: T) => ???")
+  }
+
+  test("#458 II") {
+    val name = q"x"
+    val lambda = q"($name: T) => ???"
+    assert(lambda.syntax === "(x: T) => ???")
+  }
 }


### PR DESCRIPTION
When parsing quasiquotes, the internal structure of the tree changes. The
previous ascribe case defs were not accounting for the fact that the name and
the type could be quasi.