### PR TITLE
Add logger utility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,7 @@ lazy val common = Project(
   base = file("scalameta/common")
 ) settings (
   publishableSettings,
+  libraryDependencies += "com.lihaoyi" %% "sourcecode" % "0.1.3",
   description := "Bag of private and public helpers used in scala.meta's APIs and implementations",
   enableMacros
 )

--- a/scalameta/common/src/main/scala/org/scalameta/logger.scala
+++ b/scalameta/common/src/main/scala/org/scalameta/logger.scala
@@ -1,0 +1,35 @@
+package org.scalameta
+
+class FileLine(val file: sourcecode.File, val line: sourcecode.Line) {
+  override def toString: String = {
+    val shortFilename = file.value.replaceAll("(.*/|\\.scala)", "")
+    Console.GREEN + s"$shortFilename:${line.value}" + Console.RESET
+  }
+}
+
+object FileLine {
+  implicit def generate(implicit file: sourcecode.File, line: sourcecode.Line): FileLine =
+    new FileLine(file, line)
+}
+
+object logger {
+  /** Same as println except includes the file+line number of call-site. */
+  def debug(x: Any)(implicit fileLine: FileLine): Unit = {
+    println(s"$fileLine $x")
+  }
+
+  /** Prints out the value with and it's source code representation
+    *
+    * Example: logger.elem(x) // prints "MyFile:24 [x]: 42"
+    **/
+  def elem(values: sourcecode.Text[Any]*)(implicit fileLine: FileLine): Unit = {
+    values.foreach { t =>
+      val value = {
+        val str = s"${t.value}"
+        if (str.contains("\n")) s"\n$str"
+        else str
+      }
+      println(s"$fileLine [${t.source}]: $value")
+    }
+  }
+}


### PR DESCRIPTION
When hacking on scala.meta I've desperately missed being able to println a variable during development and see the file name + line numer + variable name + variable value

```scala
val x = 1
logger.elem(x)
// Foo.scala:10 [x]: 1
```

The macros are copied from lihaoyi/sourcecode to avoid adding a new dependency. The library is really small however so I personally don't really mind adding it as a dependency.