### PR TITLE
remove UTF-8 only overload of slurp

### DIFF
--- a/langmeta/io/shared/src/main/scala/star/meta/internal/io/FileIO.scala
+++ b/langmeta/io/shared/src/main/scala/star/meta/internal/io/FileIO.scala
@@ -15,9 +15,6 @@ object FileIO {
   def slurp(path: AbsolutePath, charset: Charset): String =
     PlatformFileIO.slurp(path, charset)
 
-  def slurp(path: AbsolutePath): String =
-    slurp(path, Charset.forName("UTF-8"))
-
   def listFiles(path: AbsolutePath): ListFiles =
     PlatformFileIO.listFiles(path)
 


### PR DESCRIPTION
Assuming UTF-8 is a dangerous game that often depends on local setup.
The convenience it brings rarely outweighs the bugs that go along with
it
