### PR TITLE
Fix #46: Enable comments inside quasiquotes

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -78,7 +78,8 @@ object build extends Build {
     base = file("scalameta/inputs")
   ) settings (
     publishableSettings,
-    description := "Scala.meta's APIs for source code in textual format"
+    description := "Scala.meta's APIs for source code in textual format",
+    enableMacros
   ) dependsOn (common)
 
   lazy val parsers = Project(

--- a/scalameta/dialects/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/src/main/scala/scala/meta/dialects/package.scala
@@ -140,14 +140,14 @@ package object dialects {
     def toplevelSeparator = underlying.toplevelSeparator
   }
 
-  @leaf private[meta] class QuasiquoteTerm(underlying: Dialect, multiline: Boolean) extends Quasiquote {
+  @leaf class QuasiquoteTerm(underlying: Dialect, multiline: Boolean) extends Quasiquote {
     require(!underlying.isInstanceOf[Quasiquote])
     def qualifier = s"QuasiquoteTerm"
     private def writeReplace(): AnyRef = new Dialect.SerializationProxy(this)
     override def toString = name
   }
 
-  @leaf private[meta] class QuasiquotePat(underlying: Dialect, multiline: Boolean) extends Quasiquote {
+  @leaf class QuasiquotePat(underlying: Dialect, multiline: Boolean) extends Quasiquote {
     require(!underlying.isInstanceOf[Quasiquote])
     def qualifier = s"QuasiquotePat"
     private def writeReplace(): AnyRef = new Dialect.SerializationProxy(this)

--- a/scalameta/inputs/src/main/scala/scala/meta/inputs/Input.scala
+++ b/scalameta/inputs/src/main/scala/scala/meta/inputs/Input.scala
@@ -82,3 +82,11 @@ object Input {
   implicit def streamToInput[T <: java.io.InputStream]: Convert[T, Input] = Convert(is => Input.Stream(is, Charset.forName("UTF-8")))
   implicit val fileToInput: Convert[java.io.File, Input] = Convert(f => Input.File(f, Charset.forName("UTF-8")))
 }
+
+private[meta] trait InputLiftables {
+  val c: scala.reflect.macros.blackbox.Context
+  import c.universe._
+  implicit lazy val liftInput: Liftable[Input] = Liftable[Input] { input =>
+    q"_root_.scala.meta.inputs.Input.String(${new String(input.chars)})"
+  }
+}

--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -9,6 +9,7 @@ import scala.meta.dialects.Scala211
 
 class SuccessSuite extends FunSuite {
   test("rank-0 liftables") {
+    assert(q"foo[${42}]" === "Term.ApplyType(Term.Name(\"foo\"), Seq(Lit(42)))")
     assert(q"foo[${42}]".show[Structure] === "Term.ApplyType(Term.Name(\"foo\"), Seq(Lit(42)))")
     assert(q"${42}".show[Structure] === "Lit(42)")
   }
@@ -1372,6 +1373,8 @@ class SuccessSuite extends FunSuite {
 
   test("pt\"$lit\"") {
     val lit = q"1"
+    println(lit.structure)
+    println(pt"$lit".structure)
     assert(pt"$lit".show[Structure] === "Lit(1)")
   }
 
@@ -2261,5 +2264,29 @@ class SuccessSuite extends FunSuite {
   test("#455 - unquote Option") {
     val defnopt: Option[Stat] = Option(q"val x = 42")
     assert(q"..$defnopt".show[Structure] === "Term.Block(Seq(Defn.Val(Nil, Seq(Pat.Var.Term(Term.Name(\"x\"))), None, Lit(42))))")
+  }
+
+  test("add single-line comments to quasiquotes") {
+    assert(q"1 // comment".tokens.toString == "1 // comment")
+    assert(q"val a = 1 // comment".tokens.toString == "val a = 1 // comment")
+    assert(q"class A // comment".tokens.toString == "class A // comment")
+    assert(q"def foo: Int = ??? // comment".tokens.toString == "def foo: Int = ??? // comment")
+    assert(q"${42} // comment".tokens.toString == """${42} // comment""")
+    val stats = List(q"val a = 1", q"val b = 1")
+    assert(q"..$stats // comment".tokens.toString == "..$stats // comment")
+    val stats2 = List(List(param"a: Int"), List(param"implicit val c: Int"))
+    assert(q"def foo(...$stats2): Int = ??? // comment".tokens.toString == "def foo(...$stats2): Int = ??? // comment")
+  }
+
+  test("add multi-line comments to quasiquotes") {
+    assert(q"1 /* comment */".tokens.toString == "1 /* comment */")
+    assert(q"val a = 1 /* comment */".tokens.toString == "val a = 1 /* comment */")
+    assert(q"class A /* comment */".tokens.toString == "class A /* comment */")
+    assert(q"def foo: Int = ??? /* comment */".tokens.toString == "def foo: Int = ??? /* comment */")
+    assert(q"${42} /* comment */".tokens.toString == """${42} /* comment */""")
+    val stats = List(q"val a = 1", q"val b = 1")
+    assert(q"..$stats /* comment */".tokens.toString == "..$stats /* comment */")
+    val stats2 = List(List(param"a: Int"), List(param"implicit val c: Int"))
+    assert(q"def foo(...$stats2): Int = ??? /* comment */".tokens.toString == "def foo(...$stats2): Int = ??? /* comment */")
   }
 }

--- a/scalameta/tokens/src/main/scala/scala/meta/tokens/Token.scala
+++ b/scalameta/tokens/src/main/scala/scala/meta/tokens/Token.scala
@@ -154,15 +154,14 @@ object Token {
 // depending on how the file and its enclosing directories are called.
 // To combat that, we have TokenLiftables right here, guaranteeing that there won't be problems
 // if someone wants to refactor/rename something later.
-private[meta] trait TokenLiftables extends AdtLiftables {
-  val c: scala.reflect.macros.blackbox.Context
+private[meta] trait TokenLiftables extends AdtLiftables with InputLiftables {
   override lazy val u: c.universe.type = c.universe
 
   import c.universe._
   private val XtensionQuasiquoteTerm = "shadow scala.meta quasiquotes"
 
-  implicit lazy val liftInput: Liftable[Input] = Liftable[Input] { input =>
-    q"_root_.scala.meta.inputs.Input.String(${new String(input.chars)})"
+  implicit lazy val liftTokenStreamPosition = Liftable[TokenStreamPosition] { v =>
+    q"_root_.scala.meta.internal.tokens.TokenStreamPosition(${v.start}, ${v.end})"
   }
 
   implicit lazy val liftBigInt: Liftable[BigInt] = Liftable[BigInt] { v =>

--- a/scalameta/trees/src/main/scala/scala/meta/internal/ast/InternalTrees.scala
+++ b/scalameta/trees/src/main/scala/scala/meta/internal/ast/InternalTrees.scala
@@ -226,7 +226,7 @@ trait InternalTree {
 }
 
 trait InternalTreeXtensions {
-  private[meta] implicit class XtensionOriginTree[T <: Tree](tree: T) {
+  implicit class XtensionOriginTree[T <: Tree](tree: T) {
     def origin: Origin = if (tree.privateOrigin != null) tree.privateOrigin else Origin.None
     def withOrigin(origin: Origin): T = tree.privateWithOrigin(origin).asInstanceOf[T]
   }

--- a/scalameta/trees/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -544,12 +544,15 @@ object TreeSyntax {
     // If we prettyprint a tree that's just been parsed with the same dialect,
     // then we retain formatting. Otherwise, we don't, even in the tiniest.
     // I expect to improve on this in the nearest future, because we had it much better until recently.
+    import scala.meta.dialects.QuasiquoteTerm
     Syntax { (x: T) =>
       x.origin match {
         // NOTE: Options don't really matter,
         // because if we've parsed a tree, it's not gonna contain lazy seqs anyway.
         // case Origin.Parsed(_, originalDialect, _) if dialect == originalDialect && options == Options.Eager =>
         case Origin.Parsed(_, originalDialect, _) if dialect == originalDialect =>
+          s(new String(x.pos.input.chars, x.pos.start.offset, x.pos.end.offset - x.pos.start.offset))
+        case Origin.Parsed(_, QuasiquoteTerm(originalDialect, _), _) if dialect == originalDialect =>
           s(new String(x.pos.input.chars, x.pos.start.offset, x.pos.end.offset - x.pos.start.offset))
         case _ =>
           syntaxInstances.syntaxTree[T].apply(x)


### PR DESCRIPTION
Quasiquotes preserve now their parsed origin and `tokens` and `syntax` allow you
to access any comments from the original source.

The fix consists in tokenizing, getting the token positions, creating
the origin `Origin.Parsed` and setting it to term quasiquotes. Pattern
quasiquotes cannot benefit from this, because comments are only
preserved in the token level, not the tree level. Therefore, one cannot
pattern match on a quasiquote with a comment (because of `unapply`).

There are some tests failing because `show[Structure]`, implemented
in `TreeStructure.scala`, does not handle `Unquote`. Therefore, it
outputs an empty string when the spliced quasiquote variable should be.
Fixing this requires changing the accessibility of Unquote and
"magically" detecting the value of that spliced variable. The actual
meta tree has all this information, but I find it difficult to map it to
the tokens. Not a trivial task. Maybe we should rethink what `show[Structure]`
means and what's its actual relation with tokens (not very clear to me, atm).
