### PR TITLE
change signature of meta

### DIFF
--- a/scalameta/inline/src/main/scala/meta/inline/Api.scala
+++ b/scalameta/inline/src/main/scala/meta/inline/Api.scala
@@ -8,7 +8,7 @@ private[meta] trait Api {
   // Enables `meta` blocks, the foundation for new-style ("inline") macros.
   // This is a magic method whose argument is typechecked using special rules.
   // See https://github.com/scalameta/paradise for more information.
-  def apply(body: Any): Any = ???
+  def apply(body: Any): Nothing = ???
 
   // NOTE: Maybe in the future we will add support for error/warning,
   // but for now let's limit ourselves to what's absolutely necessary.


### PR DESCRIPTION
I think it makes more sense to have `meta: Any => Nothing`, so that user can any meaningful type annotations of def macros.