### PR TITLE
fix git.distance

### DIFF
--- a/project/os.scala
+++ b/project/os.scala
@@ -126,7 +126,8 @@ object git {
   }
 
   def distance(from: String, to: String): Int = {
-    shell.check_output(s"git rev-list $to $from --count", cwd = ".").trim.toInt
+    def ncommits(ref: String) = shell.check_output(s"git rev-list $ref --count", cwd = ".").trim.toInt
+    ncommits(to) - ncommits(from)
   }
 
   def currentSha(): String = {


### PR DESCRIPTION
It looks like the old way of invoking git describe didn’t work well
with drone 0.5, so we had to disable it: https://github.com/scalameta/scalameta/commit/b6ac41a8bea940f2e558255590bd3c406fd15496#diff-d37a6a936ab236d24b24677228b872e1L129. I suspect the problem was with
the old way using the caret symbol.

Unfortunately, the workaround changed the behavior of git.distance.
Now, instead of computing the number of commits between from and to,
it computes the number of commits between to and root.

This change restores the old behavior without utilizing the caret symbol.
We’re now using two shell invocations instead of just one,
but I hope we’ll be fine.