### PR TITLE
make it obvious what a pattern is

### DIFF
--- a/scalameta/common/src/main/scala/scala/meta/internal/ast/Liftables.scala
+++ b/scalameta/common/src/main/scala/scala/meta/internal/ast/Liftables.scala
@@ -82,7 +82,7 @@ class LiftableMacros(override val c: Context) extends AdtLiftableMacros(c) with 
           pat match {
             case q: _root_.scala.meta.internal.ast.Quasi if unquotesName(q) =>
               val action = if (q.rank == 0) "unquote" else "splice"
-              c.abort(q.pos, "can't " + action + " a name here, use a pattern instead")
+              c.abort(q.pos, "can't " + action + " a name here, use a scala.meta.Pat instead, for example Pat.Var.Term(name: Term.Name)")
             case _ =>
           }
         }

--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/quasiquotes/ErrorSuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/quasiquotes/ErrorSuite.scala
@@ -207,7 +207,7 @@ class ErrorSuite extends FunSuite {
       val name = q"x"
       q"val $name = foo"
     """) === """
-      |<macro>:5: can't unquote a name here, use a pattern instead
+      |<macro>:5: can't unquote a name here, use a scala.meta.Pat instead, for example Pat.Var.Term(name: Term.Name)
       |      q"val $name = foo"
       |            ^
     """.trim.stripMargin)
@@ -220,7 +220,7 @@ class ErrorSuite extends FunSuite {
       val name = q"x"
       q"var $name = foo"
     """) === """
-      |<macro>:5: can't unquote a name here, use a pattern instead
+      |<macro>:5: can't unquote a name here, use a scala.meta.Pat instead, for example Pat.Var.Term(name: Term.Name)
       |      q"var $name = foo"
       |            ^
     """.trim.stripMargin)
@@ -233,7 +233,7 @@ class ErrorSuite extends FunSuite {
       val name = q"x"
       p"$name: T"
     """) === """
-      |<macro>:5: can't unquote a name here, use a pattern instead
+      |<macro>:5: can't unquote a name here, use a scala.meta.Pat instead, for example Pat.Var.Term(name: Term.Name)
       |      p"$name: T"
       |        ^
     """.trim.stripMargin)
@@ -376,7 +376,7 @@ class ErrorSuite extends FunSuite {
       val ptpe = pt"y"
       p"$pat: $ptpe"
     """) === """
-      |<macro>:6: can't unquote a name here, use a pattern instead
+      |<macro>:6: can't unquote a name here, use a scala.meta.Pat instead, for example Pat.Var.Term(name: Term.Name)
       |      p"$pat: $ptpe"
       |        ^
     """.trim.stripMargin)


### PR DESCRIPTION
I was doing some like:

```scala
private def instrument(source: Source, output: Term.Name): Source = {
    val main = 
      q"""
      object Main {
        val $output = scala.collection.mutable.Map.empty[(Int, Int), (String, String)]
      }
      """
}
```

and I ran into the following error:

```
[error] /home/gui/center/scastie/instumentation/src/main/scala/instumentation/Instument.scala:49: can't unquote a name here, use a pattern instead
[error]       val $output = scala.collection.mutable.Map.empty[(Int, Int), (String, String)]
[error]           ^
```

I want to make obvious that a pattern is a `scala.meta.Pat` in my case `scala.meta.Pat.Var(output)`

solved like this:

```scala
private def instrument(source: Source, output: Term.Name): Source = {
   val pat = Pat.Val.Term(output)
    val main = 
      q"""
      object Main {
        val $pat = scala.collection.mutable.Map.empty[(Int, Int), (String, String)]
      }
      """
}
```