### PR TITLE
Fix bintray publish script.

### DIFF
--- a/bin/bintray.sh
+++ b/bin/bintray.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 if [[ "$CI_BRANCH" == "master" || "$CI_BRANCH" == "2.x" ]]; then
-  PUBLISH=publish
   mkdir -p ~/.bintray
   cat > ~/.bintray/.credentials <<EOF
 realm = Bintray API Realm
@@ -9,7 +8,7 @@ host = api.bintray.com
 user = $BINTRAY_USERNAME
 password = $BINTRAY_API_KEY
 EOF
-  sbt ++$SCALA_VERSION "$PUBLISH"
+  sbt -Dsbt.ivy.home=/drone/cache/ivy2 ++$SCALA_VERSION publish
 fi
 
 


### PR DESCRIPTION
Drone uses a specific directory for cache, the publish step has kept
failing because drone hasn't used that cache directory when publishing,
resulting in

[error] (*:update) sbt.ResolveException: unresolved dependency: me.lessis#bintray-sbt;0.3.0: not found

errors.