### PR TITLE
Add lineNumber and columnNumber to parser errors

### DIFF
--- a/scalameta/parsers/js/npm/package.json
+++ b/scalameta/parsers/js/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scalameta-parsers",
-  "version": "1.9.0-beta.1",
+  "version": "1.9.0-beta.3",
   "main": "index.js",
   "files": [
     "index.js"

--- a/scalameta/parsers/js/src/main/scala/scala/meta/parsers/JSFacade.scala
+++ b/scalameta/parsers/js/src/main/scala/scala/meta/parsers/JSFacade.scala
@@ -97,7 +97,9 @@ object JSFacade {
           case Parsed.Success(t) => toNode(t).asInstanceOf[js.Dictionary[Any]]
           case Parsed.Error(pos, message, _) => js.Dictionary(
             "error" -> message,
-            "pos" -> toPosition(pos)
+            "pos" -> toPosition(pos),
+            "lineNumber" -> pos.start.line,
+            "columnNumber" -> pos.start.column
           )
         }
     }

--- a/scalameta/parsers/js/src/test/scala/scala/meta/parsers/JSFacadeSuite.scala
+++ b/scalameta/parsers/js/src/test/scala/scala/meta/parsers/JSFacadeSuite.scala
@@ -204,7 +204,9 @@ class JSFacadeSuite extends FunSuite {
     val parsedDefaultDialect = JSFacade.parseStat(code)
     val expected = d(
       "error" -> "illegal start of simple expression",
-      "pos" -> pos(16, 17)
+      "pos" -> pos(16, 17),
+      "lineNumber" -> 3,
+      "columnNumber" -> 0
     ).asInstanceOf[js.Dictionary[Any]]
     check(parsedDefaultDialect, expected)
   }


### PR DESCRIPTION
These are useful for highlighting parse errors in AST explorer. Here's an example:

![image](https://user-images.githubusercontent.com/691940/27494873-aed90238-5847-11e7-80cc-2bc2515b1d21.png)
