### PR TITLE
Hack to fully qualify magic names.

### DIFF
--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/DenotationOps.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/DenotationOps.scala
@@ -88,7 +88,20 @@ trait DenotationOps { self: DatabaseOps =>
 
     private def info: String = {
       if (gsym.isClass || gsym.isModule) ""
-      else gsym.info.toString.stripPrefix("=> ")
+      else {
+        val code = gsym.info.toString().stripPrefix("=> ")
+        val prefix = gsym.info.prefix
+        if ((code.indexOf('.') == -1) &&
+            !prefix.typeSymbol.isInstanceOf[g.NoSymbol]) {
+          // NOTE(olafur) the default pretty printer shortens the names of several
+          // magic symbols by stripping out their prefix, see for example `shorthands`
+          // in Types.scala. Here we insert the prefix back to emit fully qualified
+          // names for DenotationInfo.
+          s"${prefix.typeSymbol.fullName}.$code"
+        } else {
+          code
+        }
+      }
     }
 
     def toDenotation: m.Denotation = {

--- a/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/SemanticSuite.scala
+++ b/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/SemanticSuite.scala
@@ -138,28 +138,28 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |_root_.F.package. => packageobject package
       |_root_.f. => package f
       |_root_.f.C1# => class C1
-      |_root_.f.C1#(p1) => param p1: Int
-      |_root_.f.C1#(p2) => val param p2: Int
+      |_root_.f.C1#(p1) => param p1: scala.Int
+      |_root_.f.C1#(p2) => val param p2: scala.Int
       |_root_.f.C1#(p3) => var param p3_=: (x$1: Int)Unit
       |_root_.f.C1#T1# => abstract type T1:  <: Int
-      |_root_.f.C1#T2# => type T2: Int
+      |_root_.f.C1#T2# => type T2: scala.Int
       |_root_.f.C1#`<init>`()V. => secondaryctor <init>: ()f.C1
       |_root_.f.C1#`<init>`(III)V. => primaryctor <init>: (p1: Int, p2: Int, p3: Int)f.C1
-      |_root_.f.C1#f1. => val f1: Nothing
-      |_root_.f.C1#f1.l1. => val l1: Nothing
-      |_root_.f.C1#f1.l2. => var l2: Nothing
+      |_root_.f.C1#f1. => val f1: scala.Nothing
+      |_root_.f.C1#f1.l1. => val l1: scala.Nothing
+      |_root_.f.C1#f1.l2. => var l2: scala.Nothing
       |_root_.f.C1#f2. => var f2_=: (x$1: Nothing)Unit
       |_root_.f.C1#m1(I)I. => def m1: [T](x: Int)Int
-      |_root_.f.C1#m1(I)I.(x) => param x: Int
+      |_root_.f.C1#m1(I)I.(x) => param x: scala.Int
       |_root_.f.C1#m1(I)I.T# => typeparam T
-      |_root_.f.C1#m2()Lscala/Nothing;. => macro m2: Nothing
+      |_root_.f.C1#m2()Lscala/Nothing;. => macro m2: scala.Nothing
       |_root_.f.C2# => abstract class C2
       |_root_.f.C2#`<init>`()V. => primaryctor <init>: ()f.C2
-      |_root_.f.C2#m3()I. => abstract def m3: Int
-      |_root_.f.C2#m4()Lscala/Nothing;. => final def m4: Nothing
+      |_root_.f.C2#m3()I. => abstract def m3: scala.Int
+      |_root_.f.C2#m4()Lscala/Nothing;. => final def m4: scala.Nothing
       |_root_.f.C3# => sealed class C3
       |_root_.f.C3#`<init>`()V. => primaryctor <init>: ()f.C3
-      |_root_.f.C3#m3()I. => def m3: Int
+      |_root_.f.C3#m3()I. => def m3: scala.Int
       |_root_.f.C3#toString()Ljava/lang/String;. => def toString: ()String
       |_root_.f.M. => final object M
       |_root_.f.M.C1# => case class C1
@@ -168,20 +168,20 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |_root_.f.M.C2#[T] => covariant typeparam T
       |_root_.f.M.C2#[U] => contravariant typeparam U
       |_root_.f.M.C2#`<init>`()V. => primaryctor <init>: ()f.M.C2[T,U]
-      |_root_.f.M.i1()Lscala/Nothing;. => implicit def i1: Nothing
-      |_root_.f.M.l1. => lazy val l1: Nothing
+      |_root_.f.M.i1()Lscala/Nothing;. => implicit def i1: scala.Nothing
+      |_root_.f.M.l1. => lazy val l1: scala.Nothing
       |_root_.f.T# => trait T
       |_root_.f.T#$init$()V. => primaryctor $init$: ()Unit
-      |_root_.f.T#f1. => private val f1: Nothing
-      |_root_.f.T#f2. => private val f2: Nothing
-      |_root_.f.T#f3. => private val f3: Nothing
+      |_root_.f.T#f1. => private val f1: scala.Nothing
+      |_root_.f.T#f2. => private val f2: scala.Nothing
+      |_root_.f.T#f3. => private val f3: scala.Nothing
       |_root_.f.T#f4. => protected var f4_=: (x$1: Nothing)Unit
       |_root_.f.T#f5. => protected var f5_=: (x$1: Nothing)Unit
       |_root_.f.T#f6. => protected var f6_=: (x$1: Nothing)Unit
       |_root_.scala. => package scala
       |_root_.scala.Int# => abstract final class Int
       |_root_.scala.Int#`<init>`()V. => primaryctor <init>: ()Int
-      |_root_.scala.Predef.`???`()Lscala/Nothing;. => def ???: Nothing
+      |_root_.scala.Predef.`???`()Lscala/Nothing;. => def ???: scala.Nothing
       |_root_.scala.language. => final object language
       |_root_.scala.language.experimental. => final object experimental
       |_root_.scala.language.experimental.macros. => implicit lazy val macros: languageFeature.experimental.macros
@@ -539,6 +539,25 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       val denot2 = db.symbols.find(_.sym == listToString).get.denot
       assert(denot1.isJavaDefined)
       assert(!denot2.isJavaDefined)
+    }
+  )
+
+  targeted(
+    """
+      |object a {
+      |  val <<a>> = new java.lang.StringBuilder
+      |  val <<b>> = new StringBuilder
+      |  val <<c>>: Traversable[Int] = List(1)
+      |  val <<d>> = Map(1 -> 2)
+      |}
+    """.stripMargin, { (db, a, b, c, d) =>
+      def check(symbol: Symbol, info: String) = {
+        assert(db.symbols.find(_.sym == symbol).get.denot.info == info)
+      }
+      check(a, "java.lang.StringBuilder")
+      check(b, "scala.collection.mutable.StringBuilder")
+      check(c, "scala.collection.Traversable[Int]")
+      check(d, "scala.collection.immutable.Map[Int,Int]")
     }
   )
 

--- a/scalameta/tests/jvm/src/test/resources/semanticdb.expect
+++ b/scalameta/tests/jvm/src/test/resources/semanticdb.expect
@@ -1,7 +1,7 @@
 scalameta/semanticdb-integration/src/main/scala/example/Example.scala
 ---------------------------------------------------------------------
 Language:
-Scala211
+Scala212
 
 Names:
 [8..15): example <= _root_.example.
@@ -17,10 +17,10 @@ Symbols:
 _root_.example. => package example
 _root_.example.Example. => final object Example
 _root_.example.Example.main([Ljava/lang/String;)V. => def main: (args: Array[String])Unit
-_root_.example.Example.main([Ljava/lang/String;)V.(args) => param args: Array[String]
+_root_.example.Example.main([Ljava/lang/String;)V.(args) => param args: scala.Array[String]
 _root_.scala.Array# => final class Array
 _root_.scala.Array#`<init>`(I)V. => primaryctor <init>: (_length: Int)Array[T]
-_root_.scala.Predef.String# => type String: String
+_root_.scala.Predef.String# => type String: java.lang.String
 _root_.scala.Predef.println(Ljava/lang/Object;)V. => def println: (x: Any)Unit
 _root_.scala.Unit# => abstract final class Unit
 _root_.scala.Unit#`<init>`()V. => primaryctor <init>: ()Unit
@@ -29,7 +29,7 @@ _root_.scala.Unit#`<init>`()V. => primaryctor <init>: ()Unit
 scalameta/semanticdb-integration/src/main/scala/example/Sugar.scala
 -------------------------------------------------------------------
 Language:
-Scala211
+Scala212
 
 Names:
 [8..15): example <= _root_.example.
@@ -53,7 +53,7 @@ _root_.scala.Array.empty(Lscala/reflect/ClassTag;)Ljava/lang/Object;. => def emp
 _root_.scala.Int# => abstract final class Int
 _root_.scala.Int#`+`(I)I. => abstract def +: (x: Int)Int
 _root_.scala.Int#`<init>`()V. => primaryctor <init>: ()Int
-_root_.scala.collection.TraversableLike#headOption()Lscala/Option;. => def headOption: Option[A]
+_root_.scala.collection.TraversableLike#headOption()Lscala/Option;. => def headOption: scala.Option[A]
 _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;. => final def map: [B, That](f: A => B)(implicit bf: scala.collection.generic.CanBuildFrom[List[A],B,That])That
 _root_.scala.collection.immutable.List. => final object List
 _root_.scala.collection.immutable.StringLike#stripPrefix(Ljava/lang/String;)Ljava/lang/String;. => def stripPrefix: (prefix: String)String
@@ -68,7 +68,7 @@ Sugars:
   [0..1): * => _star_.
   [34..46): canBuildFrom => _root_.scala.collection.immutable.List.canBuildFrom()Lscala/collection/generic/CanBuildFrom;.
 [54..70): scala.Predef.intArrayOps(*)
-  [13..24): intArrayOps => _root_.scala.Predef.intArrayOps([I)Lscala/collection/mutable/ArrayOps;.
+  [13..24): intArrayOps => _root_.scala.Predef.intArrayOps([I)[I.
   [25..26): * => _star_.
 [70..70): *(((ClassTag.Int): scala.reflect.ClassTag[Int]))
   [0..1): * => _star_.

--- a/scalameta/tests/jvm/src/test/scala/scala/meta/tests/SemanticdbExpectSuite.scala
+++ b/scalameta/tests/jvm/src/test/scala/scala/meta/tests/SemanticdbExpectSuite.scala
@@ -5,6 +5,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import scala.meta.testkit.DiffAssertions
+import lang.meta.internal.io.FileIO
 import org.scalatest.FunSuite
 
 class SemanticdbExpectSuite extends FunSuite with DiffAssertions {
@@ -16,7 +17,7 @@ class SemanticdbExpectSuite extends FunSuite with DiffAssertions {
       // later down the road if that turns out to be useful.
       case "2" :: "12" :: Nil =>
         val obtained = SemanticdbExpectSuite.loadDatabase.toString
-        val expected = new String(Files.readAllBytes(SemanticdbExpectSuite.expectPath))
+        val expected = FileIO.slurp(AbsolutePath(SemanticdbExpectSuite.expectPath))
         assertNoDiff(obtained, expected)
       case _ => // do nothing.
     }

--- a/scalameta/tests/jvm/src/test/scala/scala/meta/tests/SemanticdbExpectSuite.scala
+++ b/scalameta/tests/jvm/src/test/scala/scala/meta/tests/SemanticdbExpectSuite.scala
@@ -12,9 +12,9 @@ class SemanticdbExpectSuite extends FunSuite with DiffAssertions {
     BuildInfo.scalaVersion.split("\\.").take(2).toList match {
       // both the compiler and stdlib are different between Scala versions.
       // For the sake of simplicity, we only run the expect test against the
-      // output of 2.11. It's possible to add another expect file for 2.12
+      // output of 2.12. It's possible to add another expect file for 2.12
       // later down the road if that turns out to be useful.
-      case "2" :: "11" :: Nil =>
+      case "2" :: "12" :: Nil =>
         val obtained = SemanticdbExpectSuite.loadDatabase.toString
         val expected = new String(Files.readAllBytes(SemanticdbExpectSuite.expectPath))
         assertNoDiff(obtained, expected)


### PR DESCRIPTION
The scalac pretty printer shortens the names for several symbols by
stripping out the prefix. This causes bugs like
https://github.com/scalacenter/scalafix/issues/254

This commit adds a special case in DenotationOps to add the prefix when
the printed name contains no `.`. I spent a while trying to fix this at
the root by extending the pretty printer, but gave up eventually in
favor of this hack.