### PR TITLE
fix typo in Readme.scalatex

### DIFF
--- a/readme/Readme.scalatex
+++ b/readme/Readme.scalatex
@@ -108,7 +108,7 @@
       Our first priority is to come up with an API that will provide
       functionality to perform typechecking, name resolution, implicit inference, etc.
       It is crucial to fully model the language and
-      achieve feature parity with scala.reflect. Visit @link("#604", "https://github.com/scalameta/scalameta/issues/604")
+      achieve feature parity with scala.reflect. Visit @lnk("#604", "https://github.com/scalameta/scalameta/issues/604")
       to check out our roadmap and provide feedback.
 
     @p


### PR DESCRIPTION
Thank you @bertrandkang!

See https://github.com/scalameta/scalameta.github.com/pull/15
for the original issue report and a suggested fix.