### PR TITLE
Emit proper diffs for multiline string comparison.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -342,10 +342,12 @@ lazy val testkit = Project(id = "testkit", base = file("scalameta/testkit"))
     publishableSettings,
     hasLargeIntegrationTests,
     libraryDependencies ++= Seq(
+      "org.scalatest" %%% "scalatest" % "3.0.1",
       "com.lihaoyi" %% "geny" % "0.1.1",
       // These are used to download and extract a corpus tar.gz
       "org.rauschig" % "jarchivelib" % "0.7.1",
-      "commons-io" % "commons-io" % "2.5"
+      "commons-io" % "commons-io" % "2.5",
+      "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0"
     ),
     libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value % Test,
     description := "Testing utilities for scalameta APIs"

--- a/scalahost/nsc/src/test/scala/scala/meta/tests/scalahost/mirrors/DatabaseSuite.scala
+++ b/scalahost/nsc/src/test/scala/scala/meta/tests/scalahost/mirrors/DatabaseSuite.scala
@@ -13,8 +13,9 @@ import scala.{meta => m}
 import scala.meta.io._
 import scala.meta.internal.semantic.DatabaseOps
 import scala.meta.internal.semantic.SemanticdbMode
+import scala.meta.testkit.DiffAssertions
 
-abstract class DatabaseSuite(mode: SemanticdbMode) extends FunSuite { self =>
+abstract class DatabaseSuite(mode: SemanticdbMode) extends FunSuite with DiffAssertions { self =>
   private def test(code: String)(fn: => Unit): Unit = {
     var name = code.trim.replace(EOL, " ")
     if (name.length > 50) name = name.take(50) + "..."
@@ -88,20 +89,27 @@ abstract class DatabaseSuite(mode: SemanticdbMode) extends FunSuite { self =>
     section.mkString(EOL).replace(path, "<...>")
   }
 
+  def checkSection(code: String, expected: String, section: String): Unit = {
+    test(code) {
+      val obtained = computeDatabaseSectionFromSnippet(code, section)
+      assertNoDiff(obtained, expected)
+    }
+  }
+
   def names(code: String, expected: String): Unit = {
-    test(code)(assert(expected === computeDatabaseSectionFromSnippet(code, "Names")))
+    checkSection(code, expected, "Names")
   }
 
   def messages(code: String, expected: String): Unit = {
-    test(code)(assert(expected === computeDatabaseSectionFromSnippet(code, "Messages")))
+    checkSection(code, expected, "Messages")
   }
 
   def denotations(code: String, expected: String): Unit = {
-    test(code)(assert(expected === computeDatabaseSectionFromSnippet(code, "Denotations")))
+    checkSection(code, expected, "Denotations")
   }
 
   def sugars(code: String, expected: String): Unit = {
-    test(code)(assert(expected === computeDatabaseSectionFromSnippet(code, "Sugars")))
+    checkSection(code, expected, "Sugars")
   }
 
   private def computeDatabaseAndNamesFromMarkup(markup: String): (m.Database, List[m.Name]) = {

--- a/scalameta/testkit/src/main/scala/scala/meta/testkit/DiffAssertions.scala
+++ b/scalameta/testkit/src/main/scala/scala/meta/testkit/DiffAssertions.scala
@@ -1,0 +1,70 @@
+package scala.meta.testkit
+
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.TimeZone
+
+import org.scalatest.FunSuiteLike
+import org.scalatest.exceptions.TestFailedException
+
+trait DiffAssertions extends FunSuiteLike {
+
+  def assertNoDiff(obtained: String, expected: String, title: String = ""): Boolean = {
+    val result = compareContents(obtained, expected)
+    if (result.isEmpty) true
+    else {
+      throw DiffFailure(title, expected, obtained, result)
+    }
+  }
+
+  private def header[T](t: T): String = {
+    val line = s"=" * (t.toString.length + 3)
+    s"$line\n=> $t\n$line"
+  }
+
+  private case class DiffFailure(title: String, expected: String, obtained: String, diff: String)
+      extends TestFailedException(title + "\n" + error2message(obtained, expected), 3)
+
+  private def error2message(obtained: String, expected: String): String = {
+    val sb = new StringBuilder
+    if (obtained.length < 1000) {
+      sb.append(
+        s"""#${header("Obtained")}
+            #${stripTrailingWhitespace(obtained)}
+            #
+            #""".stripMargin('#')
+      )
+    }
+    sb.append(
+      s"""#${header("Diff")}
+          #${stripTrailingWhitespace(compareContents(obtained, expected))}""".stripMargin('#')
+    )
+    sb.toString()
+  }
+
+  private def stripTrailingWhitespace(str: String): String = str.replaceAll(" \n", "∙\n")
+
+  private def compareContents(original: String, revised: String): String =
+    compareContents(original.trim.split("\n"), revised.trim.split("\n"))
+
+  private def compareContents(original: Seq[String], revised: Seq[String]): String = {
+    import collection.JavaConverters._
+    def trim(lines: Seq[String]) = lines.map(_.trim).asJava
+    val diff = difflib.DiffUtils.diff(trim(original), trim(revised))
+    if (diff.getDeltas.isEmpty) ""
+    else
+      difflib.DiffUtils
+        .generateUnifiedDiff(
+          "original",
+          "revised",
+          original.asJava,
+          diff,
+          1
+        )
+        .asScala
+        .drop(3)
+        .mkString("\n")
+  }
+
+}


### PR DESCRIPTION
The default multiline diff reports in ScalaTest are very unclear. This
commit adds proper diffing on multiline comparions. Example:

```
// before
[info] - object First {   def main(args: Array[String]): Un... *** FAILED ***
"...)V.(args)
[32..37): [List => _root_.scala.Array#
[38..44): String => _root_.scala.Predef.String#
[48..52): Unit => _root_.scala.Unit#
[65..69): banana => <...>@61..85
[72..76): List => _root_.scala.collection.immutable.List.
[90..97): println => _root_.scala.Predef.println(Ljava/lang/Object;)V.
[98..102): list => <...>@60]..85" did not equal "...)V.(args)
[32..37): [Array => _root_.scala.Array#
[38..44): String => _root_.scala.Predef.String#
[48..52): Unit => _root_.scala.Unit#
[65..69): list => <...>@61..85
[72..76): List => _root_.scala.collection.immutable.List.
[90..97): println => _root_.scala.Predef.println(Ljava/lang/Object;)V.
[98..102): list => <...>@61]..85" (DatabaseSuite.scala:96)

// after
[info] - object First {   def main(args: Array[String]): Un... *** FAILED ***
===========
=> Obtained
===========
[7..12): First => _empty_.First.
[21..25): main => _empty_.First.main([Ljava/lang/String;)V.
[26..30): args => _empty_.First.main([Ljava/lang/String;)V.(args)
[32..37): List => _root_.scala.Array#
[38..44): String => _root_.scala.Predef.String#
[48..52): Unit => _root_.scala.Unit#
[65..69): banana => <...>@61..85
[72..76): List => _root_.scala.collection.immutable.List.
[90..97): println => _root_.scala.Predef.println(Ljava/lang/Object;)V.
[98..102): list => <...>@60..85

=======
=> Diff
=======
 [26..30): args => _empty_.First.main([Ljava/lang/String;)V.(args)
-[32..37): List => _root_.scala.Array#
+[32..37): Array => _root_.scala.Array#
 [38..44): String => _root_.scala.Predef.String#
 [48..52): Unit => _root_.scala.Unit#
-[65..69): banana => <...>@61..85
+[65..69): list => <...>@61..85
 [72..76): List => _root_.scala.collection.immutable.List.
 [90..97): println => _root_.scala.Predef.println(Ljava/lang/Object;)V.
-[98..102): list => <...>@60..85
+[98..102): list => <...>@61..85 (DatabaseSuite.scala:93)
```