### PR TITLE
Small terminology change in docs

### DIFF
--- a/changelog/1.6.0.md
+++ b/changelog/1.6.0.md
@@ -43,7 +43,7 @@ This first release of `contrib` contains:
 - collection methods on `scala.meta.Tree` such as `find`, `contains`, `collectFirst` and `exists`.
 - an `AssociatedComments` data type for finding leading and trailing comments for tree nodes.
 - `Converters` for `Name` allowing `Term.Name("foo").asType`
-- Pimps are now provided more *a-la-carte*. You can now import exactly what you need. 
+- `implicit` enrichments are now provided more *a-la-carte*. You can now import exactly what you need. 
   eg. `import scala.meta.contrib.implicits.Equality._`
 
 More utilities are planned for future release, such as extracting `Seq[Stat]` from various trees and parsing docstrings.


### PR DESCRIPTION
Switching "pimp" terminology for "enrich", per https://groups.google.com/forum/#!topic/scala-internals/kVWg7HKldjs. Many prefer the latter because the former has the potential to offend, and at the very least isn't self-explanatory to people unfamiliar with the decade-old TV show "Pimp My Ride". I hope this is uncontroversial!