### PR TITLE
Improve Xml parser performances

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -136,7 +136,7 @@ lazy val tokenizers = crossProject
   .settings(
     publishableSettings,
     description := "Scalameta APIs for tokenization and their baseline implementation",
-    libraryDependencies += "com.lihaoyi" %%% "fastparse" % "0.4.2",
+    libraryDependencies += "com.lihaoyi" %%% "fastparse" % "0.4.3",
     enableMacros
   )
   .dependsOn(common, dialects, inputs, tokens)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,8 @@ addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
 
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M15")
 
-addSbtPlugin("com.lihaoyi" % "scalatex-sbt-plugin" % "0.3.7")
+resolvers += Resolver.bintrayIvyRepo("scalameta", "sbt-plugins") // only needed for scalatex 0.3.8-pre
+addSbtPlugin("com.lihaoyi" % "scalatex-sbt-plugin" % "0.3.8-pre")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
 

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/XmlParser.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/XmlParser.scala
@@ -13,7 +13,7 @@ import fastparse.all._
   */
 class XmlParser(Block: P0,
                 Patterns: P0 = Fail,
-                WL: P0 = CharsWhile(_.isWhitespace).opaque("whitespace")) {
+                WL: P0 = CharsWhile.raw(_.isWhitespace).opaque("whitespace")) {
 
   val XmlExpr: P0 = P( Xml.XmlContent.rep(min = 1, sep = WL.?) )
   val XmlPattern: P0 = P( Xml.ElemPattern )
@@ -66,8 +66,8 @@ class XmlParser(Block: P0,
     val CharA  = P( !"'" ~ Char1 )
 
     val Name: P0  = P( NameStart ~ NameChar.rep ).!.filter(_.last != ':').opaque("Name").map(_ => Unit) // discard result
-    val NameStart = P( CharPred(isNameStart) )
-    val NameChar  = P( CharPred(isNameChar) )
+    val NameStart = P( CharPred.raw(isNameStart) )
+    val NameChar  = P( CharPred.raw(isNameChar) )
 
     val ElemPattern: P0 = P( TagPHeader ~/ ("/>" | ">" ~/ ContentP ~/ ETag ) )
     val TagPHeader      = P( "<" ~ Name ~ WL.?  )


### PR DESCRIPTION
I believe this can improve the performances of the xml parser.
We instantiate a new parser for every single xml literal we parse. I believe
most of the time is spent during initialization since our xml parsers are
short lived and not reusable. These changes reduce initialization time
and memory consumption as it avoids pre-computing the lookup tables.

A better solution would be to have a reusable parser. But we would need
to remove the parser dependency on `Dialect`.