### PR TITLE
Disable bintrayRelease on publish from tag push.

### DIFF
--- a/bin/ci-publish.sh
+++ b/bin/ci-publish.sh
@@ -4,7 +4,16 @@ PUBLISH=${CI_PUBLISH:-false}
 SECURE_VAR=${TRAVIS_SECURE_ENV_VARS:-false}
 
 bintray() {
+  sbt ci-publish
+}
+
+sonatype() {
+  sbt "sonatypeOpen scalameta-$TRAVIS_TAG" ci-publish sonatypeReleaseAll
+}
+
+if [ "$SECURE_VAR" == true ]; then
   git log | head -n 20
+  echo "$PGP_SECRET" | base64 --decode | gpg --import
   mkdir -p $HOME/.bintray
   cat > $HOME/.bintray/.credentials <<EOF
 realm = Bintray API Realm
@@ -12,15 +21,6 @@ host = api.bintray.com
 user = ${BINTRAY_USERNAME}
 password = ${BINTRAY_API_KEY}
 EOF
-  sbt ci-publish
-}
-
-sonatype() {
-  echo "$PGP_SECRET" | base64 --decode | gpg --import
-  sbt "sonatypeOpen scalameta-$TRAVIS_TAG" ci-publish sonatypeReleaseAll
-}
-
-if [ "$SECURE_VAR" == true ]; then
   if [ -n "$TRAVIS_TAG" ]; then
     sonatype
   else

--- a/build.sbt
+++ b/build.sbt
@@ -555,7 +555,7 @@ lazy val publishableSettings = Def.settings(
   publishArtifact.in(Test) := false,
   publishMavenStyle := true,
   PgpKeys.pgpPassphrase := sys.env.get("PGP_PASSPHRASE").map(_.toCharArray()),
-  bintrayReleaseOnPublish := !isCustomRepository,
+  bintrayReleaseOnPublish := publishToBintray,
   pomIncludeRepository := { x =>
     false
   },
@@ -596,6 +596,7 @@ lazy val nonPublishableSettings = Seq(
   publishArtifact in packageDoc := false,
   sources in (Compile,doc) := Seq.empty,
   publishArtifact := false,
+  PgpKeys.publishSigned := {},
   publish := {}
 )
 


### PR DESCRIPTION
Just to be sure, we setup ~/.bintray/.credentials even if we shouldn't
need it when publishing on tag push.