### PR TITLE
Fix infinite recursion.

### DIFF
--- a/scalameta/trees/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -494,7 +494,11 @@ object TreeSyntax {
           val ppat = p(Pattern, t.pat)
           val pcond = t.cond.map(cond => s(" ", kw("if"), " ", p(PostfixExpr, cond))).getOrElse(s())
           val isOneLiner = {
-            def isOneLiner(t: Case) = t.stats.length == 0 || (t.stats.length == 1 && !s(t.stats.head).toString.contains(EOL))
+            def isOneLiner(t: Case) = t.stats match {
+              case Nil => true
+              case head :: Nil => head.is[Lit] || head.is[Term.Name]
+              case _ => false
+            }
             t.parent match {
               case Some(Term.Match(_, cases)) => cases.forall(isOneLiner)
               case Some(Term.PartialFunction(cases)) => cases.forall(isOneLiner)


### PR DESCRIPTION
While working on building a scala.meta testkit, I noticed that the
pretty-printer would get stuck in an infnite loop. I can't find an
example that triggered the infinite loop, but this commit fixes it.

All tests still pass.