### PR TITLE
[DO NOT MERGE] Make XtensionClassifiable a value class.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -288,6 +288,7 @@ lazy val benchmarks = Project(
   )
   .settings(
     sharedSettings,
+    fork in Test := true, // easier to attach to from profilers.
     resourceDirectory in Jmh := (resourceDirectory in Compile).value,
     javaOptions in run ++= Seq(
       "-Djava.net.preferIPv4Stack=true",
@@ -308,7 +309,10 @@ lazy val benchmarks = Project(
       "-server"
     )
   )
-  .dependsOn(scalameta)
+  .dependsOn(
+    scalameta,
+    contrib
+  )
   .enablePlugins(JmhPlugin)
 
 lazy val readme = scalatex.ScalatexReadme(
@@ -384,6 +388,7 @@ lazy val sharedSettings = Def.settings(
   scalacOptions in (Compile, doc) ++= Seq("-groups"),
   scalacOptions ++= Seq("-Xfatal-warnings"),
   parallelExecution in Test := false, // hello, reflection sync!!
+  fork in test := true,
   logBuffered := false,
   triggeredMessage in ThisBuild := Watched.clearWhenTriggered
 )

--- a/scalameta/benchmarks/src/test/scala/org/scalameta/benchmarks/BenchmarkOK.scala
+++ b/scalameta/benchmarks/src/test/scala/org/scalameta/benchmarks/BenchmarkOK.scala
@@ -1,5 +1,6 @@
 package org.scalameta.benchmarks
 
+import org.scalameta.logger
 import org.scalatest.FunSuite
 
 class BenchmarkOK extends FunSuite {
@@ -13,6 +14,18 @@ class BenchmarkOK extends FunSuite {
     val name = s"microBenchmark: ${formatBenchmark.getClass}"
     test(name) {
       formatBenchmark.testMe()
+    }
+  }
+}
+
+// benchmarks/test:runMain org.scalameta.benchmarks.KeepBenchmarkRunning
+// will start this process, making it easy to attach to for profiling purposes.
+object KeepBenchmarkRunning {
+  def main(args: Array[String]): Unit = {
+    val extraLarge = new Micro.ExtraLarge
+    1.to(250).foreach { x =>
+      if (x % 10 == 0) logger.debug(x)
+      extraLarge.testMe()
     }
   }
 }

--- a/scalameta/common/src/main/scala/scala/meta/classifiers/Api.scala
+++ b/scalameta/common/src/main/scala/scala/meta/classifiers/Api.scala
@@ -6,15 +6,6 @@ import scala.language.experimental.macros
 import scala.annotation.StaticAnnotation
 
 private[meta] trait Api {
-  implicit class XtensionClassifiable[T: Classifiable](x: T) {
-    def is[U](implicit classifier: Classifier[T, U]): Boolean = {
-      classifier.apply(x)
-    }
-
-    def isNot[U](implicit classifier: Classifier[T, U]): Boolean = {
-      !this.is(classifier)
-    }
-  }
 }
 
 private[meta] trait Aliases {

--- a/scalameta/common/src/main/scala/scala/meta/classifiers/package.scala
+++ b/scalameta/common/src/main/scala/scala/meta/classifiers/package.scala
@@ -1,3 +1,16 @@
 package scala.meta
 
-package object classifiers extends classifiers.Api
+package object classifiers extends classifiers.Api {
+  // Note. This is an optimization. We inline this implicit class in this package
+  // in order to make it extend AnyVal, and thus making it a value class.
+  // JMH  benchmarks show this optimization yields a ~30% speedup in code that
+  // uses `.is` a lot.
+  final implicit class XtensionClassifiable[T](val x: T) extends AnyVal {
+    def is[U](implicit classifier: classifiers.Classifier[T, U], classifiable: Classifiable[T]): Boolean = {
+      classifier.apply(x)
+    }
+    def isNot[U](implicit classifier: classifiers.Classifier[T, U], classifiable: Classifiable[T]): Boolean = {
+      !this.is(classifier, classifiable)
+    }
+  }
+}

--- a/scalameta/parsers/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -424,7 +424,7 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
 
   /** Consume one token of the specified type, or signal an error if it is not there. */
   def accept[T <: Token : TokenInfo]: Unit =
-    if (token.is[T](implicitly[TokenInfo[T]])) {
+    if (token.is[T](implicitly[TokenInfo[T]], implicitly[Classifiable[Token]])) {
       if (token.isNot[EOF]) next()
     } else syntaxErrorExpected[T]
 

--- a/scalameta/scalameta/src/main/scala/scala/meta/package.scala
+++ b/scalameta/scalameta/src/main/scala/scala/meta/package.scala
@@ -12,6 +12,19 @@ package object meta extends classifiers.Api with classifiers.Aliases
                        with tokens.Api with tokens.Aliases
                        with transversers.Api with transversers.Aliases {
 
+  // Note. This is an optimization. We inline this implicit class in this package
+  // in order to make it extend AnyVal, and thus making it a value class.
+  // JMH  benchmarks show this optimization yields a ~30% speedup in code that
+  // uses `.is` a lot.
+  final implicit class XtensionClassifiable[T](val x: T) extends AnyVal {
+    def is[U](implicit classifier: classifiers.Classifier[T, U]): Boolean = {
+      classifier.apply(x)
+    }
+    def isNot[U](implicit classifier: classifiers.Classifier[T, U]): Boolean = {
+      !this.is(classifier)
+    }
+  }
+
   // TODO: The necessity of scalameta/package.scala being non-empty is unsatisfying.
   // We seriously need to come up with a better way of achieving similar functionality.
   type XtensionParsersDialectApply // shadow conflicting implicit class

--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/classifiers/ClassifierSuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/classifiers/ClassifierSuite.scala
@@ -41,7 +41,7 @@ class ClassifierSuite extends FunSuite {
       import scala.meta._
       (??? : Unclassifiable).is[Derived]
     """) === """
-      |value is is not a member of org.scalameta.tests.classifiers.Unclassifiable
+      |don't know how to check whether org.scalameta.tests.classifiers.Unclassifiable is org.scalameta.tests.classifiers.Derived
     """.trim.stripMargin)
   }
 
@@ -52,7 +52,7 @@ class ClassifierSuite extends FunSuite {
       (??? : Unclassifiable).is[Auto1]
       (??? : Unclassifiable).is[Auto2]
     """) === """
-      |value is is not a member of org.scalameta.tests.classifiers.Unclassifiable
+      |don't know how to check whether org.scalameta.tests.classifiers.Unclassifiable is org.scalameta.tests.classifiers.Manual
     """.trim.stripMargin)
   }
 

--- a/scalameta/testkit/src/test/scala/scala/meta/testkit/ScalametaParserProperties.scala
+++ b/scalameta/testkit/src/test/scala/scala/meta/testkit/ScalametaParserProperties.scala
@@ -73,7 +73,7 @@ object ScalametaParserProperties {
 object ScalametaParserPropertyTest extends FunSuiteLike {
   import ScalametaParserProperties._
   def main(args: Array[String]): Unit = {
-    val result = runAnalysis()
+    val result = runAnalysis(1000)
     val parserProken = result.count(_._2.kind == ParserBroken)
     val prettyPrinterBroken = result.count(_._2.kind == PrettyPrinterBroken)
     println(s"""Parser broken: $parserProken


### PR DESCRIPTION
(I'm opening this PR just to see if this impacts the large integration test performance on CI)

Profiling common scala.meta programs revealed that the `.is` extension
method was the biggest the source of allocations. A snapshot showed
~1.000.000 allocations from XtensionClassifiable while the second
biggest allocator had 300.000 allocations.

This change moved the implicit class to two package objects (classifiers and meta),
making is possible to make it a value class. Moreover, the Classifiable
evidence was moved from the class constructor to the `.is` method
implicit parameter list.

JMH benchmarks running the tokenizer and several `.is[T]` calls shows a ~30% speedup improvement (of total time, including tokenization)

```
// XtensionClassifiable.is
[info] Micro.ExtraLarge.is  avgt   10  28.101 ± 0.960  ms/op
// XtensionClassifiable value class
[info] Micro.ExtraLarge.is  avgt   10  19.512 ± 0.780  ms/op
```

Before making the XtensionClassifiable a value class, I explored
putting the `is` method on the `Token` and `Tree` traits.
The benchmarks from that change were not as promising:

```
// XtensionClassifiable.is
[info] Micro.ExtraLarge.is  avgt   10  28.101 ± 0.960  ms/op
// Token { def is }
[info] Micro.ExtraLarge.is  avgt   10  49.558 ± 4.823  ms/op
// Token { final def is }
[info] Micro.ExtraLarge.is  avgt   10  52.326 ± 2.968  ms/op
```