### PR TITLE
Remove os.version in favor of sbt-dynver.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,17 +11,16 @@ import Versions._
 
 lazy val LanguageVersions = Seq(LatestScala212, LatestScala211)
 lazy val LanguageVersion = LanguageVersions.head
-lazy val LibraryVersion = customVersion.getOrElse(os.version.preRelease())
 
 // ==========================================
 // Projects
 // ==========================================
 
-{
-  println(s"[info] Welcome to scalameta $LibraryVersion")
-  name := "scalametaRoot"
-}
 sharedSettings
+name := {
+  println(s"[info] Welcome to scalameta ${version.value}")
+  "scalametaRoot"
+}
 nonPublishableSettings
 unidocSettings
 // ci-fast is not a CiCommand because `plz x.y.z test` is super slow,
@@ -419,6 +418,7 @@ lazy val readme = scalatex
   .settings(
     sharedSettings,
     nonPublishableSettings,
+    buildInfoSettings,
     // only needed for scalatex 0.3.8-pre until next scalatex release
     resolvers += Resolver.bintrayIvyRepo("scalameta", "sbt-plugins"),
     resolvers += Resolver.bintrayRepo("scalameta", "maven"),
@@ -471,6 +471,7 @@ lazy val readme = scalatex
     publishM2 := {}
   )
   .dependsOn(scalametaJVM)
+  .enablePlugins(BuildInfoPlugin)
 
 // ==========================================
 // Settings
@@ -485,7 +486,7 @@ lazy val sharedSettings = Def.settings(
       case _ => CrossVersion.binary
     }
   },
-  version := LibraryVersion,
+  version := customVersion.getOrElse(version.value.replace('+', '-')),
   organization := "org.scalameta",
   addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
   libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.1" % "test",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -29,3 +29,6 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.6.0")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "2.0.0")
+

--- a/readme/Readme.scala
+++ b/readme/Readme.scala
@@ -5,6 +5,7 @@ import java.util.Calendar
 import scala.util.Try
 import scalatags.Text.all._
 import org.scalameta.os._
+import org.scalameta.BuildInfo
 import scala.compat.Platform.EOL
 import scala.tools.nsc.interpreter._
 import scala.tools.nsc.Settings
@@ -86,11 +87,17 @@ object Readme {
     pairs(List(left, right).map(x => half(hl.scala(x))): _*)
 
   def stableVersionString = {
-    version.stable()
+    val stdout = shell.check_output("git tag -l v*")
+    val StableVersion = """v(\d+.\d+.\d+)""".r
+    stdout
+      .split(EOL)
+      .reverse
+      .collectFirst { case StableVersion(version) => version }
+      .getOrElse(sys.error(s"Unable to find stable version: \n $stdout"))
   }
 
   def preReleaseVersionString = {
-    version.preRelease()
+    BuildInfo.version
   }
 
   def stableVersionBadge = {


### PR DESCRIPTION
The first attempt to publish on push tag failed due to a bug in
os.version. This commit removes os.version in favor of using
sbt-dynver, shrinking the scalameta build.