### PR TITLE
Allow specifying dialect through parsers facade

### DIFF
--- a/scalameta/parsers/js/npm/package.json
+++ b/scalameta/parsers/js/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scalameta-parsers",
-  "version": "1.9.0-beta",
+  "version": "1.9.0-beta.1",
   "main": "index.js",
   "files": [
     "index.js"

--- a/scalameta/parsers/js/src/test/scala/scala/meta/parsers/JSFacadeSuite.scala
+++ b/scalameta/parsers/js/src/test/scala/scala/meta/parsers/JSFacadeSuite.scala
@@ -209,7 +209,7 @@ class JSFacadeSuite extends FunSuite {
     check(parsedDefaultDialect, expected)
   }
 
-  test("inexisting dialects fallback to Scala 2.11") {
+  test("inexisting dialects report an error") {
     val code =
       """|List(
          |  1,
@@ -217,8 +217,7 @@ class JSFacadeSuite extends FunSuite {
          |)""".stripMargin
     val parsedDefaultDialect = JSFacade.parseStat(code, js.Dictionary("dialect" -> "wrong"))
     val expected = d(
-      "error" -> "illegal start of simple expression",
-      "pos" -> pos(16, 17)
+      "error" -> "'wrong' is not a valid dialect."
     ).asInstanceOf[js.Dictionary[Any]]
     check(parsedDefaultDialect, expected)
   }

--- a/scalameta/parsers/js/src/test/scala/scala/meta/parsers/JSFacadeSuite.scala
+++ b/scalameta/parsers/js/src/test/scala/scala/meta/parsers/JSFacadeSuite.scala
@@ -193,5 +193,54 @@ class JSFacadeSuite extends FunSuite {
     check(parsed, expected)
   }
 
+  test("default dialect is Scala 2.11") {
+    val code =
+      """|List(
+         |  1,
+         |  2,
+         |)""".stripMargin
+    val parsedDefaultDialect = JSFacade.parseStat(code)
+    val expected = d(
+      "error" -> "illegal start of simple expression"
+    ).asInstanceOf[js.Dictionary[Any]]
+    check(parsedDefaultDialect, expected)
+  }
+
+  test("inexisting dialects fallback to Scala 2.11") {
+    val code =
+      """|List(
+         |  1,
+         |  2,
+         |)""".stripMargin
+    val parsedDefaultDialect = JSFacade.parseStat(code, js.Dictionary("dialect" -> "wrong"))
+    val expected = d(
+      "error" -> "illegal start of simple expression"
+    ).asInstanceOf[js.Dictionary[Any]]
+    check(parsedDefaultDialect, expected)
+  }
+
+  test("can specify dialect") {
+    val code =
+      """|List(
+         |  1,
+         |  2,
+         |)""".stripMargin
+    val parsedDefaultDialect = JSFacade.parseStat(code, js.Dictionary("dialect" -> "Scala212"))
+    val expected = d(
+      "type" -> "Term.Apply",
+      "pos" -> pos(0, 17),
+      "fun" -> d(
+        "type" -> "Term.Name",
+        "pos" -> pos(0, 4),
+        "value" -> "List"
+      ),
+      "args" -> a(
+        lit("Lit.Int", 1, "1", pos(8, 9)),
+        lit("Lit.Int", 2, "2", pos(13, 14))
+      )
+    ).asInstanceOf[js.Dictionary[Any]]
+    check(parsedDefaultDialect, expected)
+  }
+
 }
 

--- a/scalameta/parsers/js/src/test/scala/scala/meta/parsers/JSFacadeSuite.scala
+++ b/scalameta/parsers/js/src/test/scala/scala/meta/parsers/JSFacadeSuite.scala
@@ -141,7 +141,9 @@ class JSFacadeSuite extends FunSuite {
     check(parsed, expected)
   }
 
-  test("parse Lit.Double") {
+  // Ignored because of
+  // https://github.com/scalameta/scalameta/issues/961
+  ignore("parse Lit.Double") {
     val parsed = JSFacade.parseStat("42.2")
     val expected = lit("Lit.Double", 42.2, "42.2", pos(0, 4))
     check(parsed, expected)

--- a/scalameta/parsers/js/src/test/scala/scala/meta/parsers/JSFacadeSuite.scala
+++ b/scalameta/parsers/js/src/test/scala/scala/meta/parsers/JSFacadeSuite.scala
@@ -201,7 +201,8 @@ class JSFacadeSuite extends FunSuite {
          |)""".stripMargin
     val parsedDefaultDialect = JSFacade.parseStat(code)
     val expected = d(
-      "error" -> "illegal start of simple expression"
+      "error" -> "illegal start of simple expression",
+      "pos" -> pos(16, 17)
     ).asInstanceOf[js.Dictionary[Any]]
     check(parsedDefaultDialect, expected)
   }
@@ -214,7 +215,8 @@ class JSFacadeSuite extends FunSuite {
          |)""".stripMargin
     val parsedDefaultDialect = JSFacade.parseStat(code, js.Dictionary("dialect" -> "wrong"))
     val expected = d(
-      "error" -> "illegal start of simple expression"
+      "error" -> "illegal start of simple expression",
+      "pos" -> pos(16, 17)
     ).asInstanceOf[js.Dictionary[Any]]
     check(parsedDefaultDialect, expected)
   }


### PR DESCRIPTION
This PR allows specifying a dialect through the JS api.

Here's an example of usage from ASTExplorer:

![](http://g.recordit.co/p5lY4jfBCK.gif)

This PR is based on #957 (which in turn is based on #956). I'll rebase as soon as the parent PRs get merged.