### PR TITLE
Explicitly disable publishing for readme+benchmarks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -289,6 +289,7 @@ lazy val benchmarks = Project(
   )
   .settings(
     sharedSettings,
+    noPublish,
     resourceDirectory in Jmh := (resourceDirectory in Compile).value,
     javaOptions in run ++= Seq(
       "-Djava.net.preferIPv4Stack=true",
@@ -318,6 +319,7 @@ lazy val readme = scalatex.ScalatexReadme(
   url = "https://github.com/scalameta/scalameta/tree/master",
   source = "Readme"
 ) settings (
+  noPublish,
   exposePaths("readme", Runtime),
   scalaVersion := (scalaVersion in scalameta).value,
   crossScalaVersions := ScalaVersions,
@@ -528,6 +530,12 @@ lazy val buildInfoSettings = Def.settings(
   ),
   buildInfoPackage := "org.scalameta",
   buildInfoObject := "BuildInfo"
+)
+
+lazy val noPublish = Seq(
+  publishArtifact := false,
+  publish := {},
+  publishLocal := {}
 )
 
 def exposePaths(projectName: String, config: Configuration) = {


### PR DESCRIPTION
While publishing a snapshot to bintray, I noticed that benchmarks was publishing to sonatype, because it uses the default publish settings.