### PR TITLE
Reject invalid var/val definitions (fixes #529)

### DIFF
--- a/scalameta/parsers/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -3002,9 +3002,11 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
     if (tp.isEmpty || token.is[Equals]) {
       accept[Equals]
       val rhs =
-        if (token.is[Underscore] && tp.nonEmpty && isMutable && lhs.forall(_.is[Pat.Var.Term])) {
-          next()
-          None
+        if (token.is[Underscore]) {
+          if (tp.nonEmpty && isMutable && lhs.forall(_.is[Pat.Var.Term])) {
+            next()
+            None
+          } else syntaxError("unbound placeholder parameter", at = token)
         } else Some(expr())
 
       if (isMutable) Defn.Var(mods, lhs, tp, rhs)

--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
@@ -33,6 +33,18 @@ class DefnSuite extends ParseSuite {
                  Some(Type.Name("Int")), None) = templStat("var x: Int = _")
   }
 
+  test("var x = _ is not allowed") {
+    intercept[parsers.ParseException] {
+      templStat("var x = _")
+    }
+  }
+
+  test("val x: Int = _ is not allowed") {
+    intercept[parsers.ParseException] {
+      templStat("val x: Int = _")
+    }
+  }
+
   test("val (x: Int) = 2") {
     val Defn.Val(Nil, Pat.Typed(Pat.Var.Term(Term.Name("x")), Type.Name("Int")) :: Nil,
                  None, Lit(2)) = templStat("val (x: Int) = 2")


### PR DESCRIPTION
Parser should not accept the following:

```
@ var x = _
cmd4.sc:160: unbound placeholder parameter
var x = _
        ^
Compilation Failed
```

```
@ val x: Int = _
cmd4.sc:160: unbound placeholder parameter
val x: Int = _
             ^
Compilation Failed
```