### PR TITLE
Lazy JavaScript I/O

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,6 @@ lazy val io = crossProject
     description := "Scalameta APIs for JVM/JS agnostic IO."
   )
   .dependsOn(common)
-  .jsConfigure(_.enablePlugins(ScalaJSBundlerPlugin))
 
 lazy val ioJVM = io.jvm
 lazy val ioJS = io.js
@@ -124,7 +123,6 @@ lazy val inputs = crossProject
     enableMacros
   )
   .dependsOn(common, io)
-  .jsConfigure(_.enablePlugins(ScalaJSBundlerPlugin))
 lazy val inputsJVM = inputs.jvm
 lazy val inputsJS = inputs.js
 
@@ -222,7 +220,6 @@ lazy val scalameta = crossProject
     description := "Scalameta umbrella module that includes all public APIs",
     exposePaths("scalameta", Test)
   )
-  .jsConfigure(_.enablePlugins(ScalaJSBundlerPlugin))
   .dependsOn(
     common,
     dialects,
@@ -315,7 +312,6 @@ lazy val tests = crossProject
     ),
     buildInfoPackage := "scala.meta.tests"
   )
-  .jsConfigure(_.enablePlugins(ScalaJSBundlerPlugin))
   .jvmConfigure(_.dependsOn(testkit))
   .enablePlugins(BuildInfoPlugin)
   .dependsOn(scalameta, contrib)
@@ -332,7 +328,6 @@ lazy val contrib = crossProject
     description := "Incubator for scalameta APIs"
   )
   .jvmConfigure(_.dependsOn(testkit % Test))
-  .jsConfigure(_.enablePlugins(ScalaJSBundlerPlugin))
   .dependsOn(scalameta)
 lazy val contribJVM = contrib.jvm
 lazy val contribJS = contrib.js

--- a/build.sbt
+++ b/build.sbt
@@ -100,9 +100,6 @@ lazy val io = crossProject
     description := "Scalameta APIs for JVM/JS agnostic IO."
   )
   .dependsOn(common)
-  .jsSettings(
-    npmDependencies in Compile += "shelljs" -> "0.7.7" // provides cross-platform pwd in JS
-  )
   .jsConfigure(_.enablePlugins(ScalaJSBundlerPlugin))
 
 lazy val ioJVM = io.jvm

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -22,8 +22,6 @@ libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin-shaded" % "0.
 
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalajs-bundler" % "0.6.0")
-
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")

--- a/scalameta/io/js/src/main/scala/java/io/File.scala
+++ b/scalameta/io/js/src/main/scala/java/io/File.scala
@@ -6,9 +6,8 @@ import scala.meta.internal.io._
 
 // obtained implementation by experimentation on the JDK.
 class File(path: String) {
-  private val filename = PathIO.normalizePath(path)
   def this(parent: String, child: String) =
-    this(JSPath.join(parent, child))
+    this(parent + File.separator + child)
   def this(parent: File, child: String) =
     this(parent.getPath, child)
   def this(uri: URI) =
@@ -20,7 +19,7 @@ class File(path: String) {
       }
     )
   def toPath: Path =
-    NodeNIOPath(filename)
+    NodeNIOPath(path)
   def toURI: URI = {
     val file = getAbsoluteFile.toString
     val path =
@@ -33,15 +32,15 @@ class File(path: String) {
   def getAbsolutePath: String =
     getAbsoluteFile.toString
   def getPath: String =
-    filename
+    path
   def exists(): Boolean =
-    JSIO.exists(filename)
+    JSIO.exists(path)
   def isFile: Boolean =
-    JSIO.isFile(filename)
+    JSIO.isFile(path)
   def isDirectory: Boolean =
-    JSIO.isDirectory(filename)
+    JSIO.isDirectory(path)
   override def toString: String =
-    filename
+    path
 }
 
 object File {

--- a/scalameta/io/js/src/main/scala/java/io/File.scala
+++ b/scalameta/io/js/src/main/scala/java/io/File.scala
@@ -48,10 +48,10 @@ object File {
     separator.charAt(0)
 
   def separator: String =
-    if (JSIO.isNode) JSPath.sep
+    if (JSIO.isNode) JSIO.path.sep
     else "/"
 
   def pathSeparator: String =
-    if (JSIO.isNode) JSPath.delimiter
+    if (JSIO.isNode) JSIO.path.delimiter
     else ":"
 }

--- a/scalameta/io/js/src/main/scala/java/io/File.scala
+++ b/scalameta/io/js/src/main/scala/java/io/File.scala
@@ -29,8 +29,7 @@ class File(path: String) {
     new URI("file", null, path, null)
   }
   def getAbsoluteFile: File =
-    if (PathIO.isAbsolutePath(filename)) this
-    else new File(PathIO.workingDirectory.resolve(filename).toString)
+    toPath.toAbsolutePath.toFile
   def getAbsolutePath: String =
     getAbsoluteFile.toString
   def getPath: String =

--- a/scalameta/io/js/src/main/scala/java/io/File.scala
+++ b/scalameta/io/js/src/main/scala/java/io/File.scala
@@ -36,12 +36,11 @@ class File(path: String) {
   def getPath: String =
     filename
   def exists(): Boolean =
-    JSFs.existsSync(filename)
-  private def lstat: JSStats = JSFs.lstatSync(filename)
+    JSIO.exists(filename)
   def isFile: Boolean =
-    lstat.isFile()
+    JSIO.isFile(filename)
   def isDirectory: Boolean =
-    lstat.isDirectory()
+    JSIO.isDirectory(filename)
   override def toString: String =
     filename
 }

--- a/scalameta/io/js/src/main/scala/java/io/File.scala
+++ b/scalameta/io/js/src/main/scala/java/io/File.scala
@@ -44,3 +44,16 @@ class File(path: String) {
   override def toString: String =
     filename
 }
+
+object File {
+  def separatorChar: Char =
+    separator.charAt(0)
+
+  def separator: String =
+    if (JSIO.isNode) JSPath.sep
+    else "/"
+
+  def pathSeparator: String =
+    if (JSIO.isNode) JSPath.delimiter
+    else ":"
+}

--- a/scalameta/io/js/src/main/scala/java/nio/file/Path.scala
+++ b/scalameta/io/js/src/main/scala/java/nio/file/Path.scala
@@ -15,7 +15,7 @@ trait Path {
   def startsWith(other: String): Boolean
   def endsWith(other: Path): Boolean
   def endsWith(other: String): Boolean
-  def normalize: Path
+  def normalize(): Path
   def resolve(other: Path): Path
   def resolve(other: String): Path
   def resolveSibling(other: Path): Path

--- a/scalameta/io/js/src/main/scala/java/nio/file/Paths.scala
+++ b/scalameta/io/js/src/main/scala/java/nio/file/Paths.scala
@@ -1,5 +1,6 @@
 package java.nio.file
 
+import java.io.File
 import scala.meta.internal.io.JSPath
 import scala.meta.internal.io.NodeNIOPath
 
@@ -8,6 +9,10 @@ object Paths {
   // signature than Java-style varargs. The boot classpath contains nio.file.Path
   // so call-sites to `get` will resolve to the original java.nio.file.Paths.get,
   // which results in a Scala.js linking error when using Scala varargs.
-  def get(first: String, more: Array[String] = Array.empty): Path =
-    NodeNIOPath(JSPath.join(first, more: _*))
+  def get(first: String, more: Array[String] = Array.empty): Path = {
+    val path =
+      if (more.isEmpty) first
+      else first + File.separator + more.mkString(File.separator)
+    NodeNIOPath(path)
+  }
 }

--- a/scalameta/io/js/src/main/scala/scala/meta/internal/io/JSIO.scala
+++ b/scalameta/io/js/src/main/scala/scala/meta/internal/io/JSIO.scala
@@ -80,7 +80,7 @@ object JSPath extends js.Any {
 
 object JSIO {
   private[io] val process: JSProcess = js.Dynamic.global.process.asInstanceOf[JSProcess]
-  private[io] def isNode = !js.isUndefined(process) && !js.isUndefined(process.cwd)
+  def isNode = !js.isUndefined(process) && !js.isUndefined(process.cwd)
 
   def inNode[T](f: => T): T =
     if (JSIO.isNode) f

--- a/scalameta/io/js/src/main/scala/scala/meta/internal/io/JSIO.scala
+++ b/scalameta/io/js/src/main/scala/scala/meta/internal/io/JSIO.scala
@@ -5,16 +5,17 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
 import scala.scalajs.js.annotation.JSImport.Namespace
 
-/** Facade for npm package "shelljs".
+/** Facade for the native nodejs process API
   *
-  * @see https://www.npmjs.com/package/shelljs
+  * The process object is a global that provides information about, and
+  * control over, the current Node.js process. As a global, it is always
+  * available to Node.js applications without using require().
+  *
+  * @see https://nodejs.org/api/process.html
   */
 @js.native
-@JSImport("shelljs", Namespace)
-object JSShell extends js.Any {
-
-  /** Returns the current directory. */
-  def pwd(): js.Object = js.native
+trait JSProcess extends js.Any {
+  def cwd(): String = js.native
 }
 
 /** Facade for native nodejs module "fs".
@@ -78,12 +79,18 @@ object JSPath extends js.Any {
 }
 
 object JSIO {
-  private[io] def isNode = JSFs != null
+  private[io] val process: JSProcess = js.Dynamic.global.process.asInstanceOf[JSProcess]
+  private[io] def isNode = !js.isUndefined(process) && !js.isUndefined(process.cwd)
+
   def inNode[T](f: => T): T =
     if (JSIO.isNode) f
     else {
       throw new IllegalStateException("This operation is not supported in this environment.")
     }
+
+  def cwd(): String =
+    if (isNode) process.cwd()
+    else "/"
 
   def exists(path: String): Boolean =
     if (isNode) JSFs.existsSync(path)

--- a/scalameta/io/js/src/main/scala/scala/meta/internal/io/JSIO.scala
+++ b/scalameta/io/js/src/main/scala/scala/meta/internal/io/JSIO.scala
@@ -84,4 +84,14 @@ object JSIO {
     else {
       throw new IllegalStateException("This operation is not supported in this environment.")
     }
+
+  def exists(path: String): Boolean =
+    if (isNode) JSFs.existsSync(path)
+    else false
+
+  def isFile(path: String): Boolean =
+    exists(path) && JSFs.lstatSync(path).isFile()
+
+  def isDirectory(path: String): Boolean =
+    exists(path) && JSFs.lstatSync(path).isDirectory()
 }

--- a/scalameta/io/js/src/main/scala/scala/meta/internal/io/NodeNIOPath.scala
+++ b/scalameta/io/js/src/main/scala/scala/meta/internal/io/NodeNIOPath.scala
@@ -18,7 +18,7 @@ case class NodeNIOPath(filename: String) extends Path {
   override def toFile: File =
     new File(filename)
   override def isAbsolute: Boolean =
-    if (JSIO.isNode) JSPath.isAbsolute(filename)
+    if (JSIO.isNode) JSIO.path.isAbsolute(filename)
     else filename.startsWith(File.separator)
   override def getName(index: Int): Path =
     NodeNIOPath(
@@ -27,12 +27,12 @@ case class NodeNIOPath(filename: String) extends Path {
         .lift(adjustIndex(index))
         .getOrElse(throw new IllegalArgumentException))
   override def getParent: Path =
-    NodeNIOPath(JSPath.dirname(filename))
+    NodeNIOPath(JSIO.path.dirname(filename))
   override def toAbsolutePath: Path =
     if (isAbsolute) this
     else NodeNIOPath.workingDirectory.resolve(this)
   override def relativize(other: Path): Path =
-    NodeNIOPath(JSPath.relative(filename, other.toString))
+    NodeNIOPath(JSIO.path.relative(filename, other.toString))
   override def getNameCount: Int = {
     val (first, remaining) = filename.split(File.separator + "+").span(_.isEmpty)
     if (remaining.isEmpty) first.length
@@ -40,18 +40,18 @@ case class NodeNIOPath(filename: String) extends Path {
   }
   override def toUri: URI = toFile.toURI
   override def getFileName: Path =
-    NodeNIOPath(JSPath.basename(filename))
+    NodeNIOPath(JSIO.path.basename(filename))
   override def getRoot: Path =
     if (!isAbsolute) null
     else NodeNIOPath(File.separator)
   override def normalize(): Path =
-    if (JSIO.isNode) NodeNIOPath(JSPath.normalize(filename))
+    if (JSIO.isNode) NodeNIOPath(JSIO.path.normalize(filename))
     else this
   override def endsWith(other: Path): Boolean =
     endsWith(other.toString)
   override def endsWith(other: String): Boolean =
     paths(filename).endsWith(paths(other))
-  // JSPath.resolve(relpath, relpath) produces an absolute path from cwd.
+  // JSIO.path.resolve(relpath, relpath) produces an absolute path from cwd.
   // This method turns the generated absolute path back into a relative path.
   private def adjustResolvedPath(resolved: Path): Path =
     if (isAbsolute) resolved
@@ -59,11 +59,11 @@ case class NodeNIOPath(filename: String) extends Path {
   override def resolveSibling(other: Path): Path =
     resolveSibling(other.toString)
   override def resolveSibling(other: String): Path =
-    adjustResolvedPath(NodeNIOPath(JSPath.resolve(JSPath.dirname(filename), other)))
+    adjustResolvedPath(NodeNIOPath(JSIO.path.resolve(JSIO.path.dirname(filename), other)))
   override def resolve(other: Path): Path =
     resolve(other.toString)
   override def resolve(other: String): Path =
-    adjustResolvedPath(NodeNIOPath(JSPath.resolve(filename, other)))
+    adjustResolvedPath(NodeNIOPath(JSIO.path.resolve(filename, other)))
   override def startsWith(other: Path): Boolean =
     startsWith(other.toString)
   override def startsWith(other: String): Boolean =

--- a/scalameta/io/js/src/main/scala/scala/meta/internal/io/NodeNIOPath.scala
+++ b/scalameta/io/js/src/main/scala/scala/meta/internal/io/NodeNIOPath.scala
@@ -12,7 +12,7 @@ case class NodeNIOPath(filename: String) extends Path {
   override def subpath(beginIndex: Int, endIndex: Int): Path =
     NodeNIOPath(
       filename
-        .split(PathIO.fileSeparator)
+        .split(File.separator)
         .slice(adjustIndex(beginIndex), adjustIndex(endIndex))
         .mkString)
   override def toFile: File =
@@ -22,7 +22,7 @@ case class NodeNIOPath(filename: String) extends Path {
   override def getName(index: Int): Path =
     NodeNIOPath(
       filename
-        .split(PathIO.fileSeparator)
+        .split(File.separator)
         .lift(adjustIndex(index))
         .getOrElse(throw new IllegalArgumentException))
   override def getParent: Path =
@@ -33,13 +33,13 @@ case class NodeNIOPath(filename: String) extends Path {
   override def relativize(other: Path): Path =
     NodeNIOPath(JSPath.relative(filename, other.toString))
   override def getNameCount: Int =
-    filename.count(_ == PathIO.fileSeparatorChar)
+    filename.count(_ == File.separatorChar)
   override def toUri: URI = toFile.toURI
   override def getFileName: Path =
     NodeNIOPath(JSPath.basename(filename))
   override def getRoot: Path =
     if (!isAbsolute) null
-    else NodeNIOPath(PathIO.fileSeparator)
+    else NodeNIOPath(File.separator)
   override def normalize(): Path =
     NodeNIOPath(PathIO.normalizePath(filename))
   override def endsWith(other: Path): Boolean =
@@ -64,7 +64,7 @@ case class NodeNIOPath(filename: String) extends Path {
   override def startsWith(other: String): Boolean =
     paths(filename).startsWith(paths(other))
   private def paths(name: String) =
-    name.split(PathIO.fileSeparator)
+    name.split(File.separator)
   override def toString: String =
     filename
 }

--- a/scalameta/io/js/src/main/scala/scala/meta/internal/io/NodeNIOPath.scala
+++ b/scalameta/io/js/src/main/scala/scala/meta/internal/io/NodeNIOPath.scala
@@ -33,8 +33,11 @@ case class NodeNIOPath(filename: String) extends Path {
     else NodeNIOPath.workingDirectory.resolve(this)
   override def relativize(other: Path): Path =
     NodeNIOPath(JSPath.relative(filename, other.toString))
-  override def getNameCount: Int =
-    filename.count(_ == File.separatorChar)
+  override def getNameCount: Int = {
+    val (first, remaining) = filename.split(File.separator + "+").span(_.isEmpty)
+    if (remaining.isEmpty) first.length
+    else remaining.length
+  }
   override def toUri: URI = toFile.toURI
   override def getFileName: Path =
     NodeNIOPath(JSPath.basename(filename))

--- a/scalameta/io/js/src/main/scala/scala/meta/internal/io/NodeNIOPath.scala
+++ b/scalameta/io/js/src/main/scala/scala/meta/internal/io/NodeNIOPath.scala
@@ -70,5 +70,5 @@ case class NodeNIOPath(filename: String) extends Path {
 }
 
 object NodeNIOPath {
-  def workingDirectory = NodeNIOPath(JSShell.pwd().toString)
+  def workingDirectory = NodeNIOPath(PlatformPathIO.workingDirectoryString)
 }

--- a/scalameta/io/js/src/main/scala/scala/meta/internal/io/NodeNIOPath.scala
+++ b/scalameta/io/js/src/main/scala/scala/meta/internal/io/NodeNIOPath.scala
@@ -18,7 +18,8 @@ case class NodeNIOPath(filename: String) extends Path {
   override def toFile: File =
     new File(filename)
   override def isAbsolute: Boolean =
-    PathIO.isAbsolutePath(filename)
+    if (JSIO.isNode) JSPath.isAbsolute(filename)
+    else filename.startsWith(File.separator)
   override def getName(index: Int): Path =
     NodeNIOPath(
       filename
@@ -28,7 +29,7 @@ case class NodeNIOPath(filename: String) extends Path {
   override def getParent: Path =
     NodeNIOPath(JSPath.dirname(filename))
   override def toAbsolutePath: Path =
-    if (PathIO.isAbsolutePath(filename)) this
+    if (isAbsolute) this
     else NodeNIOPath.workingDirectory.resolve(this)
   override def relativize(other: Path): Path =
     NodeNIOPath(JSPath.relative(filename, other.toString))
@@ -41,7 +42,8 @@ case class NodeNIOPath(filename: String) extends Path {
     if (!isAbsolute) null
     else NodeNIOPath(File.separator)
   override def normalize(): Path =
-    NodeNIOPath(PathIO.normalizePath(filename))
+    if (JSIO.isNode) NodeNIOPath(JSPath.normalize(filename))
+    else this
   override def endsWith(other: Path): Boolean =
     endsWith(other.toString)
   override def endsWith(other: String): Boolean =

--- a/scalameta/io/js/src/main/scala/scala/meta/internal/io/PlatformFileIO.scala
+++ b/scalameta/io/js/src/main/scala/scala/meta/internal/io/PlatformFileIO.scala
@@ -44,12 +44,11 @@ object PlatformFileIO {
     }
   }
 
-  def isFile(path: AbsolutePath): Boolean = JSIO.inNode {
-    JSFs.lstatSync(path.toString).isFile()
-  }
+  def isFile(path: AbsolutePath): Boolean =
+    JSIO.isFile(path.toString)
 
   def isDirectory(path: AbsolutePath): Boolean =
-    JSFs.lstatSync(path.toString).isDirectory()
+    JSIO.isDirectory(path.toString)
 
   def listAllFilesRecursively(root: AbsolutePath): ListFiles = {
     val builder = List.newBuilder[RelativePath]

--- a/scalameta/io/js/src/main/scala/scala/meta/internal/io/PlatformFileIO.scala
+++ b/scalameta/io/js/src/main/scala/scala/meta/internal/io/PlatformFileIO.scala
@@ -15,7 +15,7 @@ object PlatformFileIO {
     else throw new UnsupportedOperationException(s"Can't read $uri as InputStream")
 
   def readAllBytes(path: AbsolutePath): Array[Byte] = JSIO.inNode {
-    val jsArray = JSFs.readFileSync(path.toString)
+    val jsArray = JSIO.fs.readFileSync(path.toString)
     val len = jsArray.length
     val result = new Array[Byte](len)
     var curr = 0
@@ -27,12 +27,12 @@ object PlatformFileIO {
   }
 
   def slurp(path: AbsolutePath, charset: Charset): String =
-    JSIO.inNode(JSFs.readFileSync(path.toString, charset.toString))
+    JSIO.inNode(JSIO.fs.readFileSync(path.toString, charset.toString))
 
   def listFiles(path: AbsolutePath): ListFiles = JSIO.inNode {
     if (path.isFile) new ListFiles(path, Nil)
     else {
-      val jsArray = JSFs.readdirSync(path.toString)
+      val jsArray = JSIO.fs.readdirSync(path.toString)
       val builder = List.newBuilder[RelativePath]
       builder.sizeHint(jsArray.length)
       var curr = 0

--- a/scalameta/io/js/src/main/scala/scala/meta/internal/io/PlatformPathIO.scala
+++ b/scalameta/io/js/src/main/scala/scala/meta/internal/io/PlatformPathIO.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.io
 
 import scala.meta.io._
+import java.io.File
 
 object PlatformPathIO {
   def workingDirectoryString: String =
@@ -9,20 +10,9 @@ object PlatformPathIO {
   def workingDirectory: AbsolutePath =
     AbsolutePath(workingDirectoryString)
 
-  def fileSeparatorChar: Char =
-    fileSeparator.charAt(0)
-
-  def fileSeparator: String =
-    if (JSIO.isNode) JSPath.sep
-    else "/"
-
-  def pathSeparator: String =
-    if (JSIO.isNode) JSPath.delimiter
-    else ":"
-
   def isAbsolutePath(path: String): Boolean =
     if (JSIO.isNode) JSPath.isAbsolute(path)
-    else path.startsWith(fileSeparator)
+    else path.startsWith(File.separator)
 
   def normalizePath(path: String): String =
     if (JSIO.isNode) JSPath.normalize(path)

--- a/scalameta/io/js/src/main/scala/scala/meta/internal/io/PlatformPathIO.scala
+++ b/scalameta/io/js/src/main/scala/scala/meta/internal/io/PlatformPathIO.scala
@@ -6,15 +6,4 @@ import java.io.File
 object PlatformPathIO {
   def workingDirectoryString: String =
     JSIO.cwd()
-
-  def workingDirectory: AbsolutePath =
-    AbsolutePath(workingDirectoryString)
-
-  def isAbsolutePath(path: String): Boolean =
-    if (JSIO.isNode) JSPath.isAbsolute(path)
-    else path.startsWith(File.separator)
-
-  def normalizePath(path: String): String =
-    if (JSIO.isNode) JSPath.normalize(path)
-    else path
 }

--- a/scalameta/io/js/src/main/scala/scala/meta/internal/io/PlatformPathIO.scala
+++ b/scalameta/io/js/src/main/scala/scala/meta/internal/io/PlatformPathIO.scala
@@ -4,8 +4,7 @@ import scala.meta.io._
 
 object PlatformPathIO {
   def workingDirectoryString: String =
-    if (JSIO.isNode) JSShell.pwd().toString
-    else fileSeparator
+    JSIO.cwd()
 
   def workingDirectory: AbsolutePath =
     AbsolutePath(workingDirectoryString)

--- a/scalameta/io/jvm/src/main/scala/scala/meta/internal/io/PlatformPathIO.scala
+++ b/scalameta/io/jvm/src/main/scala/scala/meta/internal/io/PlatformPathIO.scala
@@ -5,16 +5,6 @@ import java.nio.file.Paths
 import scala.meta.io._
 
 object PlatformPathIO {
-
-  def fileSeparatorChar: Char =
-    File.separatorChar
-
-  def fileSeparator: String =
-    File.separator
-
-  def pathSeparator: String =
-    File.pathSeparator
-
   def workingDirectoryString: String =
     sys.props("user.dir")
 

--- a/scalameta/io/jvm/src/main/scala/scala/meta/internal/io/PlatformPathIO.scala
+++ b/scalameta/io/jvm/src/main/scala/scala/meta/internal/io/PlatformPathIO.scala
@@ -7,13 +7,4 @@ import scala.meta.io._
 object PlatformPathIO {
   def workingDirectoryString: String =
     sys.props("user.dir")
-
-  def workingDirectory: AbsolutePath =
-    AbsolutePath(workingDirectoryString)
-
-  def isAbsolutePath(path: String): Boolean =
-    Paths.get(path).isAbsolute
-
-  def normalizePath(path: String): String =
-    Paths.get(path).normalize().toString
 }

--- a/scalameta/io/shared/src/main/scala/scala/meta/internal/io/PathIO.scala
+++ b/scalameta/io/shared/src/main/scala/scala/meta/internal/io/PathIO.scala
@@ -1,22 +1,17 @@
 package scala.meta.internal.io
 
 import java.nio.file.Path
+import java.nio.file.Paths
 import java.io.File
 import scala.meta.io._
 
 object PathIO {
 
   def workingDirectory: AbsolutePath =
-    PlatformPathIO.workingDirectory
-
-  def isAbsolutePath(path: String): Boolean =
-    PlatformPathIO.isAbsolutePath(path)
-
-  def isRelativePath(path: String): Boolean =
-    !isAbsolutePath(path)
+    AbsolutePath(PlatformPathIO.workingDirectoryString)
 
   def normalizePath(path: String): String =
-    PlatformPathIO.normalizePath(path)
+    Paths.get(path).normalize().toString
 
   // These two methods work on strings instead of AbsolutePath because AbsolutePath
   // with unix / slashes is non-sensical on Windows.

--- a/scalameta/io/shared/src/main/scala/scala/meta/internal/io/PathIO.scala
+++ b/scalameta/io/shared/src/main/scala/scala/meta/internal/io/PathIO.scala
@@ -1,18 +1,10 @@
 package scala.meta.internal.io
 
 import java.nio.file.Path
+import java.io.File
 import scala.meta.io._
 
 object PathIO {
-
-  def fileSeparatorChar: Char =
-    PlatformPathIO.fileSeparatorChar
-
-  def fileSeparator: String =
-    PlatformPathIO.fileSeparator
-
-  def pathSeparator: String =
-    PlatformPathIO.pathSeparator
 
   def workingDirectory: AbsolutePath =
     PlatformPathIO.workingDirectory
@@ -29,11 +21,11 @@ object PathIO {
   // These two methods work on strings instead of AbsolutePath because AbsolutePath
   // with unix / slashes is non-sensical on Windows.
   def toUnix(path: String): String =
-    if (fileSeparatorChar != '/') path.replace(PathIO.fileSeparatorChar, '/')
+    if (File.separatorChar != '/') path.replace(File.separatorChar, '/')
     else path
 
   def fromUnix(path: String): String =
-    if (fileSeparatorChar != '/') path.replace('/', PathIO.fileSeparatorChar)
+    if (File.separatorChar != '/') path.replace('/', File.separatorChar)
     else path
 
   /** Returns file extension of this path, returns empty string if path has no extension */

--- a/scalameta/io/shared/src/main/scala/scala/meta/internal/io/PathIO.scala
+++ b/scalameta/io/shared/src/main/scala/scala/meta/internal/io/PathIO.scala
@@ -10,9 +10,6 @@ object PathIO {
   def workingDirectory: AbsolutePath =
     AbsolutePath(PlatformPathIO.workingDirectoryString)
 
-  def normalizePath(path: String): String =
-    Paths.get(path).normalize().toString
-
   // These two methods work on strings instead of AbsolutePath because AbsolutePath
   // with unix / slashes is non-sensical on Windows.
   def toUnix(path: String): String =

--- a/scalameta/io/shared/src/main/scala/scala/meta/io/Multipath.scala
+++ b/scalameta/io/shared/src/main/scala/scala/meta/io/Multipath.scala
@@ -7,7 +7,7 @@ import java.util.zip._
 import scala.collection.mutable
 import org.scalameta.adt._
 import scala.meta.internal.io.FileIO
-import scala.meta.internal.io.PathIO.pathSeparator
+import java.io.File.pathSeparator
 
 @root trait Multipath {
   def shallow: List[AbsolutePath]

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/io/IOFileTest.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/io/IOFileTest.scala
@@ -2,17 +2,19 @@ package scala.meta.tests.io
 
 import java.io.File
 import org.scalatest.FunSuite
+import scala.meta.internal.io.PathIO
 
 class IOFileTest extends FunSuite {
   val file = new File("build.sbt")
   val project = new File("project")
   val nestedFile = new File("project", "build.properties")
+  val nonNormalizedFile = new File(new File(new File(project, ".."), "bin"), "scalafmt")
 
   test(".toString") {
     assert(file.toString == "build.sbt")
     assert(project.toString == "project")
-    assert(nestedFile.toString == "project/build.properties"
-      || nestedFile.toString == "project\\build.properties")
+    assert(nestedFile.toString == PathIO.fromUnix("project/build.properties"))
+    assert(nonNormalizedFile.toString == PathIO.fromUnix("project/../bin/scalafmt"))
   }
 
   test(".isFile") {

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/io/IOFileTest.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/io/IOFileTest.scala
@@ -51,4 +51,14 @@ class IOFileTest extends FunSuite {
     assert(project.toURI.getPath.endsWith("project/"))
   }
 
+  test("File.pathSeparator") {
+    val obtained = File.pathSeparator
+    assert(obtained == ":" || obtained == ";")
+  }
+
+  test("File.fileSeparator") {
+    val obtained = File.separator
+    assert(obtained == "/" || obtained == "\\")
+  }
+
 }

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/io/IOSuite.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/io/IOSuite.scala
@@ -17,10 +17,6 @@ class IOSuite extends FunSuite {
     assert(obtained != "/")
   }
 
-  test("PathIO.isAbsolute") {
-    assert(PathIO.isAbsolutePath(PathIO.workingDirectory.toString))
-  }
-
   test("FileIO.listFiles(Directory)") {
     val obtained = FileIO.listFiles(PathIO.workingDirectory)
     assert(obtained.contains(buildSbt))

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/io/IOSuite.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/io/IOSuite.scala
@@ -17,16 +17,6 @@ class IOSuite extends FunSuite {
     assert(obtained != "/")
   }
 
-  test("PathIO.pathSeparator") {
-    val obtained = PathIO.pathSeparator
-    assert(obtained == ":" || obtained == ";")
-  }
-
-  test("PathIO.fileSeparator") {
-    val obtained = PathIO.fileSeparator
-    assert(obtained == "/" || obtained == "\\")
-  }
-
   test("PathIO.isAbsolute") {
     assert(PathIO.isAbsolutePath(PathIO.workingDirectory.toString))
   }

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/io/NIOPathTest.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/io/NIOPathTest.scala
@@ -1,15 +1,15 @@
 package scala.meta.tests.io
 
+import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
-import scala.meta.internal.io.PathIO
 import org.scalatest.FunSuite
 
 class NIOPathTest extends FunSuite {
 
   def file: Path = Paths.get("build.sbt")
   def project: Path = Paths.get("project")
-  def abs: Path = Paths.get(PathIO.fileSeparator).resolve("bar").resolve("foo")
+  def abs: Path = Paths.get(File.separator).resolve("bar").resolve("foo")
 
   test(".isAbsolute") {
     assert(!file.isAbsolute)

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/io/NIOPathTest.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/io/NIOPathTest.scala
@@ -4,16 +4,19 @@ import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
 import org.scalatest.FunSuite
+import scala.meta.internal.io.PlatformPathIO
 
 class NIOPathTest extends FunSuite {
 
   def file: Path = Paths.get("build.sbt")
   def project: Path = Paths.get("project")
   def abs: Path = Paths.get(File.separator).resolve("bar").resolve("foo")
+  def cwd: Path = Paths.get(PlatformPathIO.workingDirectoryString)
 
   test(".isAbsolute") {
     assert(!file.isAbsolute)
     assert(abs.isAbsolute)
+    assert(cwd.isAbsolute)
   }
   test(".getRoot") {
     assert(file.getRoot == null)
@@ -68,9 +71,11 @@ class NIOPathTest extends FunSuite {
   test(".toAbsolutePath") {
     assert(file.toAbsolutePath.endsWith(file))
     assert(abs.toAbsolutePath == abs)
+    assert(cwd == Paths.get("").toAbsolutePath)
   }
   test(".toFile") {
     assert(file.toFile.isFile)
     assert(project.toFile.isDirectory)
+    assert(cwd.toFile.isDirectory)
   }
 }

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/io/NIOPathTest.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/io/NIOPathTest.scala
@@ -5,6 +5,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import org.scalatest.FunSuite
 import scala.meta.internal.io.PlatformPathIO
+import scala.meta.internal.io.PathIO
 
 class NIOPathTest extends FunSuite {
 
@@ -12,6 +13,13 @@ class NIOPathTest extends FunSuite {
   def project: Path = Paths.get("project")
   def abs: Path = Paths.get(File.separator).resolve("bar").resolve("foo")
   def cwd: Path = Paths.get(PlatformPathIO.workingDirectoryString)
+  val nonNormalizedFile: Path = Paths.get("project", "..", "bin", "scalafmt")
+
+  test(".toString") {
+    assert(file.toString == "build.sbt")
+    assert(project.toString == "project")
+    assert(nonNormalizedFile.toString == PathIO.fromUnix("project/../bin/scalafmt"))
+  }
 
   test(".isAbsolute") {
     assert(!file.isAbsolute)
@@ -25,12 +33,16 @@ class NIOPathTest extends FunSuite {
   test(".getFileName") {
     assert(file.getFileName.toString == "build.sbt")
     assert(abs.getFileName.toString == "foo")
+    assert(nonNormalizedFile.getFileName.toString == "scalafmt")
   }
   test(".getParent") {
     assert(abs.getParent.getFileName.toString == "bar")
   }
   test(".getNameCount") {
+    assert(Paths.get("/").getNameCount == 0)
+    assert(Paths.get("").getNameCount == 1)
     assert(abs.getNameCount == 2)
+    assert(nonNormalizedFile.getNameCount == 4)
   }
   test(".getName(index)") {
     assert(file.getName(0).toString == "build.sbt")
@@ -52,6 +64,7 @@ class NIOPathTest extends FunSuite {
   }
   test(".normalize") {
     assert(file.resolve("foo").resolve("..").normalize().toString == "build.sbt")
+    assert(nonNormalizedFile.normalize().toString == PathIO.fromUnix("bin/scalafmt"))
   }
   test(".resolve") {
     assert(!file.resolve("bar").isAbsolute)


### PR DESCRIPTION
Extend on #1056 by loading Node.js modules used for I/O lazily.

Tested with locally published version against [metadoc](https://github.com/jonas/metadoc/commit/5d1f4ed9bf27f771722a71a23cb400ed0f4b98cf), which shows that the [JSIO](https://github.com/scalameta/metadoc/blob/196c002a5cb40368c45d78bdaef457be711e15b1/metadoc-js/src/main/scala/scala/meta/internal/io/JSIO.scala) workaround can be deleted.