### PR TITLE
Updated commons.io dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -169,7 +169,7 @@ lazy val testkit = Project(
     "com.lihaoyi" %% "geny" % "0.1.1",
     // These are used to download and extract a corpus tar.gz
     "org.rauschig" % "jarchivelib" % "0.7.1",
-    "org.apache.commons" % "commons-io"  % "1.3.2"
+    "commons-io" % "commons-io"  % "2.5"
   ),
   libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value % Test,
   description := "Testing utilities for scala.meta's metaprogramming APIs"


### PR DESCRIPTION
I was unable to build due to 
`Corpus.scala:7: object io is not a member of package org.apache.commons
[error] import org.apache.commons.io.FileUtils`

When troubleshooting resolution I noticed scalameta depended on the old location of commons-io was using an old version.  This change is just an update to the latest version of commons-io.  All tests pass locally for me now.