### PR TITLE
support Unlift.unapply

### DIFF
--- a/scalameta/quasiquotes/src/main/scala/scala/meta/quasiquotes/Unlift.scala
+++ b/scalameta/quasiquotes/src/main/scala/scala/meta/quasiquotes/Unlift.scala
@@ -6,7 +6,9 @@ import scala.reflect.ClassTag
 import scala.meta.common._
 
 @implicitNotFound(msg = "don't know how to unlift ${I} into ${O}")
-trait Unlift[I, O] extends Convert[I, Option[O]]
+trait Unlift[I, O] extends Convert[I, Option[O]] {
+  def unapply(x: I): Option[O] = apply(x)
+}
 
 object Unlift {
   def apply[I, O](pf: PartialFunction[I, O]): Unlift[I, O] = new Unlift[I, O] { def apply(x: I): Option[O] = pf.lift(x) }


### PR DESCRIPTION
Unlift.unapply is required in order to implement Quasiquotes in Dotty. Review @xeno-by .