### PR TITLE
Upgrade to Scala.js 0.6.17 for faster link times.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.16")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.17")
 
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 


### PR DESCRIPTION
My experiments show a drop from ~17s to ~3s for scalametaJS/test, see
https://github.com/scala-js/scala-js/issues/2827#issuecomment-306063974