### PR TITLE
Support syntactically and structurally for Set[Tree]

### DIFF
--- a/changelog/1.7.0.md
+++ b/changelog/1.7.0.md
@@ -11,7 +11,11 @@ Contrib:
 - `(a: Subtype).isEqual(b: Supertype)` will no longer compile, either upcast
   `a: Supertype` or swap the order to `b.isEqual(a)`
   
-## `contrib`
+## Feature guide
+
+Contrib:
 - The `Extract[A, B]` typeclass has been added for convenient extraction of Stats/Mods/Annotations/Defs.
   - See the contrib testsuite for more example usages
   - More use-cases for Extract are in the pipeline, follow #741 for more details
+- `structurally` and `syntactically` have been added as enrichments to `Set[Tree]`
+  - See the contrib testsuite for examples

--- a/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/equality/Structurally.scala
+++ b/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/equality/Structurally.scala
@@ -23,6 +23,9 @@ class Structurally[+A <: Tree](val tree: A) extends TreeEquality[A] {
 
 object Structurally {
 
+  def apply[A <: Tree](tree: A): Structurally[A] =
+    new Structurally[A](tree)
+
   def equal(a: Tree, b: Tree): Boolean = loopStructure(a, b)
 
   private def loopStructure(x: Any, y: Any): Boolean = (x, y) match {
@@ -46,5 +49,5 @@ object Structurally {
       override def isEqual(a: Structurally[A], b: Structurally[A]): Boolean = a.equals(b)
     }
 
-  implicit def toStructural[A <: Tree](e: A): Structurally[A] = new Structurally[A](e)
+  implicit def toStructural[A <: Tree](e: A): Structurally[A] = apply(e)
 }

--- a/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/equality/Syntactically.scala
+++ b/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/equality/Syntactically.scala
@@ -16,9 +16,12 @@ class Syntactically[+A <: Tree](val tree: A) extends TreeEquality[A] {
 }
 
 object Syntactically {
+  def apply[A <: Tree](tree: A): Syntactically[A] =
+    new Syntactically(tree)
+
   implicit def SyntacticEq[A <: Tree]: Equal[Syntactically[A]] =
     new Equal[Syntactically[A]] {
       override def isEqual(a: Syntactically[A], b: Syntactically[A]): Boolean = a.equals(b)
     }
-  implicit def toSyntactic[A <: Tree](e: A): Syntactically[A] = new Syntactically[A](e)
+  implicit def toSyntactic[A <: Tree](e: A): Syntactically[A] = apply(e)
 }

--- a/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/implicits/SetExtensions.scala
+++ b/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/implicits/SetExtensions.scala
@@ -1,0 +1,15 @@
+package scala.meta.contrib.implicits
+
+import scala.meta._
+import scala.meta.contrib._
+import scala.meta.contrib.equality.{Structurally, Syntactically}
+
+trait SetExtensions {
+  implicit class SetEnrichments[A <: Tree](set: Set[A]) {
+    def structurally: Set[Structurally[A]] =
+      set.map(Structurally(_))
+
+    def syntactically: Set[Syntactically[A]] =
+      set.map(Syntactically(_))
+  }
+}

--- a/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/package.scala
+++ b/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/package.scala
@@ -5,6 +5,7 @@ import scala.meta.contrib.instances._
 
 package object contrib
   extends TreeExtensions
+  with SetExtensions
   with CommentExtensions
   with Equality
   with Converters

--- a/scalameta/contrib/shared/src/test/scala/scala/meta/contrib/SetExtensionsTest.scala
+++ b/scalameta/contrib/shared/src/test/scala/scala/meta/contrib/SetExtensionsTest.scala
@@ -1,0 +1,36 @@
+package scala.meta.contrib
+
+import org.scalatest.FunSuite
+
+import scala.meta._
+import scala.meta.contrib._
+
+class SetExtensionsTest extends FunSuite {
+  val typeFoo = t"Foo"
+  val termFoo = q"Foo"
+
+  val set = Set(typeFoo, termFoo, q"Foo")
+
+  test("Reference equality holds normally") {
+    assert(set.size == 3)
+    assert(set.contains(typeFoo))
+    assert(set.contains(termFoo))
+    assert(!set.contains(q"Foo"))
+  }
+
+  test("Structurally") {
+    val structuralSet = set.structurally
+    assert(structuralSet.size == 2)
+    assert(structuralSet.contains(typeFoo))
+    assert(structuralSet.contains(termFoo))
+    assert(structuralSet.contains(q"Foo"))
+  }
+
+  test("Syntactically") {
+    val syntacticSet = set.syntactically
+    assert(syntacticSet.size == 1)
+    assert(syntacticSet.contains(typeFoo))
+    assert(syntacticSet.contains(termFoo))
+    assert(syntacticSet.contains(q"Foo"))
+  }
+}


### PR DESCRIPTION
For https://github.com/scalameta/scalameta/issues/745.

I cannot remember exactly who it was that wanted this functionality. It surfaced from gitter chat.