### PR TITLE
Add Position.RangeWithPoint, fixes #383.

### DIFF
--- a/scalahost/nsc/src/main/scala/scala/meta/internal/semantic/InputOps.scala
+++ b/scalahost/nsc/src/main/scala/scala/meta/internal/semantic/InputOps.scala
@@ -19,7 +19,14 @@ trait InputOps { self: DatabaseOps =>
     def toMeta: m.Position = {
       assert(pos.isRange)
       val input = m.Input.File(pos.source.toAbsolutePath)
-      m.Position.Range(input, m.Point.Offset(input, pos.start), m.Point.Offset(input, pos.end))
+      val mstart = m.Point.Offset(input, pos.start)
+      val mend = m.Point.Offset(input, pos.end)
+      if (pos.point > pos.start && pos.point < pos.end) {
+        val mpoint = m.Point.Offset(input, pos.point)
+        m.Position.RangeWithPoint(input, mstart, mpoint, mend)
+      } else {
+        m.Position.Range(input, mstart, mend)
+      }
     }
   }
 }

--- a/scalahost/nsc/src/test/scala/scala/meta/tests/scalahost/mirrors/SemanticSuite.scala
+++ b/scalahost/nsc/src/test/scala/scala/meta/tests/scalahost/mirrors/SemanticSuite.scala
@@ -286,4 +286,15 @@ class SemanticSuite extends DatabaseSuite {
     "class F[T: Manifest] { val arr = Array.empty[T] }",
     "[47..47) (F.this.evidence$1)".trim
   )
+
+  messages(
+    """
+      |import scala.collection.mutable.{ Map, Set, ListBuffer }
+      |object a { ListBuffer.empty[Int] }
+    """.stripMargin.trim,
+    """
+      |[0..34..56): [warning] Unused import
+      |[0..39..56): [warning] Unused import
+    """.stripMargin.trim
+  )
 }

--- a/scalameta/inputs/shared/src/main/scala/scala/meta/inputs/Point.scala
+++ b/scalameta/inputs/shared/src/main/scala/scala/meta/inputs/Point.scala
@@ -16,6 +16,8 @@ import scala.meta.common._
   def offset: Int
   def line: Int
   def column: Int
+  def syntax: String
+  def structure: String
 }
 
 object Point {
@@ -24,13 +26,17 @@ object Point {
     def offset = -1
     def line = -1
     def column = -1
-    override def toString = "Point.None"
+    def syntax = "<none>"
+    def structure = "Point.None"
+    override def toString = structure
   }
 
   @leaf class Offset(input: Input @nonEmpty, offset: Int) extends Point {
     def line: Int = input.offsetToLine(offset)
     def column: Int = offset - input.lineToOffset(line)
-    override def toString = s"$offset in $input"
+    def syntax = s"${input.syntax}@${offset}"
+    def structure = s"Point.Offset(${input.structure}, ${offset})"
+    override def toString = structure
   }
 }
 

--- a/scalameta/inputs/shared/src/main/scala/scala/meta/internal/inputs/package.scala
+++ b/scalameta/inputs/shared/src/main/scala/scala/meta/internal/inputs/package.scala
@@ -6,10 +6,11 @@ import scala.meta.inputs._
 
 package object inputs {
   implicit class XtensionPositionFormatMessage(pos: Position) {
-    def formatMessage(severity: String, message: String): String = {
-      // TODO: In order to be completely compatible with scalac, we need to support Position.point.
-      // On the other hand, do we really need to? Let's try without it. See #383 for discussion.
-      pos.start.formatMessage(severity, message)
+    def formatMessage(severity: String, message: String): String = pos match {
+      case Position.RangeWithPoint(_, _, point, end) =>
+        point.formatMessage(severity, message)
+      case _ =>
+        pos.start.formatMessage(severity, message)
     }
   }
 
@@ -17,12 +18,7 @@ package object inputs {
     def formatMessage(severity: String, message: String): String = {
       if (point != Point.None) {
         val input = point.input
-        val shortContent = input match {
-          case Input.File(path, _) => path.toString
-          case Input.LabeledString(label, _) => label
-          case _ => "<input>"
-        }
-        val header = s"$shortContent:${point.line + 1}: $severity: $message"
+        val header = s"${input.syntax}:${point.line + 1}: $severity: $message"
         val line = {
           val start = input.lineToOffset(point.line)
           val end = if (start < input.chars.length) input.lineToOffset(point.line + 1) else start
@@ -36,37 +32,11 @@ package object inputs {
     }
   }
 
-  // TODO: the extension methods below are temporary stubs that should be moved to the public API
-
-  implicit class XtensionInputSyntaxStructure(input: Input) {
-    def syntax: String = input match {
-      case Input.None => "<none>"
-      case Input.File(path, _) => path.toString
-      case Input.LabeledString(label, _) => label
-      case _ => "<input>"
-    }
-    def structure: String = input.toString
-  }
-
-  implicit class XtensionPositionSyntaxStructure(pos: Position) {
-    def syntax: String = pos match {
-      case Position.None => s"<none>"
-      case Position.Range(input, start, end) => s"${input.syntax}@${start.offset}..${end.offset}"
-    }
-    def structure: String = pos match {
-      case Position.None => s"Position.None"
-      case Position.Range(input, start, end) => s"Position.Range(${input.structure}, ${start.structure}, ${end.structure})"
-    }
-  }
-
-  implicit class XtensionPointSyntaxStructure(point: Point) {
-    def syntax: String = point match {
-      case Point.None => s"<none>"
-      case Point.Offset(input, offset) => s"${input.syntax}@${offset}"
-    }
-    def structure: String = point match {
-      case Point.None => s"Point.None"
-      case Point.Offset(input, offset) => s"Point.Offset(${input.structure}, ${offset})"
-    }
+  // TODO(olafur): Find a better name + home for this method, it's currently used
+  // in Message in Symbol. Positions.syntax should not include the input IMO
+  // because that would make it unnecessarily verbose. However, in some cases
+  // it is nice to include the input.
+  implicit class XtensionPositionPretty(position: Position) {
+    def syntaxWithInput = s"${position.input.syntax}@${position.start.offset}..${position.end.offset}"
   }
 }

--- a/scalameta/io/shared/src/main/scala/scala/meta/io/AbsolutePath.scala
+++ b/scalameta/io/shared/src/main/scala/scala/meta/io/AbsolutePath.scala
@@ -16,7 +16,11 @@ import scala.meta.internal.io.{FileIO, PathIO}
   @deprecated("Use toString() instead", "1.8")
   def absolute: String = toString()
 
-  def toRelative: RelativePath = toRelative(PathIO.workingDirectory)
+  // NOTE: Anticipating exceptions in this method is just plain terrible.
+  // It's not exceptional at all that this AbsolutePath is not relative to the
+  // working directory. Fix this once https://github.com/scalameta/scalameta/issues/821
+  // is settled.
+  def toRelative: Option[RelativePath] = scala.util.Try(toRelative(PathIO.workingDirectory)).toOption
   def toRelative(path: AbsolutePath): RelativePath = PathIO.unresolve(path, this)
   def toRelative(file: File): RelativePath = toRelative(AbsolutePath(file))
   def toRelative(path: String): RelativePath = toRelative(AbsolutePath(path))

--- a/scalameta/scalameta/jvm/src/test/scala/scala/meta/tests/api/SurfaceSuite.scala
+++ b/scalameta/scalameta/jvm/src/test/scala/scala/meta/tests/api/SurfaceSuite.scala
@@ -65,6 +65,7 @@ class SurfaceSuite extends scala.meta.tests.ast.AstSuite {
       |scala.meta.inputs.Position
       |scala.meta.inputs.Position.None
       |scala.meta.inputs.Position.Range
+      |scala.meta.inputs.Position.RangeWithPoint
       |scala.meta.internal
       |scala.meta.io
       |scala.meta.io.AbsolutePath

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/ast/InfrastructureSuite.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/ast/InfrastructureSuite.scala
@@ -10,15 +10,16 @@ class InfrastructureSuite extends FunSuite {
   test("become for Quasi-0") {
     val dialect = QuasiquoteTerm(Scala211, multiline = false)
     val q = dialect("$hello").parse[Term].get.asInstanceOf[Term.Quasi]
+    org.scalameta.logger.elem(q.become[Type.Quasi].pos.toString)
     assert(q.become[Type.Quasi].show[Structure] === """Type.Quasi(0, Term.Name("hello"))""")
-    assert(q.become[Type.Quasi].pos.toString === """[0..6) in Input.String("$hello")""")
+    assert(q.become[Type.Quasi].pos.structure === """Position.Range(Input.String("$hello"), 0, 6)""")
   }
 
   test("become for Quasi-1") {
     val dialect = QuasiquoteTerm(Scala211, multiline = false)
     val Term.Block(Seq(q: Stat.Quasi)) = dialect("..$hello").parse[Stat].get
     assert(q.become[Type.Quasi].show[Structure] === """Type.Quasi(1, Type.Quasi(0, Term.Name("hello")))""")
-    assert(q.become[Type.Quasi].pos.toString === """[0..8) in Input.String("..$hello")""")
+    assert(q.become[Type.Quasi].pos.structure === """Position.Range(Input.String("..$hello"), 0, 8)""")
   }
 
   test("copy parent") {

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/parsers/PositionSuite.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/parsers/PositionSuite.scala
@@ -62,4 +62,13 @@ class PositionSuite extends ParseSuite {
         | List(Term.Name{8..9}("c")))
     """.trim.stripMargin.split("\n").mkString)
   }
+
+  test("Position.Range.unapply") {
+    val input = Input.String("blah")
+    Position.RangeWithPoint(input, 0, 1, 2) match {
+      case Position.Range(_, start, end) =>
+        assert(start.offset == 0)
+        assert(end.offset == 2)
+    }
+  }
 }

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
@@ -137,8 +137,8 @@ class PublicSuite extends FunSuite {
     val path = RelativePath("hello.scala").toAbsolute
     val input1 = Input.File(path, Charset.forName("latin1"))
     val input2 = Input.File(path, Charset.forName("UTF-8"))
-    assert(input1.toString == """Input.File(new File("hello.scala"), Charset.forName("ISO-8859-1"))""")
-    assert(input2.toString == """Input.File(new File("hello.scala"), Charset.forName("UTF-8"))""")
+    assert(input1.structure == """Input.File(new File("hello.scala"), Charset.forName("ISO-8859-1"))""")
+    assert(input2.structure == """Input.File(new File("hello.scala"), Charset.forName("UTF-8"))""")
   }
 
   test("scala.meta.inputs.Input.Slice.toString") {
@@ -177,8 +177,8 @@ class PublicSuite extends FunSuite {
 
   test("scala.meta.inputs.Point.Offset.toString") {
     val Term.ApplyInfix(lhs, _, _, _) = "foo + bar".parse[Term].get
-    assert(lhs.pos.start.toString === """0 in Input.String("foo + bar")""")
-    assert(lhs.pos.end.toString === """3 in Input.String("foo + bar")""")
+    assert(lhs.pos.start.toString === """Point.Offset(Input.String("foo + bar"), 0)""")
+    assert(lhs.pos.end.toString === """Point.Offset(Input.String("foo + bar"), 3)""")
   }
 
   test("scala.meta.inputs.Position.toString") {
@@ -191,7 +191,13 @@ class PublicSuite extends FunSuite {
 
   test("scala.meta.inputs.Position.Range.toString") {
     val Term.ApplyInfix(lhs, _, _, _) = "foo + bar".parse[Term].get
-    assert(lhs.pos.toString === """[0..3) in Input.String("foo + bar")""")
+    assert(lhs.pos.toString === """Position.Range(Input.String("foo + bar"), 0, 3)""")
+  }
+
+  test("scala.meta.inputs.Position.RangeWithPoint.toString") {
+    val input = Input.String("foo")
+    val pos = Position.RangeWithPoint(input, 0, 1, 3)
+    assert(pos.toString === """Position.RangeWithPoint(Input.String("foo"), 0, 1, 3)""")
   }
 
   test("scala.meta.io.AbsolutePath.toString") {
@@ -300,12 +306,12 @@ class PublicSuite extends FunSuite {
     // too involved to fit here, see DatabaseSuite in scalahost
   }
 
-  test("scala.meta.semantic.Message.toString") {
+  test("scala.meta.semantic.Message.syntax") {
     val path = RelativePath("hello.scala").toAbsolute
     val input = Input.File(path)
     val position = Position.Range(input, Point.Offset(input, 40), Point.Offset(input, 42))
     val message = Message(position, Severity.Error, "does not compute")
-    assert(message.toString === s"[error] $path@40..42: does not compute")
+    assert(message.syntax === s"[error] $path@40..42 does not compute")
   }
 
   test("scala.meta.semantic.Mirror.toString") {
@@ -390,7 +396,7 @@ class PublicSuite extends FunSuite {
 
     val syntaxLocal = "/source.scala@40..42"
     val local @ Symbol.Local(Position.Range(Input.File(AbsolutePath("/source.scala"), _), Point.Offset(_, 40), Point.Offset(_, 42))) = Symbol(syntaxLocal)
-    assert(local.toString === syntaxLocal)
+    assert(local.syntax === syntaxLocal)
 
     val syntaxMulti = "_root_.C#;_root.C."
     val multi @ Symbol.Multi(List(Symbol.Global(Symbol.Global(Symbol.None, Signature.Term("_root_")), Signature.Type("C")), Symbol.Global(Symbol.Global(Symbol.None, Signature.Term("_root")), Signature.Term("C")))) = Symbol(syntaxMulti)

--- a/scalameta/semantic/shared/src/main/protobuf/semanticdb.proto
+++ b/scalameta/semantic/shared/src/main/protobuf/semanticdb.proto
@@ -20,6 +20,8 @@ message ResolvedName {
 message Range {
   int32 start = 2;
   int32 end = 3;
+  // See Position.RangeWithPoint comment for motivation of this field.
+  int32 point = 4;
 }
 
 message Message {

--- a/scalameta/semantic/shared/src/main/scala/scala/meta/internal/semantic/Schema.scala
+++ b/scalameta/semantic/shared/src/main/scala/scala/meta/internal/semantic/Schema.scala
@@ -37,7 +37,11 @@ package object schema {
             def unapply(srange: s.Range): Option[mPosition] = {
               val mstart = mPoint.Offset(minput, srange.start)
               val mend = mPoint.Offset(minput, srange.end)
-              Some(mPosition.Range(minput, mstart, mend))
+              if (srange.point > srange.start && srange.point < srange.end) {
+                val mpoint = mPoint.Offset(minput, srange.point)
+                Some(mPosition.RangeWithPoint(minput, mstart, mpoint, mend))
+              }
+              else Some(mPosition.Range(minput, mstart, mend))
             }
           }
           object sSymbol {

--- a/scalameta/semantic/shared/src/main/scala/scala/meta/internal/semantic/Syntax.scala
+++ b/scalameta/semantic/shared/src/main/scala/scala/meta/internal/semantic/Syntax.scala
@@ -32,22 +32,19 @@ object AttributesSyntax {
         lines += ""
       }
     }
-    implicit class XtensionPositionRange(pos: Position) {
-      def range = s"[${pos.start.offset}..${pos.end.offset})"
-    }
 
     val s_dialect = dialect.toString
     appendSection("Dialect", List(s_dialect))
 
     val s_names = names.toList.sortBy(_._1.start.offset).map {
       case ((pos, symbol)) =>
-        s"${pos.range}: ${pos.text} => $symbol"
+        s"${pos.syntax}: ${pos.text} => $symbol"
     }
     appendSection("Names", s_names)
 
     val s_messages = messages.toList.sortBy(_.position.start.offset).map {
       case Message(pos, severity, message) =>
-        s"${pos.range}: [${severity.toString.toLowerCase}] ${message}"
+        s"${pos.syntax}: [${severity.toString.toLowerCase}] ${message}"
     }
     appendSection("Messages", s_messages)
 
@@ -59,7 +56,7 @@ object AttributesSyntax {
 
     val s_sugars = sugars.toList.sortBy(_._1.start.offset).map {
       case ((pos, syntax)) =>
-        s"${pos.range} $syntax"
+        s"${pos.syntax} $syntax"
     }
     appendSection("Sugars", s_sugars)
 

--- a/scalameta/semantic/shared/src/main/scala/scala/meta/semantic/Message.scala
+++ b/scalameta/semantic/shared/src/main/scala/scala/meta/semantic/Message.scala
@@ -8,9 +8,9 @@ import scala.meta.inputs._
 import scala.meta.internal.inputs._
 
 @data class Message(position: Position, severity: Severity, message: String) {
-  def syntax = s"[${severity.toString.toLowerCase}] ${position.syntax}: $message"
+  def syntax = s"[${severity.toString.toLowerCase}] ${position.syntaxWithInput} $message"
   def structure = s"""Message(${position.structure}, Severity.$severity, "$message")"""
-  override def toString = syntax
+  override def toString = structure
 }
 
 @root trait Severity

--- a/scalameta/semantic/shared/src/main/scala/scala/meta/semantic/Symbol.scala
+++ b/scalameta/semantic/shared/src/main/scala/scala/meta/semantic/Symbol.scala
@@ -37,7 +37,8 @@ object Symbol {
 
   @leaf class Local(position: Position) extends Symbol {
     override def toString = syntax
-    override def syntax = position.syntax
+    // NOTE: we treat RangeWithPosition as a Range for Symbol.Local.
+    override def syntax = position.syntaxWithInput
     override def structure = s"""Symbol.Local(${position.structure})"""
     override def name: Name = ???
     override def fullName: Ref = ???

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/inputs/VirtualInput.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/inputs/VirtualInput.scala
@@ -7,5 +7,7 @@ import org.scalameta.data._
 
 @data class VirtualInput(s: scala.Predef.String) extends Input {
   lazy val chars = s.toArray
-  override def toString = "VirtualInput(\"" + s + "\")"
+  def syntax = "<input>"
+  def structure = "VirtualInput(\"" + s + "\")"
+  override def toString: String = structure
 }


### PR DESCRIPTION
Position.point is necessary in some cases where start != point != end,
for example unused import warnings. The original Position.Range did
contain a point field that got removed in https://github.com/olafurpg/scalameta/commit/918e2ecab7a0dd95c6ff769f4fd76fb2e5d097f4
Instead of adding a new `point` field to Position, this commit
introduces a new Position.RangeWithPoint type. I opted for a new type
because

- it's relatively rare when start != point != end
- it's possible to provide a custom Range.unapply extractor that works
  to extract start/end from RangeWithPoint.

The hope is that RangeWithPoint will be mostly invisible unless you
know that you need the point field, for example in the
RemoveUnusedImports rewrite in scalafix.