### PR TITLE
Return Symbol.None instead of Symbol.Local for no position, fixes #959.

### DIFF
--- a/scalahost/nsc/src/main/scala/scala/meta/internal/semantic/SymbolOps.scala
+++ b/scalahost/nsc/src/main/scala/scala/meta/internal/semantic/SymbolOps.scala
@@ -23,7 +23,13 @@ trait SymbolOps { self: DatabaseOps =>
             ((sym.owner.isAliasType || sym.owner.isAbstractType) && !sym.isParameter)
         !definitelyGlobal && (definitelyLocal || isLocal(sym.owner))
       }
-      if (isLocal(sym)) return m.Symbol.Local(sym.pos.toMeta.syntax)
+      if (isLocal(sym)) {
+        val mpos = sym.pos.toMeta
+        return {
+          if (mpos == m.Position.None) m.Symbol.None
+          else m.Symbol.Local(mpos.syntax)
+        }
+      }
 
       val owner = sym.owner.toSemantic
       val signature = {


### PR DESCRIPTION
I struggled to find a minimal repro, but the fix seems logical to me. I
tested the fix manually by re-compiling the original reported issue from
twitter/scalding and confirmed that the ResolvedName with symbol
"<none>" no longer appears in the .semanticdb file.