### PR TITLE
Fix bugs in Xml Parser

### DIFF
--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/parsers/XmlSuite.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/parsers/XmlSuite.scala
@@ -267,6 +267,8 @@ class XmlSuite extends ParseSuite {
   checkOK("<a>{1}{2}<b/>{3}</a>")
   checkOK("<a>{<b>{1}{2}</b>}</a>")
   checkOK("e match { case <a>{_*}</a> => }")
+  checkOK("<a>{{</a>")
+  checkOK("<a>}}</a>")
   checkOK(
     """
       |<a>
@@ -320,6 +322,9 @@ class XmlSuite extends ParseSuite {
   checkError("<a></ a>")
   checkError("<a></\na>")
   checkError("e match { case <a>{}</a> => ??? }")
+  checkError("<a>}</a>")
+  checkError("<a>{</a>")
+  checkError("<a>}{</a>")
   //checkError("<a></b>") // FIXME: Should not parse
 
   // FIXME These should not parse: we need to differentiate between expression and pattern position

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/XmlParser.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/XmlParser.scala
@@ -58,12 +58,13 @@ class XmlParser(Block: P0,
     val Num       = P( CharIn('0' to '9').rep )
     val HexNum    = P( CharIn('0' to '9', 'a' to 'f', 'A' to 'F').rep )
 
-    val CharData = P( (!"{" ~ Char1 | "{{").rep(1) )
+    val CharData = P( (CharB | "{{" | "}}").rep(1) )
 
     val Char   = P( AnyChar )
     val Char1  = P( !("<" | "&") ~ Char )
     val CharQ  = P( !"\"" ~ Char1 )
     val CharA  = P( !"'" ~ Char1 )
+    val CharB  = P( !("{" | "}") ~ Char1 )
 
     val Name: P0  = P( NameStart ~ NameChar.rep ).!.filter(_.last != ':').opaque("Name").map(_ => Unit) // discard result
     val NameStart = P( CharPred.raw(isNameStart) )
@@ -133,7 +134,7 @@ class ScalaExprPositionParser(dialect: Dialect) extends Parser[Unit] {
   private val splicePositions = Seq.newBuilder[RangePosition]
   def getSplicePositions = splicePositions.result()
 
-  def parseRec(cfg: ParseCtx, index: Int) = {
+  def parseRec(cfg: ParseCtx, index: Int): fastparse.core.Mutable[Unit, Char, String] = {
     var curlyBraceCount = 1
     val input = cfg.input
     val scanner =
@@ -144,9 +145,12 @@ class ScalaExprPositionParser(dialect: Dialect) extends Parser[Unit] {
       (scanner.curr.token: @switch) match {
         case LegacyToken.LBRACE => curlyBraceCount += 1
         case LegacyToken.RBRACE => curlyBraceCount -= 1
+        case LegacyToken.EOF =>
+          return fail(cfg.failure, index + scanner.curr.offset)
         case _ =>
       }
     }
+
     val nextIndex = index + scanner.curr.offset
     splicePositions += RangePosition(index, nextIndex)
     success(cfg.success, (), nextIndex, Set.empty, cut = false)


### PR DESCRIPTION
- Both `{`and `}` must be protected
- Block parser now fail if it reaches EOF