### PR TITLE
Shrink scalahost/assembly by 10mb

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -177,8 +177,7 @@ lazy val semantic = Project(
     scalapb.gen(
       flatPackage = true // Don't append filename to package
     ) -> sourceManaged.in(Compile).value
-  ),
-  libraryDependencies += "com.trueaccord.scalapb" %% "scalapb-runtime" % scalapbVersion % "protobuf"
+  )
 ) dependsOn (common, trees)
 
 lazy val scalameta = Project(

--- a/scalameta/semantic/src/main/protobuf/semanticdb.proto
+++ b/scalameta/semantic/src/main/protobuf/semanticdb.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package org.scalameta.semantic.v1.proto;
 
-import "scalapb/scalapb.proto";
-
 // scala.meta.semantic.v1.Database
 message Database {
   // a database is treated as a sequence of database files to accommodate


### PR DESCRIPTION
Apparently, those two lines added a dependency on the protobuf compiler and a whole boatload of other stuff that we don't need. Now, the scalahost assembly is 14mb instead of 24mb. 