### PR TITLE
Add support for loading the semanticdb from jars.

### DIFF
--- a/scalameta/semantic/shared/src/main/scala/scala/meta/semantic/v1/Database.scala
+++ b/scalameta/semantic/shared/src/main/scala/scala/meta/semantic/v1/Database.scala
@@ -14,6 +14,7 @@ import scala.util.Try
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
+import java.net.URI
 
 // NOTE: This is an initial take on the semantic API.
 // Instead of immediately implementing the full vision described in my dissertation,
@@ -61,4 +62,6 @@ object Database extends DatabaseOps {
     Try(p.Database.parseFrom(bytes).toMeta[Database])
   def fromFile(file: File): Try[Database] =
     Try(p.Database.parseFrom(new FileInputStream(file)).toMeta[Database])
+  def fromURI(uri: URI): Try[Database] =
+    Try(p.Database.parseFrom(uri.toURL.openStream).toMeta[Database])
 }


### PR DESCRIPTION
Adds support for loading the semanticdb from jars on the classpath.

I haven't added a test for loading them from a jar, and that should probably happen before merging.

Fixes #784.