### PR TITLE
Add configurable error handling, fixes #982.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -332,6 +332,7 @@ lazy val scalahostIntegration = project
         s"-Xplugin:$pluginJar",
         "-Yrangepos",
         s"-P:scalahost:sourceroot:${baseDirectory.in(ThisBuild).value}",
+        s"-P:scalahost:failures:error", // fail fast during development.
         "-Xplugin-require:scalahost"
       )
     }

--- a/scalahost/nsc/src/main/scala/scala/meta/internal/scalahost/ScalahostPipeline.scala
+++ b/scalahost/nsc/src/main/scala/scala/meta/internal/scalahost/ScalahostPipeline.scala
@@ -48,11 +48,12 @@ trait ScalahostPipeline extends DatabaseOps { self: ScalahostPlugin =>
             writer.write(s"failed to generate semanticdb for $path:$EOL")
             ex.printStackTrace(new PrintWriter(writer))
             val msg = writer.toString
+            import scala.meta.internal.semantic.FailureMode._
             config.failures match {
-              case Severity.ERROR => global.reporter.error(g.NoPosition, msg)
-              case Severity.WARNING => global.reporter.warning(g.NoPosition, msg)
-              case Severity.INFO => global.reporter.info(g.NoPosition, msg, force = true)
-              case _ =>
+              case Error => global.reporter.error(g.NoPosition, msg)
+              case Warning => global.reporter.warning(g.NoPosition, msg)
+              case Info => global.reporter.info(g.NoPosition, msg, force = true)
+              case Ignore => // do nothing.
             }
         }
       }

--- a/scalahost/nsc/src/main/scala/scala/meta/internal/scalahost/ScalahostPipeline.scala
+++ b/scalahost/nsc/src/main/scala/scala/meta/internal/scalahost/ScalahostPipeline.scala
@@ -14,6 +14,7 @@ import scala.meta.internal.semantic.DatabaseOps
 import scala.meta.internal.semantic.{vfs => v}
 import scala.meta.internal.semantic.{schema => s}
 import scala.tools.nsc.doc.ScaladocGlobal
+import scala.meta.internal.semantic.schema.Message.Severity
 
 trait ScalahostPipeline extends DatabaseOps { self: ScalahostPlugin =>
   lazy val scalametaTargetroot = AbsolutePath(
@@ -42,11 +43,17 @@ trait ScalahostPipeline extends DatabaseOps { self: ScalahostPlugin =>
           mminidb.save(scalametaTargetroot, config.sourceroot)
         } catch {
           case NonFatal(ex) =>
-            val msg = new StringWriter()
+            val writer = new StringWriter()
             val path = unit.source.file.path
-            msg.write(s"failed to generate semanticdb for $path:$EOL")
-            ex.printStackTrace(new PrintWriter(msg))
-            global.reporter.error(g.NoPosition, msg.toString)
+            writer.write(s"failed to generate semanticdb for $path:$EOL")
+            ex.printStackTrace(new PrintWriter(writer))
+            val msg = writer.toString
+            config.failures match {
+              case Severity.ERROR => global.reporter.error(g.NoPosition, msg)
+              case Severity.WARNING => global.reporter.warning(g.NoPosition, msg)
+              case Severity.INFO => global.reporter.info(g.NoPosition, msg, force = true)
+              case _ =>
+            }
         }
       }
 

--- a/scalahost/nsc/src/main/scala/scala/meta/internal/scalahost/ScalahostPlugin.scala
+++ b/scalahost/nsc/src/main/scala/scala/meta/internal/scalahost/ScalahostPlugin.scala
@@ -2,6 +2,7 @@ package scala.meta.internal
 package scalahost
 
 import scala.meta.internal.io.PathIO
+import scala.meta.internal.semantic.FailureMode
 import scala.meta.internal.semantic.SemanticdbMode
 import scala.meta.io.AbsolutePath
 import scala.meta.io.RelativePath
@@ -29,7 +30,7 @@ class ScalahostPlugin(val global: Global)
         config.setSourceroot(abspath)
       case SetSemanticdb(SemanticdbMode(mode)) =>
         config.setSemanticdbMode(mode)
-      case SetFailures(Failures(severity)) =>
+      case SetFailures(FailureMode(severity)) =>
         config.setFailures(severity)
       case SetSemanticdb(els) =>
         err(s"Unknown semanticdb $els. Expected one of: ${SemanticdbMode.all.mkString(", ")} ")

--- a/scalahost/nsc/src/main/scala/scala/meta/internal/scalahost/ScalahostPlugin.scala
+++ b/scalahost/nsc/src/main/scala/scala/meta/internal/scalahost/ScalahostPlugin.scala
@@ -29,10 +29,12 @@ class ScalahostPlugin(val global: Global)
         config.setSourceroot(abspath)
       case SetSemanticdb(SemanticdbMode(mode)) =>
         config.setSemanticdbMode(mode)
+      case SetFailures(Failures(severity)) =>
+        config.setFailures(severity)
       case SetSemanticdb(els) =>
         err(s"Unknown semanticdb $els. Expected one of: ${SemanticdbMode.all.mkString(", ")} ")
       case els =>
-        err(s"Ignoring unknown scalahost option $els")
+        err(s"Ignoring unknown option $els")
     }
     true
   }

--- a/scalahost/nsc/src/main/scala/scala/meta/internal/semantic/ConfigOps.scala
+++ b/scalahost/nsc/src/main/scala/scala/meta/internal/semantic/ConfigOps.scala
@@ -4,18 +4,33 @@ package semantic
 import scala.meta.internal.io.PathIO
 import scala.meta.internal.scalahost.ScalahostPlugin
 import scala.meta.io._
-import scala.meta.internal.semantic.schema.Message.Severity
 
-case class ScalahostConfig(sourceroot: AbsolutePath,
-                           semanticdb: SemanticdbMode,
-                           failures: Severity) {
+case class ScalahostConfig(
+    sourceroot: AbsolutePath,
+    semanticdb: SemanticdbMode,
+    failures: FailureMode) {
   def syntax: String =
     s"-P:${ScalahostPlugin.name}:sourceroot:$sourceroot " +
       s"-P:${ScalahostPlugin.name}:semanticdb:$semanticdb" +
-      s"-P:${ScalahostPlugin.name}:failures:${failures.name.toLowerCase()} "
+      s"-P:${ScalahostPlugin.name}:failures:${failures.name} "
 }
 object ScalahostConfig {
-  def default = ScalahostConfig(PathIO.workingDirectory, SemanticdbMode.Fat, Severity.WARNING)
+  def default = ScalahostConfig(PathIO.workingDirectory, SemanticdbMode.Fat, FailureMode.Warning)
+}
+
+sealed abstract class FailureMode {
+  def name: String = toString.toLowerCase
+}
+object FailureMode {
+  def unapply(arg: String): Option[FailureMode] = {
+    val lower = arg.toLowerCase()
+    all.find(_.name == lower)
+  }
+  case object Error extends FailureMode
+  case object Warning extends FailureMode
+  case object Info extends FailureMode
+  case object Ignore extends FailureMode
+  def all = List(Error, Warning, Info, Ignore)
 }
 
 sealed abstract class SemanticdbMode {
@@ -37,11 +52,6 @@ trait ConfigOps { self: DatabaseOps =>
   val SetSemanticdb = "semanticdb:(.*)".r
   val SetSourceroot = "sourceroot:(.*)".r
   val SetFailures = "failures:(.*)".r
-  object Failures {
-    def unapply(arg: String): Option[Severity] =
-      if (arg.compareToIgnoreCase("ignore") == 0) Some(Severity.UNKNOWN)
-      else Severity.fromName(arg.toUpperCase())
-  }
 
   var config: ScalahostConfig = ScalahostConfig.default
   implicit class XtensionScalahostConfig(ignored: ScalahostConfig) {
@@ -49,7 +59,7 @@ trait ConfigOps { self: DatabaseOps =>
       config = config.copy(sourceroot = sourceroot)
     def setSemanticdbMode(mode: SemanticdbMode): Unit =
       config = config.copy(semanticdb = mode)
-    def setFailures(severity: Severity): Unit =
+    def setFailures(severity: FailureMode): Unit =
       config = config.copy(failures = severity)
   }
 }

--- a/scalahost/nsc/src/test/scala/scala/meta/tests/scalahost/mirrors/DatabaseSuite.scala
+++ b/scalahost/nsc/src/test/scala/scala/meta/tests/scalahost/mirrors/DatabaseSuite.scala
@@ -42,6 +42,7 @@ abstract class DatabaseSuite(mode: SemanticdbMode) extends FunSuite with DiffAss
   }
   import databaseOps._
   config.setSemanticdbMode(mode)
+  config.setFailures(Severity.ERROR)
 
   private def computeDatabaseFromSnippet(code: String): m.Database = {
     val javaFile = File.createTempFile("paradise", ".scala")

--- a/scalahost/nsc/src/test/scala/scala/meta/tests/scalahost/mirrors/DatabaseSuite.scala
+++ b/scalahost/nsc/src/test/scala/scala/meta/tests/scalahost/mirrors/DatabaseSuite.scala
@@ -11,6 +11,7 @@ import scala.compat.Platform.EOL
 import scala.{meta => m}
 import scala.meta.io._
 import scala.meta.internal.semantic.DatabaseOps
+import scala.meta.internal.semantic.FailureMode
 import scala.meta.internal.semantic.SemanticdbMode
 import scala.meta.testkit.DiffAssertions
 
@@ -42,7 +43,7 @@ abstract class DatabaseSuite(mode: SemanticdbMode) extends FunSuite with DiffAss
   }
   import databaseOps._
   config.setSemanticdbMode(mode)
-  config.setFailures(Severity.ERROR)
+  config.setFailures(FailureMode.Error)
 
   private def computeDatabaseFromSnippet(code: String): m.Database = {
     val javaFile = File.createTempFile("paradise", ".scala")


### PR DESCRIPTION
Previously, it was impossible to ignore a single parse error when
compiling a large project with scalahost. This resulted in a bad user
experience with no workaround but to disable scalahost. This commit adds
the ability to configure at which level the errors are reported,
defaulting to a warning.