### PR TITLE
workaround for an sbt issue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -162,6 +162,15 @@ lazy val scalahost = Project(
   base = file("scalahost")
 ) settings (
   publishableSettings,
+  publishArtifact in (Compile, packageSrc) := {
+    // TODO: addCompilerPlugin for ivy repos is kinda broken.
+    // If sbt finds a sources jar for a compiler plugin, it tries to add it to -Xplugin,
+    // leading to nonsensical scalac invocations like `-Xplugin:...-sources.jar -Xplugin:...jar`.
+    // Until this bug is fixed, we work around.
+    if (shouldPublishToBintray) false
+    else if (shouldPublishToSonatype) true
+    else sys.error("Undefined publishing strategy")
+  },
   mergeSettings,
   description := "Scala.meta's connector to the Scala compiler",
   crossVersion := CrossVersion.full,


### PR DESCRIPTION
It turns out that addCompilerPlugin works differently for maven-based (sonatype)
and ivy-based (bintray) artifacts. We’ve been using the former for ages,
and today I tried the latter.

What I’ve found out is that, in ivy mode, addCompilerPlugin behaves weirdly.
First, it fetches all compiler plugin artifacts, as if in libraryDependencies mode.
But then, it puts both -sources.jar and the actual jar on -Xplugin leading
to nonsensical scalac invocations like:

[debug] Calling Scala compiler with arguments  (CompilerInterface):
[debug]     -Yrangepos
[debug]     -Xplugin-require:scalahost
[debug]     -Xplugin:.../srcs/scalahost_2.11.8-1.6.0-641-sources.jar
[debug]     -Xplugin:.../jars/scalahost_2.11.8-1.6.0-641.jar

Therefore, I’m disabling publishing sources for scalahost when targeting bintray.
Sources are still required by Maven Central, so we keep publishing
when targeting sonatype.