### PR TITLE
Fix #1050: Use the top-level sbt project directory as test subject

### DIFF
--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/io/IOFileTest.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/io/IOFileTest.scala
@@ -5,49 +5,50 @@ import org.scalatest.FunSuite
 
 class IOFileTest extends FunSuite {
   val file = new File("build.sbt")
-  val target = new File("target")
-  val streams = new File("target", "streams")
+  val project = new File("project")
+  val nestedFile = new File("project", "build.properties")
 
   test(".toString") {
     assert(file.toString == "build.sbt")
-    assert(target.toString == "target")
-    assert(streams.toString == "target/streams" || streams.toString == "target\\streams")
+    assert(project.toString == "project")
+    assert(nestedFile.toString == "project/build.properties"
+      || nestedFile.toString == "project\\build.properties")
   }
 
   test(".isFile") {
     assert(file.isFile)
-    assert(!streams.isFile)
+    assert(!project.isFile)
+    assert(nestedFile.isFile)
   }
 
   test(".isDirectory") {
     assert(!file.isDirectory)
-    assert(target.isDirectory)
-    assert(streams.isDirectory)
+    assert(project.isDirectory)
   }
 
   test(".getAbsolutePath") {
     assert(file.getAbsolutePath.endsWith("build.sbt"))
-    assert(target.getAbsolutePath.endsWith("target"))
+    assert(project.getAbsolutePath.endsWith("project"))
   }
 
   test(".getPath") {
     assert(file.getPath == "build.sbt")
-    assert(target.getPath == "target")
+    assert(project.getPath == "project")
   }
 
   test(".toPath") {
     assert(file.toPath.endsWith("build.sbt"))
-    assert(target.toPath.endsWith("target"))
+    assert(project.toPath.endsWith("project"))
   }
 
   test(".exists") {
     assert(file.exists())
-    assert(target.exists())
+    assert(project.exists())
   }
 
   test(".toURI") {
     assert(file.toURI.getPath.endsWith("build.sbt"))
-    assert(target.toURI.getPath.endsWith("target/"))
+    assert(project.toURI.getPath.endsWith("project/"))
   }
 
 }

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/io/NIOPathTest.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/io/NIOPathTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.FunSuite
 class NIOPathTest extends FunSuite {
 
   def file: Path = Paths.get("build.sbt")
-  def target: Path = Paths.get("target")
+  def project: Path = Paths.get("project")
   def abs: Path = Paths.get(PathIO.fileSeparator).resolve("bar").resolve("foo")
 
   test(".isAbsolute") {
@@ -63,7 +63,7 @@ class NIOPathTest extends FunSuite {
   }
   test(".toUri") {
     assert(file.toUri.getPath.endsWith("build.sbt"))
-    assert(target.toUri.getPath.endsWith("target/"))
+    assert(project.toUri.getPath.endsWith("project/"))
   }
   test(".toAbsolutePath") {
     assert(file.toAbsolutePath.endsWith(file))
@@ -71,6 +71,6 @@ class NIOPathTest extends FunSuite {
   }
   test(".toFile") {
     assert(file.toFile.isFile)
-    assert(target.toFile.isDirectory)
+    assert(project.toFile.isDirectory)
   }
 }


### PR DESCRIPTION
Several IO tests asserted that the top-level target directory existed,
which is not the case when running sbt in batch mode. Switch to use the
sbt project directory for such assertions since it is ensured to exist.

Reproducible with: sbt --batch scalametaJVM/test

Refs: #1050 