### PR TITLE
Add semantic information for denotations

### DIFF
--- a/langmeta/inputs/shared/src/main/scala/star/meta/inputs/Api.scala
+++ b/langmeta/inputs/shared/src/main/scala/star/meta/inputs/Api.scala
@@ -24,6 +24,9 @@ private[meta] trait Aliases {
     type Sugar = lang.meta.inputs.Input.Sugar
     val Sugar = lang.meta.inputs.Input.Sugar
 
+    type Denotation = lang.meta.inputs.Input.Denotation
+    val Denotation = lang.meta.inputs.Input.Denotation
+
     type Slice = lang.meta.inputs.Input.Slice
     val Slice = lang.meta.inputs.Input.Slice
   }

--- a/langmeta/inputs/shared/src/main/scala/star/meta/inputs/Input.scala
+++ b/langmeta/inputs/shared/src/main/scala/star/meta/inputs/Input.scala
@@ -81,6 +81,11 @@ object Input {
     override def toString = s"""Input.Sugar("$value", $input, $start, $end)"""
   }
 
+  final case class Denotation(value: scala.Predef.String, symbol: scala.Predef.String) extends Input {
+    lazy val chars = value.toCharArray
+    override def toString = s"""Input.Denotation("$value", "$symbol")"""
+  }
+
   // NOTE: `start` and `end` are String.substring-style,
   // i.e. `start` is inclusive and `end` is not.
   // Therefore Slice.end can point to the last character of input plus one.

--- a/langmeta/semanticdb/shared/src/main/protobuf/semanticdb.proto
+++ b/langmeta/semanticdb/shared/src/main/protobuf/semanticdb.proto
@@ -50,6 +50,7 @@ message Denotation {
   int64 flags = 1;
   string name = 2;
   string info = 3;
+  repeated ResolvedName names = 4;
 }
 
 message Sugar {

--- a/langmeta/semanticdb/shared/src/main/scala/star/meta/semanticdb/Denotation.scala
+++ b/langmeta/semanticdb/shared/src/main/scala/star/meta/semanticdb/Denotation.scala
@@ -1,8 +1,12 @@
 package lang.meta
 package semanticdb
 
-final case class Denotation(flags: Long, name: String, info: String) extends HasFlags {
-  def syntax = s"$flagSyntax $name" + (if (info != "") ": " + info else "")
+final case class Denotation(flags: Long, name: String, info: String, resolvedNames: List[ResolvedName]) extends HasFlags {
+  def syntax: String = {
+    val s_info = if (info != "") ": " + info else ""
+    val s_names = ResolvedName.syntax(resolvedNames)
+    s"$flagSyntax $name" + s_info + s_names
+  }
   def structure = s"""Denotation($flagStructure, "$name", "$info")"""
   override def toString = syntax
 }

--- a/langmeta/semanticdb/shared/src/main/scala/star/meta/semanticdb/ResolvedName.scala
+++ b/langmeta/semanticdb/shared/src/main/scala/star/meta/semanticdb/ResolvedName.scala
@@ -1,15 +1,23 @@
 package lang.meta
 package semanticdb
 
+import scala.compat.Platform.EOL
 import lang.meta.inputs._
 import lang.meta.internal.inputs._
 
 final case class ResolvedName(pos: Position, symbol: Symbol, isBinder: Boolean) {
-  def syntax = {
+  def syntax: String = {
     val text = if (pos.text.nonEmpty) pos.text else "ε"
     val binder = if (isBinder) "<=" else "=>"
     s"[${pos.start}..${pos.end}): $text $binder ${symbol.syntax}"
   }
   def structure = s"""ResolvedName(${pos.structure}, ${symbol.structure}, $isBinder)"""
   override def toString = syntax
+}
+
+object ResolvedName {
+  def syntax(names: List[ResolvedName]): String = {
+    if (names.isEmpty) ""
+    else names.map(name => "  " + name.syntax).mkString(EOL, EOL, "")
+  }
 }

--- a/langmeta/semanticdb/shared/src/main/scala/star/meta/semanticdb/Sugar.scala
+++ b/langmeta/semanticdb/shared/src/main/scala/star/meta/semanticdb/Sugar.scala
@@ -1,14 +1,13 @@
 package lang.meta
 package semanticdb
 
-import scala.compat.Platform.EOL
 import lang.meta.inputs._
 import lang.meta.internal.inputs._
 
 final case class Sugar(pos: Position, text: String, names: List[ResolvedName]) {
   def input = Input.Sugar(text, pos.input, pos.start, pos.end)
   def syntax = {
-    val s_names = if (names.isEmpty) "" else names.map(name => "  " + name.syntax).mkString(EOL, EOL, "")
+    val s_names = ResolvedName.syntax(names)
     s"[${pos.start}..${pos.end}): $text$s_names"
   }
   def structure = s"""Sugar(${pos.structure}, "$text", List(${names.map(_.structure).mkString(", ")}))"""

--- a/langmeta/semanticdb/shared/src/main/scala/star/meta/semanticdb/internal/package.scala
+++ b/langmeta/semanticdb/shared/src/main/scala/star/meta/semanticdb/internal/package.scala
@@ -58,9 +58,9 @@ package object semanticdb {
           object sResolvedSymbol {
             def unapply(sresolvedsymbol: s.ResolvedSymbol): Option[d.ResolvedSymbol] = sresolvedsymbol match {
               case s.ResolvedSymbol(d.Symbol(dsym), Some(s.Denotation(dflags, dname: String, dinfo: String, snames))) =>
+                val ddenotinput = dInput.Denotation(dinfo, dsym.syntax)
                 val dnames = snames.toIterator.map {
                   case s.ResolvedName(Some(s.Position(sstart, send)), d.Symbol(dsym), disBinder) =>
-                    val ddenotinput = dInput.Denotation(dinfo, dsym.syntax)
                     val ddenotpos = dPosition.Range(ddenotinput, sstart, send)
                     d.ResolvedName(ddenotpos, dsym, disBinder)
                   case other =>

--- a/langmeta/semanticdb/shared/src/main/scala/star/meta/semanticdb/internal/package.scala
+++ b/langmeta/semanticdb/shared/src/main/scala/star/meta/semanticdb/internal/package.scala
@@ -55,11 +55,20 @@ package object semanticdb {
               }
             }
           }
-          object sDenotation {
-            def unapply(sdenot: s.Denotation): Option[d.Denotation] = sdenot match {
-              case s.Denotation(dflags, dname: String, dinfo: String) =>
-                Some(d.Denotation(dflags, dname, dinfo))
-              case _ => None
+          object sResolvedSymbol {
+            def unapply(sresolvedsymbol: s.ResolvedSymbol): Option[d.ResolvedSymbol] = sresolvedsymbol match {
+              case s.ResolvedSymbol(d.Symbol(dsym), Some(s.Denotation(dflags, dname: String, dinfo: String, snames))) =>
+                val dnames = snames.toIterator.map {
+                  case s.ResolvedName(Some(s.Position(sstart, send)), d.Symbol(dsym), disBinder) =>
+                    val ddenotinput = dInput.Denotation(dinfo, dsym.syntax)
+                    val ddenotpos = dPosition.Range(ddenotinput, sstart, send)
+                    d.ResolvedName(ddenotpos, dsym, disBinder)
+                  case other =>
+                    sys.error(s"bad protobuf: unsupported name $other")
+                }.toList
+                val ddenot = d.Denotation(dflags, dname, dinfo, dnames)
+                Some(d.ResolvedSymbol(dsym, ddenot))
+              case other => sys.error(s"bad protobuf: unsupported denotation $other")
             }
           }
           object sSugar {
@@ -87,8 +96,7 @@ package object semanticdb {
             case other => sys.error(s"bad protobuf: unsupported message $other")
           }.toList
           val dsymbols = ssymbols.map {
-            case s.ResolvedSymbol(d.Symbol(dsym), Some(sDenotation(ddenot))) => d.ResolvedSymbol(dsym, ddenot)
-            case other => sys.error(s"bad protobuf: unsupported denotation $other")
+            case sResolvedSymbol(dresolvedsymbol) => dresolvedsymbol
           }.toList
           val dsugars = ssugars.toIterator.map {
             case sSugar(dsugar) => dsugar
@@ -123,7 +131,14 @@ package object semanticdb {
           }
           object dDenotation {
             def unapply(ddenot: d.Denotation): Option[s.Denotation] = ddenot match {
-              case d.Denotation(sflags, sname, sinfo) => Some(s.Denotation(sflags, sname, sinfo))
+              case d.Denotation(sflags, sname, sinfo, dnames) =>
+                val snames = dnames.map {
+                  case d.ResolvedName(lang.meta.inputs.Position.Range(_, sstart, send), ssym, sisBinder) =>
+                    s.ResolvedName(Some(s.Position(sstart, send)), ssym.syntax, sisBinder)
+                  case other =>
+                    sys.error(s"bad database: unsupported position $other")
+                }
+                Some(s.Denotation(sflags, sname, sinfo, snames))
               case _ => None
             }
           }

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
@@ -280,8 +280,18 @@ class PublicSuite extends FunSuite {
   }
 
   test("lang.meta.semanticdb.Denotation.toString") {
-    val denotation = Denotation(PRIVATE | CASE | CLASS, "C", "")
-    assert(denotation.toString === "private case class C")
+    val symbol = Symbol("_root_.E#")
+    val info = "[T](e: E)T"
+    val input = Input.Denotation(info, symbol.syntax)
+    val pos = Position.Range(input, 7, 8)
+    val names = List(ResolvedName(pos, symbol, isBinder = false))
+    val classC = Denotation(PRIVATE | CASE | CLASS, "C", "", Nil)
+    assert(classC.toString === "private case class C")
+    val defIdentity = Denotation(DEF | FINAL, "identity", info, names)
+    assert(defIdentity.toString ===
+      """final def identity: [T](e: E)T
+        |  [7..8): E => _root_.E#""".stripMargin
+    )
   }
 
   test("lang.meta.semanticdb.Database.toString") {

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/AttributesOps.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/AttributesOps.scala
@@ -165,11 +165,10 @@ trait AttributesOps { self: DatabaseOps =>
 
                 names(mtree.pos) = symbol
                 if (mtree.isBinder) binders += mtree.pos
-                denotations(symbol) = gsym.toDenotation(symbol)
+                denotations(symbol) = gsym.toDenotation
                 if (gsym.isClass && !gsym.isTrait) {
                   val gprim = gsym.primaryConstructor
-                  val symbol = gprim.toSemantic
-                  denotations(symbol) = gprim.toDenotation(symbol)
+                  denotations(gprim.toSemantic) = gprim.toDenotation
                 }
                 todo -= mtree
 

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/AttributesOps.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/AttributesOps.scala
@@ -165,10 +165,11 @@ trait AttributesOps { self: DatabaseOps =>
 
                 names(mtree.pos) = symbol
                 if (mtree.isBinder) binders += mtree.pos
-                denotations(symbol) = gsym.toDenotation
+                denotations(symbol) = gsym.toDenotation(symbol)
                 if (gsym.isClass && !gsym.isTrait) {
                   val gprim = gsym.primaryConstructor
-                  denotations(gprim.toSemantic) = gprim.toDenotation
+                  val symbol = gprim.toSemantic
+                  denotations(symbol) = gprim.toDenotation(symbol)
                 }
                 todo -= mtree
 

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/DenotationOps.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/DenotationOps.scala
@@ -88,11 +88,11 @@ trait DenotationOps { self: DatabaseOps =>
       gsym.decodedName.toString
     }
 
-    private def info(symbol: m.Symbol): (String, List[m.ResolvedName]) = {
+    private def info: (String, List[m.ResolvedName]) = {
       if (gsym.isClass || gsym.isModule) "" -> Nil
       else {
         val sugar = showSugar(gsym.info)
-        val input = m.Input.Denotation(sugar.text, symbol.syntax)
+        val input = m.Input.Denotation(sugar.text, gsym.toSemantic.syntax)
         val resolvedNames = sugar.names.toIterator.map {
           case SugarRange(start, end, sugarSymbol) =>
             m.ResolvedName(m.Position.Range(input, start, end), sugarSymbol, isBinder = false)
@@ -102,8 +102,8 @@ trait DenotationOps { self: DatabaseOps =>
       }
     }
 
-    def toDenotation(symbol: m.Symbol): m.Denotation = {
-      val (minfo, mnames) = info(symbol)
+    def toDenotation: m.Denotation = {
+      val (minfo, mnames) = info
       m.Denotation(flags, name, minfo, mnames)
     }
   }

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/DenotationOps.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/DenotationOps.scala
@@ -88,7 +88,20 @@ trait DenotationOps { self: DatabaseOps =>
 
     private def info: String = {
       if (gsym.isClass || gsym.isModule) ""
-      else gsym.info.toString.stripPrefix("=> ")
+      else {
+        val code = gsym.info.toString().stripPrefix("=> ")
+        val prefix = gsym.info.prefix
+        if ((code.indexOf('.') == -1) &&
+            !prefix.typeSymbol.isInstanceOf[g.NoSymbol]) {
+          // NOTE(olafur) the default pretty printer shortens the names of several
+          // magic symbols by stripping out their prefix, see for example `shorthands`
+          // in Types.scala. Here we insert the prefix back to emit fully qualified
+          // names for DenotationInfo.
+          s"${prefix.typeSymbol.fullName}.$code"
+        } else {
+          code
+        }
+      }
     }
 
     def toDenotation: m.Denotation = {

--- a/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/SemanticSuite.scala
+++ b/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/SemanticSuite.scala
@@ -139,52 +139,98 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |_root_.f. => package f
       |_root_.f.C1# => class C1
       |_root_.f.C1#(p1) => param p1: scala.Int
+      |  [6..9): Int => _root_.scala.Int#
       |_root_.f.C1#(p2) => val param p2: scala.Int
-      |_root_.f.C1#(p3) => var param p3_=: (x$1: Int)Unit
+      |  [6..9): Int => _root_.scala.Int#
+      |_root_.f.C1#(p3) => var param p3_=: (x$1: scala.Int)scala.Unit
+      |  [12..15): Int => _root_.scala.Int#
+      |  [22..26): Unit => _root_.scala.Unit#
       |_root_.f.C1#T1# => abstract type T1:  <: Int
       |_root_.f.C1#T2# => type T2: scala.Int
+      |  [6..9): Int => _root_.scala.Int#
       |_root_.f.C1#`<init>`()V. => secondaryctor <init>: ()f.C1
-      |_root_.f.C1#`<init>`(III)V. => primaryctor <init>: (p1: Int, p2: Int, p3: Int)f.C1
+      |  [4..6): C1 => _root_.f.C1#
+      |_root_.f.C1#`<init>`(III)V. => primaryctor <init>: (p1: scala.Int,p2: scala.Int,p3: scala.Int)f.C1
+      |  [45..47): C1 => _root_.f.C1#
+      |  [25..28): Int => _root_.scala.Int#
+      |  [39..42): Int => _root_.scala.Int#
+      |  [11..14): Int => _root_.scala.Int#
       |_root_.f.C1#f1. => val f1: scala.Nothing
+      |  [6..13): Nothing => _root_.scala.Nothing#
       |_root_.f.C1#f1.l1. => val l1: scala.Nothing
+      |  [6..13): Nothing => _root_.scala.Nothing#
       |_root_.f.C1#f1.l2. => var l2: scala.Nothing
-      |_root_.f.C1#f2. => var f2_=: (x$1: Nothing)Unit
-      |_root_.f.C1#m1(I)I. => def m1: [T](x: Int)Int
+      |  [6..13): Nothing => _root_.scala.Nothing#
+      |_root_.f.C1#f2. => var f2_=: (x$1: scala.Nothing)scala.Unit
+      |  [12..19): Nothing => _root_.scala.Nothing#
+      |  [26..30): Unit => _root_.scala.Unit#
+      |_root_.f.C1#m1(I)I. => def m1: [T](x: scala.Int)scala.Int
+      |  [13..16): Int => _root_.scala.Int#
+      |  [23..26): Int => _root_.scala.Int#
       |_root_.f.C1#m1(I)I.(x) => param x: scala.Int
+      |  [6..9): Int => _root_.scala.Int#
       |_root_.f.C1#m1(I)I.T# => typeparam T
       |_root_.f.C1#m2()Lscala/Nothing;. => macro m2: scala.Nothing
+      |  [6..13): Nothing => _root_.scala.Nothing#
       |_root_.f.C2# => abstract class C2
       |_root_.f.C2#`<init>`()V. => primaryctor <init>: ()f.C2
+      |  [4..6): C2 => _root_.f.C2#
       |_root_.f.C2#m3()I. => abstract def m3: scala.Int
+      |  [6..9): Int => _root_.scala.Int#
       |_root_.f.C2#m4()Lscala/Nothing;. => final def m4: scala.Nothing
+      |  [6..13): Nothing => _root_.scala.Nothing#
       |_root_.f.C3# => sealed class C3
       |_root_.f.C3#`<init>`()V. => primaryctor <init>: ()f.C3
+      |  [4..6): C3 => _root_.f.C3#
       |_root_.f.C3#m3()I. => def m3: scala.Int
-      |_root_.f.C3#toString()Ljava/lang/String;. => def toString: ()String
+      |  [6..9): Int => _root_.scala.Int#
+      |_root_.f.C3#toString()Ljava/lang/String;. => def toString: ()java.lang.String
+      |  [12..18): String => _root_.java.lang.String#
       |_root_.f.M. => final object M
       |_root_.f.M.C1# => case class C1
       |_root_.f.M.C1#`<init>`()V. => primaryctor <init>: ()f.M.C1
+      |  [6..8): C1 => _root_.f.M.C1#
       |_root_.f.M.C2# => class C2
       |_root_.f.M.C2#[T] => covariant typeparam T
       |_root_.f.M.C2#[U] => contravariant typeparam U
       |_root_.f.M.C2#`<init>`()V. => primaryctor <init>: ()f.M.C2[T,U]
+      |  [11..12): U => _root_.f.M.C2#[U]
+      |  [9..10): T => _root_.f.M.C2#[T]
+      |  [6..8): C2 => _root_.f.M.C2#
       |_root_.f.M.i1()Lscala/Nothing;. => implicit def i1: scala.Nothing
+      |  [6..13): Nothing => _root_.scala.Nothing#
       |_root_.f.M.l1. => lazy val l1: scala.Nothing
+      |  [6..13): Nothing => _root_.scala.Nothing#
       |_root_.f.T# => trait T
-      |_root_.f.T#$init$()V. => primaryctor $init$: ()Unit
+      |_root_.f.T#$init$()V. => primaryctor $init$: ()scala.Unit
+      |  [8..12): Unit => _root_.scala.Unit#
       |_root_.f.T#f1. => private val f1: scala.Nothing
+      |  [6..13): Nothing => _root_.scala.Nothing#
       |_root_.f.T#f2. => private val f2: scala.Nothing
+      |  [6..13): Nothing => _root_.scala.Nothing#
       |_root_.f.T#f3. => private val f3: scala.Nothing
-      |_root_.f.T#f4. => protected var f4_=: (x$1: Nothing)Unit
-      |_root_.f.T#f5. => protected var f5_=: (x$1: Nothing)Unit
-      |_root_.f.T#f6. => protected var f6_=: (x$1: Nothing)Unit
+      |  [6..13): Nothing => _root_.scala.Nothing#
+      |_root_.f.T#f4. => protected var f4_=: (x$1: scala.Nothing)scala.Unit
+      |  [12..19): Nothing => _root_.scala.Nothing#
+      |  [26..30): Unit => _root_.scala.Unit#
+      |_root_.f.T#f5. => protected var f5_=: (x$1: scala.Nothing)scala.Unit
+      |  [12..19): Nothing => _root_.scala.Nothing#
+      |  [26..30): Unit => _root_.scala.Unit#
+      |_root_.f.T#f6. => protected var f6_=: (x$1: scala.Nothing)scala.Unit
+      |  [12..19): Nothing => _root_.scala.Nothing#
+      |  [26..30): Unit => _root_.scala.Unit#
       |_root_.scala. => package scala
       |_root_.scala.Int# => abstract final class Int
-      |_root_.scala.Int#`<init>`()V. => primaryctor <init>: ()Int
+      |_root_.scala.Int#`<init>`()V. => primaryctor <init>: ()scala.Int
+      |  [8..11): Int => _root_.scala.Int#
       |_root_.scala.Predef.`???`()Lscala/Nothing;. => def ???: scala.Nothing
+      |  [6..13): Nothing => _root_.scala.Nothing#
       |_root_.scala.language. => final object language
       |_root_.scala.language.experimental. => final object experimental
-      |_root_.scala.language.experimental.macros. => implicit lazy val macros: languageFeature.experimental.macros
+      |_root_.scala.language.experimental.macros. => implicit lazy val macros: scala.languageFeature.experimental.macros
+      |  [35..41): macros => _root_.scala.languageFeature.experimental.macros#
+      |  [6..21): languageFeature => _root_.scala.languageFeature.
+      |  [22..34): experimental => _root_.scala.languageFeature.experimental.
   """.trim.stripMargin
   )
 
@@ -209,6 +255,8 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |[324..324): *.apply[g.Foo, g.FooDSL]
       |  [0..1): * => _star_.
       |  [2..7): apply => _root_.g.CommandeerDSL.apply(Ljava/lang/Object;Lg/CommandeerDSL;)Lg/CommandeerDSL;.
+      |  [10..13): Foo => _root_.g.Foo#
+      |  [17..23): FooDSL => _root_.g.FooDSL#
       |[348..348): *(g.Foo.fooDSL)
       |  [0..1): * => _star_.
       |  [8..14): fooDSL => _root_.g.Foo.fooDSL.
@@ -243,21 +291,29 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |}
   """.trim.stripMargin,
     """
-      |[201..201): *[Int, List[Int]]
+      |[201..201): *[scala.Int, scala.collection.immutable.List[scala.Int]]
       |  [0..1): * => _star_.
-      |[209..209): *(scala.collection.immutable.List.canBuildFrom[Int])
+      |  [8..11): Int => _root_.scala.Int#
+      |  [40..44): List => _root_.scala.collection.immutable.List#
+      |  [51..54): Int => _root_.scala.Int#
+      |[209..209): *(scala.collection.immutable.List.canBuildFrom[scala.Int])
       |  [0..1): * => _star_.
       |  [34..46): canBuildFrom => _root_.scala.collection.immutable.List.canBuildFrom()Lscala/collection/generic/CanBuildFrom;.
-      |[247..247): *(h.C.list[Int](h.C.int))
+      |  [53..56): Int => _root_.scala.Int#
+      |[247..247): *(h.C.list[scala.Int](h.C.int))
       |  [0..1): * => _star_.
+      |  [17..20): Int => _root_.scala.Int#
+      |  [26..29): int => _root_.h.C.int()Lh/C;.
       |  [6..10): list => _root_.h.C.list(Lh/C;)Lh/C;.
-      |  [20..23): int => _root_.h.C.int()Lh/C;.
-      |[273..275): h.X.cvt[Int](*)(h.C.int)
+      |[273..275): h.X.cvt[scala.Int](*)(h.C.int)
       |  [4..7): cvt => _root_.h.X.cvt(Ljava/lang/Object;Lh/C;)Lh/X;.
-      |  [13..14): * => _star_.
-      |  [20..23): int => _root_.h.C.int()Lh/C;.
-      |[304..304): *[h.C[Int]]
+      |  [14..17): Int => _root_.scala.Int#
+      |  [19..20): * => _star_.
+      |  [26..29): int => _root_.h.C.int()Lh/C;.
+      |[304..304): *[h.C[scala.Int]]
       |  [0..1): * => _star_.
+      |  [4..5): C => _root_.h.C#
+      |  [12..15): Int => _root_.scala.Int#
   """.trim.stripMargin
   )
 
@@ -281,45 +337,79 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |object a {
       |  val x = new E().x
       |  val y = new D().x
-      |  def foo(b: B): b.X = {
+      |  def foo(implicit b: B): b.X = {
       |    val result = b.x
       |    result
       |  }
       |}
     """.stripMargin,
     """
-      |<...>@350..366 => val result: b.X
+      |<...>@359..375 => val result: b.X
+      |  [2..3): X => _root_.i.B#X#
+      |  [0..1): b => _root_.i.a.foo(Li/B;)Ljava/lang/Object;.(b)
       |_root_.i. => package i
       |_root_.i.B# => trait B
       |_root_.i.B#X# => abstract type X
       |_root_.i.B#x()Ljava/lang/Object;. => abstract def x: B.this.X
+      |  [7..8): X => _root_.i.B#X#
       |_root_.i.D# => class D
-      |_root_.i.D#X# => type X: scala.collection.mutable.HashSet[Int]
+      |_root_.i.D#X# => type X: scala.collection.mutable.HashSet[scala.Int]
+      |  [25..32): HashSet => _root_.scala.collection.mutable.HashSet#
+      |  [39..42): Int => _root_.scala.Int#
       |_root_.i.D#`<init>`()V. => primaryctor <init>: ()i.D
-      |_root_.i.D#x()Lscala/collection/mutable/HashSet;. => def x: scala.collection.mutable.HashSet[Int]
+      |  [4..5): D => _root_.i.D#
+      |_root_.i.D#x()Lscala/collection/mutable/HashSet;. => def x: scala.collection.mutable.HashSet[scala.Int]
+      |  [25..32): HashSet => _root_.scala.collection.mutable.HashSet#
+      |  [39..42): Int => _root_.scala.Int#
       |_root_.i.E# => class E
-      |_root_.i.E#X# => type X: scala.collection.mutable.ListBuffer[Int]
+      |_root_.i.E#X# => type X: scala.collection.mutable.ListBuffer[scala.Int]
+      |  [42..45): Int => _root_.scala.Int#
+      |  [25..35): ListBuffer => _root_.scala.collection.mutable.ListBuffer#
       |_root_.i.E#`<init>`()V. => primaryctor <init>: ()i.E
-      |_root_.i.E#x()Lscala/collection/mutable/ListBuffer;. => def x: scala.collection.mutable.ListBuffer[Int]
+      |  [4..5): E => _root_.i.E#
+      |_root_.i.E#x()Lscala/collection/mutable/ListBuffer;. => def x: scala.collection.mutable.ListBuffer[scala.Int]
+      |  [42..45): Int => _root_.scala.Int#
+      |  [25..35): ListBuffer => _root_.scala.collection.mutable.ListBuffer#
       |_root_.i.a. => final object a
-      |_root_.i.a.foo(Li/B;)Ljava/lang/Object;. => def foo: (b: i.B)b.X
-      |_root_.i.a.foo(Li/B;)Ljava/lang/Object;.(b) => param b: i.B
-      |_root_.i.a.x. => val x: scala.collection.mutable.ListBuffer[Int]
-      |_root_.i.a.y. => val y: scala.collection.mutable.HashSet[Int]
-      |_root_.java.lang.Object#`<init>`()V. => primaryctor <init>: ()Object
+      |_root_.i.a.foo(Li/B;)Ljava/lang/Object;. => def foo: (implicit b: i.B)b.X
+      |  [17..18): b => _root_.i.a.foo(Li/B;)Ljava/lang/Object;.(b)
+      |  [15..16): B => _root_.i.B#
+      |  [19..20): X => _root_.i.B#X#
+      |_root_.i.a.foo(Li/B;)Ljava/lang/Object;.(b) => implicit param b: i.B
+      |  [2..3): B => _root_.i.B#
+      |_root_.i.a.x. => val x: scala.collection.mutable.ListBuffer[scala.Int]
+      |  [42..45): Int => _root_.scala.Int#
+      |  [25..35): ListBuffer => _root_.scala.collection.mutable.ListBuffer#
+      |_root_.i.a.y. => val y: scala.collection.mutable.HashSet[scala.Int]
+      |  [25..32): HashSet => _root_.scala.collection.mutable.HashSet#
+      |  [39..42): Int => _root_.scala.Int#
+      |_root_.java.lang.Object#`<init>`()V. => primaryctor <init>: ()java.lang.Object
+      |  [12..18): Object => _root_.java.lang.Object#
       |_root_.scala. => package scala
       |_root_.scala.Int# => abstract final class Int
-      |_root_.scala.Int#`<init>`()V. => primaryctor <init>: ()Int
+      |_root_.scala.Int#`<init>`()V. => primaryctor <init>: ()scala.Int
+      |  [8..11): Int => _root_.scala.Int#
       |_root_.scala.collection. => package collection
-      |_root_.scala.collection.generic.GenericCompanion#empty()Lscala/collection/GenTraversable;. => def empty: [A]=> CC[A]
+      |_root_.scala.collection.generic.GenericCompanion#empty()Lscala/collection/GenTraversable;. => def empty: [A]CC[A]
+      |  [6..7): A => _root_.scala.collection.generic.GenericCompanion#empty()Lscala/collection/GenTraversable;.[A]
+      |  [3..5): CC => _root_.scala.collection.generic.GenericCompanion#[CC]
       |_root_.scala.collection.mutable. => package mutable
       |_root_.scala.collection.mutable.HashSet# => class HashSet
       |_root_.scala.collection.mutable.HashSet#`<init>`(Lscala/collection/mutable/FlatHashTable/Contents;)V. => private primaryctor <init>: (contents: scala.collection.mutable.FlatHashTable.Contents[A])scala.collection.mutable.HashSet[A]
+      |  [36..49): FlatHashTable => _root_.scala.collection.mutable.FlatHashTable.
+      |  [50..58): Contents => _root_.scala.collection.mutable.FlatHashTable.Contents#
+      |  [95..96): A => _root_.scala.collection.mutable.HashSet#[A]
+      |  [87..94): HashSet => _root_.scala.collection.mutable.HashSet#
+      |  [59..60): A => _root_.scala.collection.mutable.HashSet#[A]
       |_root_.scala.collection.mutable.HashSet. => final object HashSet
       |_root_.scala.collection.mutable.HashSet.;_root_.scala.collection.mutable.HashSet# => val <import scala.collection.mutable.HashSet>: scala.collection.mutable.HashSet.type <and> scala.collection.mutable.HashSet
-      |_root_.scala.collection.mutable.HashSet.empty()Lscala/collection/mutable/HashSet;. => def empty: [A]=> scala.collection.mutable.HashSet[A]
+      |_root_.scala.collection.mutable.HashSet.empty()Lscala/collection/mutable/HashSet;. => def empty: [A]scala.collection.mutable.HashSet[A]
+      |  [28..35): HashSet => _root_.scala.collection.mutable.HashSet#
+      |  [36..37): A => _root_.scala.collection.mutable.HashSet.empty()Lscala/collection/mutable/HashSet;.[A]
       |_root_.scala.collection.mutable.ListBuffer# => final class ListBuffer
       |_root_.scala.collection.mutable.ListBuffer#`<init>`()V. => primaryctor <init>: ()scala.collection.mutable.ListBuffer[A]
+      |  [27..37): ListBuffer => _root_.scala.collection.mutable.ListBuffer#
+      |  [38..39): A => _root_.scala.collection.mutable.ListBuffer#[A]
       |_root_.scala.collection.mutable.ListBuffer. => final object ListBuffer
       |_root_.scala.collection.mutable.ListBuffer.;_root_.scala.collection.mutable.ListBuffer# => val <import scala.collection.mutable.ListBuffer>: scala.collection.mutable.ListBuffer.type <and> scala.collection.mutable.ListBuffer
     """.stripMargin.trim
@@ -430,18 +520,25 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
   )
 
   symbols(
-    """
-      |object o {
+    """object o {
       |  List.newBuilder[Int].result
       |  List(1).head
       |}""".stripMargin,
-    """_empty_.o. => final object o
+    """
+      |_empty_.o. => final object o
       |_root_.scala.Int# => abstract final class Int
-      |_root_.scala.Int#`<init>`()V. => primaryctor <init>: ()Int
+      |_root_.scala.Int#`<init>`()V. => primaryctor <init>: ()scala.Int
+      |  [8..11): Int => _root_.scala.Int#
       |_root_.scala.collection.IterableLike#head()Ljava/lang/Object;. => def head: A
+      |  [0..1): A => _root_.scala.collection.IterableLike#[A]
       |_root_.scala.collection.immutable.List. => final object List
-      |_root_.scala.collection.immutable.List.newBuilder()Lscala/collection/mutable/Builder;. => def newBuilder: [A]=> scala.collection.mutable.Builder[A,List[A]]
+      |_root_.scala.collection.immutable.List.newBuilder()Lscala/collection/mutable/Builder;. => def newBuilder: [A]scala.collection.mutable.Builder[A,scala.collection.immutable.List[A]]
+      |  [65..69): List => _root_.scala.collection.immutable.List#
+      |  [28..35): Builder => _root_.scala.collection.mutable.Builder#
+      |  [36..37): A => _root_.scala.collection.immutable.List.newBuilder()Lscala/collection/mutable/Builder;.[A]
+      |  [70..71): A => _root_.scala.collection.immutable.List.newBuilder()Lscala/collection/mutable/Builder;.[A]
       |_root_.scala.collection.mutable.Builder#result()Ljava/lang/Object;. => abstract def result: ()To
+      |  [2..4): To => _root_.scala.collection.mutable.Builder#[To]
     """.stripMargin.trim
   )
 
@@ -467,12 +564,16 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
        |  List(1) + "blaH"
        |}
     """.stripMargin,
-    """|[13..20): scala.Predef.any2stringadd[List[Int]](*)
+    """|
+       |[13..20): scala.Predef.any2stringadd[scala.collection.immutable.List[scala.Int]](*)
        |  [13..26): any2stringadd => _root_.scala.Predef.any2stringadd(Ljava/lang/Object;)Ljava/lang/Object;.
-       |  [38..39): * => _star_.
-       |[17..17): *.apply[Int]
+       |  [65..68): Int => _root_.scala.Int#
+       |  [54..58): List => _root_.scala.collection.immutable.List#
+       |  [71..72): * => _star_.
+       |[17..17): *.apply[scala.Int]
        |  [0..1): * => _star_.
        |  [2..7): apply => _root_.scala.collection.immutable.List.apply(Lscala/collection/Seq;)Lscala/collection/immutable/List;.
+       |  [14..17): Int => _root_.scala.Int#
        |""".stripMargin
   )
 
@@ -485,6 +586,7 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
     """.stripMargin,
     """|[86..91): scala.math.Ordered.orderingToOrdered[r.F](*)(r.this.ordering)
        |  [19..36): orderingToOrdered => _root_.scala.math.Ordered.orderingToOrdered(Ljava/lang/Object;Lscala/math/Ordering;)Lscala/math/Ordered;.
+       |  [39..40): F => _empty_.r.F#
        |  [42..43): * => _star_.
        |  [52..60): ordering => _empty_.r.ordering.
        |""".stripMargin
@@ -524,7 +626,14 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
     "case class u(a: Int); object ya { u.<<unapply>>(u(2)) }", { (db, first) =>
       val denot = db.symbols.find(_.symbol == first).get.denot
       assert(first == Symbol("_empty_.u.unapply(Lu;)Lscala/Option;."))
-      assert(denot.toString == "case def unapply: (x$0: u)Option[Int]")
+      assertNoDiff(
+        denot.toString,
+        """case def unapply: (x$0: u)scala.Option[scala.Int]
+          |  [6..7): u => _empty_.u#
+          |  [27..30): Int => _root_.scala.Int#
+          |  [14..20): Option => _root_.scala.Option#
+        """.stripMargin
+      )
     }
   )
 
@@ -552,12 +661,12 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |}
     """.stripMargin, { (db, a, b, c, d) =>
       def check(symbol: Symbol, info: String) = {
-        assert(db.symbols.find(_.sym == symbol).get.denot.info == info)
+        assertNoDiff(db.symbols.find(_.sym == symbol).get.denot.info, info)
       }
       check(a, "java.lang.StringBuilder")
       check(b, "scala.collection.mutable.StringBuilder")
-      check(c, "scala.collection.Traversable[Int]")
-      check(d, "scala.collection.immutable.Map[Int,Int]")
+      check(c, "scala.package.Traversable[scala.Int]")
+      check(d, "scala.collection.immutable.Map[scala.Int,scala.Int]")
     }
   )
 

--- a/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/SemanticSuite.scala
+++ b/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/SemanticSuite.scala
@@ -151,10 +151,10 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |_root_.f.C1#`<init>`()V. => secondaryctor <init>: ()f.C1
       |  [4..6): C1 => _root_.f.C1#
       |_root_.f.C1#`<init>`(III)V. => primaryctor <init>: (p1: scala.Int,p2: scala.Int,p3: scala.Int)f.C1
-      |  [45..47): C1 => _root_.f.C1#
+      |  [11..14): Int => _root_.scala.Int#
       |  [25..28): Int => _root_.scala.Int#
       |  [39..42): Int => _root_.scala.Int#
-      |  [11..14): Int => _root_.scala.Int#
+      |  [45..47): C1 => _root_.f.C1#
       |_root_.f.C1#f1. => val f1: scala.Nothing
       |  [6..13): Nothing => _root_.scala.Nothing#
       |_root_.f.C1#f1.l1. => val l1: scala.Nothing
@@ -194,9 +194,9 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |_root_.f.M.C2#[T] => covariant typeparam T
       |_root_.f.M.C2#[U] => contravariant typeparam U
       |_root_.f.M.C2#`<init>`()V. => primaryctor <init>: ()f.M.C2[T,U]
-      |  [11..12): U => _root_.f.M.C2#[U]
-      |  [9..10): T => _root_.f.M.C2#[T]
       |  [6..8): C2 => _root_.f.M.C2#
+      |  [9..10): T => _root_.f.M.C2#[T]
+      |  [11..12): U => _root_.f.M.C2#[U]
       |_root_.f.M.i1()Lscala/Nothing;. => implicit def i1: scala.Nothing
       |  [6..13): Nothing => _root_.scala.Nothing#
       |_root_.f.M.l1. => lazy val l1: scala.Nothing
@@ -228,9 +228,9 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |_root_.scala.language. => final object language
       |_root_.scala.language.experimental. => final object experimental
       |_root_.scala.language.experimental.macros. => implicit lazy val macros: scala.languageFeature.experimental.macros
-      |  [35..41): macros => _root_.scala.languageFeature.experimental.macros#
       |  [6..21): languageFeature => _root_.scala.languageFeature.
       |  [22..34): experimental => _root_.scala.languageFeature.experimental.
+      |  [35..41): macros => _root_.scala.languageFeature.experimental.macros#
   """.trim.stripMargin
   )
 
@@ -345,8 +345,8 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
     """.stripMargin,
     """
       |<...>@359..375 => val result: b.X
-      |  [2..3): X => _root_.i.B#X#
       |  [0..1): b => _root_.i.a.foo(Li/B;)Ljava/lang/Object;.(b)
+      |  [2..3): X => _root_.i.B#X#
       |_root_.i. => package i
       |_root_.i.B# => trait B
       |_root_.i.B#X# => abstract type X
@@ -363,23 +363,23 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |  [39..42): Int => _root_.scala.Int#
       |_root_.i.E# => class E
       |_root_.i.E#X# => type X: scala.collection.mutable.ListBuffer[scala.Int]
-      |  [42..45): Int => _root_.scala.Int#
       |  [25..35): ListBuffer => _root_.scala.collection.mutable.ListBuffer#
+      |  [42..45): Int => _root_.scala.Int#
       |_root_.i.E#`<init>`()V. => primaryctor <init>: ()i.E
       |  [4..5): E => _root_.i.E#
       |_root_.i.E#x()Lscala/collection/mutable/ListBuffer;. => def x: scala.collection.mutable.ListBuffer[scala.Int]
-      |  [42..45): Int => _root_.scala.Int#
       |  [25..35): ListBuffer => _root_.scala.collection.mutable.ListBuffer#
+      |  [42..45): Int => _root_.scala.Int#
       |_root_.i.a. => final object a
       |_root_.i.a.foo(Li/B;)Ljava/lang/Object;. => def foo: (implicit b: i.B)b.X
-      |  [17..18): b => _root_.i.a.foo(Li/B;)Ljava/lang/Object;.(b)
       |  [15..16): B => _root_.i.B#
+      |  [17..18): b => _root_.i.a.foo(Li/B;)Ljava/lang/Object;.(b)
       |  [19..20): X => _root_.i.B#X#
       |_root_.i.a.foo(Li/B;)Ljava/lang/Object;.(b) => implicit param b: i.B
       |  [2..3): B => _root_.i.B#
       |_root_.i.a.x. => val x: scala.collection.mutable.ListBuffer[scala.Int]
-      |  [42..45): Int => _root_.scala.Int#
       |  [25..35): ListBuffer => _root_.scala.collection.mutable.ListBuffer#
+      |  [42..45): Int => _root_.scala.Int#
       |_root_.i.a.y. => val y: scala.collection.mutable.HashSet[scala.Int]
       |  [25..32): HashSet => _root_.scala.collection.mutable.HashSet#
       |  [39..42): Int => _root_.scala.Int#
@@ -391,16 +391,16 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |  [8..11): Int => _root_.scala.Int#
       |_root_.scala.collection. => package collection
       |_root_.scala.collection.generic.GenericCompanion#empty()Lscala/collection/GenTraversable;. => def empty: [A]CC[A]
-      |  [6..7): A => _root_.scala.collection.generic.GenericCompanion#empty()Lscala/collection/GenTraversable;.[A]
       |  [3..5): CC => _root_.scala.collection.generic.GenericCompanion#[CC]
+      |  [6..7): A => _root_.scala.collection.generic.GenericCompanion#empty()Lscala/collection/GenTraversable;.[A]
       |_root_.scala.collection.mutable. => package mutable
       |_root_.scala.collection.mutable.HashSet# => class HashSet
       |_root_.scala.collection.mutable.HashSet#`<init>`(Lscala/collection/mutable/FlatHashTable/Contents;)V. => private primaryctor <init>: (contents: scala.collection.mutable.FlatHashTable.Contents[A])scala.collection.mutable.HashSet[A]
       |  [36..49): FlatHashTable => _root_.scala.collection.mutable.FlatHashTable.
       |  [50..58): Contents => _root_.scala.collection.mutable.FlatHashTable.Contents#
-      |  [95..96): A => _root_.scala.collection.mutable.HashSet#[A]
-      |  [87..94): HashSet => _root_.scala.collection.mutable.HashSet#
       |  [59..60): A => _root_.scala.collection.mutable.HashSet#[A]
+      |  [87..94): HashSet => _root_.scala.collection.mutable.HashSet#
+      |  [95..96): A => _root_.scala.collection.mutable.HashSet#[A]
       |_root_.scala.collection.mutable.HashSet. => final object HashSet
       |_root_.scala.collection.mutable.HashSet.;_root_.scala.collection.mutable.HashSet# => val <import scala.collection.mutable.HashSet>: scala.collection.mutable.HashSet.type <and> scala.collection.mutable.HashSet
       |_root_.scala.collection.mutable.HashSet.empty()Lscala/collection/mutable/HashSet;. => def empty: [A]scala.collection.mutable.HashSet[A]
@@ -533,9 +533,9 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |  [0..1): A => _root_.scala.collection.IterableLike#[A]
       |_root_.scala.collection.immutable.List. => final object List
       |_root_.scala.collection.immutable.List.newBuilder()Lscala/collection/mutable/Builder;. => def newBuilder: [A]scala.collection.mutable.Builder[A,scala.collection.immutable.List[A]]
-      |  [65..69): List => _root_.scala.collection.immutable.List#
       |  [28..35): Builder => _root_.scala.collection.mutable.Builder#
       |  [36..37): A => _root_.scala.collection.immutable.List.newBuilder()Lscala/collection/mutable/Builder;.[A]
+      |  [65..69): List => _root_.scala.collection.immutable.List#
       |  [70..71): A => _root_.scala.collection.immutable.List.newBuilder()Lscala/collection/mutable/Builder;.[A]
       |_root_.scala.collection.mutable.Builder#result()Ljava/lang/Object;. => abstract def result: ()To
       |  [2..4): To => _root_.scala.collection.mutable.Builder#[To]
@@ -630,8 +630,8 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
         denot.toString,
         """case def unapply: (x$0: u)scala.Option[scala.Int]
           |  [6..7): u => _empty_.u#
-          |  [27..30): Int => _root_.scala.Int#
           |  [14..20): Option => _root_.scala.Option#
+          |  [27..30): Int => _root_.scala.Int#
         """.stripMargin
       )
     }

--- a/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/SemanticSuite.scala
+++ b/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/SemanticSuite.scala
@@ -138,28 +138,28 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |_root_.F.package. => packageobject package
       |_root_.f. => package f
       |_root_.f.C1# => class C1
-      |_root_.f.C1#(p1) => param p1: Int
-      |_root_.f.C1#(p2) => val param p2: Int
+      |_root_.f.C1#(p1) => param p1: scala.Int
+      |_root_.f.C1#(p2) => val param p2: scala.Int
       |_root_.f.C1#(p3) => var param p3_=: (x$1: Int)Unit
       |_root_.f.C1#T1# => abstract type T1:  <: Int
-      |_root_.f.C1#T2# => type T2: Int
+      |_root_.f.C1#T2# => type T2: scala.Int
       |_root_.f.C1#`<init>`()V. => secondaryctor <init>: ()f.C1
       |_root_.f.C1#`<init>`(III)V. => primaryctor <init>: (p1: Int, p2: Int, p3: Int)f.C1
-      |_root_.f.C1#f1. => val f1: Nothing
-      |_root_.f.C1#f1.l1. => val l1: Nothing
-      |_root_.f.C1#f1.l2. => var l2: Nothing
+      |_root_.f.C1#f1. => val f1: scala.Nothing
+      |_root_.f.C1#f1.l1. => val l1: scala.Nothing
+      |_root_.f.C1#f1.l2. => var l2: scala.Nothing
       |_root_.f.C1#f2. => var f2_=: (x$1: Nothing)Unit
       |_root_.f.C1#m1(I)I. => def m1: [T](x: Int)Int
-      |_root_.f.C1#m1(I)I.(x) => param x: Int
+      |_root_.f.C1#m1(I)I.(x) => param x: scala.Int
       |_root_.f.C1#m1(I)I.T# => typeparam T
-      |_root_.f.C1#m2()Lscala/Nothing;. => macro m2: Nothing
+      |_root_.f.C1#m2()Lscala/Nothing;. => macro m2: scala.Nothing
       |_root_.f.C2# => abstract class C2
       |_root_.f.C2#`<init>`()V. => primaryctor <init>: ()f.C2
-      |_root_.f.C2#m3()I. => abstract def m3: Int
-      |_root_.f.C2#m4()Lscala/Nothing;. => final def m4: Nothing
+      |_root_.f.C2#m3()I. => abstract def m3: scala.Int
+      |_root_.f.C2#m4()Lscala/Nothing;. => final def m4: scala.Nothing
       |_root_.f.C3# => sealed class C3
       |_root_.f.C3#`<init>`()V. => primaryctor <init>: ()f.C3
-      |_root_.f.C3#m3()I. => def m3: Int
+      |_root_.f.C3#m3()I. => def m3: scala.Int
       |_root_.f.C3#toString()Ljava/lang/String;. => def toString: ()String
       |_root_.f.M. => final object M
       |_root_.f.M.C1# => case class C1
@@ -168,20 +168,20 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |_root_.f.M.C2#[T] => covariant typeparam T
       |_root_.f.M.C2#[U] => contravariant typeparam U
       |_root_.f.M.C2#`<init>`()V. => primaryctor <init>: ()f.M.C2[T,U]
-      |_root_.f.M.i1()Lscala/Nothing;. => implicit def i1: Nothing
-      |_root_.f.M.l1. => lazy val l1: Nothing
+      |_root_.f.M.i1()Lscala/Nothing;. => implicit def i1: scala.Nothing
+      |_root_.f.M.l1. => lazy val l1: scala.Nothing
       |_root_.f.T# => trait T
       |_root_.f.T#$init$()V. => primaryctor $init$: ()Unit
-      |_root_.f.T#f1. => private val f1: Nothing
-      |_root_.f.T#f2. => private val f2: Nothing
-      |_root_.f.T#f3. => private val f3: Nothing
+      |_root_.f.T#f1. => private val f1: scala.Nothing
+      |_root_.f.T#f2. => private val f2: scala.Nothing
+      |_root_.f.T#f3. => private val f3: scala.Nothing
       |_root_.f.T#f4. => protected var f4_=: (x$1: Nothing)Unit
       |_root_.f.T#f5. => protected var f5_=: (x$1: Nothing)Unit
       |_root_.f.T#f6. => protected var f6_=: (x$1: Nothing)Unit
       |_root_.scala. => package scala
       |_root_.scala.Int# => abstract final class Int
       |_root_.scala.Int#`<init>`()V. => primaryctor <init>: ()Int
-      |_root_.scala.Predef.`???`()Lscala/Nothing;. => def ???: Nothing
+      |_root_.scala.Predef.`???`()Lscala/Nothing;. => def ???: scala.Nothing
       |_root_.scala.language. => final object language
       |_root_.scala.language.experimental. => final object experimental
       |_root_.scala.language.experimental.macros. => implicit lazy val macros: languageFeature.experimental.macros
@@ -539,6 +539,25 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       val denot2 = db.symbols.find(_.symbol == listToString).get.denot
       assert(denot1.isJavaDefined)
       assert(!denot2.isJavaDefined)
+    }
+  )
+
+  targeted(
+    """
+      |object a {
+      |  val <<a>> = new java.lang.StringBuilder
+      |  val <<b>> = new StringBuilder
+      |  val <<c>>: Traversable[Int] = List(1)
+      |  val <<d>> = Map(1 -> 2)
+      |}
+    """.stripMargin, { (db, a, b, c, d) =>
+      def check(symbol: Symbol, info: String) = {
+        assert(db.symbols.find(_.sym == symbol).get.denot.info == info)
+      }
+      check(a, "java.lang.StringBuilder")
+      check(b, "scala.collection.mutable.StringBuilder")
+      check(c, "scala.collection.Traversable[Int]")
+      check(d, "scala.collection.immutable.Map[Int,Int]")
     }
   )
 

--- a/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/SemanticSuite.scala
+++ b/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/SemanticSuite.scala
@@ -661,7 +661,7 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |}
     """.stripMargin, { (db, a, b, c, d) =>
       def check(symbol: Symbol, info: String) = {
-        assertNoDiff(db.symbols.find(_.sym == symbol).get.denot.info, info)
+        assertNoDiff(db.symbols.find(_.symbol == symbol).get.denot.info, info)
       }
       check(a, "java.lang.StringBuilder")
       check(b, "scala.collection.mutable.StringBuilder")

--- a/scalameta/tests/jvm/src/test/resources/semanticdb.expect
+++ b/scalameta/tests/jvm/src/test/resources/semanticdb.expect
@@ -29,6 +29,7 @@ Messages:
 Symbols:
 _root_.example. => package example
 _root_.example.Example. => final object Example
+<<<<<<< 9dd45b2c41b09f1d3d5fa79bb7aa959242bf107b
 _root_.example.Example.main([Ljava/lang/String;)V. => def main: (args: Array[String])Unit
 _root_.example.Example.main([Ljava/lang/String;)V.(args) => param args: Array[String]
 _root_.scala. => package scala
@@ -47,6 +48,32 @@ _root_.scala.collection.mutable.Stack#`<init>`()V. => secondaryctor <init>: ()sc
 _root_.scala.collection.mutable.Stack#`<init>`(Lscala/collection/immutable/List;)V. => private primaryctor <init>: (elems: List[A])scala.collection.mutable.Stack[A]
 _root_.scala.concurrent. => package concurrent
 _root_.scala.concurrent.Future.;_root_.scala.concurrent.Future# => val <import scala.concurrent.Future>: scala.concurrent.Future.type <and> scala.concurrent.Future
+=======
+_root_.example.Example.main([Ljava/lang/String;)V. => def main: (args: scala.Array[scala.Predef.String])scala.Unit
+  [46..50): Unit => _root_.scala.Unit#
+  [13..18): Array => _root_.scala.Array#
+  [19..24): scala => _root_.scala.
+  [25..31): Predef => _root_.scala.Predef.
+  [32..38): String => _root_.scala.Predef.String#
+_root_.example.Example.main([Ljava/lang/String;)V.(args) => param args: scala.Array[scala.Predef.String]
+  [18..24): Predef => _root_.scala.Predef.
+  [25..31): String => _root_.scala.Predef.String#
+  [6..11): Array => _root_.scala.Array#
+  [12..17): scala => _root_.scala.
+_root_.scala.Array# => final class Array
+_root_.scala.Array#`<init>`(I)V. => primaryctor <init>: (_length: scala.Int)scala.Array[T]
+  [26..31): Array => _root_.scala.Array#
+  [32..33): T => _root_.scala.Array#[T]
+  [16..19): Int => _root_.scala.Int#
+_root_.scala.Predef.String# => type String: java.lang.String
+  [10..16): String => _root_.java.lang.String#
+_root_.scala.Predef.println(Ljava/lang/Object;)V. => def println: (x: scala.Any)scala.Unit
+  [20..24): Unit => _root_.scala.Unit#
+  [10..13): Any => _root_.scala.Any#
+_root_.scala.Unit# => abstract final class Unit
+_root_.scala.Unit#`<init>`()V. => primaryctor <init>: ()scala.Unit
+  [8..12): Unit => _root_.scala.Unit#
+>>>>>>> Add semantic information for denotation types.
 
 
 scalameta/semanticdb-integration/src/main/scala/example/Sugar.scala
@@ -71,30 +98,67 @@ Symbols:
 _root_.example. => package example
 _root_.example.Sugar# => class Sugar
 _root_.example.Sugar#`<init>`()V. => primaryctor <init>: ()example.Sugar
+  [10..15): Sugar => _root_.example.Sugar#
 _root_.scala.Array. => final object Array
-_root_.scala.Array.empty(Lscala/reflect/ClassTag;)Ljava/lang/Object;. => def empty: [T](implicit evidence$1: scala.reflect.ClassTag[T])Array[T]
+_root_.scala.Array.empty(Lscala/reflect/ClassTag;)Ljava/lang/Object;. => def empty: [T](implicit evidence$1: scala.reflect.ClassTag[T])scala.Array[T]
+  [63..64): T => _root_.scala.Array.empty(Lscala/reflect/ClassTag;)Ljava/lang/Object;.[T]
+  [39..47): ClassTag => _root_.scala.reflect.ClassTag#
+  [48..49): T => _root_.scala.Array.empty(Lscala/reflect/ClassTag;)Ljava/lang/Object;.[T]
+  [57..62): Array => _root_.scala.Array#
 _root_.scala.Int# => abstract final class Int
+<<<<<<< 9dd45b2c41b09f1d3d5fa79bb7aa959242bf107b
 _root_.scala.Int#`+`(I)I. => abstract def +: (x: Int)Int
 _root_.scala.Int#`<init>`()V. => primaryctor <init>: ()Int
 _root_.scala.collection.TraversableLike#headOption()Lscala/Option;. => def headOption: Option[A]
 _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;. => final def map: [B, That](f: A => B)(implicit bf: scala.collection.generic.CanBuildFrom[List[A],B,That])That
+=======
+_root_.scala.Int#`+`(I)I. => abstract def +: (x: scala.Int)scala.Int
+  [20..23): Int => _root_.scala.Int#
+  [10..13): Int => _root_.scala.Int#
+_root_.scala.Int#`<init>`()V. => primaryctor <init>: ()scala.Int
+  [8..11): Int => _root_.scala.Int#
+_root_.scala.collection.TraversableLike#headOption()Lscala/Option;. => def headOption: scala.Option[A]
+  [6..12): Option => _root_.scala.Option#
+  [13..14): A => _root_.scala.collection.TraversableLike#[A]
+_root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;. => final def map: [B,That](f: scala.Function1[A,B])(implicit bf: scala.collection.generic.CanBuildFrom[scala.collection.immutable.List[A],B,That])That
+  [112..116): List => _root_.scala.collection.immutable.List#
+  [128..132): That => _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.[That]
+  [117..118): A => _root_.scala.collection.immutable.List#[A]
+  [122..126): That => _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.[That]
+  [72..84): CanBuildFrom => _root_.scala.collection.generic.CanBuildFrom#
+  [120..121): B => _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.[B]
+  [18..27): Function1 => _root_.scala.Function1#
+  [28..29): A => _root_.scala.collection.immutable.List#[A]
+  [30..31): B => _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.[B]
+>>>>>>> Add semantic information for denotation types.
 _root_.scala.collection.immutable.List. => final object List
-_root_.scala.collection.immutable.StringLike#stripPrefix(Ljava/lang/String;)Ljava/lang/String;. => def stripPrefix: (prefix: String)String
+_root_.scala.collection.immutable.StringLike#stripPrefix(Ljava/lang/String;)Ljava/lang/String;. => def stripPrefix: (prefix: scala.Predef.String)java.lang.String
+  [39..45): String => _root_.java.lang.String#
+  [9..14): scala => _root_.scala.
+  [22..28): String => _root_.scala.Predef.String#
+  [15..21): Predef => _root_.scala.Predef.
 
 Sugars:
-[37..37): *.apply[Int]
+[37..37): *.apply[scala.Int]
   [0..1): * => _star_.
   [2..7): apply => _root_.scala.collection.immutable.List.apply(Lscala/collection/Seq;)Lscala/collection/immutable/List;.
-[44..44): *[Int, List[Int]]
+  [14..17): Int => _root_.scala.Int#
+[44..44): *[scala.Int, scala.collection.immutable.List[scala.Int]]
   [0..1): * => _star_.
-[51..51): *(scala.collection.immutable.List.canBuildFrom[Int])
+  [8..11): Int => _root_.scala.Int#
+  [40..44): List => _root_.scala.collection.immutable.List#
+  [51..54): Int => _root_.scala.Int#
+[51..51): *(scala.collection.immutable.List.canBuildFrom[scala.Int])
   [0..1): * => _star_.
   [34..46): canBuildFrom => _root_.scala.collection.immutable.List.canBuildFrom()Lscala/collection/generic/CanBuildFrom;.
+  [53..56): Int => _root_.scala.Int#
 [54..70): scala.Predef.intArrayOps(*)
   [13..24): intArrayOps => _root_.scala.Predef.intArrayOps([I)[I.
   [25..26): * => _star_.
-[70..70): *(((ClassTag.Int): scala.reflect.ClassTag[Int]))
+[70..70): *(((ClassTag.Int): scala.reflect.ClassTag[scala.Int]))
   [0..1): * => _star_.
+  [48..51): Int => _root_.scala.Int#
+  [33..41): ClassTag => _root_.scala.reflect.ClassTag#
   [13..16): Int => _root_.scala.reflect.ClassTag.Int.
 [84..90): scala.Predef.augmentString(*)
   [13..26): augmentString => _root_.scala.Predef.augmentString(Ljava/lang/String;)Ljava/lang/String;.

--- a/scalameta/tests/jvm/src/test/resources/semanticdb.expect
+++ b/scalameta/tests/jvm/src/test/resources/semanticdb.expect
@@ -29,26 +29,6 @@ Messages:
 Symbols:
 _root_.example. => package example
 _root_.example.Example. => final object Example
-<<<<<<< 9dd45b2c41b09f1d3d5fa79bb7aa959242bf107b
-_root_.example.Example.main([Ljava/lang/String;)V. => def main: (args: Array[String])Unit
-_root_.example.Example.main([Ljava/lang/String;)V.(args) => param args: Array[String]
-_root_.scala. => package scala
-_root_.scala.Array# => final class Array
-_root_.scala.Array#`<init>`(I)V. => primaryctor <init>: (_length: Int)Array[T]
-_root_.scala.Int# => abstract final class Int
-_root_.scala.Int#`<init>`()V. => primaryctor <init>: ()Int
-_root_.scala.Predef.String# => type String: String
-_root_.scala.Predef.println(Ljava/lang/Object;)V. => def println: (x: Any)Unit
-_root_.scala.Unit# => abstract final class Unit
-_root_.scala.Unit#`<init>`()V. => primaryctor <init>: ()Unit
-_root_.scala.collection. => package collection
-_root_.scala.collection.mutable. => package mutable
-_root_.scala.collection.mutable.Stack# => class Stack
-_root_.scala.collection.mutable.Stack#`<init>`()V. => secondaryctor <init>: ()scala.collection.mutable.Stack[A]
-_root_.scala.collection.mutable.Stack#`<init>`(Lscala/collection/immutable/List;)V. => private primaryctor <init>: (elems: List[A])scala.collection.mutable.Stack[A]
-_root_.scala.concurrent. => package concurrent
-_root_.scala.concurrent.Future.;_root_.scala.concurrent.Future# => val <import scala.concurrent.Future>: scala.concurrent.Future.type <and> scala.concurrent.Future
-=======
 _root_.example.Example.main([Ljava/lang/String;)V. => def main: (args: scala.Array[scala.Predef.String])scala.Unit
   [13..18): Array => _root_.scala.Array#
   [19..24): scala => _root_.scala.
@@ -60,11 +40,15 @@ _root_.example.Example.main([Ljava/lang/String;)V.(args) => param args: scala.Ar
   [12..17): scala => _root_.scala.
   [18..24): Predef => _root_.scala.Predef.
   [25..31): String => _root_.scala.Predef.String#
+_root_.scala. => package scala
 _root_.scala.Array# => final class Array
 _root_.scala.Array#`<init>`(I)V. => primaryctor <init>: (_length: scala.Int)scala.Array[T]
   [16..19): Int => _root_.scala.Int#
   [26..31): Array => _root_.scala.Array#
   [32..33): T => _root_.scala.Array#[T]
+_root_.scala.Int# => abstract final class Int
+_root_.scala.Int#`<init>`()V. => primaryctor <init>: ()scala.Int
+  [8..11): Int => _root_.scala.Int#
 _root_.scala.Predef.String# => type String: java.lang.String
   [10..16): String => _root_.java.lang.String#
 _root_.scala.Predef.println(Ljava/lang/Object;)V. => def println: (x: scala.Any)scala.Unit
@@ -73,7 +57,19 @@ _root_.scala.Predef.println(Ljava/lang/Object;)V. => def println: (x: scala.Any)
 _root_.scala.Unit# => abstract final class Unit
 _root_.scala.Unit#`<init>`()V. => primaryctor <init>: ()scala.Unit
   [8..12): Unit => _root_.scala.Unit#
->>>>>>> Add semantic information for denotation types.
+_root_.scala.collection. => package collection
+_root_.scala.collection.mutable. => package mutable
+_root_.scala.collection.mutable.Stack# => class Stack
+_root_.scala.collection.mutable.Stack#`<init>`()V. => secondaryctor <init>: ()scala.collection.mutable.Stack[A]
+  [27..32): Stack => _root_.scala.collection.mutable.Stack#
+  [33..34): A => _root_.scala.collection.mutable.Stack#[A]
+_root_.scala.collection.mutable.Stack#`<init>`(Lscala/collection/immutable/List;)V. => private primaryctor <init>: (elems: scala.collection.immutable.List[A])scala.collection.mutable.Stack[A]
+  [35..39): List => _root_.scala.collection.immutable.List#
+  [40..41): A => _root_.scala.collection.mutable.Stack#[A]
+  [68..73): Stack => _root_.scala.collection.mutable.Stack#
+  [74..75): A => _root_.scala.collection.mutable.Stack#[A]
+_root_.scala.concurrent. => package concurrent
+_root_.scala.concurrent.Future.;_root_.scala.concurrent.Future# => val <import scala.concurrent.Future>: scala.concurrent.Future.type <and> scala.concurrent.Future
 
 
 scalameta/semanticdb-integration/src/main/scala/example/Sugar.scala
@@ -106,12 +102,6 @@ _root_.scala.Array.empty(Lscala/reflect/ClassTag;)Ljava/lang/Object;. => def emp
   [57..62): Array => _root_.scala.Array#
   [63..64): T => _root_.scala.Array.empty(Lscala/reflect/ClassTag;)Ljava/lang/Object;.[T]
 _root_.scala.Int# => abstract final class Int
-<<<<<<< 9dd45b2c41b09f1d3d5fa79bb7aa959242bf107b
-_root_.scala.Int#`+`(I)I. => abstract def +: (x: Int)Int
-_root_.scala.Int#`<init>`()V. => primaryctor <init>: ()Int
-_root_.scala.collection.TraversableLike#headOption()Lscala/Option;. => def headOption: Option[A]
-_root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;. => final def map: [B, That](f: A => B)(implicit bf: scala.collection.generic.CanBuildFrom[List[A],B,That])That
-=======
 _root_.scala.Int#`+`(I)I. => abstract def +: (x: scala.Int)scala.Int
   [10..13): Int => _root_.scala.Int#
   [20..23): Int => _root_.scala.Int#
@@ -124,16 +114,12 @@ _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/ge
   [18..27): Function1 => _root_.scala.Function1#
   [28..29): A => _root_.scala.collection.immutable.List#[A]
   [30..31): B => _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.[B]
-<<<<<<< 983f05bfa27149eac8e97060ba8678bc6f727a9c
->>>>>>> Add semantic information for denotation types.
-=======
   [72..84): CanBuildFrom => _root_.scala.collection.generic.CanBuildFrom#
   [112..116): List => _root_.scala.collection.immutable.List#
   [117..118): A => _root_.scala.collection.immutable.List#[A]
   [120..121): B => _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.[B]
   [122..126): That => _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.[That]
   [128..132): That => _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.[That]
->>>>>>> Fix issues caught after running CI.
 _root_.scala.collection.immutable.List. => final object List
 _root_.scala.collection.immutable.StringLike#stripPrefix(Ljava/lang/String;)Ljava/lang/String;. => def stripPrefix: (prefix: scala.Predef.String)java.lang.String
   [9..14): scala => _root_.scala.

--- a/scalameta/tests/jvm/src/test/resources/semanticdb.expect
+++ b/scalameta/tests/jvm/src/test/resources/semanticdb.expect
@@ -50,26 +50,26 @@ _root_.scala.concurrent. => package concurrent
 _root_.scala.concurrent.Future.;_root_.scala.concurrent.Future# => val <import scala.concurrent.Future>: scala.concurrent.Future.type <and> scala.concurrent.Future
 =======
 _root_.example.Example.main([Ljava/lang/String;)V. => def main: (args: scala.Array[scala.Predef.String])scala.Unit
-  [46..50): Unit => _root_.scala.Unit#
   [13..18): Array => _root_.scala.Array#
   [19..24): scala => _root_.scala.
   [25..31): Predef => _root_.scala.Predef.
   [32..38): String => _root_.scala.Predef.String#
+  [46..50): Unit => _root_.scala.Unit#
 _root_.example.Example.main([Ljava/lang/String;)V.(args) => param args: scala.Array[scala.Predef.String]
-  [18..24): Predef => _root_.scala.Predef.
-  [25..31): String => _root_.scala.Predef.String#
   [6..11): Array => _root_.scala.Array#
   [12..17): scala => _root_.scala.
+  [18..24): Predef => _root_.scala.Predef.
+  [25..31): String => _root_.scala.Predef.String#
 _root_.scala.Array# => final class Array
 _root_.scala.Array#`<init>`(I)V. => primaryctor <init>: (_length: scala.Int)scala.Array[T]
+  [16..19): Int => _root_.scala.Int#
   [26..31): Array => _root_.scala.Array#
   [32..33): T => _root_.scala.Array#[T]
-  [16..19): Int => _root_.scala.Int#
 _root_.scala.Predef.String# => type String: java.lang.String
   [10..16): String => _root_.java.lang.String#
 _root_.scala.Predef.println(Ljava/lang/Object;)V. => def println: (x: scala.Any)scala.Unit
-  [20..24): Unit => _root_.scala.Unit#
   [10..13): Any => _root_.scala.Any#
+  [20..24): Unit => _root_.scala.Unit#
 _root_.scala.Unit# => abstract final class Unit
 _root_.scala.Unit#`<init>`()V. => primaryctor <init>: ()scala.Unit
   [8..12): Unit => _root_.scala.Unit#
@@ -101,10 +101,10 @@ _root_.example.Sugar#`<init>`()V. => primaryctor <init>: ()example.Sugar
   [10..15): Sugar => _root_.example.Sugar#
 _root_.scala.Array. => final object Array
 _root_.scala.Array.empty(Lscala/reflect/ClassTag;)Ljava/lang/Object;. => def empty: [T](implicit evidence$1: scala.reflect.ClassTag[T])scala.Array[T]
-  [63..64): T => _root_.scala.Array.empty(Lscala/reflect/ClassTag;)Ljava/lang/Object;.[T]
   [39..47): ClassTag => _root_.scala.reflect.ClassTag#
   [48..49): T => _root_.scala.Array.empty(Lscala/reflect/ClassTag;)Ljava/lang/Object;.[T]
   [57..62): Array => _root_.scala.Array#
+  [63..64): T => _root_.scala.Array.empty(Lscala/reflect/ClassTag;)Ljava/lang/Object;.[T]
 _root_.scala.Int# => abstract final class Int
 <<<<<<< 9dd45b2c41b09f1d3d5fa79bb7aa959242bf107b
 _root_.scala.Int#`+`(I)I. => abstract def +: (x: Int)Int
@@ -113,30 +113,33 @@ _root_.scala.collection.TraversableLike#headOption()Lscala/Option;. => def headO
 _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;. => final def map: [B, That](f: A => B)(implicit bf: scala.collection.generic.CanBuildFrom[List[A],B,That])That
 =======
 _root_.scala.Int#`+`(I)I. => abstract def +: (x: scala.Int)scala.Int
-  [20..23): Int => _root_.scala.Int#
   [10..13): Int => _root_.scala.Int#
+  [20..23): Int => _root_.scala.Int#
 _root_.scala.Int#`<init>`()V. => primaryctor <init>: ()scala.Int
   [8..11): Int => _root_.scala.Int#
 _root_.scala.collection.TraversableLike#headOption()Lscala/Option;. => def headOption: scala.Option[A]
   [6..12): Option => _root_.scala.Option#
   [13..14): A => _root_.scala.collection.TraversableLike#[A]
 _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;. => final def map: [B,That](f: scala.Function1[A,B])(implicit bf: scala.collection.generic.CanBuildFrom[scala.collection.immutable.List[A],B,That])That
-  [112..116): List => _root_.scala.collection.immutable.List#
-  [128..132): That => _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.[That]
-  [117..118): A => _root_.scala.collection.immutable.List#[A]
-  [122..126): That => _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.[That]
-  [72..84): CanBuildFrom => _root_.scala.collection.generic.CanBuildFrom#
-  [120..121): B => _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.[B]
   [18..27): Function1 => _root_.scala.Function1#
   [28..29): A => _root_.scala.collection.immutable.List#[A]
   [30..31): B => _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.[B]
+<<<<<<< 983f05bfa27149eac8e97060ba8678bc6f727a9c
 >>>>>>> Add semantic information for denotation types.
+=======
+  [72..84): CanBuildFrom => _root_.scala.collection.generic.CanBuildFrom#
+  [112..116): List => _root_.scala.collection.immutable.List#
+  [117..118): A => _root_.scala.collection.immutable.List#[A]
+  [120..121): B => _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.[B]
+  [122..126): That => _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.[That]
+  [128..132): That => _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.[That]
+>>>>>>> Fix issues caught after running CI.
 _root_.scala.collection.immutable.List. => final object List
 _root_.scala.collection.immutable.StringLike#stripPrefix(Ljava/lang/String;)Ljava/lang/String;. => def stripPrefix: (prefix: scala.Predef.String)java.lang.String
-  [39..45): String => _root_.java.lang.String#
   [9..14): scala => _root_.scala.
-  [22..28): String => _root_.scala.Predef.String#
   [15..21): Predef => _root_.scala.Predef.
+  [22..28): String => _root_.scala.Predef.String#
+  [39..45): String => _root_.java.lang.String#
 
 Sugars:
 [37..37): *.apply[scala.Int]

--- a/scalameta/tests/shared/src/test/scala/scala/meta/tests/SugarSuite.scala
+++ b/scalameta/tests/shared/src/test/scala/scala/meta/tests/SugarSuite.scala
@@ -2,9 +2,30 @@ package scala.meta
 package tests
 
 class SugarSuite extends BaseSemanticSuite {
+  implicit val database = Database.load(classpath, sourcepath)
+
+  test("Database.symbols") {
+    val entry = database.entries.find(_.input.syntax.contains("Example")).get
+    val source = entry.input.parse[Source].get
+    val sugarAsserts = source.collect {
+      case t: Defn.Def if t.name.value == "main" =>
+        val symbol = entry.names.find(_.pos == t.name.pos).get.sym
+        val expectedInput =
+          Input.Denotation("(args: scala.Array[scala.Predef.String])scala.Unit", symbol.syntax)
+        val infoSymbols = entry.symbols.find(_.sym == symbol).get.denot.resolvedNames
+        assert(infoSymbols.nonEmpty)
+        infoSymbols.foreach {
+          case ResolvedName(Position.Range(input, _, _), _, false) =>
+            assert(input == expectedInput)
+          case els =>
+            sys.error(s"Unexpected $els")
+        }
+    }
+    assert(sugarAsserts.nonEmpty)
+
+  }
 
   test("Database.sugars") {
-    implicit val database = Database.load(classpath, sourcepath)
     val entry = database.entries.find(_.input.syntax.contains("Sugar")).get
     val source = entry.input.parse[Source].get
     val sugarAsserts = source.collect {

--- a/scalameta/tests/shared/src/test/scala/scala/meta/tests/SugarSuite.scala
+++ b/scalameta/tests/shared/src/test/scala/scala/meta/tests/SugarSuite.scala
@@ -9,10 +9,10 @@ class SugarSuite extends BaseSemanticSuite {
     val source = entry.input.parse[Source].get
     val sugarAsserts = source.collect {
       case t: Defn.Def if t.name.value == "main" =>
-        val symbol = entry.names.find(_.pos == t.name.pos).get.sym
+        val symbol = entry.names.find(_.pos == t.name.pos).get.symbol
         val expectedInput =
           Input.Denotation("(args: scala.Array[scala.Predef.String])scala.Unit", symbol.syntax)
-        val infoSymbols = entry.symbols.find(_.sym == symbol).get.denot.resolvedNames
+        val infoSymbols = entry.symbols.find(_.symbol == symbol).get.denot.resolvedNames
         assert(infoSymbols.nonEmpty)
         infoSymbols.foreach {
           case ResolvedName(Position.Range(input, _, _), _, false) =>


### PR DESCRIPTION
Fixes #1015. Note, this PR does not add Type.Method since it's not necessary for me at the moment in scalafix. Type.Method can be added separately to make Denotation.info parseable.