### PR TITLE
Gracefully handle non-range positions, fixes #836.

### DIFF
--- a/scalahost/nsc/src/main/scala/scala/meta/internal/semantic/InputOps.scala
+++ b/scalahost/nsc/src/main/scala/scala/meta/internal/semantic/InputOps.scala
@@ -17,9 +17,15 @@ trait InputOps { self: DatabaseOps =>
 
   implicit class XtensionGPositionMPosition(pos: GPosition) {
     def toMeta: m.Position = {
-      assert(pos.isRange)
       val input = m.Input.File(pos.source.toAbsolutePath)
-      m.Position.Range(input, m.Point.Offset(input, pos.start), m.Point.Offset(input, pos.end))
+      if (pos.isRange) {
+        m.Position.Range(input, m.Point.Offset(input, pos.start), m.Point.Offset(input, pos.end))
+      } else {
+        // NOTE: Even with -Yrangepos enabled we cannot be guaranteed that all positions are
+        // range positions. In the case we encounter a non-range position we assume start == end.
+        val mpoint = m.Point.Offset(input, pos.point)
+        m.Position.Range(input, mpoint, mpoint)
+      }
     }
   }
 }


### PR DESCRIPTION
Before this commit, when we encountered a non-range positions we would
fail with an AssertionError. After this commit, we create a m.Position
with start and end using the same offset: point.

I was unable to minimize a test-case for this error, but I confirmed manually that this change fixes the error by running sbt-scalahost on acyclic that crashed before the fix and no longer crashes