### PR TITLE
add David Dudson as a maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The current maintainers (people who can merge pull requests) are:
 * Eugene Burmako - [`@xeno-by`](https://github.com/xeno-by)
 * Denys Shabalin - [`@densh`](https://github.com/densh)
 * Ólafur Páll Geirsson - [`@olafurpg`](https://github.com/olafurpg)
+* David Dudson - [`@DavidDudson`](https://github.com/DavidDudson)
 
 An up-to-date list of contributors is available here: https://github.com/scalameta/scalameta/graphs/contributors.
 


### PR DESCRIPTION
@DavidDudson has been very a active community member for quite a while.
He has contributed to a lot of valuable discussions on Gitter,
project issue trackers and pull requests. We are honored to work with David!

Thanks a bunch, @DavidDudson. Please give a 👍 if you'd like
to be added as a maintainer.