### PR TITLE
Contrib extract

### DIFF
--- a/changelog/1.7.0.md
+++ b/changelog/1.7.0.md
@@ -16,4 +16,4 @@ Contrib:
   - eg. `q"trait Foo[A] { def bar = 2; val baz = 2}".extract[Vals]`
   - In future this will be supplemented by the ability to replace/update based on extract.
   - In future we will also add many more extractors. 
-  - If you would like a specific extractor implemented early, please open a ticket.
+  - If you would like a specific extractor implemented, please open a ticket or send us a pull request.

--- a/changelog/1.7.0.md
+++ b/changelog/1.7.0.md
@@ -10,3 +10,10 @@ Contrib:
   write `[Structurally]` in `a.isEqual[Structurally](b)`.
 - `(a: Subtype).isEqual(b: Supertype)` will no longer compile, either upcast
   `a: Supertype` or swap the order to `b.isEqual(a)`
+- The `Extract[A, B]` typeclass has been added.
+  - This means that you can extract Stats/Mods/Annotations etc.
+  - eg. `q"@Foo @Bar sealed final class Foo".extract[Annotations]`
+  - eg. `q"trait Foo[A] { def bar = 2; val baz = 2}".extract[Vals]`
+  - In future this will be supplemented by the ability to replace/update based on extract.
+  - In future we will also add many more extractors. 
+  - If you would like a specific extractor implemented early, please open a ticket.

--- a/scalameta/contrib/src/main/scala/scala/meta/contrib/Extract.scala
+++ b/scalameta/contrib/src/main/scala/scala/meta/contrib/Extract.scala
@@ -1,0 +1,15 @@
+package scala.meta.contrib
+
+/**
+  * Logical extraction of B from A.
+  *
+  * Meaning that this is supposed to replicate what the use thinks should happen.
+  * Not the actual class representation
+  *
+  * eg. Extract[Defn.Class, Seq[Stat]]
+  *
+  * is actually extracting the stats from the Template, which is a child of Defn.Class.
+  */
+trait Extract[A, B] {
+  def extract(a: A): B
+}

--- a/scalameta/contrib/src/main/scala/scala/meta/contrib/implicits/ExtractPimps.scala
+++ b/scalameta/contrib/src/main/scala/scala/meta/contrib/implicits/ExtractPimps.scala
@@ -1,0 +1,20 @@
+package scala.meta.contrib.implicits
+
+import scala.meta.contrib.Extract
+
+trait ExtractPimps {
+  implicit class XtensionExtractors[A](a: A) {
+
+    /**
+      * Logical extraction of B from A.
+      *
+      * Meaning that this is supposed to replicate what the use thinks should happen.
+      * Not the actual class representation
+      *
+      * eg. Extract[Defn.Class, Seq[Stat]]
+      *
+      * is actually extracting the stats from the Template, which is a child of Defn.Class.
+      */
+    def extract[B](implicit ev: Extract[A, B]): B = ev.extract(a)
+  }
+}

--- a/scalameta/contrib/src/main/scala/scala/meta/contrib/implicits/ExtractPimps.scala
+++ b/scalameta/contrib/src/main/scala/scala/meta/contrib/implicits/ExtractPimps.scala
@@ -1,8 +1,23 @@
 package scala.meta.contrib.implicits
 
+import scala.meta._
 import scala.meta.contrib.Extract
+import scala.collection.immutable.Seq
 
 trait ExtractPimps {
+
+  // Helper types since Seq has to be immutable
+  type Stats = Seq[Stat]
+  type Defs = Seq[Defn.Def]
+  type Vals = Seq[Defn.Val]
+  type Vars = Seq[Defn.Var]
+  type Traits = Seq[Defn.Trait]
+  type Objects = Seq[Defn.Object]
+  type Classes = Seq[Defn.Class]
+  type Types = Seq[Defn.Type]
+  type Mods = Seq[Mod]
+  type Annotations = Seq[Mod.Annot]
+
   implicit class XtensionExtractors[A](a: A) {
 
     /**

--- a/scalameta/contrib/src/main/scala/scala/meta/contrib/instances/ExtractAnnotationInstances.scala
+++ b/scalameta/contrib/src/main/scala/scala/meta/contrib/instances/ExtractAnnotationInstances.scala
@@ -1,0 +1,16 @@
+package scala.meta.contrib.instances
+
+import scala.collection.immutable.Seq
+import scala.meta.Mod
+import scala.meta.contrib.Extract
+
+trait ExtractAnnotationInstances {
+  implicit def extractAnnotationsFromMods[A](
+      implicit ev: Extract[A, Seq[Mod]]): Extract[A, Seq[Mod.Annot]] =
+    new Extract[A, Seq[Mod.Annot]] {
+      override def extract(a: A): Seq[Mod.Annot] =
+        ev.extract(a).collect { case d: Mod.Annot => d }
+    }
+}
+
+object ExtractAnnotationInstances

--- a/scalameta/contrib/src/main/scala/scala/meta/contrib/instances/ExtractModsInstances.scala
+++ b/scalameta/contrib/src/main/scala/scala/meta/contrib/instances/ExtractModsInstances.scala
@@ -1,0 +1,42 @@
+package scala.meta.contrib.instances
+
+import scala.collection.immutable.Seq
+import scala.meta._
+import scala.meta.contrib.Extract
+
+trait ExtractModsInstances {
+  implicit val extractClassMods: Extract[Defn.Class, Seq[Mod]] =
+    new Extract[Defn.Class, Seq[Mod]] {
+      override def extract(c: Defn.Class): Seq[Mod] =
+        c.mods
+    }
+
+  implicit val extractTraitMods: Extract[Defn.Trait, Seq[Mod]] =
+    new Extract[Defn.Trait, Seq[Mod]] {
+      override def extract(t: Defn.Trait): Seq[Mod] =
+        t.mods
+    }
+
+  implicit val extractObjectMods: Extract[Defn.Object, Seq[Mod]] =
+    new Extract[Defn.Object, Seq[Mod]] {
+      override def extract(o: Defn.Object): Seq[Mod] =
+        o.mods
+    }
+
+  implicit val extractDefMods: Extract[Defn.Def, Seq[Mod]] = new Extract[Defn.Def, Seq[Mod]] {
+    override def extract(d: Defn.Def): Seq[Mod] =
+      d.mods
+  }
+
+  implicit val extractValMods: Extract[Defn.Val, Seq[Mod]] = new Extract[Defn.Val, Seq[Mod]] {
+    override def extract(v: Defn.Val): Seq[Mod] =
+      v.mods
+  }
+
+  implicit val extractVarMods: Extract[Defn.Var, Seq[Mod]] = new Extract[Defn.Var, Seq[Mod]] {
+    override def extract(v: Defn.Var): Seq[Mod] =
+      v.mods
+  }
+}
+
+object ExtractModsInstances extends ExtractModsInstances

--- a/scalameta/contrib/src/main/scala/scala/meta/contrib/instances/ExtractStatInstances.scala
+++ b/scalameta/contrib/src/main/scala/scala/meta/contrib/instances/ExtractStatInstances.scala
@@ -1,0 +1,67 @@
+package scala.meta.contrib.instances
+
+import scala.meta._
+import scala.meta.contrib._
+import scala.collection.immutable.Seq
+
+trait ExtractStatInstances {
+
+  implicit val extractTemplateStats: Extract[Template, Seq[Stat]] =
+    new Extract[Template, Seq[Stat]] {
+      override def extract(t: Template): Seq[Stat] =
+        t.stats.getOrElse(Nil)
+    }
+
+  implicit val extractClassStats: Extract[Defn.Class, Seq[Stat]] =
+    new Extract[Defn.Class, Seq[Stat]] {
+      override def extract(c: Defn.Class): Seq[Stat] =
+        c.templ.stats.getOrElse(Nil)
+    }
+
+  implicit val extractTraitStats: Extract[Defn.Trait, Seq[Stat]] =
+    new Extract[Defn.Trait, Seq[Stat]] {
+      override def extract(t: Defn.Trait): Seq[Stat] =
+        t.templ.stats.getOrElse(Nil)
+    }
+
+  implicit val extractObjectStats: Extract[Defn.Object, Seq[Stat]] =
+    new Extract[Defn.Object, Seq[Stat]] {
+      override def extract(o: Defn.Object): Seq[Stat] =
+        o.templ.stats.getOrElse(Nil)
+    }
+
+  implicit val extractPkgStats: Extract[Pkg, Seq[Stat]] = new Extract[Pkg, Seq[Stat]] {
+    override def extract(p: Pkg): Seq[Stat] =
+      p.stats
+  }
+
+  implicit val extractSourcetats: Extract[Source, Seq[Stat]] = new Extract[Source, Seq[Stat]] {
+    override def extract(s: Source): Seq[Stat] =
+      s.stats
+  }
+
+  implicit val extractDefStats: Extract[Defn.Def, Seq[Stat]] = new Extract[Defn.Def, Seq[Stat]] {
+    override def extract(d: Defn.Def): Seq[Stat] =
+      extractStatsFromTerm(d.body)
+  }
+
+  implicit val extractValStats: Extract[Defn.Val, Seq[Stat]] = new Extract[Defn.Val, Seq[Stat]] {
+    override def extract(v: Defn.Val): Seq[Stat] =
+      extractStatsFromTerm(v.rhs)
+  }
+
+  implicit val extractVarStats: Extract[Defn.Var, Seq[Stat]] = new Extract[Defn.Var, Seq[Stat]] {
+    override def extract(v: Defn.Var): Seq[Stat] =
+      v.rhs
+        .map(extractStatsFromTerm)
+        .getOrElse(Nil)
+  }
+
+  private def extractStatsFromTerm(term: Term): Seq[Stat] =
+    term match {
+      case Term.Block(stats) => stats
+      case s => s :: Nil
+    }
+}
+
+object ExtractStatInstances extends ExtractStatInstances

--- a/scalameta/contrib/src/main/scala/scala/meta/contrib/instances/ExtractStatSubtypeInstances.scala
+++ b/scalameta/contrib/src/main/scala/scala/meta/contrib/instances/ExtractStatSubtypeInstances.scala
@@ -1,0 +1,60 @@
+package scala.meta.contrib.instances
+
+import scala.collection.immutable.Seq
+import scala.meta._
+import scala.meta.contrib.Extract
+
+// These could be optimised if necessary. As they currently build an intermediate list
+// TODO: Consider completely covering all stat subtypes here. We may actually just be able to macro this
+trait ExtractStatSubtypeInstances {
+  implicit def extractDefsFromStats[A](
+      implicit ev: Extract[A, Seq[Stat]]): Extract[A, Seq[Defn.Def]] =
+    new Extract[A, Seq[Defn.Def]] {
+      override def extract(a: A): Seq[Defn.Def] =
+        ev.extract(a).collect { case d: Defn.Def => d }
+    }
+
+  implicit def extractValsFromStats[A](
+      implicit ev: Extract[A, Seq[Stat]]): Extract[A, Seq[Defn.Val]] =
+    new Extract[A, Seq[Defn.Val]] {
+      override def extract(a: A): Seq[Defn.Val] =
+        ev.extract(a).collect { case v: Defn.Val => v }
+    }
+
+  implicit def extractVarsFromStats[A](
+      implicit ev: Extract[A, Seq[Stat]]): Extract[A, Seq[Defn.Var]] =
+    new Extract[A, Seq[Defn.Var]] {
+      override def extract(a: A): Seq[Defn.Var] =
+        ev.extract(a).collect { case v: Defn.Var => v }
+    }
+
+  implicit def extractTraitsFromStats[A](
+      implicit ev: Extract[A, Seq[Stat]]): Extract[A, Seq[Defn.Trait]] =
+    new Extract[A, Seq[Defn.Trait]] {
+      override def extract(a: A): Seq[Defn.Trait] =
+        ev.extract(a).collect { case t: Defn.Trait => t }
+    }
+
+  implicit def extractObjectsFromStats[A](
+      implicit ev: Extract[A, Seq[Stat]]): Extract[A, Seq[Defn.Object]] =
+    new Extract[A, Seq[Defn.Object]] {
+      override def extract(a: A): Seq[Defn.Object] =
+        ev.extract(a).collect { case o: Defn.Object => o }
+    }
+
+  implicit def extractClassesFromStats[A](
+      implicit ev: Extract[A, Seq[Stat]]): Extract[A, Seq[Defn.Class]] =
+    new Extract[A, Seq[Defn.Class]] {
+      override def extract(a: A): Seq[Defn.Class] =
+        ev.extract(a).collect { case c: Defn.Class => c }
+    }
+
+  implicit def extractTypesFromStats[A](
+      implicit ev: Extract[A, Seq[Stat]]): Extract[A, Seq[Defn.Type]] =
+    new Extract[A, Seq[Defn.Type]] {
+      override def extract(a: A): Seq[Defn.Type] =
+        ev.extract(a).collect { case t: Defn.Type => t }
+    }
+}
+
+object ExtractStatSubtypeInstances

--- a/scalameta/contrib/src/main/scala/scala/meta/contrib/package.scala
+++ b/scalameta/contrib/src/main/scala/scala/meta/contrib/package.scala
@@ -9,5 +9,6 @@ package object contrib
   with Equality
   with Converters
   with ExtractStatInstances
+  with ExtractStatSubtypeInstances
   with ExtractPimps
 

--- a/scalameta/contrib/src/main/scala/scala/meta/contrib/package.scala
+++ b/scalameta/contrib/src/main/scala/scala/meta/contrib/package.scala
@@ -1,9 +1,13 @@
 package scala.meta
 
-import scala.meta.contrib.implicits.{Converters, Equality, TreeExtensions, CommentExtensions}
+import scala.meta.contrib.implicits._
+import scala.meta.contrib.instances._
 
 package object contrib
   extends TreeExtensions
   with CommentExtensions
   with Equality
   with Converters
+  with ExtractStatInstances
+  with ExtractPimps
+

--- a/scalameta/contrib/src/main/scala/scala/meta/contrib/package.scala
+++ b/scalameta/contrib/src/main/scala/scala/meta/contrib/package.scala
@@ -11,5 +11,6 @@ package object contrib
   with ExtractStatInstances
   with ExtractStatSubtypeInstances
   with ExtractModsInstances
+  with ExtractAnnotationInstances
   with ExtractPimps
 

--- a/scalameta/contrib/src/main/scala/scala/meta/contrib/package.scala
+++ b/scalameta/contrib/src/main/scala/scala/meta/contrib/package.scala
@@ -10,5 +10,6 @@ package object contrib
   with Converters
   with ExtractStatInstances
   with ExtractStatSubtypeInstances
+  with ExtractModsInstances
   with ExtractPimps
 

--- a/scalameta/contrib/src/test/scala/scala/meta/contrib/AnnotationExtractionTests.scala
+++ b/scalameta/contrib/src/test/scala/scala/meta/contrib/AnnotationExtractionTests.scala
@@ -2,12 +2,11 @@ package scala.meta.contrib
 
 import org.scalatest.FunSuite
 
-import scala.collection.immutable.Seq
 import scala.meta._
 
 class AnnotationExtractionTests extends FunSuite {
   test("Test extract annotations from class") {
-    val annots = q"@foo final class Foo".extract[Seq[Mod.Annot]]
+    val annots = q"@foo final class Foo".extract[Annotations]
     assert(annots.exists(_ isEqual mod"@foo"))
     assert(annots.size == 1)
   }

--- a/scalameta/contrib/src/test/scala/scala/meta/contrib/AnnotationExtractionTests.scala
+++ b/scalameta/contrib/src/test/scala/scala/meta/contrib/AnnotationExtractionTests.scala
@@ -1,0 +1,14 @@
+package scala.meta.contrib
+
+import org.scalatest.FunSuite
+
+import scala.collection.immutable.Seq
+import scala.meta._
+
+class AnnotationExtractionTests extends FunSuite {
+  test("Test extract annotations from class") {
+    val annots = q"@foo final class Foo".extract[Seq[Mod.Annot]]
+    assert(annots.exists(_ isEqual mod"@foo"))
+    assert(annots.size == 1)
+  }
+}

--- a/scalameta/contrib/src/test/scala/scala/meta/contrib/ModExtractionTest.scala
+++ b/scalameta/contrib/src/test/scala/scala/meta/contrib/ModExtractionTest.scala
@@ -2,47 +2,46 @@ package scala.meta.contrib
 
 import org.scalatest.FunSuite
 
-import scala.collection.immutable.Seq
 import scala.meta._
 
 class ModExtractionTest extends FunSuite {
   test("Test extract class mods with no mods") {
-    val mods = q"class Foo".extract[Seq[Mod]]
+    val mods = q"class Foo".extract[Mods]
     assert(mods == Nil)
   }
 
   test("Test extract class mods with mods") {
-    val mods = q"final class Foo".extract[Seq[Mod]]
+    val mods = q"final class Foo".extract[Mods]
     assert(mods.exists(_ isEqual mod"final"))
     assert(mods.size == 1)
   }
 
   test("Test extract trait mods with mods") {
-    val mods = q"sealed trait Foo".extract[Seq[Mod]]
+    val mods = q"sealed trait Foo".extract[Mods]
     assert(mods.exists(_ isEqual mod"sealed"))
     assert(mods.size == 1)
   }
 
   test("Test extract object mods with mods") {
-    val mods = q"private trait Foo".extract[Seq[Mod]]
+    val mods = q"private trait Foo".extract[Mods]
     assert(mods.exists(_ isEqual mod"private"))
     assert(mods.size == 1)
   }
 
   test("Test extract def mods with mods") {
-    val mods = q"private def foo = 2".extract[Seq[Mod]]
+    val mods = q"private def foo = 2".extract[Mods]
     assert(mods.exists(_ isEqual mod"private"))
     assert(mods.size == 1)
   }
 
   test("Test extract val mods with mods") {
-    val mods = q"private val foo = 2".extract[Seq[Mod]]
+    val mods = q"private val foo = 2".extract[Mods]
     assert(mods.exists(_ isEqual mod"private"))
     assert(mods.size == 1)
   }
 
   test("Test extract var mods with mods") {
-    val mods = q"private var foo = 2".extract[Seq[Mod]]
+    val mods = q"private var foo = 2".extract[Mods]
     assert(mods.exists(_ isEqual mod"private"))
     assert(mods.size == 1)
   }

--- a/scalameta/contrib/src/test/scala/scala/meta/contrib/ModExtractionTest.scala
+++ b/scalameta/contrib/src/test/scala/scala/meta/contrib/ModExtractionTest.scala
@@ -1,0 +1,49 @@
+package scala.meta.contrib
+
+import org.scalatest.FunSuite
+
+import scala.collection.immutable.Seq
+import scala.meta._
+
+class ModExtractionTest extends FunSuite {
+  test("Test extract class mods with no mods") {
+    val mods = q"class Foo".extract[Seq[Mod]]
+    assert(mods == Nil)
+  }
+
+  test("Test extract class mods with mods") {
+    val mods = q"final class Foo".extract[Seq[Mod]]
+    assert(mods.exists(_ isEqual mod"final"))
+    assert(mods.size == 1)
+  }
+
+  test("Test extract trait mods with mods") {
+    val mods = q"sealed trait Foo".extract[Seq[Mod]]
+    assert(mods.exists(_ isEqual mod"sealed"))
+    assert(mods.size == 1)
+  }
+
+  test("Test extract object mods with mods") {
+    val mods = q"private trait Foo".extract[Seq[Mod]]
+    assert(mods.exists(_ isEqual mod"private"))
+    assert(mods.size == 1)
+  }
+
+  test("Test extract def mods with mods") {
+    val mods = q"private def foo = 2".extract[Seq[Mod]]
+    assert(mods.exists(_ isEqual mod"private"))
+    assert(mods.size == 1)
+  }
+
+  test("Test extract val mods with mods") {
+    val mods = q"private val foo = 2".extract[Seq[Mod]]
+    assert(mods.exists(_ isEqual mod"private"))
+    assert(mods.size == 1)
+  }
+
+  test("Test extract var mods with mods") {
+    val mods = q"private var foo = 2".extract[Seq[Mod]]
+    assert(mods.exists(_ isEqual mod"private"))
+    assert(mods.size == 1)
+  }
+}

--- a/scalameta/contrib/src/test/scala/scala/meta/contrib/StatExtractionTest.scala
+++ b/scalameta/contrib/src/test/scala/scala/meta/contrib/StatExtractionTest.scala
@@ -2,44 +2,43 @@ package scala.meta.contrib
 
 import org.scalatest.FunSuite
 
-import scala.collection.immutable.Seq
 import scala.meta._
 
 class StatExtractionTest extends FunSuite {
 
   test("Test extract class stats") {
-    val stats = q"class Foo".extract[Seq[Stat]]
+    val stats = q"class Foo".extract[Stats]
     assert(stats == Nil)
   }
 
   test("Test extract trait stats") {
-    val stats = q"trait Foo".extract[Seq[Stat]]
+    val stats = q"trait Foo".extract[Stats]
     assert(stats == Nil)
   }
 
   test("Test extract object stats") {
-    val stats = q"object Foo".extract[Seq[Stat]]
+    val stats = q"object Foo".extract[Stats]
     assert(stats == Nil)
   }
 
   test("Test extract def stats") {
-    val stats = q"def foo = {}".extract[Seq[Stat]]
+    val stats = q"def foo = {}".extract[Stats]
     assert(stats == Nil)
   }
 
   test("Test extract def stats with single stat") {
-    val stats = q"def foo = 2".extract[Seq[Stat]]
+    val stats = q"def foo = 2".extract[Stats]
     assert(stats.exists(_ isEqual q"2"))
   }
 
   test("Test extract val stats with single stat") {
-    val stats = q"val foo = 2".extract[Seq[Stat]]
+    val stats = q"val foo = 2".extract[Stats]
     assert(stats.exists(_ isEqual q"2"))
     assert(stats.size == 1)
   }
 
   test("Test extract var stats with single stat") {
-    val stats = q"var foo = 2".extract[Seq[Stat]]
+    val stats = q"var foo = 2".extract[Stats]
     assert(stats.exists(_ isEqual q"2"))
     assert(stats.size == 1)
   }

--- a/scalameta/contrib/src/test/scala/scala/meta/contrib/StatExtractionTest.scala
+++ b/scalameta/contrib/src/test/scala/scala/meta/contrib/StatExtractionTest.scala
@@ -1,0 +1,46 @@
+package scala.meta.contrib
+
+import org.scalatest.FunSuite
+
+import scala.collection.immutable.Seq
+import scala.meta._
+
+class StatExtractionTest extends FunSuite {
+
+  test("Test extract class stats") {
+    val stats = q"class Foo".extract[Seq[Stat]]
+    assert(stats == Nil)
+  }
+
+  test("Test extract trait stats") {
+    val stats = q"trait Foo".extract[Seq[Stat]]
+    assert(stats == Nil)
+  }
+
+  test("Test extract object stats") {
+    val stats = q"object Foo".extract[Seq[Stat]]
+    assert(stats == Nil)
+  }
+
+  test("Test extract def stats") {
+    val stats = q"def foo = {}".extract[Seq[Stat]]
+    assert(stats == Nil)
+  }
+
+  test("Test extract def stats with single stat") {
+    val stats = q"def foo = 2".extract[Seq[Stat]]
+    assert(stats.exists(_ isEqual q"2"))
+  }
+
+  test("Test extract val stats with single stat") {
+    val stats = q"val foo = 2".extract[Seq[Stat]]
+    assert(stats.exists(_ isEqual q"2"))
+    assert(stats.size == 1)
+  }
+
+  test("Test extract var stats with single stat") {
+    val stats = q"var foo = 2".extract[Seq[Stat]]
+    assert(stats.exists(_ isEqual q"2"))
+    assert(stats.size == 1)
+  }
+}

--- a/scalameta/contrib/src/test/scala/scala/meta/contrib/StatSubtypeExtractionTest.scala
+++ b/scalameta/contrib/src/test/scala/scala/meta/contrib/StatSubtypeExtractionTest.scala
@@ -1,0 +1,57 @@
+package scala.meta.contrib
+
+import org.scalatest.FunSuite
+
+import scala.collection.immutable.Seq
+import scala.meta._
+import scala.meta.contrib._
+
+class StatSubtypeExtractionTest extends FunSuite {
+
+  test("Test extract when none exist") {
+    val stats = q"class Foo".extract[Seq[Defn.Def]]
+    assert(stats == Nil)
+  }
+
+  test("Test extract Defs") {
+    val stats = q"class Foo { def foo = 2 }".extract[Seq[Defn.Def]]
+    assert(stats.exists(_ isEqual q"def foo = 2"))
+    assert(stats.size == 1)
+  }
+
+  test("Test extract Vals") {
+    val stats = q"class Foo { val foo = 2 }".extract[Seq[Defn.Val]]
+    assert(stats.exists(_ isEqual q"val foo = 2"))
+    assert(stats.size == 1)
+  }
+
+  test("Test extract Vars") {
+    val stats = q"class Foo { var foo = 2 }".extract[Seq[Defn.Var]]
+    assert(stats.exists(_ isEqual q"var foo = 2"))
+    assert(stats.size == 1)
+  }
+
+  test("Test extract Types") {
+    val stats = q"class Foo { type Foo = A with B }".extract[Seq[Defn.Type]]
+    assert(stats.exists(_ isEqual q"type Foo = A with B"))
+    assert(stats.size == 1)
+  }
+
+  test("Test extract Objects") {
+    val stats = q"class Foo { object Bar }".extract[Seq[Defn.Object]]
+    assert(stats.exists(_ isEqual q"object Bar"))
+    assert(stats.size == 1)
+  }
+
+  test("Test extract Classes") {
+    val stats = q"class Foo { class Bar }".extract[Seq[Defn.Class]]
+    assert(stats.exists(_ isEqual q"class Bar"))
+    assert(stats.size == 1)
+  }
+
+  test("Test extract Traits") {
+    val stats = q"class Foo { trait Bar }".extract[Seq[Defn.Trait]]
+    assert(stats.exists(_ isEqual q"trait Bar"))
+    assert(stats.size == 1)
+  }
+}

--- a/scalameta/contrib/src/test/scala/scala/meta/contrib/StatSubtypeExtractionTest.scala
+++ b/scalameta/contrib/src/test/scala/scala/meta/contrib/StatSubtypeExtractionTest.scala
@@ -2,55 +2,54 @@ package scala.meta.contrib
 
 import org.scalatest.FunSuite
 
-import scala.collection.immutable.Seq
 import scala.meta._
 import scala.meta.contrib._
 
 class StatSubtypeExtractionTest extends FunSuite {
 
   test("Test extract when none exist") {
-    val stats = q"class Foo".extract[Seq[Defn.Def]]
+    val stats = q"class Foo".extract[Defs]
     assert(stats == Nil)
   }
 
   test("Test extract Defs") {
-    val stats = q"class Foo { def foo = 2 }".extract[Seq[Defn.Def]]
+    val stats = q"class Foo { def foo = 2 }".extract[Defs]
     assert(stats.exists(_ isEqual q"def foo = 2"))
     assert(stats.size == 1)
   }
 
   test("Test extract Vals") {
-    val stats = q"class Foo { val foo = 2 }".extract[Seq[Defn.Val]]
+    val stats = q"class Foo { val foo = 2 }".extract[Vals]
     assert(stats.exists(_ isEqual q"val foo = 2"))
     assert(stats.size == 1)
   }
 
   test("Test extract Vars") {
-    val stats = q"class Foo { var foo = 2 }".extract[Seq[Defn.Var]]
+    val stats = q"class Foo { var foo = 2 }".extract[Vars]
     assert(stats.exists(_ isEqual q"var foo = 2"))
     assert(stats.size == 1)
   }
 
   test("Test extract Types") {
-    val stats = q"class Foo { type Foo = A with B }".extract[Seq[Defn.Type]]
+    val stats = q"class Foo { type Foo = A with B }".extract[Types]
     assert(stats.exists(_ isEqual q"type Foo = A with B"))
     assert(stats.size == 1)
   }
 
   test("Test extract Objects") {
-    val stats = q"class Foo { object Bar }".extract[Seq[Defn.Object]]
+    val stats = q"class Foo { object Bar }".extract[Objects]
     assert(stats.exists(_ isEqual q"object Bar"))
     assert(stats.size == 1)
   }
 
   test("Test extract Classes") {
-    val stats = q"class Foo { class Bar }".extract[Seq[Defn.Class]]
+    val stats = q"class Foo { class Bar }".extract[Classes]
     assert(stats.exists(_ isEqual q"class Bar"))
     assert(stats.size == 1)
   }
 
   test("Test extract Traits") {
-    val stats = q"class Foo { trait Bar }".extract[Seq[Defn.Trait]]
+    val stats = q"class Foo { trait Bar }".extract[Traits]
     assert(stats.exists(_ isEqual q"trait Bar"))
     assert(stats.size == 1)
   }


### PR DESCRIPTION
This is Phase 1 of 3.

I may want to beef up the test suite a little bit.
The only implicit added is `extract`. More may come at a later point in time.
This can be merged as is, and the others can be pushed separately