### PR TITLE
Parses empty unquote Xml expression

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1591,7 +1591,7 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
 
   def unquoteXmlExpr(): Term = {
     // TODO: verify this
-    dropAnyBraces(expr())
+    unquoteExpr()
   }
 
   // TODO: when parsing `(2 + 3)`, do we want the ApplyInfix's position to include parentheses?

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1590,7 +1590,6 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
   }
 
   def unquoteXmlExpr(): Term = {
-    // TODO: verify this
     unquoteExpr()
   }
 
@@ -2342,7 +2341,6 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
     }
 
     def unquoteXmlPattern(): Pat = {
-      // TODO: verify this
       dropAnyBraces(pattern().require[Pat])
     }
 

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/parsers/XmlSuite.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/parsers/XmlSuite.scala
@@ -288,7 +288,7 @@ class XmlSuite extends ParseSuite {
     """.trim.stripMargin)
 
 
-  //checkOK("<a>{}</a>") // FIXME: Should parse
+  checkOK("<a>{}</a>")
   //checkError("<a></b>") // FIXME: Should not parse
 
   // Matches bugs in scalac

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/parsers/XmlSuite.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/parsers/XmlSuite.scala
@@ -289,6 +289,7 @@ class XmlSuite extends ParseSuite {
 
 
   checkOK("<a>{}</a>")
+  checkError("e match { case <a>{}</a> => ??? }")
   //checkError("<a></b>") // FIXME: Should not parse
 
   // Matches bugs in scalac

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -528,6 +528,18 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     assert(tree.show[Syntax] === "<foo>{bar}</foo>")
   }
 
+  test("xml literals unit") {
+    val tree = term("<foo>{}</foo>")
+    assert(tree.show[Structure] == """Term.Xml(Seq(Lit.String("<foo>"), Lit.String("</foo>")), Seq(Term.Block(Nil)))""")
+    assert(tree.show[Syntax] == "<foo>{{}}</foo>")
+  }
+
+  test("interpolator unit") {
+    val tree = term("""s"Hello${}World"""")
+    assert(tree.show[Structure] == """Term.Interpolate(Term.Name("s"), Seq(Lit.String("Hello"), Lit.String("World")), Seq(Term.Block(Nil)))""")
+    assert(tree.show[Syntax] == """s"Hello${{}}World"""")
+  }
+
   test("empty-arglist application") {
     val tree = term("foo.toString()")
     assert(tree.show[Structure] === "Term.Apply(Term.Select(Term.Name(\"foo\"), Term.Name(\"toString\")), Nil)")


### PR DESCRIPTION
Parses "unquote Xml expression" similarly to "unquote expression".
This fixes a bug with empty expression (e.g. <a>{}</a>).