### PR TITLE
remove UTF-8 only overload of slurp

### DIFF
--- a/langmeta/io/shared/src/main/scala/star/meta/internal/io/FileIO.scala
+++ b/langmeta/io/shared/src/main/scala/star/meta/internal/io/FileIO.scala
@@ -15,9 +15,6 @@ object FileIO {
   def slurp(path: AbsolutePath, charset: Charset): String =
     PlatformFileIO.slurp(path, charset)
 
-  def slurp(path: AbsolutePath): String =
-    slurp(path, Charset.forName("UTF-8"))
-
   def listFiles(path: AbsolutePath): ListFiles =
     PlatformFileIO.listFiles(path)
 

--- a/scalameta/tests/jvm/src/test/scala/scala/meta/tests/SemanticdbExpectSuite.scala
+++ b/scalameta/tests/jvm/src/test/scala/scala/meta/tests/SemanticdbExpectSuite.scala
@@ -4,6 +4,7 @@ package tests
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.nio.charset.Charset
 import scala.meta.testkit.DiffAssertions
 import lang.meta.internal.io.FileIO
 import org.scalatest.FunSuite
@@ -17,7 +18,7 @@ class SemanticdbExpectSuite extends FunSuite with DiffAssertions {
       // later down the road if that turns out to be useful.
       case "2" :: "12" :: Nil =>
         val obtained = SemanticdbExpectSuite.loadDatabase.toString
-        val expected = FileIO.slurp(AbsolutePath(SemanticdbExpectSuite.expectPath))
+        val expected = FileIO.slurp(AbsolutePath(SemanticdbExpectSuite.expectPath), Charset.forName("UTF-8"))
         assertNoDiff(obtained, expected)
       case _ => // do nothing.
     }


### PR DESCRIPTION
Assuming UTF-8 is a dangerous game that often depends on local setup.
The convenience it brings rarely outweighs the bugs that go along with
it