### PR TITLE
change versioning scheme

### DIFF
--- a/project/os.scala
+++ b/project/os.scala
@@ -109,16 +109,27 @@ object shutil {
 }
 
 object git {
-  def stableSha() = {
-    val currentSha = shell.check_output("git rev-parse HEAD", cwd = ".")
-    val changed = shell.check_output("git diff --name-status", cwd = ".")
-    if (changed.trim.nonEmpty) sys.error("repository " + new File(".").getAbsolutePath + " is dirty (has modified files)")
-    val staged = shell.check_output("git diff --staged --name-status", cwd = ".")
-    if (staged.trim.nonEmpty) sys.error("repository " + new File(".").getAbsolutePath + " is dirty (has staged files)")
-    val untracked = shell.check_output("git ls-files --others --exclude-standard", cwd = ".")
-    if (untracked.trim.nonEmpty) sys.error("repository " + new File(".").getAbsolutePath + " is dirty (has untracked files)")
-    val (exitcode, stdout, stderr) = shell.exec(s"git branch -r --contains $currentSha")
-    if (exitcode != 0 || stdout.isEmpty) sys.error("repository " + new File(".").getAbsolutePath + " doesn't contain commit " + currentSha)
-    currentSha.trim
+  def isStable(): Boolean = {
+    def noUntrackedFiles = {
+      val untracked = shell.check_output("git ls-files --others --exclude-standard", cwd = ".")
+      untracked.trim.isEmpty
+    }
+    def noModifiedFiles = {
+      val changed = shell.check_output("git diff --name-status", cwd = ".")
+      changed.trim.isEmpty
+    }
+    def noStagedFiles = {
+      val staged = shell.check_output("git diff --staged --name-status", cwd = ".")
+      staged.trim.isEmpty
+    }
+    noUntrackedFiles && noModifiedFiles && noStagedFiles
+  }
+
+  def distance(from: String, to: String): Int = {
+    shell.check_output(s"git rev-list $to ^$from --count", cwd = ".").trim.toInt
+  }
+
+  def currentSha(): String = {
+    shell.check_output("git rev-parse HEAD", cwd = ".").trim
   }
 }


### PR DESCRIPTION
We no longer use PR numbers to derive prerelease versions, because
such versions aren’t guaranteed to be ordered lexicographically.
Earlier pull requests can be merged later, and vice versa,
which brings significant confusion.

The new versioning scheme is very similar to git-describe.
A typical prerelease version looks like 1.6.0-344-a9f6f83e,
where the first number after the dash is the number of commits between
HEAD and v1.0.0, and the second number is the sha of HEAD.
This is a little bit more verbose than the old scheme, which only featured
one number, but that’s what it takes to be (almost) lexicographic and unique.

Finally, if an artifact is built from a dirty repository, i.e.
if the sources aren’t uniquely identified by the current sha, then we
append a timestamp, e.g. 1.6.0-344-a9f6f83e.1487281742717.