### PR TITLE
Cross-build langmeta to 2.10.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ env:
     - CI_TEST: check
     - CI_TEST: ci-fast
       CI_SCALA_VERSION: 2.11.11
-      CI_PUBLISH: true
     - CI_TEST: ci-fast
       CI_SCALA_VERSION: 2.11.11
       CI_SCALA_JS: true

--- a/build.sbt
+++ b/build.sbt
@@ -35,11 +35,11 @@ commands += CiCommand("ci-slow")(
   "testkit/test:runMain scala.meta.testkit.ScalametaParserPropertyTest" ::
   Nil
 )
-commands += CiCommand("ci-publish")(
-  if (isCiPublish && isTagPush) s"publishSigned" :: Nil
-  else if (isCiPublish) s"publish" :: Nil
-  else Nil
-)
+commands += Command.command("ci-publish") { s =>
+  if (isCiPublish && isTagPush) s"very publishSigned" :: s
+  else if (isCiPublish) s"very publish" :: s
+  else s
+}
 // NOTE: These tasks are aliased here in order to support running "tests/test"
 // from a command. Running "test" inside a command will trigger the `test` task
 // to run in all defined modules, including ones like inputs/io/dialects which

--- a/build.sbt
+++ b/build.sbt
@@ -84,10 +84,15 @@ console := console.in(scalametaJVM, Compile).value
 
 /** ======================== LANGMETA ======================== **/
 
+lazy val langmetaSettings = List(
+  crossScalaVersions := List(LatestScala210, LatestScala211, LatestScala212)
+)
+
 lazy val langmetaIo = crossProject
   .in(file("langmeta/io"))
   .settings(
     publishableSettings,
+    langmetaSettings,
     moduleName := "langmeta-io",
     description := "Langmeta APIs for input/output"
   )
@@ -99,6 +104,7 @@ lazy val langmetaInputs = crossProject
   .in(file("langmeta/inputs"))
   .settings(
     publishableSettings,
+    langmetaSettings,
     moduleName := "langmeta-inputs",
     description := "Langmeta APIs for source code"
   )
@@ -110,6 +116,7 @@ lazy val langmetaSemanticdb = crossProject
   .in(file("langmeta/semanticdb"))
   .settings(
     publishableSettings,
+    langmetaSettings,
     moduleName := "langmeta-semanticdb",
     description := "Semantic database APIs",
     // Protobuf setup for binary serialization.
@@ -129,10 +136,16 @@ lazy val langmeta = crossProject
   .in(file("langmeta/langmeta"))
   .settings(
     publishableSettings,
+    langmetaSettings,
     description := "Langmeta umbrella module that includes all public APIs",
     exposePaths("langmeta", Test)
   )
   .dependsOn(
+    langmetaInputs,
+    langmetaIo,
+    langmetaSemanticdb
+  )
+  .aggregate(
     langmetaInputs,
     langmetaIo,
     langmetaSemanticdb

--- a/build.sbt
+++ b/build.sbt
@@ -145,11 +145,6 @@ lazy val langmeta = crossProject
     langmetaIo,
     langmetaSemanticdb
   )
-  .aggregate(
-    langmetaInputs,
-    langmetaIo,
-    langmetaSemanticdb
-  )
 lazy val langmetaJVM = langmeta.jvm
 lazy val langmetaJS = langmeta.js
 

--- a/langmeta/semanticdb/shared/src/main/scala/star/meta/semanticdb/Symbol.scala
+++ b/langmeta/semanticdb/shared/src/main/scala/star/meta/semanticdb/Symbol.scala
@@ -11,7 +11,7 @@ sealed trait Symbol extends Product {
 object Symbol {
   case object None extends Symbol {
     override def toString = syntax
-    override def syntax = s""
+    override def syntax = ""
     override def structure = s"""Symbol.None"""
   }
 

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,4 +1,5 @@
 object Versions {
+  val LatestScala210 = "2.10.6"
   val LatestScala211 = "2.11.11"
   val LatestScala212 = "2.12.3"
 }


### PR DESCRIPTION
This allows semanticdb-sbt (previously sbthost) to depend on it directly
instead of duplicating protobuf generation.