### PR TITLE
Add a dialect-aware `validate` method to Tree

### DIFF
--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/parsers/DottySuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/parsers/DottySuite.scala
@@ -40,6 +40,8 @@ class DottySuite extends ParseSuite {
   test("trait parameters are allowed") {
     val tree = dialects.Dotty("trait Foo(bar: Int)").parse[Stat].get
     assert(tree.syntax === "trait Foo(bar: Int)")
+    assert(tree.validate(dialects.Dotty).isEmpty)
+    assert(tree.validate(dialects.Scala211).nonEmpty)
   }
 
   test("view bounds not allowed") {

--- a/scalameta/trees/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/src/main/scala/scala/meta/Trees.scala
@@ -19,6 +19,9 @@ import scala.meta.internal.ast.Helpers._
   def pos: Position
   def tokens(implicit dialect: Dialect): Tokens
 
+  // TODO have a proper Success/Failure result type?
+  def validate(implicit dialect: Dialect): Seq[String] = Nil
+
   final override def canEqual(that: Any): Boolean = this eq that.asInstanceOf[AnyRef]
   final override def equals(that: Any): Boolean = this eq that.asInstanceOf[AnyRef]
   final override def hashCode: Int = System.identityHashCode(this)
@@ -375,13 +378,11 @@ object Defn {
     // TODO: hardcoded in the @ast macro, find out a better way
     // require(templ.stats.getOrElse(Nil).forall(!_.is[Ctor]))
 
-    // TODO this doesn't work because the Dialect in implicit
-    // scope is the dialect of the host Scala environment
-    // (i.e. Scala211), not the parser's dialect.
-    //require (
-    //  implicitly[Dialect].allowTraitParameters ||
-    //    (ctor.mods.isEmpty && ctor.paramss.isEmpty)
-    //)
+    override def validate(implicit dialect: Dialect): Seq[String] = {
+      if (!dialect.allowTraitParameters && (ctor.mods.nonEmpty || ctor.paramss.nonEmpty))
+        Seq("Trait parameters are not allowed in this dialect")
+      else Nil
+    }
   }
   @ast class Object(mods: Seq[Mod],
                     name: Term.Name,


### PR DESCRIPTION
Following on from the discussion on #498 about how to validate trees for a given dialect, I propose adding a `validate` method to `Tree`. This would replace all the `require` statements, so we no longer throw exceptions, and it also allows validation to take account of the dialect, which is currently not possible.

The downside is that it becomes possible to build invalid trees. The user becomes responsible for calling `validate` on any trees they build.

Things to discuss:

* What should the return type of `validate` be? For now I just made it a `Seq` of error messages, with an empty list representing validity.
* Where should `validate` be called? I guess the pretty-printers will want to validate trees before printing them, but I don't have any experience with that area of the codebase.

If this looks reasonable, I can rewrite all the other `require`s similarly.