### PR TITLE
Setup build to publish to sonatype on tag push #677

### DIFF
--- a/bin/ci-publish.sh
+++ b/bin/ci-publish.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -eu
 PUBLISH=${CI_PUBLISH:-false}
+SECURE_VAR=${TRAVIS_SECURE_ENV_VARS:-false}
 
-if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" = "false" && "$PUBLISH" == "true" ]]; then
+bintray() {
   git log | head -n 20
   mkdir -p $HOME/.bintray
   cat > $HOME/.bintray/.credentials <<EOF
@@ -12,8 +13,19 @@ user = ${BINTRAY_USERNAME}
 password = ${BINTRAY_API_KEY}
 EOF
   sbt ci-publish
+}
+
+sonatype() {
+  sbt "sonatypeOpen scalameta-$TRAVIS_TAG" ci-publish sonatypeReleaseAll
+}
+
+if [ "$SECURE_VAR" == true ]; then
+  echo "$PGP_SECRET" | base64 --decode | gpg --import
+  if [ -n "$TRAVIS_TAG" ]; then
+    sonatype
+  else
+    bintray
+  fi
 else
   echo "Skipping publish, branch=$TRAVIS_BRANCH publish=$PUBLISH test=$CI_TEST"
 fi
-
-


### PR DESCRIPTION
If this turns out to work well, then I propose we ditch the bintray
pre-releases altogether and more regularly publish milestone releases
by demand.