### PR TITLE
Allow trait parameters in Dotty dialect

### DIFF
--- a/scalameta/dialects/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/src/main/scala/scala/meta/dialects/package.scala
@@ -51,6 +51,10 @@ import scala.compat.Platform.EOL
   // What level of quoting are we at?
   // The underlying data structure captures additional information necessary for parsing.
   def metalevel: Metalevel
+
+  // Are trait allowed to have parameters?
+  // They are in Dotty, but not in Scala 2.12 or older.
+  def allowTraitParameters: Boolean
 }
 
 package object dialects {
@@ -63,6 +67,7 @@ package object dialects {
     def allowToplevelTerms = false
     def toplevelSeparator = ""
     def metalevel = Metalevel.Zero
+    def allowTraitParameters = false
     private def writeReplace(): AnyRef = new Dialect.SerializationProxy(this)
   }
 
@@ -75,6 +80,7 @@ package object dialects {
     def allowToplevelTerms = true
     def toplevelSeparator = EOL
     def metalevel = Metalevel.Zero
+    def allowTraitParameters = false
     private def writeReplace(): AnyRef = new Dialect.SerializationProxy(this)
   }
 
@@ -87,6 +93,7 @@ package object dialects {
     def allowToplevelTerms = true
     def toplevelSeparator = ""
     def metalevel = Metalevel.Zero
+    def allowTraitParameters = false
     private def writeReplace(): AnyRef = new Dialect.SerializationProxy(this)
   }
 
@@ -99,6 +106,7 @@ package object dialects {
     def allowToplevelTerms = Scala210.allowToplevelTerms
     def toplevelSeparator = Scala210.toplevelSeparator
     def metalevel = Metalevel.Zero
+    def allowTraitParameters = false
     private def writeReplace(): AnyRef = new Dialect.SerializationProxy(this)
   }
 
@@ -111,6 +119,7 @@ package object dialects {
     def allowToplevelTerms = Scala211.allowToplevelTerms
     def toplevelSeparator = Scala211.toplevelSeparator
     def metalevel = Metalevel.Zero
+    def allowTraitParameters = false
     private def writeReplace(): AnyRef = new Dialect.SerializationProxy(this)
   }
 
@@ -123,6 +132,7 @@ package object dialects {
     def allowToplevelTerms = false
     def toplevelSeparator = ""
     def metalevel = Metalevel.Zero
+    def allowTraitParameters = true
     private def writeReplace(): AnyRef = new Dialect.SerializationProxy(this)
   }
 
@@ -138,6 +148,7 @@ package object dialects {
     def allowSpliceUnderscore = underlying.allowSpliceUnderscore
     def allowToplevelTerms = underlying.allowToplevelTerms
     def toplevelSeparator = underlying.toplevelSeparator
+    def allowTraitParameters = underlying.allowTraitParameters
   }
 
   @leaf private[meta] class QuasiquoteTerm(underlying: Dialect, multiline: Boolean) extends Quasiquote {

--- a/scalameta/dialects/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/src/main/scala/scala/meta/dialects/package.scala
@@ -80,7 +80,7 @@ package object dialects {
     def allowToplevelTerms = true
     def toplevelSeparator = EOL
     def metalevel = Metalevel.Zero
-    def allowTraitParameters = false
+    def allowTraitParameters = Scala210.allowTraitParameters
     private def writeReplace(): AnyRef = new Dialect.SerializationProxy(this)
   }
 
@@ -93,7 +93,7 @@ package object dialects {
     def allowToplevelTerms = true
     def toplevelSeparator = ""
     def metalevel = Metalevel.Zero
-    def allowTraitParameters = false
+    def allowTraitParameters = Scala210.allowTraitParameters
     private def writeReplace(): AnyRef = new Dialect.SerializationProxy(this)
   }
 
@@ -106,7 +106,7 @@ package object dialects {
     def allowToplevelTerms = Scala210.allowToplevelTerms
     def toplevelSeparator = Scala210.toplevelSeparator
     def metalevel = Metalevel.Zero
-    def allowTraitParameters = false
+    def allowTraitParameters = Scala210.allowTraitParameters
     private def writeReplace(): AnyRef = new Dialect.SerializationProxy(this)
   }
 
@@ -119,7 +119,7 @@ package object dialects {
     def allowToplevelTerms = Scala211.allowToplevelTerms
     def toplevelSeparator = Scala211.toplevelSeparator
     def metalevel = Metalevel.Zero
-    def allowTraitParameters = false
+    def allowTraitParameters = Scala211.allowTraitParameters
     private def writeReplace(): AnyRef = new Dialect.SerializationProxy(this)
   }
 

--- a/scalameta/parsers/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -3108,7 +3108,7 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
   // therefore, I'm going to use `Term.Name("this")` here for the time being
 
   def primaryCtor(owner: TemplateOwner): Ctor.Primary = autoPos {
-    if (owner.isClass) {
+    if (owner.isClass || (owner.isTrait && dialect.allowTraitParameters)) {
       val mods = constructorAnnots() ++ accessModifierOpt()
       val name = atPos(in.tokenPos, in.prevTokenPos)(Ctor.Name("this"))
       val paramss = paramClauses(ownerIsType = true, owner == OwnedByCaseClass)

--- a/scalameta/parsers/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -3359,8 +3359,10 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
       (self, Some(body))
     } else {
       if (token.is[LeftParen]) {
-        if (parenMeansSyntaxError) syntaxError("traits or objects may not have parameters", at = token)
-        else syntaxError("unexpected opening parenthesis", at = token)
+        if (parenMeansSyntaxError) {
+          val what = if (dialect.allowTraitParameters) "objects" else "traits or objects"
+          syntaxError(s"$what may not have parameters", at = token)
+        } else syntaxError("unexpected opening parenthesis", at = token)
       }
       (autoPos(Term.Param(Nil, autoPos(Name.Anonymous()), None, None)), None)
     }

--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/parsers/DottySuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/parsers/DottySuite.scala
@@ -36,4 +36,9 @@ class DottySuite extends ParseSuite {
       dialects.Dotty("{ val inline = 42 }").parse[Term].get
     }
   }
+
+  test("trait parameters are allowed") {
+    val tree = dialects.Dotty("trait Foo(bar: Int)").parse[Stat].get
+    assert(tree.syntax === "trait Foo(bar: Int)")
+  }
 }

--- a/scalameta/trees/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/src/main/scala/scala/meta/Trees.scala
@@ -373,7 +373,14 @@ object Defn {
                    templ: Template) extends Defn with Member.Type {
     // TODO: hardcoded in the @ast macro, find out a better way
     // require(templ.stats.getOrElse(Nil).forall(!_.is[Ctor]))
-    require(ctor.mods.isEmpty && ctor.paramss.isEmpty)
+
+    // TODO this doesn't work because the Dialect in implicit
+    // scope is the dialect of the host Scala environment
+    // (i.e. Scala211), not the parser's dialect.
+    //require (
+    //  implicitly[Dialect].allowTraitParameters ||
+    //    (ctor.mods.isEmpty && ctor.paramss.isEmpty)
+    //)
   }
   @ast class Object(mods: Seq[Mod],
                     name: Term.Name,


### PR DESCRIPTION
Fixes #493

* Add a flag to `Dialect`
* Update logic in `ScalametaParser` to look at the flag
* Comment out an invariant check in AST class because it's no longer an invariant
* Add a test

Commenting out the invariant check is a shame, but it was unavoidable because it's not currently possible to access the parser's dialect in order to check the appropriate flag.