### PR TITLE
Publish sbt-scalahost ivy style.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -255,6 +255,7 @@ lazy val scalahostSbt = project
     buildInfoSettings,
     sbt.ScriptedPlugin.scriptedSettings,
     sbtPlugin := true,
+    publishMavenStyle := false, // necessary for pre-releases to work with addSbtPlugin
     bintrayRepository := "maven", // sbtPlugin overrides this to sbt-plugins
     testQuick := {
       // runs tests for 2.11 only, avoiding the need to publish for 2.12


### PR DESCRIPTION
Currently, it's not possible to depend on sbt-scalahost pre-releases
with addSbtPlugin or libraryDependencies because it's published
maven-style to bintray.