### PR TITLE
fix "foo { i: Int => () }".toString

### DIFF
--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -472,11 +472,13 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     assert(t"((a, b), c) => c".syntax == "((a, b), c) => c")
   }
 
-  test("Term.Apply(_, Seq(Term.Function(...))) #572") {
+  test("Term.Apply(_, Seq(Term.Function(...))) #572, #574") {
     import scala.collection.immutable.Seq
-    val tree1= Term.Apply(Term.Name("foo"), Seq(Term.Function(Seq(Term.Param(Seq(), Term.Name("i"), Some(Type.Name("Int")), None)), Lit(()))))
-    val tree2= Term.Apply(Term.Name("foo"), Seq(Term.Function(Seq(Term.Param(Seq(Mod.Implicit()), Term.Name("i"), Some(Type.Name("Int")), None)), Lit(()))))
-    assert(tree1.toString == "foo { (i: Int) => () }")
-    assert(tree2.toString == "foo { implicit i: Int => () }")
+    val tree1 = Term.Apply(Term.Name("foo"), Seq(Term.Function(Seq(Term.Param(Seq(), Term.Name("i"), Some(Type.Name("Int")), None)), Lit(()))))
+    val tree2 = Term.Apply(Term.Name("foo"), Seq(Term.Function(Seq(Term.Param(Seq(Mod.Implicit()), Term.Name("i"), Some(Type.Name("Int")), None)), Lit(()))))
+    val tree3 = Term.Apply(Term.Name("foo"), Seq(Term.Function(Seq(Term.Param(Seq(), Term.Name("i"), None, None)), Lit(()))))
+    assert(tree1.syntax == "foo { (i: Int) => () }")
+    assert(tree2.syntax == "foo { implicit i: Int => () }")
+    assert(tree3.syntax == "foo(i => ())")
   }
 }

--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -471,4 +471,12 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     assert(t"((a, b)) => c".syntax    == "((a, b)) => c")
     assert(t"((a, b), c) => c".syntax == "((a, b), c) => c")
   }
+
+  test("Term.Apply(_, Seq(Term.Function(...))) #572") {
+    import scala.collection.immutable.Seq
+    val tree1= Term.Apply(Term.Name("foo"), Seq(Term.Function(Seq(Term.Param(Seq(), Term.Name("i"), Some(Type.Name("Int")), None)), Lit(()))))
+    val tree2= Term.Apply(Term.Name("foo"), Seq(Term.Function(Seq(Term.Param(Seq(Mod.Implicit()), Term.Name("i"), Some(Type.Name("Int")), None)), Lit(()))))
+    assert(tree1.toString == "foo { (i: Int) => () }")
+    assert(tree2.toString == "foo { implicit i: Int => () }")
+  }
 }

--- a/scalameta/trees/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -518,8 +518,9 @@ object TreeSyntax {
 
       // Multiples and optionals
       implicit def syntaxArgs: Syntax[Seq[Term.Arg]] = Syntax {
-        case (b: Term.Block) :: Nil => s(" ", b)
-        case args                   => s("(", r(args, ", "), ")")
+        case (b: Term.Block) :: Nil    => s(" ", b)
+        case (f: Term.Function) :: Nil => s(" { ", f, " }")
+        case args                      => s("(", r(args, ", "), ")")
       }
       implicit def syntaxArgss: Syntax[Seq[Seq[Term.Arg]]] = Syntax {
         r(_)

--- a/scalameta/trees/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -518,9 +518,9 @@ object TreeSyntax {
 
       // Multiples and optionals
       implicit def syntaxArgs: Syntax[Seq[Term.Arg]] = Syntax {
-        case (b: Term.Block) :: Nil    => s(" ", b)
-        case (f: Term.Function) :: Nil => s(" { ", f, " }")
-        case args                      => s("(", r(args, ", "), ")")
+        case (b: Term.Block) :: Nil                                                     => s(" ", b)
+        case (f @ Term.Function(params, _)) :: Nil if !params.exists(_.decltpe.isEmpty) => s(" { ", f, " }")
+        case args                                                                       => s("(", r(args, ", "), ")")
       }
       implicit def syntaxArgss: Syntax[Seq[Seq[Term.Arg]]] = Syntax {
         r(_)


### PR DESCRIPTION
Term.Apply with function as its arg is printed using braces instead of parenthesis.
solves #572