### PR TITLE
Use regular sbt to fix ci-publish.

### DIFF
--- a/bin/bintray.sh
+++ b/bin/bintray.sh
@@ -5,14 +5,14 @@ api_key=$2
 if [[ "$DRONE_BRANCH" == "master" && "$TEST" == "ci-fast" ]]; then
   echo "Running publish from $(pwd)"
   git log | head -n 20
-  mkdir -p ~/.bintray
-  cat > ~/.bintray/.credentials <<EOF
+  mkdir -p $HOME/.bintray
+  cat > $HOME/.bintray/.credentials <<EOF
 realm = Bintray API Realm
 host = api.bintray.com
 user = ${BINTRAY_USERNAME}
 password = ${BINTRAY_API_KEY}
 EOF
-  sbt ci-publish
+  /usr/bin/sbt ci-publish
 else
   echo "Skipping publish, branch=$DRONE_BRANCH test=$TEST"
 fi


### PR DESCRIPTION
The `sbt` script on the docker image runs a few custom steps before
passing the command to the actual sbt. Maybe this change will
eventually fix the cryptic bintray publish errors.