### PR TITLE
change scalafmt config

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,5 @@
-style = defaultWithAlign
+style = default
+assumeStandardLibraryStripMargin = true
 maxColumn = 100
 project.includeFilters = [
   "scalahost"

--- a/scalahost/src/main/scala/scala/meta/internal/scalahost/HijackAnalyzer.scala
+++ b/scalahost/src/main/scala/scala/meta/internal/scalahost/HijackAnalyzer.scala
@@ -14,7 +14,7 @@ trait HijackAnalyzer { self: ScalahostPlugin =>
 
   def hijackAnalyzer(): global.analyzer.type = {
     // NOTE: need to hijack the right `analyzer` field - it's different for batch compilers and repl compilers
-    val isRepl        = global.isInstanceOf[NscReplGlobal]
+    val isRepl = global.isInstanceOf[NscReplGlobal]
     val isInteractive = global.isInstanceOf[NscInteractiveGlobal]
     val newAnalyzer = {
       if (isInteractive) {
@@ -53,7 +53,7 @@ trait HijackAnalyzer { self: ScalahostPlugin =>
     analyzerField.set(global, newAnalyzer)
 
     val phasesSetMapGetter = classOf[NscGlobal].getDeclaredMethod("phasesSet")
-    val phasesSet          = phasesSetMapGetter.invoke(global).asInstanceOf[mutable.Set[SubComponent]]
+    val phasesSet = phasesSetMapGetter.invoke(global).asInstanceOf[mutable.Set[SubComponent]]
     if (phasesSet.exists(_.phaseName == "typer")) { // `scalac -help` doesn't instantiate standard phases
       def subcomponentNamed(name: String) = phasesSet.find(_.phaseName == name).head
       val oldScs @ List(oldNamer, oldPackageobjects, oldTyper) = List(

--- a/scalahost/src/main/scala/scala/meta/internal/scalahost/ReflectionToolkit.scala
+++ b/scalahost/src/main/scala/scala/meta/internal/scalahost/ReflectionToolkit.scala
@@ -62,34 +62,34 @@ trait ReflectionToolkit {
     def transform(f: Map[String, Any] => Map[String, Any]): Unit =
       carrier.updateAttachment(f(toMap).toJavaMap)
     def contains(key: String): Boolean = toMap.contains(key)
-    def apply(key: String): Any        = toMap(key)
-    def get(key: String): Option[Any]  = toMap.get(key)
+    def apply(key: String): Any = toMap(key)
+    def get(key: String): Option[Any] = toMap.get(key)
     def getOrElse[T: ClassTag](key: String, value: => T): T =
       toMap.get(key).map(_.asInstanceOf[T]).getOrElse(value)
     def getOrElseUpdate[T: ClassTag](key: String, default: => T): T = {
       val valueopt = toMap.get(key).map(_.asInstanceOf[T])
-      val value    = valueopt.getOrElse(default)
+      val value = valueopt.getOrElse(default)
       if (valueopt.isEmpty) update(key, value)
       value
     }
     def update(key: String, value: Any): Unit = transform(_ + (key -> value))
-    def remove(key: String): Unit             = transform(_ - key)
-    def +=(kvp: (String, Any)): Unit          = update(kvp._1, kvp._2)
-    def ++=(other: Map[String, Any]): Unit    = transform(_ ++ other)
-    def ++=(other: Metadata[T]): Unit         = transform(_ ++ other.toMap)
-    def -=(key: String): Unit                 = remove(key)
-    def --=(other: List[String]): Unit        = transform(_ -- other)
-    def --=(other: Metadata[T]): Unit         = transform(_ -- other.toMap.keys)
-    override def toString                     = toMap.toString
+    def remove(key: String): Unit = transform(_ - key)
+    def +=(kvp: (String, Any)): Unit = update(kvp._1, kvp._2)
+    def ++=(other: Map[String, Any]): Unit = transform(_ ++ other)
+    def ++=(other: Metadata[T]): Unit = transform(_ ++ other.toMap)
+    def -=(key: String): Unit = remove(key)
+    def --=(other: List[String]): Unit = transform(_ -- other)
+    def --=(other: Metadata[T]): Unit = transform(_ -- other.toMap.keys)
+    override def toString = toMap.toString
   }
 
   class CompilationUnitCache(unit: CompilationUnit) {
     def getOrElse[T](key: String, op: => T): T = {
-      val dummyName   = g.TermName("<" + key + "Carrier>")
+      val dummyName = g.TermName("<" + key + "Carrier>")
       val dummySymbol = unit.checkedFeatures.find(_.name == dummyName)
-      val cached      = dummySymbol.flatMap(_.metadata.get(key).map(_.asInstanceOf[T]))
+      val cached = dummySymbol.flatMap(_.metadata.get(key).map(_.asInstanceOf[T]))
       cached.getOrElse({
-        val computed    = op
+        val computed = op
         val dummySymbol = g.NoSymbol.newValue(dummyName).appendMetadata(key -> computed)
         unit.checkedFeatures += dummySymbol
         computed
@@ -107,15 +107,15 @@ trait ReflectionToolkit {
       else carrier.appendMetadata(designation -> original)
     }
     def rememberConstfoldOf(original: Tree) = rememberOriginal("constantFoldingOriginal", original)
-    def rememberClassOf(original: Tree)     = rememberOriginal("classOfOriginal", original)
-    def rememberNewArrayOf(original: Tree)  = rememberOriginal("newArrayOriginal", original)
+    def rememberClassOf(original: Tree) = rememberOriginal("classOfOriginal", original)
+    def rememberNewArrayOf(original: Tree) = rememberOriginal("newArrayOriginal", original)
     def rememberSingletonTypeTreeOf(original: Tree) =
       rememberOriginal("singletonTypeTreeOriginal", original)
     // def rememberCompoundTypeTreeOf(original: Tree) = rememberOriginal("compoundTypeTreeOriginal", original)
     def rememberExistentialTypeTreeOf(original: Tree) =
       rememberOriginal("existentialTypeTreeOriginal", original)
     def rememberAnnotatedOf(original: Tree) = rememberOriginal("annotatedOriginal", original)
-    def rememberSelfTypeOf(original: Tree)  = rememberOriginal("selfTypeOriginal", original)
+    def rememberSelfTypeOf(original: Tree) = rememberOriginal("selfTypeOriginal", original)
   }
 
   object ConstfoldOf {

--- a/scalahost/src/main/scala/scala/meta/internal/scalahost/ScalahostPipeline.scala
+++ b/scalahost/src/main/scala/scala/meta/internal/scalahost/ScalahostPipeline.scala
@@ -13,11 +13,11 @@ trait ScalahostPipeline { self: ScalahostPlugin =>
 
   object ScalahostComponent extends PluginComponent {
     val global: ScalahostPipeline.this.global.type = ScalahostPipeline.this.global
-    val runsAfter                                  = List("typer")
-    override val runsRightAfter                    = Some("typer")
-    val phaseName                                  = "scalameta"
-    override val description                       = "compute the scala.meta semantic database"
-    def newPhase(_prev: Phase)                     = new ScalahostPhase(_prev)
+    val runsAfter = List("typer")
+    override val runsRightAfter = Some("typer")
+    val phaseName = "scalameta"
+    override val description = "compute the scala.meta semantic database"
+    def newPhase(_prev: Phase) = new ScalahostPhase(_prev)
 
     class ScalahostPhase(prev: Phase) extends StdPhase(prev) {
       override def apply(unit: g.CompilationUnit): Unit = {
@@ -26,11 +26,11 @@ trait ScalahostPipeline { self: ScalahostPlugin =>
 
       override def run(): Unit = {
         super.run()
-        val databaseFile   = new File(global.settings.d.value + "/semanticdb")
-        val prevDatabase   = if (databaseFile.exists) Database(databaseFile) else Database()
-        val database       = new OnlineMirror(global).database
+        val databaseFile = new File(global.settings.d.value + "/semanticdb")
+        val prevDatabase = if (databaseFile.exists) Database(databaseFile) else Database()
+        val database = new OnlineMirror(global).database
         val mergedDatabase = prevDatabase.append(database)
-        val allowedAddrs   = global.currentRun.units.map(_.source.toAddr).toSet
+        val allowedAddrs = global.currentRun.units.map(_.source.toAddr).toSet
         val trimmedDatabase = Database(
           mergedDatabase.symbols.filterKeys(k => allowedAddrs.contains(k.addr)))
         trimmedDatabase.toFile(databaseFile)

--- a/scalahost/src/main/scala/scala/meta/internal/scalahost/ScalahostPlugin.scala
+++ b/scalahost/src/main/scala/scala/meta/internal/scalahost/ScalahostPlugin.scala
@@ -13,7 +13,7 @@ class ScalahostPlugin(val global: Global)
     with ReflectionToolkit
     with ScalahostAnalyzer
     with ScalahostPipeline {
-  val name        = "scalahost"
+  val name = "scalahost"
   val description = "scala.meta's connector to the Scala compiler"
   hijackAnalyzer()
   val components = List[PluginComponent](ScalahostComponent)

--- a/scalahost/src/main/scala/scala/meta/internal/scalahost/converters/LogicalTrees.scala
+++ b/scalahost/src/main/scala/scala/meta/internal/scalahost/converters/LogicalTrees.scala
@@ -100,14 +100,14 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
     def displayName: String = tree match {
       case tree: ModuleDef if tree.name == nme.PACKAGE =>
         unreachable(debug(tree, showRaw(tree))) // dveim was abort(tree)
-      case tree: NameTree            => tree.name.displayName
-      case This(name)                => name.displayName // NOTE: This(tpnme.EMPTY) is also accounted for
-      case Super(_, name)            => name.displayName
+      case tree: NameTree => tree.name.displayName
+      case This(name) => name.displayName // NOTE: This(tpnme.EMPTY) is also accounted for
+      case Super(_, name) => name.displayName
       case tree: l.IndeterminateName => tree.value
-      case tree: l.TermName          => tree.value
-      case tree: l.TypeName          => tree.value
-      case tree: l.CtorName          => tree.value
-      case _                         => unreachable(debug(tree, showRaw(tree)))
+      case tree: l.TermName => tree.value
+      case tree: l.TypeName => tree.value
+      case tree: l.CtorName => tree.value
+      case _ => unreachable(debug(tree, showRaw(tree)))
     }
   }
 
@@ -243,7 +243,7 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
               synthetic1.decodedName.toString.contains("$") =>
           val args = rhs match {
             case q"$tuple(..$args)" if tuple.toString.startsWith("scala.Tuple") => args
-            case arg                                                            => List(arg)
+            case arg => List(arg)
           }
           Some((lhs, l.TermName(op.displayName), targs, args))
         case _ =>
@@ -385,11 +385,11 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
     def unapply(tree: g.Tree): Option[l.Template] = tree match {
       case g.Apply(g.Select(g.New(tpt), nme.CONSTRUCTOR), args) =>
         val lparent = l.Parent(g.Apply(tpt, args))
-        val lself   = l.Self(l.AnonymousName(), g.TypeTree())
+        val lself = l.Self(l.AnonymousName(), g.TypeTree())
         Some(l.Template(Nil, List(lparent), lself, None))
       case g.Select(g.New(tpt), nme.CONSTRUCTOR) =>
         val lparent = l.Parent(tpt)
-        val lself   = l.Self(l.AnonymousName(), g.TypeTree())
+        val lself = l.Self(l.AnonymousName(), g.TypeTree())
         Some(l.Template(Nil, List(lparent), lself, None))
       case g.Block(
           List(
@@ -406,7 +406,7 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
   object EtaExpansion {
     def unapply(tree: g.Tree): Boolean = tree match {
       case g.Function(Nil, g.EmptyTree) => true
-      case _                            => false
+      case _ => false
     }
   }
 
@@ -425,14 +425,14 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
     object Named {
       def unapply(tree: g.Tree): Option[(g.Tree, g.Tree)] = tree match {
         case g.AssignOrNamedArg(lhs, rhs) => Some((lhs, rhs))
-        case _                            => None
+        case _ => None
       }
     }
 
     object Repeated {
       def unapply(tree: g.Tree): Option[g.Ident] = tree match {
         case g.Typed(ident: g.Ident, g.Ident(g.typeNames.WILDCARD_STAR)) => Some(ident)
-        case _                                                           => None
+        case _ => None
       }
     }
   }
@@ -448,8 +448,8 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
   object TermParamDef {
     def apply(tree: g.ValDef): l.TermParamDef = {
       val g.ValDef(_, _, tpt, default) = tree
-      val ltpt                         = if (tpt.nonEmpty) Some(tpt) else None
-      val ldefault                     = if (default.nonEmpty) Some(default) else None
+      val ltpt = if (tpt.nonEmpty) Some(tpt) else None
+      val ldefault = if (default.nonEmpty) Some(default) else None
       val lname =
         if (tree.name.startsWith(nme.FRESH_TERM_NAME_PREFIX) ||
             tree.name == nme.WILDCARD) l.AnonymousName()
@@ -507,7 +507,7 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
     def unapply(tree: g.AppliedTypeTree): Option[g.Tree] = {
       tree match {
         case TypeApply(TypeSelect(_, TypeName("<byname>")), Seq(tpe)) => Some(tpe)
-        case _                                                        => None
+        case _ => None
       }
     }
   }
@@ -516,7 +516,7 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
     def unapply(tree: g.AppliedTypeTree): Option[g.Tree] = {
       tree match {
         case TypeApply(TypeSelect(_, TypeName("<repeated>")), Seq(tpe)) => Some(tpe)
-        case _                                                          => None
+        case _ => None
       }
     }
   }
@@ -571,8 +571,8 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
       case tree @ g.CompoundTypeTree(g.Template(parents0, _, Nil)) =>
         val parents = parents0.filter(_.toString != "scala.AnyRef")
         parents match {
-          case Nil               => None
-          case List(tpe)         => None
+          case Nil => None
+          case List(tpe) => None
           case List(left, right) => Some((left, right))
           case lefts :+ right =>
             Some((g.CompoundTypeTree(g.Template(lefts, noSelfType, Nil)), right))
@@ -592,7 +592,7 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
   object TypeRefine {
     def unapply(tree: g.CompoundTypeTree): Option[(Option[g.Tree], List[g.Tree])] = {
       val g.Template(parents0, _, stats) = tree.templ
-      val parents                        = parents0.filter(_.toString != "scala.AnyRef")
+      val parents = parents0.filter(_.toString != "scala.AnyRef")
       parents match {
         case Nil =>
           Some((None, stats))
@@ -629,8 +629,8 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
   object TypeBounds {
     def unapply(tree: g.TypeBoundsTree): Option[(Option[g.Tree], Option[g.Tree])] = {
       val g.TypeBoundsTree(glo, ghi) = tree
-      val llo                        = if (glo.nonEmpty) Some(glo) else None
-      val lhi                        = if (ghi.nonEmpty) Some(ghi) else None
+      val llo = if (glo.nonEmpty) Some(glo) else None
+      val lhi = if (ghi.nonEmpty) Some(ghi) else None
       Some((llo, lhi))
     }
   }
@@ -733,10 +733,10 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
   object PatAlternative {
     def unapply(tree: g.Alternative): Option[(g.Tree, g.Tree)] = {
       val g.Alternative(head :: tail) = tree
-      val llhs                        = head
+      val llhs = head
       val lrhs = tail match {
-        case Nil                    => return None
-        case head :: Nil            => head
+        case Nil => return None
+        case head :: Nil => head
         case trees @ (head :: tail) => g.Alternative(trees)
       }
       Some((llhs, lrhs))
@@ -767,11 +767,11 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
       if (TermOrPatInterpolate.unapply(tree).isDefined) return None
       val (fun, targs, args) = tree match {
         case g.Apply(g.TypeApply(fun, targs), args) => (fun, targs, args)
-        case g.Apply(fun, args)                     => (fun, Nil, args)
+        case g.Apply(fun, args) => (fun, Nil, args)
         case g.UnApply(g.Apply(g.TypeApply(fun, targs), List(unapplySelector)), args) =>
           (fun, targs, args)
         case g.UnApply(g.Apply(fun, List(unapplySelector)), args) => (fun, Nil, args)
-        case _                                                    => return None
+        case _ => return None
       }
       Some((fun, targs, args))
     }
@@ -802,7 +802,7 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
     def unapply(tree: g.Star): Boolean = {
       tree match {
         case g.Star(g.Ident(g.termNames.WILDCARD)) => true
-        case _                                     => false
+        case _ => false
       }
     }
   }
@@ -812,7 +812,7 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
       if (!patterns(tree)) return false
       tree match {
         case g.Bind(typeNames.WILDCARD, g.EmptyTree) => true
-        case _                                       => false
+        case _ => false
       }
     }
   }
@@ -828,10 +828,10 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
 
   object Literal {
     def unapply(tree: g.Literal): Option[Any] = tree match {
-      case g.Literal(g.Constant(_: g.Type))   => None
+      case g.Literal(g.Constant(_: g.Type)) => None
       case g.Literal(g.Constant(_: g.Symbol)) => None
-      case g.Literal(g.Constant(value))       => Some(value)
-      case _                                  => None
+      case g.Literal(g.Constant(value)) => Some(value)
+      case _ => None
     }
   }
 
@@ -863,7 +863,7 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
     def unapply(tree: ValOrVarDefs): Option[g.Tree] = Some(tree.pats.head)
 
     def apply(tree: g.ValDef, pat: List[g.Tree], tpt: Option[Tree], rhs: g.Tree): l.ValOrVarDefs = {
-      val ltpt  = tpt.filterNot(_.isEmpty)
+      val ltpt = tpt.filterNot(_.isEmpty)
       val lmods = l.Modifiers(tree)
       tree match {
         case g.ValDef(mods, _, _, g.EmptyTree) if mods.hasAllFlags(DEFERRED | MUTABLE) =>
@@ -950,7 +950,7 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
               !nme.isConstructorName(tree.name) =>
           val ltparams = mkTparams(tparams, paramss)
           val lparamss = mkVparamss(paramss)
-          val ltpt     = if (tpt.nonEmpty) Some(tpt) else None
+          val ltpt = if (tpt.nonEmpty) Some(tpt) else None
           Some((l.Modifiers(tree), l.TermName(tree), ltparams, lparamss, ltpt, rhs))
         case _ =>
           None
@@ -1015,7 +1015,7 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
         case g.ClassDef(mods, _, tparams, templ @ g.Template(_, _, body))
             if !mods.hasFlag(TRAIT) =>
           var lprimaryctor = l.PrimaryCtorDef(tree)
-          val ltparams     = mkTparams(tparams, tree.primaryCtor.vparamss)
+          val ltparams = mkTparams(tparams, tree.primaryCtor.vparamss)
           Some((l.Modifiers(tree), l.TypeName(tree), ltparams, lprimaryctor, l.Template(tree)))
         case _ =>
           None
@@ -1087,7 +1087,7 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
         case PackageObject(_) :: _ =>
           None
         case _ =>
-          val lpid   = tree.pid
+          val lpid = tree.pid
           val lstats = tree.stats
           Some((lpid, lstats))
       }
@@ -1121,13 +1121,13 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
         List[g.Tree]
     )] = {
       val g.DefDef(_, _, _, vparamss, _, body) = tree
-      val lname                                = l.CtorName(tree)
-      val lparamss                             = mkVparamss(tree.vparamss)
-      val g.Block(binit, UnitConstant())       = body
+      val lname = l.CtorName(tree)
+      val lparamss = mkVparamss(tree.vparamss)
+      val g.Block(binit, UnitConstant()) = body
       val lstats = binit.dropWhile {
         case g.pendingSuperCall => true
-        case _: DefnVal         => true
-        case _                  => false
+        case _: DefnVal => true
+        case _ => false
       }
       Some((l.Modifiers(tree), lname, lparamss, lstats))
     }
@@ -1172,7 +1172,7 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
       }.toMap
       val lparamss = paramss match {
         case List(List()) if !tree.mods.hasFlag(CASE) => Nil
-        case paramss                                  =>
+        case paramss =>
           // consolidate paramAccessorMods with <init> constructor parameters.
           paramss.map(_.map { param =>
             val newMods = paramAccessorMods.getOrElse(param.name.displayName, Nil)
@@ -1193,12 +1193,12 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
   object SecondaryCtorDef {
     def replaceInitWithCtorName(tree: g.Tree): g.Tree = tree match {
       case g.Ident(nme.CONSTRUCTOR) => l.CtorName("this")
-      case g.Apply(fun, args)       => g.Apply(replaceInitWithCtorName(fun), args)
-      case _                        => tree
+      case g.Apply(fun, args) => g.Apply(replaceInitWithCtorName(fun), args)
+      case _ => tree
     }
     def apply(tree: g.DefDef): l.SecondaryCtorDef = {
       val CtorDef(lmods, lname, lparamss, gbody :: _) = tree
-      val lbody                                       = replaceInitWithCtorName(gbody)
+      val lbody = replaceInitWithCtorName(gbody)
       SecondaryCtorDef(lmods, lname, lparamss, lbody)
     }
   }
@@ -1265,15 +1265,15 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
         }
       }
       val g.Template(parents, self, stats) = template
-      val lself                            = l.Self(self)
-      val (rawEdefs, rest)                 = stats.span(isEarlyDef)
-      val (gvdefs, etdefs)                 = rawEdefs.partition(isEarlyValDef)
+      val lself = l.Self(self)
+      val (rawEdefs, rest) = stats.span(isEarlyDef)
+      val (gvdefs, etdefs) = rawEdefs.partition(isEarlyValDef)
       val (evdefs, userDefinedStats) = rest.splitAt(indexOfFirstCtor(rest)) match {
         // TODO: superArgss are non-empty only in semantic mode
         case (fieldDefs, ctor @ LowlevelCtor(_, lvdefs, superArgss) :: body) =>
           val bodyWithSecondaryCtors = body.map {
             case t @ g.DefDef(_, nme.CONSTRUCTOR, _, _, _, _) => l.SecondaryCtorDef.apply(t)
-            case x                                            => x
+            case x => x
           }
           (gvdefs.zip(lvdefs).map {
             case (gvdef @ g.ValDef(_, _, tpt, _), g.ValDef(_, _, _, rhs)) =>
@@ -1288,7 +1288,7 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
       val edefs = evdefs ::: etdefs
       val lparents = parents.zipWithIndex.map {
         case (parent, i) =>
-          val applied        = dissectApplied(parent)
+          val applied = dissectApplied(parent)
           val syntacticArgss = applied.argss
           val argss =
             if (syntacticArgss.isEmpty)
@@ -1322,28 +1322,28 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
       val isAnonymous = tree.name == g.nme.WILDCARD || tree.name.startsWith(
           g.nme.FRESH_TERM_NAME_PREFIX)
       val lvalue = if (isAnonymous) "this" else tree.displayName
-      val lname  = if (isAnonymous) l.AnonymousName() else l.TermName(lvalue)
+      val lname = if (isAnonymous) l.AnonymousName() else l.TermName(lvalue)
       Self(lname, tree.tpt)
     }
   }
 
   // ============ MODIFIERS ============
 
-  trait Modifier                       extends Tree
-  case class Private(within: g.Tree)   extends Modifier // TODO: `within: l.QualifierName`
+  trait Modifier extends Tree
+  case class Private(within: g.Tree) extends Modifier // TODO: `within: l.QualifierName`
   case class Protected(within: g.Tree) extends Modifier // TODO: `within: l.QualifierName`
-  case class Implicit()                extends Modifier
-  case class Final()                   extends Modifier
-  case class Sealed()                  extends Modifier
-  case class Override()                extends Modifier
-  case class Case()                    extends Modifier
-  case class Abstract()                extends Modifier
-  case class Covariant()               extends Modifier
-  case class Contravariant()           extends Modifier
-  case class Lazy()                    extends Modifier
-  case class ValParam()                extends Modifier
-  case class VarParam()                extends Modifier
-  case class Inline()                  extends Modifier
+  case class Implicit() extends Modifier
+  case class Final() extends Modifier
+  case class Sealed() extends Modifier
+  case class Override() extends Modifier
+  case class Case() extends Modifier
+  case class Abstract() extends Modifier
+  case class Covariant() extends Modifier
+  case class Contravariant() extends Modifier
+  case class Lazy() extends Modifier
+  case class ValParam() extends Modifier
+  case class VarParam() extends Modifier
+  case class Inline() extends Modifier
 
   object Modifiers {
     def apply(tree: g.MemberDef): List[l.Modifier] = {
@@ -1374,14 +1374,14 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
         }
         val semantically = {
           if (tree.symbol.owner.isPrimaryConstructor) {
-            val param     = tree.require[g.ValDef]
-            val ctorSym   = param.symbol.owner
-            val ctor      = g.DefDef(ctorSym, g.EmptyTree)
-            val classSym  = ctorSym.owner
-            val cdef      = g.ClassDef(classSym, g.Template(Nil, g.noSelfType, Nil))
+            val param = tree.require[g.ValDef]
+            val ctorSym = param.symbol.owner
+            val ctor = g.DefDef(ctorSym, g.EmptyTree)
+            val classSym = ctorSym.owner
+            val cdef = g.ClassDef(classSym, g.Template(Nil, g.noSelfType, Nil))
             val getterSym = classSym.info.member(param.name)
-            val fieldSym  = getterSym.map(_.owner.info.member(getterSym.localName))
-            val field     = if (fieldSym != g.NoSymbol) Some(g.ValDef(fieldSym)) else None
+            val fieldSym = getterSym.map(_.owner.info.member(getterSym.localName))
+            val field = if (fieldSym != g.NoSymbol) Some(g.ValDef(fieldSym)) else None
             Some(ClassParameterInfo(param, field, ctor, cdef))
           } else None
         }
@@ -1413,8 +1413,8 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
           .filter(InlineExtractor.unapply(_).isEmpty)
           .map({
             case tree @ g.Apply(_: g.Apply, _) => tree
-            case g.Apply(tpt, Nil)             => tpt
-            case annot                         => annot
+            case g.Apply(tpt, Nil) => tpt
+            case annot => annot
           })
         trimmedAnnots.map(Annotation.apply)
       }
@@ -1460,11 +1460,11 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
       }
 
       val lvalVarParamMods: List[l.Modifier] = {
-        val lmods            = scala.collection.mutable.ListBuffer[l.Modifier]()
-        val field            = cpinfo.flatMap(_.field)
+        val lmods = scala.collection.mutable.ListBuffer[l.Modifier]()
+        val field = cpinfo.flatMap(_.field)
         val isImmutableField = field.map(!_.mods.hasFlag(MUTABLE)).getOrElse(false)
-        val isMutableField   = field.map(_.mods.hasFlag(MUTABLE)).getOrElse(false)
-        val inCaseClass      = cpinfo.map(_.cdef).map(_.mods.hasFlag(CASE)).getOrElse(false)
+        val isMutableField = field.map(_.mods.hasFlag(MUTABLE)).getOrElse(false)
+        val inCaseClass = cpinfo.map(_.cdef).map(_.mods.hasFlag(CASE)).getOrElse(false)
         if (isMutableField) lmods += l.VarParam()
         if (isImmutableField && !inCaseClass) lmods += l.ValParam()
         lmods.toList
@@ -1485,16 +1485,16 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
 
   // ============ ODDS & ENDS ============
 
-  trait Importee                                                                extends Tree
-  case class ImporteeWildcard()                                                 extends Importee
-  case class ImporteeName(value: l.IndeterminateName)                           extends Importee
+  trait Importee extends Tree
+  case class ImporteeWildcard() extends Importee
+  case class ImporteeName(value: l.IndeterminateName) extends Importee
   case class ImporteeRename(from: l.IndeterminateName, to: l.IndeterminateName) extends Importee
-  case class ImporteeUnimport(name: l.IndeterminateName)                        extends Importee
+  case class ImporteeUnimport(name: l.IndeterminateName) extends Importee
 
   object Importer {
     def unapply(tree: g.Import): Option[(g.Tree, List[l.Importee])] = {
       val g.Import(expr, selectors) = tree
-      val lname                     = expr
+      val lname = expr
       val lselectors = selectors.map {
         case g.ImportSelector(nme.WILDCARD, _, _, _) =>
           l.ImporteeWildcard()
@@ -1537,7 +1537,7 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
           val (fromTpe, toTpe) = targs match {
             case List(from, to) => (from, to); case _ => (g.NoType, g.NoType)
           }
-          val fromSym      = fromTpe.typeSymbol
+          val fromSym = fromTpe.typeSymbol
           val tyconMatches = tycon == g.definitions.FunctionClass(1)
           if (tyconMatches) tparam(Ident(fromSym)).map(tparam => (tparam, g.TypeTree(toTpe)))
           else None
@@ -1548,7 +1548,7 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
             case g.Select(pre, g.TypeName("Function1")) =>
               pre.symbol == g.definitions.ScalaPackage
             case tycon: g.RefTree => tycon.symbol == g.definitions.FunctionClass(1)
-            case _                => false
+            case _ => false
           }
           if (tyconMatches) tparam(from).map(tparam => (tparam, to))
           else None
@@ -1589,10 +1589,10 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
     if (paramss.isEmpty) return Nil
     val init :+ last = paramss
     val hasImplicits = last.exists(_.mods.hasFlag(IMPLICIT))
-    val explicitss   = if (hasImplicits) init else init :+ last
-    val implicits    = if (hasImplicits) last else Nil
-    val limplicits   = implicits.filter(!_.name.startsWith(nme.EVIDENCE_PARAM_PREFIX))
-    val lparamss     = if (limplicits.nonEmpty) explicitss :+ limplicits else explicitss
+    val explicitss = if (hasImplicits) init else init :+ last
+    val implicits = if (hasImplicits) last else Nil
+    val limplicits = implicits.filter(!_.name.startsWith(nme.EVIDENCE_PARAM_PREFIX))
+    val lparamss = if (limplicits.nonEmpty) explicitss :+ limplicits else explicitss
     lparamss.map(_.map(l.TermParamDef.apply))
   }
 
@@ -1601,15 +1601,15 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
     // * subclasses of MultiEnsugarer: DefaultGetter, VanillaAccessor, AbstractAccessor, LazyAccessor
     // * ToMtree.mstats: PatDef, InlinableHoistedTemporaryVal
     val lresult = mutable.ListBuffer[g.Tree]()
-    var i       = 0
+    var i = 0
     while (i < stats.length) {
       val stat = stats(i)
       i += 1
       stat match {
-        case g.DefDef(_, nme.MIXIN_CONSTRUCTOR, _, _, _, _)         => // and this
+        case g.DefDef(_, nme.MIXIN_CONSTRUCTOR, _, _, _, _) => // and this
         case g.ValDef(mods, _, _, _) if mods.hasFlag(PARAMACCESSOR) => // and this
-        case g.EmptyTree                                            => // and this
-        case _                                                      => lresult += stat
+        case g.EmptyTree => // and this
+        case _ => lresult += stat
       }
     }
     undoValDefDesugarings(lresult).toList
@@ -1654,7 +1654,7 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
   private object UnitConstant {
     def unapply(tree: g.Tree): Boolean = tree match {
       case g.Literal(g.Constant(())) => true
-      case _                         => false
+      case _ => false
     }
   }
 
@@ -1664,7 +1664,7 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
 
   // Transforms g.ValDef into l.ValOrValDef. See l.ValOrVarDef for more explanations.
   def undoValDefDesugarings(stats: Seq[g.Tree]): Seq[g.Tree] = {
-    val toCollapse         = mutable.Set.empty[g.Tree]
+    val toCollapse = mutable.Set.empty[g.Tree]
     val valDefFingerprints = mutable.Map.empty[g.Tree, (g.Position, String)]
     def addFingerprint(valDefPattern: g.Tree, mods: g.Modifiers, rhs: g.Tree): Unit = {
       mods.positions.headOption.foreach {
@@ -1683,14 +1683,14 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
           if syntheticMods.hasFlag(PRIVATE | LOCAL | SYNTHETIC | ARTIFACT) =>
         val statsToRemove = stats.drop(i + 1).takeWhile {
           case g.ValDef(_, _, _, g.Select(g.Ident(`name`), _)) => true
-          case UnitConstant()                                  => true
-          case _                                               => false
+          case UnitConstant() => true
+          case _ => false
         }
         addFingerprint(pat, syntheticMods, rhs)
         toCollapse ++= statsToRemove
         val mods: g.Modifiers = statsToRemove.headOption match {
           case Some(g.ValDef(mods, _, _, _)) => mods
-          case _                             => g.Modifiers()
+          case _ => g.Modifiers()
         }
         l.ValOrVarDefs(origin.copy(mods = mods | syntheticMods.flags), List(pat), tpt, rhs)
       // case: val Foo(a) = rhs
@@ -1699,7 +1699,7 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
         addFingerprint(pat, mods, rhs)
         stats.drop(i + 1).headOption match {
           case Some(remove @ UnitConstant()) => toCollapse += remove
-          case _                             =>
+          case _ =>
         }
         l.ValOrVarDefs(origin, List(pat), tpt, rhs)
       // case: val a = rhs
@@ -1719,8 +1719,8 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
       case (v1 @ ValOrVarDefs(pat1), i) if !toCollapse(v1) =>
         val toMerge = allValOrValDefs.drop(i + 1).takeWhile {
           case ValOrVarDefs(pat2) if fingerprintsMatch(pat1, pat2) => true
-          case l.UnitConstant()                                    => true
-          case _                                                   => false
+          case l.UnitConstant() => true
+          case _ => false
         }
         toCollapse ++= toMerge
         val newPatterns = toMerge.collect { case v2: l.ValOrVarDefs => v2.pats }.flatten
@@ -1742,7 +1742,7 @@ class LogicalTrees[G <: Global](val global: G, root: G#Tree) extends ReflectTool
   private def flattenAnnotated(gtree: g.Tree, accum: List[g.Tree] = Nil): (g.Tree, List[g.Tree]) = {
     gtree match {
       case g.Annotated(annot, arg) => flattenAnnotated(arg, annot :: accum)
-      case tree                    => (tree, accum)
+      case tree => (tree, accum)
     }
   }
 }

--- a/scalahost/src/main/scala/scala/meta/internal/scalahost/converters/ReflectToolkit.scala
+++ b/scalahost/src/main/scala/scala/meta/internal/scalahost/converters/ReflectToolkit.scala
@@ -15,16 +15,16 @@ trait ReflectToolkit {
 
   implicit class XtensionName(name: g.Name) {
     def isAnonymous = {
-      val isTermPlaceholder        = name.isTermName && name.startsWith(nme.FRESH_TERM_NAME_PREFIX)
-      val isTypePlaceholder        = name.isTypeName && name.startsWith("_$")
-      val isAnonymousSelf          = name.isTermName && (name.startsWith(nme.FRESH_TERM_NAME_PREFIX) || name == nme.this_)
+      val isTermPlaceholder = name.isTermName && name.startsWith(nme.FRESH_TERM_NAME_PREFIX)
+      val isTypePlaceholder = name.isTypeName && name.startsWith("_$")
+      val isAnonymousSelf = name.isTermName && (name.startsWith(nme.FRESH_TERM_NAME_PREFIX) || name == nme.this_)
       val isAnonymousTypeParameter = name == tpnme.WILDCARD
       isTermPlaceholder || isTypePlaceholder || isAnonymousSelf || isAnonymousTypeParameter
     }
     def looksLikeInfix = {
       val hasSymbolicName =
         !name.decoded.forall(c => Character.isLetter(c) || Character.isDigit(c) || c == '_')
-      val idiomaticallyUsedAsInfix    = name == nme.eq || name == nme.ne
+      val idiomaticallyUsedAsInfix = name == nme.eq || name == nme.ne
       val idiomaticallyNotUsedAsInfix = name == nme.CONSTRUCTOR
       (hasSymbolicName || idiomaticallyUsedAsInfix) && !idiomaticallyNotUsedAsInfix
     }

--- a/scalahost/src/main/scala/scala/meta/internal/scalahost/converters/ToMtree.scala
+++ b/scalahost/src/main/scala/scala/meta/internal/scalahost/converters/ToMtree.scala
@@ -39,7 +39,7 @@ trait ToMtree { self: Converter =>
                 m.Term.This(mname)
 
               case l.TermSuper(lthis, lsuper) =>
-                val mthis  = lthis.toMtree[m.Name.Qualifier]
+                val mthis = lthis.toMtree[m.Name.Qualifier]
                 val msuper = lsuper.toMtree[m.Name.Qualifier]
                 m.Term.Super(mthis, msuper)
 
@@ -50,30 +50,30 @@ trait ToMtree { self: Converter =>
                 lname.toMtree[m.Term.Name]
 
               case l.TermSelect(lpre, lname) =>
-                val mpre  = lpre.toMtree[m.Term]
+                val mpre = lpre.toMtree[m.Term]
                 val mname = lname.toMtree[m.Term.Name]
                 m.Term.Select(mpre, mname)
 
               case l.TermInterpolate(lprefix, lparts, largs) =>
                 val mprefix = lprefix.toMtree[m.Term.Name]
-                val mparts  = lparts.toMtrees[m.Lit]
-                val margs   = largs.toMtrees[m.Term]
+                val mparts = lparts.toMtrees[m.Lit]
+                val margs = largs.toMtrees[m.Term]
                 m.Term.Interpolate(mprefix, mparts, margs)
 
               case l.TermApply(lfun, largs) =>
-                val mfun  = lfun.toMtree[m.Term]
+                val mfun = lfun.toMtree[m.Term]
                 val margs = largs.toMtrees[m.Term.Arg]
                 m.Term.Apply(mfun, margs)
 
               case l.TermApplyInfix(llhs, lop, ltargs, largs) =>
-                val mlhs   = llhs.toMtree[m.Term]
-                val mop    = lop.toMtree[m.Term.Name]
+                val mlhs = llhs.toMtree[m.Term]
+                val mop = lop.toMtree[m.Term.Name]
                 val mtargs = ltargs.toMtrees[m.Type]
-                val margs  = largs.toMtrees[m.Term.Arg]
+                val margs = largs.toMtrees[m.Term.Arg]
                 m.Term.ApplyInfix(mlhs, mop, mtargs, margs)
 
               case l.TermApplyType(lfun, ltargs) =>
-                val mfun   = lfun.toMtree[m.Term]
+                val mfun = lfun.toMtree[m.Term]
                 val mtargs = ltargs.toMtrees[m.Type]
                 m.Term.ApplyType(mfun, mtargs)
 
@@ -91,12 +91,12 @@ trait ToMtree { self: Converter =>
                 m.Term.Throw(mexpr)
 
               case l.TermAscribe(lexpr, ldecltpe) =>
-                val mexpr    = lexpr.toMtree[m.Term]
+                val mexpr = lexpr.toMtree[m.Term]
                 val mdecltpe = ldecltpe.toMtree[m.Type]
                 m.Term.Ascribe(mexpr, mdecltpe)
 
               case l.TermAnnotate(lexpr, lannots) =>
-                val mexpr   = lexpr.toMtree[m.Term]
+                val mexpr = lexpr.toMtree[m.Term]
                 val mannots = lannots.toMtrees[m.Mod.Annot]
                 m.Term.Annotate(mexpr, mannots)
 
@@ -120,14 +120,14 @@ trait ToMtree { self: Converter =>
                 m.Term.Match(mscrut, mcases)
 
               case l.TermTryWithCases(lexpr, lcatches, lfinally) =>
-                val mexpr    = lexpr.toMtree[m.Term]
+                val mexpr = lexpr.toMtree[m.Term]
                 val mcatches = lcatches.toMtrees[m.Case]
                 val mfinally = lfinally.toMtreeopt[m.Term]
                 m.Term.TryWithCases(mexpr, mcatches, mfinally)
 
               case l.TermFunction(lparams, lbody) =>
                 val mparams = lparams.toMtrees[m.Term.Param]
-                val mbody   = lbody.toMtree[m.Term]
+                val mbody = lbody.toMtree[m.Term]
                 m.Term.Function(mparams, mbody)
 
               case l.TermPartialFunction(lcases) =>
@@ -157,7 +157,7 @@ trait ToMtree { self: Converter =>
 
               case l.TermArg.Named(lname, lrhs) =>
                 val mname = lname.toMtree[m.Term.Name]
-                val mrhs  = lrhs.toMtree[m.Term.Arg]
+                val mrhs = lrhs.toMtree[m.Term.Arg]
                 m.Term.Arg.Named(mname, mrhs)
 
               case l.TermArg.Repeated(lident) =>
@@ -165,9 +165,9 @@ trait ToMtree { self: Converter =>
                 m.Term.Arg.Repeated(mterm)
 
               case l.TermParamDef(lmods, lname, ltpt, ldefault) =>
-                val mmods    = lmods.toMtrees[m.Mod]
-                val mname    = lname.toMtree[m.Term.Param.Name]
-                val mtpt     = ltpt.toMtreeopt[m.Type.Arg]
+                val mmods = lmods.toMtrees[m.Mod]
+                val mname = lname.toMtree[m.Term.Param.Name]
+                val mtpt = ltpt.toMtreeopt[m.Type.Arg]
                 val mdefault = ldefault.toMtreeopt[m.Term]
                 m.Term.Param(mmods, mname, mtpt, mdefault)
 
@@ -202,19 +202,19 @@ trait ToMtree { self: Converter =>
                 m.Type.Arg.Repeated(mtpe)
 
               case l.TypeApply(ltpt, largs) =>
-                val mtpt  = ltpt.toMtree[m.Type]
+                val mtpt = ltpt.toMtree[m.Type]
                 val margs = largs.toMtrees[m.Type]
                 m.Type.Apply(mtpt, margs)
 
               case l.TypeApplyInfix(llhs, lop, lrhs) =>
                 val mlhs = llhs.toMtree[m.Type]
-                val mop  = lop.toMtree[m.Type.Name]
+                val mop = lop.toMtree[m.Type.Name]
                 val mrhs = lrhs.toMtree[m.Type]
                 m.Type.ApplyInfix(mlhs, mop, mrhs)
 
               case l.TypeFunction(lparams, lres) =>
                 val mparams = lparams.toMtrees[m.Type.Arg]
-                val mres    = lres.toMtree[m.Type]
+                val mres = lres.toMtree[m.Type]
                 m.Type.Function(mparams, mres)
 
               case l.TypeTuple(lelements) =>
@@ -227,17 +227,17 @@ trait ToMtree { self: Converter =>
                 m.Type.With(mlhs, mrhs)
 
               case l.TypeRefine(ltpe, lstats) =>
-                val mtpe   = ltpe.toMtreeopt[m.Type]
+                val mtpe = ltpe.toMtreeopt[m.Type]
                 val mstats = lstats.toMtrees[m.Stat]
                 m.Type.Refine(mtpe, mstats)
 
               case l.TypeExistential(ltpe, lstats) =>
-                val mtpe   = ltpe.toMtree[m.Type]
+                val mtpe = ltpe.toMtree[m.Type]
                 val mstats = lstats.toMtrees[m.Stat]
                 m.Type.Existential(mtpe, mstats)
 
               case l.TypeAnnotate(ltpe, lannots) =>
-                val mtpe    = ltpe.toMtree[m.Type]
+                val mtpe = ltpe.toMtree[m.Type]
                 val mannots = lannots.toMtrees[m.Mod.Annot]
                 m.Type.Annotate(mtpe, mannots)
 
@@ -247,8 +247,8 @@ trait ToMtree { self: Converter =>
                 m.Type.Bounds(mlo, mhi)
 
               case l.TypeParamDef(lmods, lname, ltparams, ltbounds, lvbounds, lcbounds) =>
-                val mmods    = lmods.toMtrees[m.Mod]
-                val mname    = lname.toMtree[m.Type.Param.Name]
+                val mmods = lmods.toMtrees[m.Mod]
+                val mname = lname.toMtree[m.Type.Param.Name]
                 val mtparams = ltparams.toMtrees[m.Type.Param]
                 val mtbounds = ltbounds.toMtree[m.Type.Bounds]
                 val mvbounds = lvbounds.toMtrees[m.Type]
@@ -276,7 +276,7 @@ trait ToMtree { self: Converter =>
                 // However, in this case, that'd be too complicated engineering-wise, so I make an exception.
                 mrhs match {
                   case m.Pat.Wildcard() => mlhs
-                  case mrhs             => m.Pat.Bind(mlhs, mrhs)
+                  case mrhs => m.Pat.Bind(mlhs, mrhs)
                 }
 
               case l.PatAlternative(llhs, lrhs) =>
@@ -289,20 +289,20 @@ trait ToMtree { self: Converter =>
                 m.Pat.Tuple(melements)
 
               case l.PatExtract(lref, ltargs, largs) =>
-                val mref   = lref.toMtree[m.Term.Ref]
+                val mref = lref.toMtree[m.Term.Ref]
                 val mtargs = ltargs.toMtrees[m.Pat.Type]
-                val margs  = largs.toMtrees[m.Pat.Arg]
+                val margs = largs.toMtrees[m.Pat.Arg]
                 m.Pat.Extract(mref, mtargs, margs)
 
               case l.PatInterpolate(lprefix, lparts, largs) =>
                 val mprefix = lprefix.toMtree[m.Term.Name]
-                val mparts  = lparts.toMtrees[m.Lit]
-                val margs   = largs.toMtrees[m.Pat]
+                val mparts = lparts.toMtrees[m.Lit]
+                val margs = largs.toMtrees[m.Pat]
                 m.Pat.Interpolate(mprefix, mparts, margs)
 
               case l.PatTyped(llhs, lrhs) =>
                 val mlrhs = llhs.toMtree[m.Pat]
-                val mrhs  = lrhs.toMtree[m.Pat.Type]
+                val mrhs = lrhs.toMtree[m.Pat.Type]
                 m.Pat.Typed(mlrhs, mrhs)
 
               case l.PatArgSeqWildcard() =>
@@ -312,12 +312,12 @@ trait ToMtree { self: Converter =>
                 m.Pat.Type.Wildcard()
 
               case l.PatTypeAnnotate(ltpe, lannots) =>
-                val mtpe    = ltpe.toMtree[m.Pat.Type]
+                val mtpe = ltpe.toMtree[m.Pat.Type]
                 val mannots = lannots.toMtrees[m.Mod.Annot]
                 m.Pat.Type.Annotate(mtpe, mannots)
 
               case l.PatTypeApply(ltpt, largs) =>
-                val mtpt  = ltpt.toMtree[m.Pat.Type]
+                val mtpt = ltpt.toMtree[m.Pat.Type]
                 val margs = largs.toMtrees[m.Pat.Type]
                 m.Pat.Type.Apply(mtpt, margs)
 
@@ -333,30 +333,30 @@ trait ToMtree { self: Converter =>
 
               // ============ DECLS ============
               case l.DeclVal(lmods, lpats, ldecltpe) =>
-                val mmods    = lmods.toMtrees[m.Mod]
-                val mpats    = lpats.toMtrees[m.Pat.Var.Term]
+                val mmods = lmods.toMtrees[m.Mod]
+                val mpats = lpats.toMtrees[m.Pat.Var.Term]
                 val mdecltpe = ldecltpe.toMtree[m.Type]
                 m.Decl.Val(mmods, mpats, mdecltpe)
 
               case l.DeclVar(lmods, lpats, ldecltpe) =>
-                val mmods    = lmods.toMtrees[m.Mod]
-                val mpats    = lpats.toMtrees[m.Pat.Var.Term]
+                val mmods = lmods.toMtrees[m.Mod]
+                val mpats = lpats.toMtrees[m.Pat.Var.Term]
                 val mdecltpe = ldecltpe.toMtree[m.Type]
                 m.Decl.Var(mmods, mpats, mdecltpe)
 
               case l.AbstractDefDef(lmods, lname, ltparams, lparamss, ltpt) =>
-                val mmods    = lmods.toMtrees[m.Mod]
-                val mname    = lname.toMtree[m.Term.Name]
+                val mmods = lmods.toMtrees[m.Mod]
+                val mname = lname.toMtree[m.Term.Name]
                 val mtparams = ltparams.toMtrees[m.Type.Param]
                 val mparamss = lparamss.toMtreess[m.Term.Param]
-                val mtpt     = ltpt.toMtree[m.Type]
+                val mtpt = ltpt.toMtree[m.Type]
                 m.Decl.Def(mmods, mname, mtparams, mparamss, mtpt)
 
               case l.AbstractTypeDef(lmods, lname, ltparams, lbounds) =>
-                val mmods    = lmods.toMtrees[m.Mod]
-                val mname    = lname.toMtree[m.Type.Name]
+                val mmods = lmods.toMtrees[m.Mod]
+                val mname = lname.toMtree[m.Type.Name]
                 val mtparams = ltparams.toMtrees[m.Type.Param]
-                val mbounds  = lbounds.toMtree[m.Type.Bounds]
+                val mbounds = lbounds.toMtree[m.Type.Bounds]
                 m.Decl.Type(mmods, mname, mtparams, mbounds)
 
               // ============ DEFNS ============
@@ -364,53 +364,53 @@ trait ToMtree { self: Converter =>
               case l.DefnVal(lmods, lpats, ltpt, lrhs) =>
                 val mmods = lmods.toMtrees[m.Mod]
                 val mpats = lpats.toMtrees[m.Pat]
-                val mtpt  = ltpt.toMtreeopt[m.Type]
-                val mrhs  = lrhs.toMtree[m.Term]
+                val mtpt = ltpt.toMtreeopt[m.Type]
+                val mrhs = lrhs.toMtree[m.Term]
                 m.Defn.Val(mmods, mpats, mtpt, mrhs)
 
               case l.DefnVar(lmods, lpats, ltpt, lrhs) =>
                 val mmods = lmods.toMtrees[m.Mod]
                 val mpats = lpats.toMtrees[m.Pat]
-                val mtpt  = ltpt.toMtreeopt[m.Type]
-                val mrhs  = lrhs.toMtreeopt[m.Term]
+                val mtpt = ltpt.toMtreeopt[m.Type]
+                val mrhs = lrhs.toMtreeopt[m.Term]
                 m.Defn.Var(mmods, mpats, mtpt, mrhs)
 
               case l.DefDef(lmods, lname, ltparams, lparamss, ltpt, lrhs) =>
-                val mmods    = lmods.toMtrees[m.Mod]
-                val mname    = lname.toMtree[m.Term.Name]
+                val mmods = lmods.toMtrees[m.Mod]
+                val mname = lname.toMtree[m.Term.Name]
                 val mtparams = ltparams.toMtrees[m.Type.Param]
                 val mparamss = lparamss.toMtreess[m.Term.Param]
-                val mtpt     = ltpt.toMtreeopt[m.Type]
-                val mrhs     = lrhs.toMtree[m.Term]
+                val mtpt = ltpt.toMtreeopt[m.Type]
+                val mrhs = lrhs.toMtree[m.Term]
                 m.Defn.Def(mmods, mname, mtparams, mparamss, mtpt, mrhs)
 
               case l.MacroDef(lmods, lname, ltparams, lparamss, ltpt, lrhs) =>
-                val mmods    = lmods.toMtrees[m.Mod]
-                val mname    = lname.toMtree[m.Term.Name]
+                val mmods = lmods.toMtrees[m.Mod]
+                val mname = lname.toMtree[m.Term.Name]
                 val mtparams = ltparams.toMtrees[m.Type.Param]
                 val mparamss = lparamss.toMtreess[m.Term.Param]
-                val mtpt     = ltpt.toMtreeopt[m.Type]
-                val mrhs     = lrhs.toMtree[m.Term]
+                val mtpt = ltpt.toMtreeopt[m.Type]
+                val mrhs = lrhs.toMtree[m.Term]
                 m.Defn.Macro(mmods, mname, mtparams, mparamss, mtpt, mrhs)
 
               case l.TypeDef(lmods, lname, ltparams, lbody) =>
-                val mmods    = lmods.toMtrees[m.Mod]
-                val mname    = lname.toMtree[m.Type.Name]
+                val mmods = lmods.toMtrees[m.Mod]
+                val mname = lname.toMtree[m.Type.Name]
                 val mtparams = ltparams.toMtrees[m.Type.Param]
-                val mbody    = lbody.toMtree[m.Type]
+                val mbody = lbody.toMtree[m.Type]
                 m.Defn.Type(mmods, mname, mtparams, mbody)
 
               case l.ClassDef(lmods, lname, ltparams, lctor, limpl) =>
-                val mmods    = lmods.toMtrees[m.Mod]
-                val mname    = lname.toMtree[m.Type.Name]
+                val mmods = lmods.toMtrees[m.Mod]
+                val mname = lname.toMtree[m.Type.Name]
                 val mtparams = ltparams.toMtrees[m.Type.Param]
-                val mctor    = lctor.toMtree[m.Ctor.Primary]
-                val mimpl    = limpl.toMtree[m.Template]
+                val mctor = lctor.toMtree[m.Ctor.Primary]
+                val mimpl = limpl.toMtree[m.Template]
                 m.Defn.Class(mmods, mname, mtparams, mctor, mimpl)
 
               case l.TraitDef(lmods, lname, ltparams, lctor, limpl) =>
-                val mmods    = lmods.toMtrees[m.Mod]
-                val mname    = lname.toMtree[m.Type.Name]
+                val mmods = lmods.toMtrees[m.Mod]
+                val mname = lname.toMtree[m.Type.Name]
                 val mtparams = ltparams.toMtrees[m.Type.Param]
                 val mctor = {
                   // TODO: This conditional expression is non-idiomatic.
@@ -430,13 +430,13 @@ trait ToMtree { self: Converter =>
               // ============ PKGS ============
 
               case l.PackageDef(lref, lstats) =>
-                val mref   = lref.toMtree[m.Term.Ref]
+                val mref = lref.toMtree[m.Term.Ref]
                 val mstats = lstats.toMtrees[m.Stat]
                 m.Pkg(mref, mstats)
 
               case l.PackageObjectDef(lmods, lname, ltempl) =>
-                val mmods  = lmods.toMtrees[m.Mod]
-                val mname  = lname.toMtree[m.Term.Name]
+                val mmods = lmods.toMtrees[m.Mod]
+                val mname = lname.toMtree[m.Term.Name]
                 val mtempl = ltempl.toMtree[m.Template]
                 m.Pkg.Object(mmods, mname, mtempl)
 
@@ -446,15 +446,15 @@ trait ToMtree { self: Converter =>
                 val mmods = lmods.toMtrees[m.Mod]
                 // TODO: fixme https://github.com/xeno-by/scalameta/blob/7b9632ff889268a1c8c7c71432998e553146eab0/scalameta/parsers/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala#L3096
                 // val mname = lname.toMtree[m.Ctor.Name]
-                val mname    = m.Ctor.Name("this")
+                val mname = m.Ctor.Name("this")
                 val mparamss = lparamss.toMtreess[m.Term.Param]
                 m.Ctor.Primary(mmods, mname, mparamss)
 
               case l.SecondaryCtorDef(lmods, lname, lparamss, lbody) =>
-                val mmods    = lmods.toMtrees[m.Mod]
-                val mname    = m.Ctor.Name("this")
+                val mmods = lmods.toMtrees[m.Mod]
+                val mname = m.Ctor.Name("this")
                 val mparamss = lparamss.toMtreess[m.Term.Param]
-                val mbody    = lbody.toMtree[m.Term]
+                val mbody = lbody.toMtree[m.Term]
                 m.Ctor.Secondary(mmods, mname, mparamss, mbody)
 
               case l.CtorName(lvalue) =>
@@ -465,15 +465,15 @@ trait ToMtree { self: Converter =>
               // ============ TEMPLATES ============
 
               case l.Template(learly, lparents, lself, lstats) =>
-                val mearly   = learly.toMtrees[m.Stat]
+                val mearly = learly.toMtrees[m.Stat]
                 val mparents = lparents.toMtrees[m.Ctor.Call]
-                val mself    = lself.toMtree[m.Term.Param]
-                val mstats   = lstats.map(_.toMtrees[m.Stat])
+                val mself = lself.toMtree[m.Term.Param]
+                val mstats = lstats.map(_.toMtrees[m.Stat])
                 m.Template(mearly, mparents, mself, mstats)
 
               case l.Parent(ltpt, lctor, largss) =>
-                val mtpt   = ltpt.toMtree[m.Type]
-                val mctor  = mtpt.ctorRef(lctor.toMtree[m.Ctor.Name])
+                val mtpt = ltpt.toMtree[m.Type]
+                val mctor = mtpt.ctorRef(lctor.toMtree[m.Ctor.Name])
                 val margss = largss.toMtreess[m.Term.Arg]
                 margss.foldLeft(mctor)((mcurr, margs) => {
                   m.Term.Apply(mcurr, margs)
@@ -481,7 +481,7 @@ trait ToMtree { self: Converter =>
 
               case l.Self(lname, ltpt) =>
                 val mname = lname.toMtree[m.Term.Param.Name]
-                val mtpt  = if (ltpt.nonEmpty) Some(ltpt.toMtree[m.Type]) else None
+                val mtpt = if (ltpt.nonEmpty) Some(ltpt.toMtree[m.Type]) else None
                 m.Term.Param(Nil, mname, mtpt, None)
 
               // ============ MODIFIERS ============
@@ -543,7 +543,7 @@ trait ToMtree { self: Converter =>
               // ============ ODDS & ENDS ============
 
               case l.Importer(lref, limportees) =>
-                val mref       = lref.toMtree[m.Term.Ref]
+                val mref = lref.toMtree[m.Term.Ref]
                 val mimportees = limportees.toMtrees[m.Importee]
                 m.Import(List(m.Importer(mref, mimportees)))
 
@@ -555,7 +555,7 @@ trait ToMtree { self: Converter =>
                 m.Importee.Name(mname)
 
               case l.ImporteeRename(lname, lrename) =>
-                val mname   = lname.toMtree[m.Name.Indeterminate]
+                val mname = lname.toMtree[m.Name.Indeterminate]
                 val mrename = lrename.toMtree[m.Name.Indeterminate]
                 m.Importee.Rename(mname, mrename)
 
@@ -564,9 +564,9 @@ trait ToMtree { self: Converter =>
                 m.Importee.Unimport(mname)
 
               case l.CaseDef(lpat, lguard, lbody) =>
-                val mpat   = lpat.toMtree[m.Pat]
+                val mpat = lpat.toMtree[m.Pat]
                 val mguard = lguard.toMtreeopt[m.Term]
-                val mbody  = lbody.toMtree[m.Term]
+                val mbody = lbody.toMtree[m.Term]
                 m.Case(mpat, mguard, mbody)
 
               case _ =>
@@ -594,11 +594,11 @@ trait ToMtree { self: Converter =>
         val isDuplicate = backtrace.nonEmpty && backtrace.head == gtree0
         if (!isDuplicate) backtrace = gtree0 +: backtrace
         try {
-          val (gtree, gexpansion)   = (gtree0, g.EmptyTree)
-          val undesugaredTree       = l.UndoDesugaring.unapply(gtree).getOrElse(gtree)
-          val convertedTree         = converter(undesugaredTree, gexpansion)
+          val (gtree, gexpansion) = (gtree0, g.EmptyTree)
+          val undesugaredTree = l.UndoDesugaring.unapply(gtree).getOrElse(gtree)
+          val convertedTree = converter(undesugaredTree, gexpansion)
           val maybeTypecheckedMtree = convertedTree
-          val maybeIndexedMtree     = maybeTypecheckedMtree
+          val maybeIndexedMtree = maybeTypecheckedMtree
           if (classTag[T].runtimeClass.isAssignableFrom(maybeIndexedMtree.getClass)) {
             maybeIndexedMtree.asInstanceOf[T]
           } else {
@@ -606,7 +606,7 @@ trait ToMtree { self: Converter =>
             expected = expected.stripPrefix("scala.meta.internal.ast.").stripPrefix("scala.meta.")
             expected = expected.stripSuffix("$Impl")
             expected = expected.replace("$", ".")
-            val actual  = maybeIndexedMtree.productPrefix
+            val actual = maybeIndexedMtree.productPrefix
             val summary = s"expected = $expected, actual = $actual"
             val details = s"${g.showRaw(gtree)}$EOL${maybeIndexedMtree.structure}"
             fail(s"unexpected result: $summary$EOL$details")
@@ -626,7 +626,7 @@ trait ToMtree { self: Converter =>
       def fail(diagnostics: String, ex: Option[Throwable] = None): Nothing = {
         val s_backtrace = backtrace
           .map(gtree => {
-            val prefix  = gtree.productPrefix
+            val prefix = gtree.productPrefix
             val details = gtree.toString()
             s"($prefix) $details"
           })

--- a/scalahost/src/main/scala/scala/meta/internal/scalahost/v1/LocationOps.scala
+++ b/scalahost/src/main/scala/scala/meta/internal/scalahost/v1/LocationOps.scala
@@ -19,14 +19,14 @@ trait LocationOps {
   implicit class XtensionGFileAddr(gfile: GFile) {
     def toAddr: Address = gfile match {
       case gfile: GPlainFile => Address.File(gfile.file.getAbsolutePath)
-      case other             => sys.error(s"unsupported file " + other)
+      case other => sys.error(s"unsupported file " + other)
     }
   }
 
   implicit class XtensionMInputAddr(minput: m.Input) {
     def toAddr: Address = minput match {
       case scala.meta.inputs.Input.File(file, _) => Address.File(file.getAbsolutePath)
-      case other                                 => sys.error(s"unsupported input " + other)
+      case other => sys.error(s"unsupported input " + other)
     }
   }
 

--- a/scalahost/src/main/scala/scala/meta/internal/scalahost/v1/Mirror.scala
+++ b/scalahost/src/main/scala/scala/meta/internal/scalahost/v1/Mirror.scala
@@ -34,22 +34,22 @@ trait Mirror extends MirrorApi with LocationOps {
       val ref1 = if (isTypechecked(ref)) ref else typecheck(ref)
       val symbol1 = {
         def relevantPosition(tree1: Tree): Position = tree1 match {
-          case name1: Name                => name1.pos
-          case _: Term.This               => ???
-          case _: Term.Super              => ???
-          case Term.Select(_, name1)      => name1.pos
-          case Term.ApplyUnary(_, name1)  => name1.pos
-          case Type.Select(_, name1)      => name1.pos
-          case Type.Project(_, name1)     => name1.pos
-          case Type.Singleton(ref1)       => relevantPosition(ref1)
-          case Ctor.Ref.Select(_, name1)  => name1.pos
+          case name1: Name => name1.pos
+          case _: Term.This => ???
+          case _: Term.Super => ???
+          case Term.Select(_, name1) => name1.pos
+          case Term.ApplyUnary(_, name1) => name1.pos
+          case Type.Select(_, name1) => name1.pos
+          case Type.Project(_, name1) => name1.pos
+          case Type.Singleton(ref1) => relevantPosition(ref1)
+          case Ctor.Ref.Select(_, name1) => name1.pos
           case Ctor.Ref.Project(_, name1) => name1.pos
-          case Ctor.Ref.Function(name1)   => ???
-          case _: Importee.Wildcard       => ???
-          case Importee.Name(name1)       => name1.pos
-          case Importee.Rename(name1, _)  => name1.pos
-          case Importee.Unimport(name1)   => name1.pos
-          case _                          => unreachable(debug(tree1.syntax, tree1.structure))
+          case Ctor.Ref.Function(name1) => ???
+          case _: Importee.Wildcard => ???
+          case Importee.Name(name1) => name1.pos
+          case Importee.Rename(name1, _) => name1.pos
+          case Importee.Unimport(name1) => name1.pos
+          case _ => unreachable(debug(tree1.syntax, tree1.structure))
         }
         val position = relevantPosition(ref1)
         val location = position.toSemantic
@@ -68,7 +68,7 @@ trait Mirror extends MirrorApi with LocationOps {
 
   private def isTypechecked(tree: Tree): Boolean = {
     val indexedAddrs = database.symbols.keys.map(_.addr).toSet
-    var allIndexed   = true
+    var allIndexed = true
     object traverser extends Traverser {
       override def apply(tree: Tree): Unit = {
         val addr = {

--- a/scalahost/src/main/scala/scala/meta/internal/scalahost/v1/offline/Mirror.scala
+++ b/scalahost/src/main/scala/scala/meta/internal/scalahost/v1/offline/Mirror.scala
@@ -71,7 +71,7 @@ class Mirror(classpath: String, sourcepath: String)
       }
       def autodetectFromProperties: Option[String] = {
         val customPath = Option(sys.props("scalahost.jar"))
-        val sbtPath    = Option(sys.props("sbt.paths.scalahost.compile.jar"))
+        val sbtPath = Option(sys.props("sbt.paths.scalahost.compile.jar"))
         customPath.orElse(sbtPath)
       }
       def fail(): Nothing = {
@@ -82,14 +82,14 @@ class Mirror(classpath: String, sourcepath: String)
     }
     val global: Global = {
       def fail(msg: String) = sys.error(s"mirror initialization failed: $msg")
-      val options           = "-Yrangepos -cp " + classpath + " -Xplugin:" + pluginpath + " -Xplugin-require:scalahost"
-      val args              = CommandLineParser.tokenize(options)
-      val emptySettings     = new Settings(error => fail(s"couldn't apply settings because $error"))
-      val reporter          = new StoreReporter()
-      val command           = new CompilerCommand(args, emptySettings)
-      val settings          = command.settings
-      val g                 = new Global(settings, reporter)
-      val run               = new g.Run
+      val options = "-Yrangepos -cp " + classpath + " -Xplugin:" + pluginpath + " -Xplugin-require:scalahost"
+      val args = CommandLineParser.tokenize(options)
+      val emptySettings = new Settings(error => fail(s"couldn't apply settings because $error"))
+      val reporter = new StoreReporter()
+      val command = new CompilerCommand(args, emptySettings)
+      val settings = command.settings
+      val g = new Global(settings, reporter)
+      val run = new g.Run
       if (reporter.hasErrors) reporter.infos.foreach(info => fail(info.msg))
       g.phase = run.phaseNamed("patmat")
       g.globalPhase = run.phaseNamed("patmat")

--- a/scalahost/src/main/scala/scala/meta/internal/scalahost/v1/offline/PathOps.scala
+++ b/scalahost/src/main/scala/scala/meta/internal/scalahost/v1/offline/PathOps.scala
@@ -37,7 +37,7 @@ trait PathOps { self: Mirror =>
           } else if (file.getName.endsWith(".jar")) {
             val stream = new FileInputStream(file)
             try {
-              val zip   = new ZipInputStream(stream)
+              val zip = new ZipInputStream(stream)
               var entry = zip.getNextEntry()
               while (entry != null) {
                 addZipEntry(file, entry)

--- a/scalahost/src/main/scala/scala/meta/internal/scalahost/v1/online/DatabaseOps.scala
+++ b/scalahost/src/main/scala/scala/meta/internal/scalahost/v1/online/DatabaseOps.scala
@@ -30,12 +30,12 @@ trait DatabaseOps { self: Mirror =>
         if (g.phase.id > g.currentRun.phaseNamed("patmat").id)
           sys.error("the compiler phase must be not later than patmat")
 
-        val symbols      = mutable.Map[Location, m.Symbol]()
-        val todo         = mutable.Set[m.Name]() // names to map to global trees
-        val mstarts      = mutable.Map[Int, m.Name]() // start offset -> tree
-        val mends        = mutable.Map[Int, m.Name]() // end offset -> tree
-        val margnames    = mutable.Map[Int, List[m.Name]]() // start offset of enclosing apply -> its arg names
-        val mwithins     = mutable.Map[m.Tree, m.Name]() // name of enclosing member -> name of private/protected within
+        val symbols = mutable.Map[Location, m.Symbol]()
+        val todo = mutable.Set[m.Name]() // names to map to global trees
+        val mstarts = mutable.Map[Int, m.Name]() // start offset -> tree
+        val mends = mutable.Map[Int, m.Name]() // end offset -> tree
+        val margnames = mutable.Map[Int, List[m.Name]]() // start offset of enclosing apply -> its arg names
+        val mwithins = mutable.Map[m.Tree, m.Name]() // name of enclosing member -> name of private/protected within
         val mwithinctors = mutable.Map[m.Tree, m.Name]() // name of enclosing class -> name of private/protected within for primary ctor
 
         locally {
@@ -43,9 +43,9 @@ trait DatabaseOps { self: Mirror =>
             private def indexName(mname: m.Name): Unit = {
               todo += mname
               // TODO: also drop trivia (no idea how to formulate this concisely)
-              val tok     = mname.tokens.dropWhile(_.is[m.Token.LeftParen]).headOption
+              val tok = mname.tokens.dropWhile(_.is[m.Token.LeftParen]).headOption
               val mstart1 = tok.map(_.start).getOrElse(-1)
-              val mend1   = tok.map(_.end).getOrElse(-1)
+              val mend1 = tok.map(_.end).getOrElse(-1)
               if (mstarts.contains(mstart1))
                 sys.error(
                   s"ambiguous mstart ${syntaxAndPos(mname)} ${syntaxAndPos(mstarts(mstart1))}")
@@ -83,9 +83,9 @@ trait DatabaseOps { self: Mirror =>
                   def findBinder(pat: m.Pat) =
                     pat.collect { case m.Pat.Var.Term(name) => name }.head
                   val menclosingName = menclosing match {
-                    case mtree: m.Member                 => mtree.name
-                    case m.Decl.Val(_, pat :: Nil, _)    => findBinder(pat)
-                    case m.Decl.Var(_, pat :: Nil, _)    => findBinder(pat)
+                    case mtree: m.Member => mtree.name
+                    case m.Decl.Val(_, pat :: Nil, _) => findBinder(pat)
+                    case m.Decl.Var(_, pat :: Nil, _) => findBinder(pat)
                     case m.Defn.Val(_, pat :: Nil, _, _) => findBinder(pat)
                     case m.Defn.Var(_, pat :: Nil, _, _) => findBinder(pat)
                   }
@@ -97,7 +97,7 @@ trait DatabaseOps { self: Mirror =>
             }
             override def apply(mtree: m.Tree): Unit = {
               val mstart = mtree.pos.start.offset
-              val mend   = mtree.pos.end.offset
+              val mend = mtree.pos.end.offset
               if (mstart != mend) {
                 mtree match {
                   case mtree @ m.Term.Apply(_, margs) =>
@@ -178,7 +178,7 @@ trait DatabaseOps { self: Mirror =>
               if (gtree.pos == null || gtree.pos == NoPosition) return
               val gstart = gtree.pos.start
               val gpoint = gtree.pos.point
-              val gend   = gtree.pos.end
+              val gend = gtree.pos.end
 
               if (margnames.contains(gstart) || margnames.contains(gpoint)) {
                 (margnames.get(gstart) ++ margnames.get(gpoint)).flatten.foreach(margname => {

--- a/scalahost/src/main/scala/scala/meta/internal/scalahost/v1/online/Mirror.scala
+++ b/scalahost/src/main/scala/scala/meta/internal/scalahost/v1/online/Mirror.scala
@@ -43,7 +43,7 @@ class Mirror(val global: Global)
 
   def database: Database = {
     var unmappedNames = ""
-    val units         = compilerUnits ++ adhocUnits
+    val units = compilerUnits ++ adhocUnits
     val databases = units.map(unit => {
       try unit.toDatabase
       catch {
@@ -62,7 +62,7 @@ class Mirror(val global: Global)
       def typecheckRoot(tree: Tree): Tree = {
         tree.parent match {
           case Some(parent) =>
-            val index   = parent.children.indexOf(tree)
+            val index = parent.children.indexOf(tree)
             val parent1 = typecheckRoot(parent)
             parent1.children(index)
           case _ =>
@@ -70,17 +70,17 @@ class Mirror(val global: Global)
               // NOTE: We stringify and reparse to obtain unique positions.
               // That's done because semantic APIs don't work without positions.
               val objectName = Term.fresh("scalahost$")
-              val wrapper    = q"object $objectName { $member }".syntax.parse[Source].get
-              val addr       = scala.meta.semantic.v1.Address.Snippet(wrapper.syntax)
+              val wrapper = q"object $objectName { $member }".syntax.parse[Source].get
+              val addr = scala.meta.semantic.v1.Address.Snippet(wrapper.syntax)
               minputMap(wrapper.pos.input) = addr
               val member1 = wrapper.children(0).children(1).children(1)
 
               val abstractFile = new GVirtualFile(randomUUID.toString)
               gfileMap(abstractFile) = addr
-              val sourceFile  = new GBatchSourceFile(abstractFile, wrapper.syntax)
-              val unit        = new g.CompilationUnit(sourceFile)
+              val sourceFile = new GBatchSourceFile(abstractFile, wrapper.syntax)
+              val unit = new g.CompilationUnit(sourceFile)
               val oldReporter = g.reporter
-              val reporter    = new GStoreReporter()
+              val reporter = new GStoreReporter()
               g.reporter = reporter
               try g.currentRun.compileLate(unit)
               finally g.reporter = oldReporter
@@ -120,15 +120,15 @@ class Mirror(val global: Global)
             }
             tree match {
               case tree: Term =>
-                val member  = q"val ${Pat.fresh("scalahost$")} = { $tree }"
+                val member = q"val ${Pat.fresh("scalahost$")} = { $tree }"
                 val member1 = wrapAndTypecheck(member)
                 member1.children(1).children(0)
               case tree: Type =>
-                val member  = q"type ${Type.fresh("scalahost$")} = $tree"
+                val member = q"type ${Type.fresh("scalahost$")} = $tree"
                 val member1 = wrapAndTypecheck(member)
                 member1.children(1)
               case _ =>
-                val what        = "quasiquotes that are neither terms nor types"
+                val what = "quasiquotes that are neither terms nor types"
                 val restriction = s"implementation restriction: semantic API doesn't support $what"
                 throw new SemanticException(tree.pos, restriction)
             }

--- a/scalahost/src/main/scala/scala/meta/internal/scalahost/v1/online/ParseOps.scala
+++ b/scalahost/src/main/scala/scala/meta/internal/scalahost/v1/online/ParseOps.scala
@@ -15,7 +15,7 @@ trait ParseOps { self: Mirror =>
         // always ensures a newline at the end of its compilation units.
         val input = unit.source.file match {
           case gplainFile: GPlainFile => m.Input.File(gplainFile.file)
-          case _                      => m.Input.String(new String(unit.source.content).trim)
+          case _ => m.Input.String(new String(unit.source.content).trim)
         }
         dialect(input).parse[m.Source].get
       })

--- a/scalahost/src/main/scala/scala/meta/internal/scalahost/v1/online/SymbolOps.scala
+++ b/scalahost/src/main/scala/scala/meta/internal/scalahost/v1/online/SymbolOps.scala
@@ -51,7 +51,7 @@ trait SymbolOps { self: Mirror =>
             else "L" + sym.fullName.replace(".", "/") + ";"
           }
           val g.MethodType(params, ret) = sym.info.erasure
-          val jvmRet                    = if (!sym.isConstructor) ret else g.definitions.UnitClass.toType
+          val jvmRet = if (!sym.isConstructor) ret else g.definitions.UnitClass.toType
           "(" + params.map(param => encode(param.info)).mkString("") + ")" + encode(jvmRet)
         }
 

--- a/scalahost/src/test/scala/scala/meta/tests/scalahost/converters/ConverterSuite.scala
+++ b/scalahost/src/test/scala/scala/meta/tests/scalahost/converters/ConverterSuite.scala
@@ -17,16 +17,16 @@ trait ConverterSuite extends FunSuiteLike {
 
   private lazy val g: Global = {
     def fail(msg: String) = sys.error(s"ReflectToMeta initialization failed: $msg")
-    val classpath         = System.getProperty("sbt.paths.scalahost.test.classes")
-    val pluginpath        = System.getProperty("sbt.paths.plugin.jar")
-    val options           = "-cp " + classpath + " -Xplugin:" + pluginpath + ":" + classpath + " -Xplugin-require:macroparadise"
-    val args              = CommandLineParser.tokenize(options)
-    val emptySettings     = new Settings(error => fail(s"couldn't apply settings because $error"))
-    val reporter          = new StoreReporter()
-    val command           = new CompilerCommand(args, emptySettings)
-    val settings          = command.settings
-    val g                 = new Global(settings, reporter)
-    val run               = new g.Run
+    val classpath = System.getProperty("sbt.paths.scalahost.test.classes")
+    val pluginpath = System.getProperty("sbt.paths.plugin.jar")
+    val options = "-cp " + classpath + " -Xplugin:" + pluginpath + ":" + classpath + " -Xplugin-require:macroparadise"
+    val args = CommandLineParser.tokenize(options)
+    val emptySettings = new Settings(error => fail(s"couldn't apply settings because $error"))
+    val reporter = new StoreReporter()
+    val command = new CompilerCommand(args, emptySettings)
+    val settings = command.settings
+    val g = new Global(settings, reporter)
+    val run = new g.Run
     g.phase = run.parserPhase
     g.globalPhase = run.parserPhase
     g
@@ -52,19 +52,19 @@ trait ConverterSuite extends FunSuiteLike {
               def unapply(tree: Tree): Option[(Term, Seq[Seq[Type]], Seq[Seq[Term.Arg]])] =
                 tree match {
                   case q"$fun[..$targs](...$argss)" => Some((fun, Seq(targs), argss))
-                  case q"$fun(...$argss)"           => Some((fun, Nil, argss))
-                  case _                            => None
+                  case q"$fun(...$argss)" => Some((fun, Nil, argss))
+                  case _ => None
                 }
             }
             object NestedTermAnnotated {
               def flatTerm(t: Term, accum: Seq[Mod.Annot] = Nil): (Term, Seq[Mod.Annot]) =
                 t match {
                   case Term.Annotate(t2, as) => flatTerm(t2, as ++ accum)
-                  case _                     => (t, accum)
+                  case _ => (t, accum)
                 }
               def unapply(tree: Tree): Option[(Term, Seq[Mod.Annot])] = tree match {
                 case t: Term.Annotate => Some(flatTerm(t))
-                case _                => None
+                case _ => None
               }
             }
 
@@ -123,7 +123,7 @@ trait ConverterSuite extends FunSuiteLike {
     g.reporter = reporter
     val tree = {
       if (parseAsCompilationUnit) {
-        val cu     = new g.CompilationUnit(g.newSourceFile(code))
+        val cu = new g.CompilationUnit(g.newSourceFile(code))
         val parser = new g.syntaxAnalyzer.UnitParser(cu, Nil)
         parser.parse()
       } else {
@@ -158,7 +158,7 @@ trait ConverterSuite extends FunSuiteLike {
   def getConvertedMetaTree(code: String): m.Tree = {
     object converter extends Converter {
       lazy val global: ConverterSuite.this.g.type = ConverterSuite.this.g
-      def apply(gtree: g.Tree): m.Tree            = gtree.toMtree[m.Tree]
+      def apply(gtree: g.Tree): m.Tree = gtree.toMtree[m.Tree]
     }
     converter(getParsedScalacTree(code))
   }
@@ -166,7 +166,7 @@ trait ConverterSuite extends FunSuiteLike {
   def syntactic(code: String): Unit = {
     test(code.trim) {
       val convertedMetaTree = getConvertedMetaTree(code)
-      val parsedMetaTree    = getParsedMetaTree(code)
+      val parsedMetaTree = getParsedMetaTree(code)
       try {
         checkMismatchesModuloDesugarings(parsedMetaTree, convertedMetaTree)
       } catch {

--- a/scalahost/src/test/scala/scala/meta/tests/scalahost/v1/OnlineMirrorSuite.scala
+++ b/scalahost/src/test/scala/scala/meta/tests/scalahost/v1/OnlineMirrorSuite.scala
@@ -24,16 +24,16 @@ abstract class OnlineMirrorSuite extends FunSuite {
 
   lazy val g: Global = {
     def fail(msg: String) = sys.error(s"OnlineMirrorSuite initialization failed: $msg")
-    val classpath         = System.getProperty("sbt.paths.scalahost.test.classes")
-    val pluginpath        = System.getProperty("sbt.paths.scalahost.compile.jar")
-    val options           = "-Yrangepos -cp " + classpath + " -Xplugin:" + pluginpath + ":" + classpath + " -Xplugin-require:scalahost"
-    val args              = CommandLineParser.tokenize(options)
-    val emptySettings     = new Settings(error => fail(s"couldn't apply settings because $error"))
-    val reporter          = new StoreReporter()
-    val command           = new CompilerCommand(args, emptySettings)
-    val settings          = command.settings
-    val g                 = new Global(settings, reporter)
-    val run               = new g.Run
+    val classpath = System.getProperty("sbt.paths.scalahost.test.classes")
+    val pluginpath = System.getProperty("sbt.paths.scalahost.compile.jar")
+    val options = "-Yrangepos -cp " + classpath + " -Xplugin:" + pluginpath + ":" + classpath + " -Xplugin-require:scalahost"
+    val args = CommandLineParser.tokenize(options)
+    val emptySettings = new Settings(error => fail(s"couldn't apply settings because $error"))
+    val reporter = new StoreReporter()
+    val command = new CompilerCommand(args, emptySettings)
+    val settings = command.settings
+    val g = new Global(settings, reporter)
+    val run = new g.Run
     g.phase = run.parserPhase
     g.globalPhase = run.parserPhase
     g
@@ -44,14 +44,14 @@ abstract class OnlineMirrorSuite extends FunSuite {
 
   private def computeDatabaseFromSnippet(code: String): Database = {
     val javaFile = File.createTempFile("paradise", ".scala")
-    val writer   = new PrintWriter(javaFile)
+    val writer = new PrintWriter(javaFile)
     try writer.write(code)
     finally writer.close()
 
-    val run          = new g.Run
+    val run = new g.Run
     val abstractFile = AbstractFile.getFile(javaFile)
-    val sourceFile   = g.getSourceFile(abstractFile)
-    val unit         = new g.CompilationUnit(sourceFile)
+    val sourceFile = g.getSourceFile(abstractFile)
+    val unit = new g.CompilationUnit(sourceFile)
     run.compileUnits(List(unit), run.phaseNamed("terminal"))
 
     g.phase = run.parserPhase
@@ -63,7 +63,7 @@ abstract class OnlineMirrorSuite extends FunSuite {
     errors.foreach(error => fail(s"scalac parse error: ${error.msg} at ${error.pos}"))
 
     val packageobjectsPhase = run.phaseNamed("packageobjects")
-    val phases              = List(run.parserPhase, run.namerPhase, packageobjectsPhase, run.typerPhase)
+    val phases = List(run.parserPhase, run.namerPhase, packageobjectsPhase, run.typerPhase)
     reporter.reset()
 
     phases.foreach(phase => {
@@ -82,20 +82,20 @@ abstract class OnlineMirrorSuite extends FunSuite {
   def database(code: String, expected: String): Unit = {
     test(code) {
       val database = computeDatabaseFromSnippet(code)
-      val path     = g.currentRun.units.toList.last.source.file.file.getAbsolutePath
-      val actual   = database.toString.split(EOL).drop(1).mkString(EOL).replace(path, "<...>")
+      val path = g.currentRun.units.toList.last.source.file.file.getAbsolutePath
+      val actual = database.toString.split(EOL).drop(1).mkString(EOL).replace(path, "<...>")
       assert(expected === actual)
     }
   }
 
   private def computeDatabaseFromMarkup(markup: String): List[m.Name] = {
     val chevrons = "<<(.*?)>>".r
-    val ps0      = chevrons.findAllIn(markup).matchData.map(m => (m.start, m.end)).toList
-    val ps       = ps0.zipWithIndex.map { case ((s, e), i) => (s - 4 * i, e - 4 * i - 4) }
-    val code     = chevrons.replaceAllIn(markup, "$1")
+    val ps0 = chevrons.findAllIn(markup).matchData.map(m => (m.start, m.end)).toList
+    val ps = ps0.zipWithIndex.map { case ((s, e), i) => (s - 4 * i, e - 4 * i - 4) }
+    val code = chevrons.replaceAllIn(markup, "$1")
     val database = computeDatabaseFromSnippet(code)
-    val unit     = g.currentRun.units.toList.last.asInstanceOf[mirror.g.CompilationUnit]
-    val source   = unit.toSource
+    val unit = g.currentRun.units.toList.last.asInstanceOf[mirror.g.CompilationUnit]
+    val source = unit.toSource
     ps.map {
       case (s, e) =>
         val names = source.collect {
@@ -103,9 +103,9 @@ abstract class OnlineMirrorSuite extends FunSuite {
         }
         val chevron = "<<" + code.substring(s, e) + ">>"
         names match {
-          case Nil        => sys.error(chevron + " does not wrap a name")
+          case Nil => sys.error(chevron + " does not wrap a name")
           case List(name) => name
-          case _          => sys.error("fatal error processing " + chevron)
+          case _ => sys.error("fatal error processing " + chevron)
         }
     }
   }
@@ -115,7 +115,7 @@ abstract class OnlineMirrorSuite extends FunSuite {
       val names = computeDatabaseFromMarkup(markup)
       names match {
         case List() => fn()
-        case _      => sys.error(s"0 chevrons expected, ${names.length} chevrons found")
+        case _ => sys.error(s"0 chevrons expected, ${names.length} chevrons found")
       }
     }
   }
@@ -125,7 +125,7 @@ abstract class OnlineMirrorSuite extends FunSuite {
       val names = computeDatabaseFromMarkup(markup)
       names match {
         case List(name1) => fn(name1)
-        case _           => sys.error(s"1 chevron expected, ${names.length} chevrons found")
+        case _ => sys.error(s"1 chevron expected, ${names.length} chevrons found")
       }
     }
   }
@@ -135,7 +135,7 @@ abstract class OnlineMirrorSuite extends FunSuite {
       val names = computeDatabaseFromMarkup(markup)
       names match {
         case List(name1, name2) => fn(name1, name2)
-        case _                  => sys.error(s"2 chevrons expected, ${names.length} chevrons found")
+        case _ => sys.error(s"2 chevrons expected, ${names.length} chevrons found")
       }
     }
   }
@@ -145,7 +145,7 @@ abstract class OnlineMirrorSuite extends FunSuite {
       val names = computeDatabaseFromMarkup(markup)
       names match {
         case List(name1, name2, name3) => fn(name1, name2, name3)
-        case _                         => sys.error(s"3 chevrons expected, ${names.length} chevrons found")
+        case _ => sys.error(s"3 chevrons expected, ${names.length} chevrons found")
       }
     }
   }
@@ -155,7 +155,7 @@ abstract class OnlineMirrorSuite extends FunSuite {
       val names = computeDatabaseFromMarkup(markup)
       names match {
         case List(name1, name2, name3, name4) => fn(name1, name2, name3, name4)
-        case _                                => sys.error(s"4 chevrons expected, ${names.length} chevrons found")
+        case _ => sys.error(s"4 chevrons expected, ${names.length} chevrons found")
       }
     }
   }

--- a/scalameta/contrib/src/main/scala/scala/meta/contrib/AssociatedComments.scala
+++ b/scalameta/contrib/src/main/scala/scala/meta/contrib/AssociatedComments.scala
@@ -10,13 +10,13 @@ sealed abstract class AssociatedComments(leadingMap: Map[Token, Seq[Comment]],
                                          trailingMap: Map[Token, Seq[Comment]]) {
   def leading(tree: Tree): Set[Comment] =
     (for {
-      token    <- tree.tokens.headOption
+      token <- tree.tokens.headOption
       comments <- leadingMap.get(token)
     } yield comments).getOrElse(Nil).toSet
 
   def trailing(tree: Tree): Set[Comment] =
     (for {
-      token    <- tree.tokens.lastOption
+      token <- tree.tokens.lastOption
       comments <- trailingMap.get(token)
     } yield comments).getOrElse(Nil).toSet
 
@@ -29,18 +29,18 @@ object AssociatedComments {
   def apply(tree: Tree): AssociatedComments = apply(tree.tokens)
   def apply(tokens: Tokens): AssociatedComments = {
     import scala.meta.tokens.Token._
-    val leadingBuilder   = Map.newBuilder[Token, Seq[Comment]]
-    val trailingBuilder  = Map.newBuilder[Token, Seq[Comment]]
-    val leading          = Seq.newBuilder[Comment]
-    val trailing         = Seq.newBuilder[Comment]
-    var isLeading        = true
+    val leadingBuilder = Map.newBuilder[Token, Seq[Comment]]
+    val trailingBuilder = Map.newBuilder[Token, Seq[Comment]]
+    val leading = Seq.newBuilder[Comment]
+    val trailing = Seq.newBuilder[Comment]
+    var isLeading = true
     var lastToken: Token = tokens.head
     tokens.foreach {
       case c: Comment =>
         if (isLeading) leading += c
         else trailing += c
       case Token.LF() => isLeading = true
-      case Trivia()   =>
+      case Trivia() =>
       case currentToken =>
         val t = trailing.result()
         if (t.nonEmpty) {

--- a/scalameta/contrib/src/main/scala/scala/meta/contrib/Structurally.scala
+++ b/scalameta/contrib/src/main/scala/scala/meta/contrib/Structurally.scala
@@ -12,12 +12,12 @@ import scala.meta.Tree
   */
 class Structurally[+A <: Tree](val tree: A) {
   // TODO(olafur) more efficient hashCode
-  private lazy val hash: Int   = tree.structure.hashCode
+  private lazy val hash: Int = tree.structure.hashCode
   override def hashCode(): Int = hash
   override def equals(obj: scala.Any): Boolean = {
     obj match {
       case e2: Structurally[_] => Structurally.equal(tree, e2.tree)
-      case _                   => false
+      case _ => false
     }
   }
 }
@@ -28,8 +28,8 @@ object Structurally {
 
   private def loopStructure(x: Any, y: Any): Boolean = (x, y) match {
     case (x, y) if x == null || y == null => x == null && y == null
-    case (Some(x), Some(y))               => loopStructure(x, y)
-    case (None, None)                     => true
+    case (Some(x), Some(y)) => loopStructure(x, y)
+    case (None, None) => true
     case (xs: Seq[_], ys: Seq[_]) =>
       xs.length == ys.length &&
         xs.zip(ys).forall { case (x, y) => loopStructure(x, y) }

--- a/scalameta/contrib/src/main/scala/scala/meta/contrib/Syntactically.scala
+++ b/scalameta/contrib/src/main/scala/scala/meta/contrib/Syntactically.scala
@@ -7,11 +7,11 @@ import scala.meta.Tree
   * Two trees are syntactically equal if their .show[Syntax] is equal.
   **/
 class Syntactically[+A <: Tree](val tree: A) {
-  private lazy val syntax      = tree.syntax
+  private lazy val syntax = tree.syntax
   override def hashCode(): Int = syntax.hashCode
   override def equals(obj: scala.Any): Boolean = obj match {
     case e2: Syntactically[_] => syntax == e2.syntax
-    case _                    => false
+    case _ => false
   }
 }
 

--- a/scalameta/contrib/src/main/scala/scala/meta/contrib/TreeOps.scala
+++ b/scalameta/contrib/src/main/scala/scala/meta/contrib/TreeOps.scala
@@ -58,6 +58,6 @@ object TreeOps {
   final def ancestors(tree: Tree, accum: Seq[Tree] = Seq.empty[Tree]): Seq[Tree] =
     tree.parent match {
       case Some(parent) => ancestors(parent, parent +: accum)
-      case _            => accum
+      case _ => accum
     }
 }

--- a/scalameta/contrib/src/test/scala/scala/meta/contrib/AssociatedCommentsTest.scala
+++ b/scalameta/contrib/src/test/scala/scala/meta/contrib/AssociatedCommentsTest.scala
@@ -17,8 +17,8 @@ class AssociatedCommentsTest extends FunSuite {
   val comments = AssociatedComments(input)
   test("leading") {
     val defnObject = input.find(_.is[Defn.Object]).get
-    val defnVal    = input.find(_.is[Defn.Val]).get
-    val lit        = input.find(_.is[Lit]).get
+    val defnVal = input.find(_.is[Defn.Val]).get
+    val lit = input.find(_.is[Lit]).get
     comments.leading(defnVal).head match {
       case Token.Comment(a) =>
         println(s"'$a'")

--- a/scalameta/contrib/src/test/scala/scala/meta/contrib/EqualSuite.scala
+++ b/scalameta/contrib/src/test/scala/scala/meta/contrib/EqualSuite.scala
@@ -5,10 +5,10 @@ import scala.meta.testkit._
 import org.scalatest.FunSuite
 
 class EqualSuite extends FunSuite {
-  val a: Stat       = "val x = 2 // foo".parse[Stat].get
-  val b: Defn.Val   = q"val x = 2"
-  val c: Defn.Val   = q"val x = 2"
-  val d: Defn.Def   = q"def x = 2"
+  val a: Stat = "val x = 2 // foo".parse[Stat].get
+  val b: Defn.Val = q"val x = 2"
+  val c: Defn.Val = q"val x = 2"
+  val d: Defn.Def = q"def x = 2"
   val e: Defn.Class = q"class Foo { val x = 2 }"
 
   test("syntactic") {
@@ -32,9 +32,9 @@ class EqualSuite extends FunSuite {
   test("structural property") {
     val errors = SyntaxAnalysis.onParsed[Tree](ContribSuite.corpus) { ast =>
       // empty transformation preserve structural equality
-      val a               = ast.transform { case Term.Name(x) => Term.Name(x) }
-      val b               = ast.transform { case Type.Name(x) => Type.Name(x) }
-      val refEqual        = a.equals(b) // should be false
+      val a = ast.transform { case Term.Name(x) => Term.Name(x) }
+      val b = ast.transform { case Type.Name(x) => Type.Name(x) }
+      val refEqual = a.equals(b) // should be false
       val structuralEqual = a.equal[Structurally](b) // should be true
       if (refEqual || !structuralEqual) Seq(a)
       else Nil


### PR DESCRIPTION
Vertical alignment is now disabled. From personal experience, it was too much
of a disruption with little benefit.

stripMargin is now assumed to be String.stripMargin from scala-library.jar.
Allegedly, this should lead to better-looking multiline strings with margins.