### PR TITLE
Setup Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+language: scala
+script:
+  - ./bin/runci.sh $CI_TEST
+jdk:
+  - oraclejdk8
+env:
+  matrix:
+    - CI_TEST: scalafmt
+    - CI_TEST: ci-fast
+      CI_SCALA_VERSION: 2.11.11
+    - CI_TEST: ci-fast
+      CI_SCALA_VERSION: 2.11.11
+      CI_SCALA_JS: true
+    - CI_TEST: ci-fast
+      CI_SCALA_VERSION: 2.12.2
+    - CI_TEST: ci-fast
+      CI_SCALA_VERSION: 2.12.2
+      CI_SCALA_JS: true
+    - CI_TEST: ci-sbt-scalahost
+      CI_SCALA_VERSION: 2.10.6
+
+cache:
+  directories:
+  - $HOME/.sbt/0.13/dependency
+  - $HOME/.sbt/boot/scala*
+  - $HOME/.sbt/launchers
+  - $HOME/.ivy2/cache
+  - $HOME/.coursier
+
+before_cache:
+  - du -h -d 1 $HOME/.ivy2/cache
+  - du -h -d 2 $HOME/.sbt/
+  - find $HOME/.sbt -name "*.lock" -type f -delete
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete
+  - find $HOME/.ivy2/cache -name "*scalafix*.xml" -type f -delete
+  - rm -rf $HOME/.ivy2/local

--- a/bin/runci.sh
+++ b/bin/runci.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eux
+TEST=${1}
+
+case "$TEST" in
+  "scalafmt" )
+    ./scalafmt --test
+    ;;
+  * )
+    sbt $TEST
+    ;;
+esac
+


### PR DESCRIPTION
We are experiencing resolution errors with the platform-ci, which is
slowing us down. My hypothesis is that our bandwith is being limited,
partly due to bad caching setup. The dotty-ci is apparently downloading
50gb a day. Instead of spending more days on the drone CI, I'm setting
up travis again. I disable the ci-slow tests since those are too heavy
for the free-tier Travis servers.