### PR TITLE
Update bin/ci-publish.sh

### DIFF
--- a/bin/ci-publish.sh
+++ b/bin/ci-publish.sh
@@ -3,15 +3,7 @@ set -eu
 PUBLISH=${CI_PUBLISH:-false}
 SECURE_VAR=${TRAVIS_SECURE_ENV_VARS:-false}
 
-bintray() {
-  sbt ci-publish
-}
-
-sonatype() {
-  sbt "sonatypeOpen scalameta-$TRAVIS_TAG" ci-publish sonatypeReleaseAll
-}
-
-if [ "$SECURE_VAR" == true ]; then
+if [ "$SECURE_VAR" == true && -n "$TRAVIS_TAG" ]; then
   git log | head -n 20
   echo "$PGP_SECRET" | base64 --decode | gpg --import
   mkdir -p $HOME/.bintray
@@ -21,11 +13,7 @@ host = api.bintray.com
 user = ${BINTRAY_USERNAME}
 password = ${BINTRAY_API_KEY}
 EOF
-  if [ -n "$TRAVIS_TAG" ]; then
-    sonatype
-  else
-    bintray
-  fi
+  sbt "sonatypeOpen scalameta-$TRAVIS_TAG" ci-publish sonatypeReleaseAll
 else
   echo "Skipping publish, branch=$TRAVIS_BRANCH publish=$PUBLISH test=$CI_TEST"
 fi


### PR DESCRIPTION
After we removed sbt-bintray, the CI started leaving hanging staging
repositories on sonatype for every merge. This was because it ran `sbt
publish`  if it wasn't a tag push. Now it will only run `sbt publish`
on tag push.