### PR TITLE
make withOrigin available

### DIFF
--- a/scalameta/trees/src/main/scala/scala/meta/internal/ast/InternalTrees.scala
+++ b/scalameta/trees/src/main/scala/scala/meta/internal/ast/InternalTrees.scala
@@ -226,7 +226,7 @@ trait InternalTree {
 }
 
 trait InternalTreeXtensions {
-  private[meta] implicit class XtensionOriginTree[T <: Tree](tree: T) {
+  implicit class XtensionOriginTree[T <: Tree](tree: T) {
     def origin: Origin = if (tree.privateOrigin != null) tree.privateOrigin else Origin.None
     def withOrigin(origin: Origin): T = tree.privateWithOrigin(origin).asInstanceOf[T]
   }


### PR DESCRIPTION
In order to carry positions in the conversion, we need to make `withOrigin` available for usage. Review @xeno-by .