### PR TITLE
Add Select.unapply and Name.unapply.

### DIFF
--- a/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/TreeExtractors.scala
+++ b/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/TreeExtractors.scala
@@ -1,0 +1,13 @@
+package scala.meta
+package contrib
+
+trait TreeExtractors {
+  object Select {
+    def unapply(tree: Tree): Option[(Term, Name)] = tree match {
+      case Term.Select(qual, name) => Some(qual -> name)
+      case Type.Select(qual, name) => Some(qual -> name)
+      case Ctor.Ref.Select(qual, name) => Some(qual -> name)
+      case _ => None
+    }
+  }
+}

--- a/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/package.scala
+++ b/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/package.scala
@@ -5,6 +5,7 @@ import scala.meta.contrib.instances._
 
 package object contrib
   extends TreeExtensions
+  with TreeExtractors
   with SetExtensions
   with CommentExtensions
   with Equality

--- a/scalameta/contrib/shared/src/test/scala/scala/meta/contrib/TreeExtractorsSuite.scala
+++ b/scalameta/contrib/shared/src/test/scala/scala/meta/contrib/TreeExtractorsSuite.scala
@@ -1,0 +1,12 @@
+package scala.meta
+package contrib
+
+import org.scalatest.FunSuite
+
+class TreeExtractorsSuite extends FunSuite {
+  test("Select.unapply") {
+    val Some((q"a", q"b")) = Select.unapply(q"a.b")
+    val Some((q"a", t"b")) = Select.unapply(t"a.b")
+    val Some((q"a", ctor"b")) = Select.unapply(ctor"a.b")
+  }
+}

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/ast/TreeSuite.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/ast/TreeSuite.scala
@@ -1,0 +1,13 @@
+package scala.meta.tests.ast
+
+import scala.meta._
+
+import org.scalatest._
+
+class TreeSuite extends FunSuite {
+  test("Name.unapply") {
+    assert(Name.unapply(q"a").contains("a"))
+    assert(Name.unapply(t"a").contains("a"))
+    assert(Name.unapply(Ctor.Ref.Name("a")).contains("a"))
+  }
+}

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -37,6 +37,7 @@ object Tree extends InternalTreeXtensions {
 
 @branch trait Name extends Ref { def value: String }
 object Name {
+  def unapply(name: Name): Option[String] = Some(name.value)
   @ast class Anonymous extends Name with Term.Param.Name with Type.Param.Name with Qualifier { def value = "_" }
   @ast class Indeterminate(value: Predef.String @nonEmpty) extends Name with Qualifier
   @branch trait Qualifier extends Ref


### PR DESCRIPTION
Motivation, make this answer simpler: http://stackoverflow.com/a/43415867/1469245

- Name.unapply is added for consistency with other tree unapply extractors.
- Select.unapply is put in contrib because otherwise it would conflict
  with existing code that does `import scala.meta._, Type._/Type._`.