### PR TITLE
Allows for inline modifier. Fixes #466.

### DIFF
--- a/notes/quasiquotes.md
+++ b/notes/quasiquotes.md
@@ -206,6 +206,7 @@ Literal  | `q"$lit"` (construction only), `q"${lit: Lit}"` (also deconstruction)
  Lazy             | `mod"lazy"`
  Val Param        | `mod"valparam"`
  Var Param        | `mod"varparam"`
+ Inline           | `mod"inline"`
 
 ## Enumerators (meta.Enum)
 

--- a/scalameta/dialects/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/src/main/scala/scala/meta/dialects/package.scala
@@ -29,6 +29,9 @@ import scala.compat.Platform.EOL
   // might go ahead and drop support completely.
   def allowXmlLiterals: Boolean
 
+  // Are inline vals and defs supported by this dialect?
+  def allowInline: Boolean
+
   // Permission to parse unquotes.
   // Necessary to support quasiquotes, e.g. `q"$x + $y"`.
   def allowUnquotes: Boolean = metalevel.isQuoted
@@ -55,6 +58,7 @@ package object dialects {
     def name = "Scala210"
     def bindToSeqWildcardDesignator = "@" // List(1, 2, 3) match { case List(xs @ _*) => ... }
     def allowXmlLiterals = true // Not even deprecated yet, so we need to support xml literals
+    def allowInline = false
     def allowSpliceUnderscore = false // SI-7715, only fixed in 2.11.0-M5
     def allowToplevelTerms = false
     def toplevelSeparator = ""
@@ -66,6 +70,7 @@ package object dialects {
     def name = "Sbt0136"
     def bindToSeqWildcardDesignator = Scala210.bindToSeqWildcardDesignator
     def allowXmlLiterals = Scala210.allowXmlLiterals
+    def allowInline = false
     def allowSpliceUnderscore = Scala210.allowSpliceUnderscore
     def allowToplevelTerms = true
     def toplevelSeparator = EOL
@@ -77,6 +82,7 @@ package object dialects {
     def name = "Sbt0137"
     def bindToSeqWildcardDesignator = Scala210.bindToSeqWildcardDesignator
     def allowXmlLiterals = Scala210.allowXmlLiterals
+    def allowInline = false
     def allowSpliceUnderscore = Scala210.allowSpliceUnderscore
     def allowToplevelTerms = true
     def toplevelSeparator = ""
@@ -88,9 +94,22 @@ package object dialects {
     def name = "Scala211"
     def bindToSeqWildcardDesignator = Scala210.bindToSeqWildcardDesignator
     def allowXmlLiterals = Scala210.allowXmlLiterals
+    def allowInline = false
     def allowSpliceUnderscore = true // SI-7715, only fixed in 2.11.0-M5
     def allowToplevelTerms = Scala210.allowToplevelTerms
     def toplevelSeparator = Scala210.toplevelSeparator
+    def metalevel = Metalevel.Zero
+    private def writeReplace(): AnyRef = new Dialect.SerializationProxy(this)
+  }
+
+  @leaf implicit object Paradise extends Dialect {
+    def name = "Paradise"
+    def bindToSeqWildcardDesignator = Scala211.bindToSeqWildcardDesignator
+    def allowXmlLiterals = Scala211.allowXmlLiterals
+    def allowInline = true
+    def allowSpliceUnderscore = Scala211.allowSpliceUnderscore
+    def allowToplevelTerms = Scala211.allowToplevelTerms
+    def toplevelSeparator = Scala211.toplevelSeparator
     def metalevel = Metalevel.Zero
     private def writeReplace(): AnyRef = new Dialect.SerializationProxy(this)
   }
@@ -99,6 +118,7 @@ package object dialects {
     def name = "Dotty"
     def bindToSeqWildcardDesignator = ":" // // List(1, 2, 3) match { case List(xs: _*) => ... }
     def allowXmlLiterals = false // Dotty parser doesn't have the corresponding code, so it can't really support xml literals
+    def allowInline = true
     def allowSpliceUnderscore = true
     def allowToplevelTerms = false
     def toplevelSeparator = ""
@@ -114,6 +134,7 @@ package object dialects {
     def metalevel = Metalevel.Quoted
     def bindToSeqWildcardDesignator = underlying.bindToSeqWildcardDesignator
     def allowXmlLiterals = underlying.allowXmlLiterals
+    def allowInline = underlying.allowInline
     def allowSpliceUnderscore = underlying.allowSpliceUnderscore
     def allowToplevelTerms = underlying.allowToplevelTerms
     def toplevelSeparator = underlying.toplevelSeparator

--- a/scalameta/parsers/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -34,6 +34,7 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
   require(Set("", EOL).contains(dialect.toplevelSeparator))
   implicit val currentDialect: Dialect = dialect
   def inQuasiquote = dialect.metalevel.isQuoted
+  def allowInline = dialect.allowInline
 
 /* ------------- PARSER ENTRY POINTS -------------------------------------------- */
 
@@ -140,6 +141,7 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
       case KwVar() if !inQuasiquote          => parser.next(); Mod.VarParam()
       case Ident("valparam") if inQuasiquote => parser.next(); Mod.ValParam()
       case Ident("varparam") if inQuasiquote => parser.next(); Mod.VarParam()
+      case KwInline() if allowInline         => parser.next(); Mod.Inline()
       case _                                 => fail()
     }))
   }
@@ -522,7 +524,8 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
       token.is[KwAbstract] || token.is[KwFinal] ||
       token.is[KwSealed] || token.is[KwImplicit] ||
       token.is[KwLazy] || token.is[KwPrivate] ||
-      token.is[KwProtected] || token.is[KwOverride]
+      token.is[KwProtected] || token.is[KwOverride] ||
+      token.is[KwInline]
     }
   }
 
@@ -2555,17 +2558,18 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
   }
 
   def modifier(): Mod = autoPos(token match {
-    case Unquote(_)    => unquote[Mod]
-    case Ellipsis(_)   => ellipsis(1, astInfo[Mod])
-    case KwAbstract()  => next(); Mod.Abstract()
-    case KwFinal()     => next(); Mod.Final()
-    case KwSealed()    => next(); Mod.Sealed()
-    case KwImplicit()  => next(); Mod.Implicit()
-    case KwLazy()      => next(); Mod.Lazy()
-    case KwOverride()  => next(); Mod.Override()
-    case KwPrivate()   => accessModifier()
-    case KwProtected() => accessModifier()
-    case _             => syntaxError(s"modifier expected but ${token.name} found", at = token)
+    case Unquote(_)                  => unquote[Mod]
+    case Ellipsis(_)                 => ellipsis(1, astInfo[Mod])
+    case KwAbstract()                => next(); Mod.Abstract()
+    case KwFinal()                   => next(); Mod.Final()
+    case KwSealed()                  => next(); Mod.Sealed()
+    case KwImplicit()                => next(); Mod.Implicit()
+    case KwLazy()                    => next(); Mod.Lazy()
+    case KwOverride()                => next(); Mod.Override()
+    case KwPrivate()                 => accessModifier()
+    case KwProtected()               => accessModifier()
+    case KwInline() if allowInline   => next(); Mod.Inline()
+    case _                           => syntaxError(s"modifier expected but ${token.name} found", at = token)
   })
 
   /** {{{
@@ -3505,7 +3509,7 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
 
   def localDef(implicitMod: Option[Mod.Implicit]): Stat = {
     val mods = (implicitMod ++: annots(skipNewLines = true)) ++ localModifiers()
-    if (mods forall { case _: Mod.Implicit | _: Mod.Lazy | _: Mod.Annot => true; case _ => false })
+    if (mods forall { case _: Mod.Implicit | _: Mod.Lazy | _: Mod.Inline | _: Mod.Annot => true; case _ => false })
       (defOrDclOrSecondaryCtor(mods) match {
         case stat if stat.isBlockStat => stat
         case other                    => syntaxError("is not a valid block statement", at = other)

--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/api/SurfaceSuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/api/SurfaceSuite.scala
@@ -42,6 +42,7 @@ class SurfaceSuite extends scala.meta.tests.ast.AstSuite {
       |scala.meta.dialects.Metalevel *
       |scala.meta.dialects.Metalevel.Quoted *
       |scala.meta.dialects.Metalevel.Zero *
+      |scala.meta.dialects.Paradise *
       |scala.meta.dialects.Sbt0136 *
       |scala.meta.dialects.Sbt0137 *
       |scala.meta.dialects.Scala210 *
@@ -187,6 +188,7 @@ class SurfaceSuite extends scala.meta.tests.ast.AstSuite {
       |scala.meta.Mod.Covariant
       |scala.meta.Mod.Final
       |scala.meta.Mod.Implicit
+      |scala.meta.Mod.Inline
       |scala.meta.Mod.Lazy
       |scala.meta.Mod.Override
       |scala.meta.Mod.Private
@@ -340,6 +342,7 @@ class SurfaceSuite extends scala.meta.tests.ast.AstSuite {
       |scala.meta.tokens.Token.KwIf
       |scala.meta.tokens.Token.KwImplicit
       |scala.meta.tokens.Token.KwImport
+      |scala.meta.tokens.Token.KwInline
       |scala.meta.tokens.Token.KwLazy
       |scala.meta.tokens.Token.KwMacro
       |scala.meta.tokens.Token.KwMatch

--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/ast/ReflectionSuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/ast/ReflectionSuite.scala
@@ -15,7 +15,7 @@ class ReflectionSuite extends AstSuite {
   test("root") {
     assert(symbolOf[scala.meta.Tree].isRoot)
     assert(symbolOf[scala.meta.Tree].asRoot.allBranches.length === 30)
-    assert(symbolOf[scala.meta.Tree].asRoot.allLeafs.length === 272)
+    assert(symbolOf[scala.meta.Tree].asRoot.allLeafs.length === 274)
   }
 
   test("If") {

--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/ast/TokensSuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/ast/TokensSuite.scala
@@ -35,4 +35,9 @@ class TokensSuite extends FunSuite {
     assert(emptySelf.structure === "Template(Nil, Nil, Term.Param(Nil, Name.Anonymous(), None, None), None)")
     assert(emptySelf.tokens.structure === "Tokens()")
   }
+
+  test("inline is not a token") {
+    val tree = dialects.Scala211("{ val inline = 42 }").parse[Term].get
+    assert(tree.syntax === "{ val inline = 42 }")
+  }
 }

--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
@@ -97,4 +97,10 @@ class DefnSuite extends ParseSuite {
                    (Term.Param(List(), Term.Name(x), Some(Type.Name("Int")), None) :: Nil) :: Nil,
                    Some(Type.Name("Int")), Term.Name("impl")) = templStat("def f(x: Int): Int = macro impl")
   }
+
+  test("inline is not allowed") {
+    intercept[parsers.ParseException] {
+      blockStat("inline def x = 42")
+    }
+  }
 }

--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/parsers/DottySuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/parsers/DottySuite.scala
@@ -1,7 +1,6 @@
 package scala.meta.tests
 package parsers
 
-import org.scalatest._
 import scala.meta._
 import scala.meta.dialects.Dotty
 
@@ -13,5 +12,28 @@ class DottySuite extends ParseSuite {
   }
   test("xml literals") {
     intercept[TokenizeException]{ term("<foo>{bar}</foo>") }
+  }
+
+  test("inline def x = 42") {
+    val tree1@Defn.Def(Seq(Mod.Inline()), Term.Name("x"), Nil, Nil, None, Lit(42)) = templStat("inline def x = 42")
+    val tree2@Defn.Def(Seq(Mod.Inline()), Term.Name("x"), Nil, Nil, None, Lit(42)) = blockStat("inline def x = 42")
+
+    assert(tree1.show[Syntax] === "inline def x = 42")
+    assert(tree2.show[Syntax] === "inline def x = 42")
+  }
+
+  test("inline tokens are allowed") {
+    val tree = dialects.Dotty("{ inline def x = 42 }").parse[Term].get
+    assert(tree.syntax === "{ inline def x = 42 }")
+  }
+
+  test("mod\"inline\"") {
+    assert(mod"inline".show[Structure] === "Mod.Inline()")
+  }
+
+  test("a val cannot be called inline") {
+    intercept[ParseException] {
+      dialects.Dotty("{ val inline = 42 }").parse[Term].get
+    }
   }
 }

--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
@@ -102,6 +102,10 @@ class PublicSuite extends FunSuite {
     // covered above
   }
 
+  test("scala.meta.dialects.Paradise.toString") {
+    // covered above
+  }
+
   test("scala.meta.inputs.Input.toString") {
     // covered below
   }

--- a/scalameta/tokenizers/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
+++ b/scalameta/tokenizers/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
@@ -131,6 +131,8 @@ class LegacyScanner(input: Input, dialect: Dialect) {
           if (emitIdentifierDeprecationWarnings)
             deprecationWarning(s"$name is now a reserved word; usage as an identifier is deprecated", at = token)
         }
+      } else if (dialect.allowInline && name == "inline") {
+        token = INLINE
       }
     }
   }

--- a/scalameta/tokenizers/src/main/scala/scala/meta/internal/tokenizers/LegacyToken.scala
+++ b/scalameta/tokenizers/src/main/scala/scala/meta/internal/tokenizers/LegacyToken.scala
@@ -49,6 +49,7 @@ object LegacyToken {
   final val SEALED = 45
   final val LAZY = 55
   final val MACRO = 57
+  final val INLINE = 58
 
   /** templates */
   final val PACKAGE = 60

--- a/scalameta/tokenizers/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
+++ b/scalameta/tokenizers/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
@@ -70,6 +70,7 @@ class ScalametaTokenizer(input: Input, dialect: Dialect) {
         case SEALED    => Token.KwSealed(input, dialect, curr.offset)
         case LAZY      => Token.KwLazy(input, dialect, curr.offset)
         case MACRO     => Token.KwMacro(input, dialect, curr.offset)
+        case INLINE    => Token.KwInline(input, dialect, curr.offset)
 
         case PACKAGE    => Token.KwPackage(input, dialect, curr.offset)
         case IMPORT     => Token.KwImport(input, dialect, curr.offset)

--- a/scalameta/tokens/src/main/scala/scala/meta/tokens/Token.scala
+++ b/scalameta/tokens/src/main/scala/scala/meta/tokens/Token.scala
@@ -43,6 +43,7 @@ object Token {
   @fixed("if") class KwIf extends Token
   @fixed("implicit") class KwImplicit extends Token
   @fixed("import") class KwImport extends Token
+  @fixed("inline") class KwInline extends Token
   @fixed("lazy") class KwLazy extends Token
   @fixed("match") class KwMatch extends Token
   @fixed("macro") class KwMacro extends Token

--- a/scalameta/trees/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/src/main/scala/scala/meta/Trees.scala
@@ -464,6 +464,7 @@ object Mod {
   // and that has proven to be very clunky (e.g. such XXX.Param type has to be a supertype for Term.Param)
   @ast class ValParam() extends Mod
   @ast class VarParam() extends Mod
+  @ast class Inline() extends Mod
 }
 
 @branch trait Enumerator extends Tree

--- a/scalameta/trees/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -448,6 +448,7 @@ object TreeSyntax {
         case _: Mod.Lazy                     => kw("lazy")
         case _: Mod.ValParam                 => kw("val")
         case _: Mod.VarParam                 => kw("var")
+        case _: Mod.Inline                   => kw("inline")
 
         // Enumerator
         case t: Enumerator.Val           => s(p(Pattern1, t.pat), " = ", p(Expr, t.rhs))


### PR DESCRIPTION
 - A new Dialect for Paradise, which allows inline, has been created.
 - Defined inline modifier only, valid only for Dotty and Paradise. Other dialects work as before.