### PR TITLE
Fix TreeSyntax for macro definitions

### DIFF
--- a/scalameta/trees/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -415,7 +415,7 @@ object TreeSyntax {
         case t: Defn.Trait     => s(w(t.mods, " "), kw("trait"), " ", t.name, t.tparams, templ(t.templ))
         case t: Defn.Object    => s(w(t.mods, " "), kw("object"), " ", t.name, templ(t.templ))
         case t: Defn.Def       => s(w(t.mods, " "), kw("def"), " ", t.name, t.tparams, t.paramss, t.decltpe, " = ", t.body)
-        case t: Defn.Macro     => s(w(t.mods, " "), kw("def"), " ", t.name, t.tparams, t.paramss, kw(":"), " ", t.decltpe, " ", kw("="), " ", kw("macro"), " ", t.body)
+        case t: Defn.Macro     => s(w(t.mods, " "), kw("def"), " ", t.name, t.tparams, t.paramss, t.decltpe, " ", kw("="), " ", kw("macro"), " ", t.body)
         case t: Pkg            =>
           if (options.isLazy && t.stats.isLazy) s(kw("package"), " ", t.ref, " { ... }")
           else if (guessHasBraces(t)) s(kw("package"), " ", t.ref, " {", r(t.stats.map(i(_)), ""), n("}"))


### PR DESCRIPTION
I wasn't able to add def macros in an annotation macro because the generated tree for Defn.Macro contained a syntax error.

scala> import scala.meta._
import scala.meta._

scala> q"def foo = macro fooImpl"
res0: meta.Defn.Macro = def foo:  = macro fooImpl

scala> q"def foo: Int = macro fooImpl"
res1: meta.Defn.Macro = def foo: : Int = macro fooImpl

After making this change, I was able to add def macros in my annotation
macros and the syntax looks correct in the console.

scala> import scala.meta._
import scala.meta._

scala> q"def foo = macro fooImpl"
res0: meta.Defn.Macro = def foo = macro fooImpl

scala> q"def foo: Int = macro fooImpl"
res1: meta.Defn.Macro = def foo: Int = macro fooImpl

I have no idea if there are some tests that should be updated
or if a new test should be added.