### PR TITLE
Add back .absolute method.

### DIFF
--- a/scalameta/io/shared/src/main/scala/scala/meta/io/AbsolutePath.scala
+++ b/scalameta/io/shared/src/main/scala/scala/meta/io/AbsolutePath.scala
@@ -7,6 +7,8 @@ import scala.meta.internal.io.{FileIO, PathIO}
 @data class AbsolutePath private (value: String) {
   override def toString: String = value
   def toFile: File = new File(value)
+  @deprecated("Use toString() instead", "1.8")
+  def absolute: String = toString()
 
   def toRelative: RelativePath = toRelative(PathIO.workingDirectory)
   def toRelative(path: AbsolutePath): RelativePath = PathIO.unresolve(path, this)


### PR DESCRIPTION
Removing the method makes it hard to use pre-releases from scalafix.
Note, we should add mima checks to our CI.