### PR TITLE
Fix parsing wildcard functions

### DIFF
--- a/scalameta/parsers/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -3001,13 +3001,14 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
 
     if (tp.isEmpty || token.is[Equals]) {
       accept[Equals]
-      val rhs =
-        if (token.is[Underscore]) {
-          if (tp.nonEmpty && isMutable && lhs.forall(_.is[Pat.Var.Term])) {
-            next()
+      val rhsExpr = expr()
+      val rhs = 
+        if (rhsExpr.is[Term.Placeholder]) {
+          if (tp.nonEmpty && isMutable && lhs.forall(_.is[Pat.Var.Term]))
             None
-          } else syntaxError("unbound placeholder parameter", at = token)
-        } else Some(expr())
+          else 
+            syntaxError("unbound placeholder parameter", at = token)
+        } else Some(rhsExpr)
 
       if (isMutable) Defn.Var(mods, lhs, tp, rhs)
       else Defn.Val(mods, lhs, tp, rhs.get)

--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
@@ -37,6 +37,16 @@ class DefnSuite extends ParseSuite {
         templStat("val f: Int => String = _.toString")
   }
 
+  test("var f: Int => String = _.toString") {
+    val Defn.Var(
+      Nil, 
+      Pat.Var.Term(Term.Name("f")) :: Nil, 
+      Some(Type.Function(Type.Name("Int") :: Nil, Type.Name("String"))), 
+      Some(Term.Select(Term.Placeholder(), Term.Name("toString")))) = 
+        templStat("var f: Int => String = _.toString")
+  }
+
+
   test("var x: Int = _") {
     val Defn.Var(Nil, Pat.Var.Term(Term.Name("x")) :: Nil,
                  Some(Type.Name("Int")), None) = templStat("var x: Int = _")

--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
@@ -28,6 +28,15 @@ class DefnSuite extends ParseSuite {
                  Some(Type.Name("Int")), Lit(2)) = templStat("val `x`: Int = 2")
   }
 
+  test("val f: Int => String = _.toString") {
+    val Defn.Val(
+      Nil, 
+      Pat.Var.Term(Term.Name("f")) :: Nil, 
+      Some(Type.Function(Type.Name("Int") :: Nil, Type.Name("String"))), 
+      Term.Select(Term.Placeholder(), Term.Name("toString"))) = 
+        templStat("val f: Int => String = _.toString")
+  }
+
   test("var x: Int = _") {
     val Defn.Var(Nil, Pat.Var.Term(Term.Name("x")) :: Nil,
                  Some(Type.Name("Int")), None) = templStat("var x: Int = _")


### PR DESCRIPTION
This is a fix for #561, the regression in parsing `val f: Int => String = _.toString` which was introduced in #541.

It also fixes parsing of `var f: Int => String = _.toString`, which was broken even before #541.

The underlying problem was that the decision on whether a statement had an RHS was based on whether the first token after the `=` was an underscore. But this is not sufficient, because an RHS expression can start with an underscore.

My solution is to first parse the RHS as an expression, then check if the resulting tree is `Placeholder`. Happy to take expert advice on whether this is a reasonable strategy.

@xeno-by @olafurpg review please
@liufengyun Sorry for the regression

