### PR TITLE
Issue-#896 - Fix ScaladocParser not parsing multilevel headings

### DIFF
--- a/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/DocToken.scala
+++ b/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/DocToken.scala
@@ -264,11 +264,6 @@ object DocToken {
   /**
     * Documents a Scaladoc Heading.
     */
-  case object Heading extends Kind
-
-  /**
-    * Documents a Scaladoc sub-heading.
-    */
-  case object SubHeading extends Kind
+  case class Heading(level: Int) extends Kind
 
 }

--- a/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/DocToken.scala
+++ b/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/DocToken.scala
@@ -32,6 +32,7 @@ case class DocToken(kind: DocToken.Kind, name: Option[String], body: Option[Stri
             case _ => Seq[DocToken.Reference]()
           }
         }
+
         parseBodyFrom(0)
       }
       .getOrElse(Nil)
@@ -264,6 +265,48 @@ object DocToken {
   /**
     * Documents a Scaladoc Heading.
     */
-  case class Heading(level: Int) extends Kind
+  abstract class Heading(val level: Int) extends Kind
+
+  /**
+    * Represents a first level heading:
+    *
+    * i.e: '=HEADING='
+    */
+  case object Heading1 extends Heading(1)
+
+  /**
+    * Represents a second level heading:
+    *
+    * i.e: '==HEADING=='
+    */
+  case object Heading2 extends Heading(2)
+
+  /**
+    * Represents a third level heading:
+    *
+    * i.e: '===HEADING==='
+    */
+  case object Heading3 extends Heading(3)
+
+  /**
+    * Represents a fourth level heading:
+    *
+    * i.e: '====HEADING===='
+    */
+  case object Heading4 extends Heading(4)
+
+  /**
+    * Represents a fifth level heading:
+    *
+    * i.e: '=====HEADING====='
+    */
+  case object Heading5 extends Heading(5)
+
+  /**
+    * Represents a sixth level heading:
+    *
+    * i.e: '======HEADING======'
+    */
+  case object Heading6 extends Heading(6)
 
 }

--- a/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/DocToken.scala
+++ b/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/DocToken.scala
@@ -309,4 +309,14 @@ object DocToken {
     */
   case object Heading6 extends Heading(6)
 
+  /**
+    * Contains all the implemented [[Heading]]'s.
+    */
+  def allHeadings: Seq[Heading] = List(Heading1, Heading2, Heading3, Heading4, Heading5, Heading6)
+
+  /**
+    * Obtains a heading by its level if available.
+    */
+  def headingForLevel(level: Int): Option[Heading] = allHeadings.find(_.level == level)
+
 }

--- a/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/ScaladocParser.scala
+++ b/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/ScaladocParser.scala
@@ -45,15 +45,15 @@ object ScaladocParser {
     comment.content.map(parseRec)
   }
 
-  private[this] def generateHeadingParser(level: Int, f: (String) => DocToken): Parser[DocToken] = {
-    val headingSimbols = "=" * level
+  private[this] def generateHeadingParser(headingType: Heading): Parser[DocToken] = {
+    val headingSymbols = "=" * headingType.level
     P(
       // Code block start
-      headingSimbols
+      headingSymbols
       // Heading description
-        ~ ((AnyChar ~ !"=").rep ~ AnyChar).!.map(f(_))
+        ~ ((AnyChar ~ !"=").rep ~ AnyChar).!.map(c => DocToken(headingType, c.trim))
       // Code block end
-        ~ headingSimbols
+        ~ headingSymbols
     )
   }
 
@@ -79,14 +79,7 @@ object ScaladocParser {
       )
 
     // Parsers for headings/subheadings instances.
-    val headingsParsers = Seq(
-      generateHeadingParser(6, (c: String) => DocToken(Heading6, c.trim)),
-      generateHeadingParser(5, (c: String) => DocToken(Heading5, c.trim)),
-      generateHeadingParser(4, (c: String) => DocToken(Heading4, c.trim)),
-      generateHeadingParser(3, (c: String) => DocToken(Heading3, c.trim)),
-      generateHeadingParser(2, (c: String) => DocToken(Heading2, c.trim)),
-      generateHeadingParser(1, (c: String) => DocToken(Heading1, c.trim))
-    )
+    val headingsParsers = DocToken.allHeadings.reverse.map(generateHeadingParser(_))
 
     // Parser for Inheritdoc instances
     val inheritDocParser = P("@inheritdoc".!).map(_ => DocToken(InheritDoc))

--- a/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/ScaladocParser.scala
+++ b/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/ScaladocParser.scala
@@ -45,13 +45,13 @@ object ScaladocParser {
     comment.content.map(parseRec)
   }
 
-  private[this] def generateHeadingParser(level: Int): Parser[DocToken] = {
+  private[this] def generateHeadingParser(level: Int, f: (String) => DocToken): Parser[DocToken] = {
     val headingSimbols = "=" * level
     P(
       // Code block start
       headingSimbols
       // Heading description
-        ~ ((AnyChar ~ !"=").rep ~ AnyChar).!.map(c => DocToken(Heading(level), c.trim))
+        ~ ((AnyChar ~ !"=").rep ~ AnyChar).!.map(f(_))
       // Code block end
         ~ headingSimbols
     )
@@ -78,9 +78,15 @@ object ScaladocParser {
           ~ "}}}"
       )
 
-    // Parser
-    val headingsParsers =
-      (1 until numberOfSupportedHeadingLevels).reverse.map(generateHeadingParser(_))
+    // Parsers for headings/subheadings instances.
+    val headingsParsers = Seq(
+      generateHeadingParser(6, (c: String) => DocToken(Heading6, c.trim)),
+      generateHeadingParser(5, (c: String) => DocToken(Heading5, c.trim)),
+      generateHeadingParser(4, (c: String) => DocToken(Heading4, c.trim)),
+      generateHeadingParser(3, (c: String) => DocToken(Heading3, c.trim)),
+      generateHeadingParser(2, (c: String) => DocToken(Heading2, c.trim)),
+      generateHeadingParser(1, (c: String) => DocToken(Heading1, c.trim))
+    )
 
     // Parser for Inheritdoc instances
     val inheritDocParser = P("@inheritdoc".!).map(_ => DocToken(InheritDoc))

--- a/scalameta/contrib/shared/src/test/scala/scala/meta/contrib/ScaladocParserSuite.scala
+++ b/scalameta/contrib/shared/src/test/scala/scala/meta/contrib/ScaladocParserSuite.scala
@@ -154,6 +154,7 @@ class ScaladocParserSuite extends FunSuite {
     val level3HeadingBody = "Level 3"
     val level4HeadingBody = "Level 4"
     val level5HeadingBody = "Level 5"
+    val level6HeadingBody = "Level 6"
 
     val result: Option[Seq[DocToken]] =
       parseString(
@@ -164,17 +165,19 @@ class ScaladocParserSuite extends FunSuite {
           * ===$level3HeadingBody===
           * ====$level4HeadingBody====
           * =====$level5HeadingBody=====
+          * ======$level6HeadingBody======
           */
          case class foo(bar : String)
          """
       )
     val expectation = Option(
       Seq(
-        DocToken(Heading(1), level1HeadingBody),
-        DocToken(Heading(2), level2HeadingBody),
-        DocToken(Heading(3), level3HeadingBody),
-        DocToken(Heading(4), level4HeadingBody),
-        DocToken(Heading(5), level5HeadingBody)
+        DocToken(Heading1, level1HeadingBody),
+        DocToken(Heading2, level2HeadingBody),
+        DocToken(Heading3, level3HeadingBody),
+        DocToken(Heading4, level4HeadingBody),
+        DocToken(Heading5, level5HeadingBody),
+        DocToken(Heading6, level6HeadingBody)
       )
     )
     assert(result === expectation)

--- a/scalameta/contrib/shared/src/test/scala/scala/meta/contrib/ScaladocParserSuite.scala
+++ b/scalameta/contrib/shared/src/test/scala/scala/meta/contrib/ScaladocParserSuite.scala
@@ -149,26 +149,34 @@ class ScaladocParserSuite extends FunSuite {
   }
 
   test("headings") {
-    val headingBody = "Overview"
-    val subHeadingBody = "Of the heading"
+    val level1HeadingBody = "Level 1"
+    val level2HeadingBody = "Level 2"
+    val level3HeadingBody = "Level 3"
+    val level4HeadingBody = "Level 4"
+    val level5HeadingBody = "Level 5"
 
     val result: Option[Seq[DocToken]] =
       parseString(
         s"""
         /**
-          * =$headingBody=
-          * ==$subHeadingBody==
+          * =$level1HeadingBody=
+          * ==$level2HeadingBody==
+          * ===$level3HeadingBody===
+          * ====$level4HeadingBody====
+          * =====$level5HeadingBody=====
           */
          case class foo(bar : String)
          """
       )
     val expectation = Option(
       Seq(
-        DocToken(Heading, headingBody),
-        DocToken(SubHeading, subHeadingBody)
+        DocToken(Heading(1), level1HeadingBody),
+        DocToken(Heading(2), level2HeadingBody),
+        DocToken(Heading(3), level3HeadingBody),
+        DocToken(Heading(4), level4HeadingBody),
+        DocToken(Heading(5), level5HeadingBody)
       )
     )
-
     assert(result === expectation)
   }
 


### PR DESCRIPTION
This commit changes the 'DocToken' AST, including the heading level on `Heading` directly. I should use another approach, or I need to add the change to the changelog?

