### PR TITLE
Expose issue #945

### DIFF
--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/parsers/XmlSuite.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/parsers/XmlSuite.scala
@@ -305,6 +305,7 @@ class XmlSuite extends ParseSuite {
   checkOK("<a>&#;</a>")
   checkOK("<a>&#x;</a>")
   checkOK("<a>]]></a>")
+  //checkOK("<a/>{0}") // FIXME
   //checkOK("""<a b="&:;"/>""") // FIXME
   //checkOK("""<a b="&:a;"/>""") //FIXME
   //checkOK("""<a b="&a:;"/>""") // FIXME

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
@@ -258,14 +258,14 @@ class ScalametaTokenizer(input: Input, dialect: Dialect) {
               emitContents()
 
             case _ =>
-            // We have reached the final xml part
+              // We have reached the final xml part
           }
         }
-
 
         // Xml.Start has been emitted. Backtrack to emit first part
         legacyIndex -= 1
         emitContents()
+        assert(prev.token == XMLLIT)
         val xmlEndIndex = prev.endOffset + 1
         tokens += Token.Xml.End(input, dialect, xmlEndIndex, xmlEndIndex)
       }


### PR DESCRIPTION
This is not a fix for #945. I don't see an easy solution.
Now Scalameta will crash instead of emitting wrong tokens