### PR TITLE
Add upgrade guide to changelog.

### DIFF
--- a/changelog/1.6.0.md
+++ b/changelog/1.6.0.md
@@ -85,6 +85,10 @@ to your sbt configuration to make use of them: `resolvers += Resolver.bintrayIvy
   * SIP-23 literal types syntax support ([#620](https://github.com/scalameta/scalameta/issues/620))
   * Parse error in Paradise211 dialect ([#684](https://github.com/scalameta/scalameta/issues/684))
 
+## Upgrade guide
+
+  * If you use scala.meta macro annotations, you should upgrade to paradise 3.0.0-M7
+
 ## Contributors
 
 We would like to heartily thank everyone who has contributed to scala.meta by participating in discussions,


### PR DESCRIPTION
See https://gitter.im/scalameta/scalameta?at=58b406971465c46a56bd6e87
for a question about upgrading to 1.6 causing paradise macros to fail.