### PR TITLE
Fix publishing.

### DIFF
--- a/bin/bintray.sh
+++ b/bin/bintray.sh
@@ -10,7 +10,7 @@ host = api.bintray.com
 user = $BINTRAY_USERNAME
 password = $BINTRAY_API_KEY
 EOF
-  sbt "such publish"
+  sbt ci-publish
 else
   echo "Skipping publish, branch=$DRONE_BRANCH test=$TEST"
 fi

--- a/build.sbt
+++ b/build.sbt
@@ -38,6 +38,11 @@ lazy val scalametaRoot = Project(
     "scalahostSbt/test" ::
     state
   },
+  commands += Command.command("ci-publish") { state =>
+    streams.value.log.info("Publishing...")
+    "very publish" ::
+      state
+  },
   packagedArtifacts := Map.empty,
   unidocProjectFilter in (ScalaUnidoc, unidoc) := inAnyProject,
   aggregate in test := false,


### PR DESCRIPTION
The bintray.sh script runs 'sbt very' instead of 'sbt "very publish"',
for some reason, causing the publish step to fail after merge into
master. This commit moves the "very publish" part into a ci-publish
command.