### PR TITLE
WIP Prototype implementation of Statements typeclass

### DIFF
--- a/scalameta/contrib/src/main/scala/scala/meta/contrib/implicits/Statements.scala
+++ b/scalameta/contrib/src/main/scala/scala/meta/contrib/implicits/Statements.scala
@@ -1,0 +1,105 @@
+package scala.meta.contrib.implicits
+
+import scala.collection.immutable.Seq
+import scala.language.higherKinds
+import scala.language.implicitConversions
+import scala.meta._
+import scala.meta.contrib.Equal
+
+/**
+  * Typeclass to deal with scalameta trees which have an expected set of statements.
+  *
+  * For trees that have multiple stat lists (such as Defn.Class) the main stats are used.
+  *
+  * This allows you to do things like add a statement to the
+  * body of a class without digging through the low level meta api
+  *
+  * TODO: Consider using a meta variant of simulacrum to
+  * generate the boilerplate once one is avaliable
+  */
+trait Statements[A] {
+  def getStats(a: A): Seq[Stat]
+  def replaceStats(a: A, newStats: Seq[Stat]): A
+}
+
+object Statements {
+
+  trait Ops[A] {
+    val self: A
+    val typeClassInstance: Statements[A]
+
+    def getStats: Seq[Stat] =
+      typeClassInstance.getStats(self)
+
+    def replaceStats(newStats: Seq[Stat]): A =
+      typeClassInstance.replaceStats(self, newStats)
+
+// DAVETODO: Get F param working (Aka Structurally/Syntactically)
+//    Is this going to be useful?
+//    def replaceStatWith[F[_ <: Tree]](stat: Stat, replacement: Stat)(
+//        implicit conv: Tree => F[Tree], eq: Equal[F[Tree]]): A = {
+//
+//      val newStats: Seq[Stat] = getStats.collect {
+//        case candidate if eq.equal(candidate, stat) => replacement
+//        case other => other
+//      }
+//
+//      replaceStats(newStats)
+//    }
+//    def removeStat[F[_]](stat: Stat)(implicit eq: Equal[F[A]]): A =
+//      removeStats[F](stat :: Nil)
+//
+//    def removeStats[F[_]](stats: Seq[Stat])(
+//      implicit conv: Tree => F[Tree], eq: Equal[F[Tree]]): A = {
+//
+//      val filtered: Seq[Stat] = getStats.filter(stat => stats.exists(eq.equals(_, stat)))
+//      replaceStats(filtered)
+//    }
+
+
+    def appendStat(stat: Stat): A =
+      replaceStats(getStats :+ stat)
+
+    def appendStats(stats: Seq[Stat]): A =
+      replaceStats(getStats ++ stats)
+
+    def prependStat(stat: Stat): A =
+      replaceStats(stat +: getStats)
+
+    def prependStats(stats: Seq[Stat]): A =
+      replaceStats(stats ++ getStats)
+
+    def deleteAllStats(): A =
+      replaceStats(Nil)
+
+    def typeDefs(): Seq[Defn.Type] =
+      getStats.collect { case t: Defn.Type => t}
+
+    def defDefs(): Seq[Defn.Def] =
+      getStats.collect { case d: Defn.Def => d}
+
+    def valDefs(): Seq[Defn.Val] =
+      getStats.collect { case v: Defn.Val => v}
+
+    def varDefs(): Seq[Defn.Var] =
+      getStats.collect { case v: Defn.Var => v}
+
+    def traitDefs(): Seq[Defn.Trait] =
+      getStats.collect { case t: Defn.Trait => t}
+
+    def objectDefs(): Seq[Defn.Object] =
+      getStats.collect { case o: Defn.Object => o}
+
+    def classDefs(): Seq[Defn.Class] =
+      getStats.collect { case c: Defn.Class => c}
+  }
+
+  trait ToStatementOps {
+    implicit def toStatementsOps[A](target: A)(implicit tc: Statements[A]): Ops[A] = new Ops[A] {
+      override val self: A = target
+      override val typeClassInstance: Statements[A] = tc
+    }
+  }
+
+  def apply[A](implicit instance: Statements[A]): Statements[A] = instance
+}

--- a/scalameta/contrib/src/main/scala/scala/meta/contrib/implicits/Statements.scala
+++ b/scalameta/contrib/src/main/scala/scala/meta/contrib/implicits/Statements.scala
@@ -19,87 +19,42 @@ import scala.meta.contrib.Equal
   */
 trait Statements[A] {
   def getStats(a: A): Seq[Stat]
-  def replaceStats(a: A, newStats: Seq[Stat]): A
+  def withStats(a: A, newStats: Seq[Stat]): A
 }
 
-object Statements {
+trait StatementsTypeClass {
 
-  trait Ops[A] {
-    val self: A
-    val typeClassInstance: Statements[A]
+  implicit def statementsTypeClass[A](implicit ev: Statements[A]): Statements[A] = ev
 
+  implicit class XtensionStatements[A](a: A)(implicit ev: Statements[A]) {
     def getStats: Seq[Stat] =
-      typeClassInstance.getStats(self)
+      ev.getStats(a)
 
-    def replaceStats(newStats: Seq[Stat]): A =
-      typeClassInstance.replaceStats(self, newStats)
+    def withStats(newStats: Seq[Stat]): A =
+      ev.withStats(a, newStats)
 
-// DAVETODO: Get F param working (Aka Structurally/Syntactically)
-//    Is this going to be useful?
-//    def replaceStatWith[F[_ <: Tree]](stat: Stat, replacement: Stat)(
-//        implicit conv: Tree => F[Tree], eq: Equal[F[Tree]]): A = {
-//
-//      val newStats: Seq[Stat] = getStats.collect {
-//        case candidate if eq.equal(candidate, stat) => replacement
-//        case other => other
-//      }
-//
-//      replaceStats(newStats)
-//    }
-//    def removeStat[F[_]](stat: Stat)(implicit eq: Equal[F[A]]): A =
-//      removeStats[F](stat :: Nil)
-//
-//    def removeStats[F[_]](stats: Seq[Stat])(
-//      implicit conv: Tree => F[Tree], eq: Equal[F[Tree]]): A = {
-//
-//      val filtered: Seq[Stat] = getStats.filter(stat => stats.exists(eq.equals(_, stat)))
-//      replaceStats(filtered)
-//    }
+    def updateStats(f: Seq[Stat] => Seq[Stat]): A =
+      withStats(f(getStats))
 
-
-    def appendStat(stat: Stat): A =
-      replaceStats(getStats :+ stat)
-
-    def appendStats(stats: Seq[Stat]): A =
-      replaceStats(getStats ++ stats)
-
-    def prependStat(stat: Stat): A =
-      replaceStats(stat +: getStats)
-
-    def prependStats(stats: Seq[Stat]): A =
-      replaceStats(stats ++ getStats)
-
-    def deleteAllStats(): A =
-      replaceStats(Nil)
-
-    def typeDefs(): Seq[Defn.Type] =
+    def types(): Seq[Defn.Type] =
       getStats.collect { case t: Defn.Type => t}
 
-    def defDefs(): Seq[Defn.Def] =
+    def defs(): Seq[Defn.Def] =
       getStats.collect { case d: Defn.Def => d}
 
-    def valDefs(): Seq[Defn.Val] =
+    def vals(): Seq[Defn.Val] =
       getStats.collect { case v: Defn.Val => v}
 
-    def varDefs(): Seq[Defn.Var] =
+    def vars(): Seq[Defn.Var] =
       getStats.collect { case v: Defn.Var => v}
 
-    def traitDefs(): Seq[Defn.Trait] =
+    def traits(): Seq[Defn.Trait] =
       getStats.collect { case t: Defn.Trait => t}
 
-    def objectDefs(): Seq[Defn.Object] =
+    def objects(): Seq[Defn.Object] =
       getStats.collect { case o: Defn.Object => o}
 
-    def classDefs(): Seq[Defn.Class] =
+    def classes(): Seq[Defn.Class] =
       getStats.collect { case c: Defn.Class => c}
   }
-
-  trait ToStatementOps {
-    implicit def toStatementsOps[A](target: A)(implicit tc: Statements[A]): Ops[A] = new Ops[A] {
-      override val self: A = target
-      override val typeClassInstance: Statements[A] = tc
-    }
-  }
-
-  def apply[A](implicit instance: Statements[A]): Statements[A] = instance
 }

--- a/scalameta/contrib/src/main/scala/scala/meta/contrib/implicits/implicits.scala
+++ b/scalameta/contrib/src/main/scala/scala/meta/contrib/implicits/implicits.scala
@@ -1,0 +1,3 @@
+package scala.meta.contrib.implicits
+
+trait implicits extends Statements.ToStatementOps

--- a/scalameta/contrib/src/main/scala/scala/meta/contrib/implicits/implicits.scala
+++ b/scalameta/contrib/src/main/scala/scala/meta/contrib/implicits/implicits.scala
@@ -1,3 +1,3 @@
 package scala.meta.contrib.implicits
 
-trait implicits extends Statements.ToStatementOps
+trait implicits extends StatementsTypeClass

--- a/scalameta/contrib/src/main/scala/scala/meta/contrib/instances/StatementsInstances.scala
+++ b/scalameta/contrib/src/main/scala/scala/meta/contrib/instances/StatementsInstances.scala
@@ -1,0 +1,117 @@
+package scala.meta.contrib.instances
+
+import scala.collection.immutable.Seq
+import scala.meta._
+import scala.meta.contrib._
+import scala.meta.contrib.implicits.Statements
+
+trait StatementsInstances {
+  implicit val termBlockStats: Statements[Term.Block] = new Statements[Term.Block] {
+    override def getStats(block: Term.Block): Seq[Stat] = block.stats
+
+    override def replaceStats(block: Term.Block, newStats: Seq[Stat]): Term.Block =
+      block.copy(stats = newStats)
+  }
+
+  implicit val packageStats: Statements[Pkg] = new Statements[Pkg] {
+    override def getStats(pkg: Pkg): Seq[Stat] = pkg.stats
+
+    // TODO: Packages have restrictions that all others dont.
+    // aka top level stats only
+    override def replaceStats(pkg: Pkg, newStats: Seq[Stat]): Pkg =
+      pkg.copy(stats = newStats)
+  }
+
+  implicit val templStats: Statements[Template] = new Statements[Template] {
+    override def getStats(templ: Template): Seq[Stat] =
+      templ.stats match {
+        case Some(stats) => stats
+        case None => Nil
+      }
+
+    override def replaceStats(templ: Template, newStats: Seq[Stat]): Template = {
+      newStats match {
+        case Nil => templ.copy(stats = None)
+        case s => templ.copy(stats = Some(s))
+      }
+    }
+  }
+
+  implicit val classStats: Statements[Defn.Class] = new Statements[Defn.Class] {
+    override def getStats(clazz: Defn.Class): Seq[Stat] =
+      clazz.templ.getStats
+
+    override def replaceStats(clazz: Defn.Class, newStats: Seq[Stat]): Defn.Class = {
+      clazz.copy(templ = clazz.templ.replaceStats(newStats))
+    }
+  }
+
+  implicit val objectStats: Statements[Defn.Object] = new Statements[Defn.Object] {
+    override def getStats(obj: Defn.Object): Seq[Stat] =
+      obj.templ.getStats
+
+    override def replaceStats(obj: Defn.Object, newStats: Seq[Stat]): Defn.Object =
+      obj.copy(templ = obj.templ.replaceStats(newStats))
+  }
+
+  implicit val traitStats: Statements[Defn.Trait] = new Statements[Defn.Trait] {
+    override def getStats(trat: Defn.Trait): Seq[Stat] =
+      trat.templ.getStats
+
+    override def replaceStats(trat: Defn.Trait, newStats: Seq[Stat]): Defn.Trait =
+      trat.copy(templ = trat.templ.replaceStats(newStats))
+  }
+
+  // All terms are stats, but not all stats are terms
+  // The RHS must be a term, or Seq[Stat] wrapped in a Term.Block
+  implicit val varStats: Statements[Defn.Var] = new Statements[Defn.Var] {
+    override def getStats(varr: Defn.Var): Seq[Stat] = {
+      varr.rhs match {
+        case None => Nil
+        case Some(term) => extractStatsFromTerm(term)
+
+      }
+    }
+
+    override def replaceStats(varr: Defn.Var, newStats: Seq[Stat]): Defn.Var = {
+      val maybeTerm = newStats match {
+        case Nil => None
+        case s => Some(createTermFromStats(s))
+      }
+      varr.copy(rhs = maybeTerm)
+    }
+  }
+
+  implicit val valStats: Statements[Defn.Val] = new Statements[Defn.Val] {
+    override def getStats(vall: Defn.Val): Seq[Stat] =
+      extractStatsFromTerm(vall.rhs)
+
+    override def replaceStats(vall: Defn.Val, newStats: Seq[Stat]): Defn.Val =
+      vall.copy(rhs = createTermFromStats(newStats))
+  }
+
+  implicit val defStats: Statements[Defn.Def] = new Statements[Defn.Def] {
+    override def getStats(deff: Defn.Def): Seq[Stat] =
+      extractStatsFromTerm(deff.body)
+
+    override def replaceStats(deff: Defn.Def, newStats: Seq[Stat]): Defn.Def =
+      deff.copy(body = createTermFromStats(newStats))
+  }
+
+  // TODO: Should this be another typeclass instance?
+  // Does it make sense to call getStats on an arbitrary Term???
+  private def extractStatsFromTerm(term: Term): Seq[Stat] =
+    term match {
+      case Term.Block(stats) => stats
+      case s => s :: Nil
+    }
+
+  // TODO: The isInstanceof seems ugly. consider better options
+  private def createTermFromStats(stats: Seq[Stat]): Term =
+    stats match {
+      case head :: Nil if head.isInstanceOf[Term] => head.asInstanceOf[Term]
+      case s => Term.Block(s)
+    }
+}
+
+

--- a/scalameta/contrib/src/main/scala/scala/meta/contrib/instances/instances.scala
+++ b/scalameta/contrib/src/main/scala/scala/meta/contrib/instances/instances.scala
@@ -1,0 +1,3 @@
+package scala.meta.contrib.instances
+
+trait instances extends StatementsInstances

--- a/scalameta/contrib/src/main/scala/scala/meta/contrib/package.scala
+++ b/scalameta/contrib/src/main/scala/scala/meta/contrib/package.scala
@@ -2,8 +2,10 @@ package scala.meta
 
 import scala.language.higherKinds
 import scala.language.implicitConversions
+import scala.meta.contrib.implicits.implicits
+import scala.meta.contrib.instances.instances
 
-package object contrib {
+package object contrib extends implicits with instances{
   implicit class XtensionTreeOps[A <: Tree](val a: A) extends AnyVal {
     @inline
     def ancestors: Seq[Tree] =

--- a/scalameta/contrib/src/test/scala/scala/meta/contrib/implicits/StatementsImplicitsSuite.scala
+++ b/scalameta/contrib/src/test/scala/scala/meta/contrib/implicits/StatementsImplicitsSuite.scala
@@ -1,0 +1,103 @@
+package scala.meta.contrib.implicits
+
+import org.scalatest.FunSuite
+
+import scala.meta._
+import scala.meta.contrib._
+
+class StatementsImplicitsSuite extends FunSuite {
+
+  private val classA = q"class a"
+
+  private val valA = q"val a = 2"
+  private val valB = q"val b = 2"
+
+  private val classWithVal = q"class a { val a = 2 }"
+  private val classWith2Vals = q"class a { val a = 2; val b = 2 }"
+  private val classWith2ValsInverted = q"class a { val b = 2; val a = 2 }"
+
+  test("getStats") {
+    assert(classA.getStats.isEmpty)
+    assert(classWithVal.getStats.size === 1)
+  }
+
+  test("replaceStats") {
+    assert(classA.replaceStats(valA :: Nil).equal[Structurally](classWithVal))
+  }
+
+  test("removeAllStats") {
+    assert(classWithVal.deleteAllStats.getStats.isEmpty)
+  }
+
+//  TODO: Enable
+//  test("removeStat") {
+//    assert(classWith2Vals.removeStat(valA).getStats.size === 1)
+//  }
+//
+//  test("removeStats") {
+//    assert(classWith2Vals.removeStats(valA :: valB :: Nil).getStats.isEmpty)
+//  }
+
+  test("appendStat") {
+    assert(classA.appendStat(valA).equal[Structurally](classWithVal))
+    assert(classWithVal.appendStat(valB).equal[Structurally](classWith2Vals))
+  }
+
+  test("appendStats") {
+    assert(classA.appendStats(valA :: valB :: Nil).equal[Structurally](classWith2Vals))
+    assert(classA.appendStats(valB :: valA :: Nil).equal[Structurally](classWith2ValsInverted))
+  }
+
+  test("prependStat") {
+    assert(classA.prependStat(valA).equal[Structurally](classWithVal))
+    assert(classWithVal.prependStat(valB).equal[Structurally](classWith2ValsInverted))
+  }
+
+  test("prependStats") {
+    assert(classA.prependStats(valB :: valA :: Nil).equal[Structurally](classWith2ValsInverted))
+    assert(classA.prependStats(valA :: valB :: Nil).equal[Structurally](classWith2Vals))
+    assert(classWithVal.prependStats(valB :: Nil).equal[Structurally](classWith2ValsInverted))
+  }
+
+  test("classDefs") {
+    assert(q"object foo { }".classDefs.isEmpty)
+    assert(q"object foo { class a }".classDefs.size === 1)
+    assert(q"object foo { class a; object b }".classDefs.size === 1)
+  }
+
+  test("objectDefs") {
+    assert(q"object foo { }".objectDefs.isEmpty)
+    assert(q"object foo { object a }".objectDefs.size === 1)
+    assert(q"object foo { class a; object b }".objectDefs.size === 1)
+  }
+
+  test("traitDefs") {
+    assert(q"object foo { }".classDefs.isEmpty)
+    assert(q"object foo { trait a }".traitDefs.size === 1)
+    assert(q"object foo { class a; trait b }".traitDefs.size === 1)
+  }
+
+  test("varDefs") {
+    assert(q"object foo { }".varDefs.isEmpty)
+    assert(q"object foo { var a = 1 }".varDefs.size === 1)
+    assert(q"object foo { class a; var b = 1 }".varDefs.size === 1)
+  }
+
+  test("valDefs") {
+    assert(q"object foo { }".valDefs.isEmpty)
+    assert(q"object foo { val a = 1 }".valDefs.size === 1)
+    assert(q"object foo { class a; val b = 1 }".valDefs.size === 1)
+  }
+
+  test("defDefs") {
+    assert(q"object foo { }".defDefs.isEmpty)
+    assert(q"object foo { def a = 1 }".defDefs.size === 1)
+    assert(q"object foo { class a; def b = 1 }".defDefs.size === 1)
+  }
+
+  test("typeDefs") {
+    assert(q"object foo { }".typeDefs.isEmpty)
+    assert(q"object foo { type A = Foo }".typeDefs.size === 1)
+    assert(q"object foo { class a; type A = Foo }".typeDefs.size === 1)
+  }
+}

--- a/scalameta/contrib/src/test/scala/scala/meta/contrib/implicits/StatementsImplicitsSuite.scala
+++ b/scalameta/contrib/src/test/scala/scala/meta/contrib/implicits/StatementsImplicitsSuite.scala
@@ -21,83 +21,53 @@ class StatementsImplicitsSuite extends FunSuite {
     assert(classWithVal.getStats.size === 1)
   }
 
-  test("replaceStats") {
-    assert(classA.replaceStats(valA :: Nil).equal[Structurally](classWithVal))
+  test("withStats") {
+    assert(classA.withStats(valA :: Nil).equal[Structurally](classWithVal))
   }
 
-  test("removeAllStats") {
-    assert(classWithVal.deleteAllStats.getStats.isEmpty)
+  test("updateStats mapper") {
+    assert(classWithVal.updateStats(_ :+ valB).equal[Structurally](classWith2Vals))
   }
 
-//  TODO: Enable
-//  test("removeStat") {
-//    assert(classWith2Vals.removeStat(valA).getStats.size === 1)
-//  }
-//
-//  test("removeStats") {
-//    assert(classWith2Vals.removeStats(valA :: valB :: Nil).getStats.isEmpty)
-//  }
-
-  test("appendStat") {
-    assert(classA.appendStat(valA).equal[Structurally](classWithVal))
-    assert(classWithVal.appendStat(valB).equal[Structurally](classWith2Vals))
+  test("classes") {
+    assert(q"object foo { }".classes.isEmpty)
+    assert(q"object foo { class a }".classes.size === 1)
+    assert(q"object foo { class a; object b }".classes.size === 1)
   }
 
-  test("appendStats") {
-    assert(classA.appendStats(valA :: valB :: Nil).equal[Structurally](classWith2Vals))
-    assert(classA.appendStats(valB :: valA :: Nil).equal[Structurally](classWith2ValsInverted))
+  test("objects") {
+    assert(q"object foo { }".objects.isEmpty)
+    assert(q"object foo { object a }".objects.size === 1)
+    assert(q"object foo { class a; object b }".objects.size === 1)
   }
 
-  test("prependStat") {
-    assert(classA.prependStat(valA).equal[Structurally](classWithVal))
-    assert(classWithVal.prependStat(valB).equal[Structurally](classWith2ValsInverted))
+  test("traits") {
+    assert(q"object foo { }".classes.isEmpty)
+    assert(q"object foo { trait a }".traits.size === 1)
+    assert(q"object foo { class a; trait b }".traits.size === 1)
   }
 
-  test("prependStats") {
-    assert(classA.prependStats(valB :: valA :: Nil).equal[Structurally](classWith2ValsInverted))
-    assert(classA.prependStats(valA :: valB :: Nil).equal[Structurally](classWith2Vals))
-    assert(classWithVal.prependStats(valB :: Nil).equal[Structurally](classWith2ValsInverted))
+  test("vars") {
+    assert(q"object foo { }".vars.isEmpty)
+    assert(q"object foo { var a = 1 }".vars.size === 1)
+    assert(q"object foo { class a; var b = 1 }".vars.size === 1)
   }
 
-  test("classDefs") {
-    assert(q"object foo { }".classDefs.isEmpty)
-    assert(q"object foo { class a }".classDefs.size === 1)
-    assert(q"object foo { class a; object b }".classDefs.size === 1)
+  test("vals") {
+    assert(q"object foo { }".vals.isEmpty)
+    assert(q"object foo { val a = 1 }".vals.size === 1)
+    assert(q"object foo { class a; val b = 1 }".vals.size === 1)
   }
 
-  test("objectDefs") {
-    assert(q"object foo { }".objectDefs.isEmpty)
-    assert(q"object foo { object a }".objectDefs.size === 1)
-    assert(q"object foo { class a; object b }".objectDefs.size === 1)
+  test("defs") {
+    assert(q"object foo { }".defs.isEmpty)
+    assert(q"object foo { def a = 1 }".defs.size === 1)
+    assert(q"object foo { class a; def b = 1 }".defs.size === 1)
   }
 
-  test("traitDefs") {
-    assert(q"object foo { }".classDefs.isEmpty)
-    assert(q"object foo { trait a }".traitDefs.size === 1)
-    assert(q"object foo { class a; trait b }".traitDefs.size === 1)
-  }
-
-  test("varDefs") {
-    assert(q"object foo { }".varDefs.isEmpty)
-    assert(q"object foo { var a = 1 }".varDefs.size === 1)
-    assert(q"object foo { class a; var b = 1 }".varDefs.size === 1)
-  }
-
-  test("valDefs") {
-    assert(q"object foo { }".valDefs.isEmpty)
-    assert(q"object foo { val a = 1 }".valDefs.size === 1)
-    assert(q"object foo { class a; val b = 1 }".valDefs.size === 1)
-  }
-
-  test("defDefs") {
-    assert(q"object foo { }".defDefs.isEmpty)
-    assert(q"object foo { def a = 1 }".defDefs.size === 1)
-    assert(q"object foo { class a; def b = 1 }".defDefs.size === 1)
-  }
-
-  test("typeDefs") {
-    assert(q"object foo { }".typeDefs.isEmpty)
-    assert(q"object foo { type A = Foo }".typeDefs.size === 1)
-    assert(q"object foo { class a; type A = Foo }".typeDefs.size === 1)
+  test("types") {
+    assert(q"object foo { }".types.isEmpty)
+    assert(q"object foo { type A = Foo }".types.size === 1)
+    assert(q"object foo { class a; type A = Foo }".types.size === 1)
   }
 }

--- a/scalameta/contrib/src/test/scala/scala/meta/contrib/instances/StatementsInstancesSuite.scala
+++ b/scalameta/contrib/src/test/scala/scala/meta/contrib/instances/StatementsInstancesSuite.scala
@@ -1,0 +1,49 @@
+package scala.meta.contrib.instances
+
+import org.scalatest.FunSuite
+
+import scala.meta._
+import scala.meta.contrib._
+
+// TODO: Add replaceStat tests
+class StatementsInstancesSuite extends FunSuite {
+
+  test("class instance") {
+    assert(q"class foo".getStats.isEmpty)
+    assert(q"class foo { }".getStats.isEmpty)
+    assert(q"class foo { val foo = 2 }".getStats.size === 1)
+  }
+
+  test("trait instance") {
+    assert(q"trait foo".getStats.isEmpty)
+    assert(q"trait foo { }".getStats.isEmpty)
+    assert(q"trait foo { val foo = 2 }".getStats.size === 1)
+  }
+
+  test("object instance") {
+    assert(q"object foo { }".getStats.isEmpty)
+    assert(q"object foo".getStats.isEmpty)
+    assert(q"object foo { val foo = 2 }".getStats.size === 1)
+  }
+
+  test("val instance") {
+    assert(q"val foo = 2".getStats.size === 1)
+    assert(q"val foo = { println(1); 2 }".getStats.size === 2)
+  }
+
+  test("var instance") {
+    assert(q"var foo = 2".getStats.size === 1)
+    assert(q"var foo = { println(1); 2 }".getStats.size === 2)
+  }
+
+  test("def instance") {
+    assert(q"def foo = 2".getStats.size === 1)
+    assert(q"def foo = { println(1); 2 }".getStats.size === 2)
+  }
+
+  test("pkg instance") {
+    assert(q"package foo { }".getStats.isEmpty)
+    assert(q"package foo { class foo }".getStats.size === 1)
+    assert(q"package foo { class foo; class bar }".getStats.size === 2)
+  }
+}

--- a/scalameta/contrib/src/test/scala/scala/meta/contrib/instances/StatementsInstancesSuite.scala
+++ b/scalameta/contrib/src/test/scala/scala/meta/contrib/instances/StatementsInstancesSuite.scala
@@ -5,7 +5,7 @@ import org.scalatest.FunSuite
 import scala.meta._
 import scala.meta.contrib._
 
-// TODO: Add replaceStat tests
+// TODO: Add withStat tests
 class StatementsInstancesSuite extends FunSuite {
 
   test("class instance") {
@@ -45,5 +45,6 @@ class StatementsInstancesSuite extends FunSuite {
     assert(q"package foo { }".getStats.isEmpty)
     assert(q"package foo { class foo }".getStats.size === 1)
     assert(q"package foo { class foo; class bar }".getStats.size === 2)
+    assert(q"package foo { package bar { class foo; class bar } }".getStats.size === 2)
   }
 }


### PR DESCRIPTION
Basically this pimps all the trees that have a stat block with methods such as

- appendStats
- getStats
- replaceStats

and extra methods such as:

- defDefs (returning all defs contained in that thing)
- valDefs
- typeDefs

and many more.

If this approach is liked by the maintainers I will add other typeclasses for similar things, such as modifers and parameters.

This will make it possible to do the following

Initial:
```
class Foo {
  val baz: Int = 2
  def bar: Int = {
    println("foo")
    2
  }
}
```

```clazz.defDefs.map(_.replaceStat[Structurally](List(2), List(3)))```

Result:
```
class Foo {
  val baz: Int = 2
  def bar: Int = {
    println("foo")
    3
  }
}
```