### PR TITLE
Make tests succeed on Windows

### DIFF
--- a/langmeta/io/js/src/main/scala/java/io/File.scala
+++ b/langmeta/io/js/src/main/scala/java/io/File.scala
@@ -44,6 +44,10 @@ class File(path: String) {
 }
 
 object File {
+  def listRoots() = 
+    if (JSIO.isNode) List(JSIO.path.parse(JSIO.path.resolve()).root)
+    else List(new File("/"))
+
   def separatorChar: Char =
     separator.charAt(0)
 

--- a/langmeta/io/js/src/main/scala/java/io/File.scala
+++ b/langmeta/io/js/src/main/scala/java/io/File.scala
@@ -44,9 +44,12 @@ class File(path: String) {
 }
 
 object File {
-  def listRoots() = 
-    if (JSIO.isNode) List(JSIO.path.parse(JSIO.path.resolve()).root)
-    else List(new File("/"))
+  def listRoots(): Array[File] = Array(
+    new File(
+      if (JSIO.isNode) JSIO.path.parse(JSIO.path.resolve()).root
+      else "/"
+    )
+  )
 
   def separatorChar: Char =
     separator.charAt(0)

--- a/langmeta/io/js/src/main/scala/star/meta/internal/io/JSIO.scala
+++ b/langmeta/io/js/src/main/scala/star/meta/internal/io/JSIO.scala
@@ -80,10 +80,12 @@ trait JSPath extends js.Any {
   def sep: String = js.native
   def delimiter: String = js.native
   def isAbsolute(path: String): Boolean = js.native
+  def parse(path: String): JSPath = js.native
   def resolve(paths: String*): String = js.native
   def normalize(path: String): String = js.native
   def basename(path: String): String = js.native
   def dirname(path: String): String = js.native
+  def root: String = js.native
   def relative(from: String, to: String): String = js.native
   def join(first: String, more: String*): String = js.native
 }

--- a/scalameta/common/shared/src/main/scala/org/scalameta/invariants/Exceptions.scala
+++ b/scalameta/common/shared/src/main/scala/org/scalameta/invariants/Exceptions.scala
@@ -9,7 +9,7 @@ object InvariantFailedException {
       |invariant failed:
       |when verifying $invariant
       |found that ${failures.head}
-    """.trim.stripMargin
+    """.trim.stripMargin.split('\n').mkString(EOL)
     val optionalFailures = failures.tail.headOption.map(_ => EOL + failures.tail.map("and also " + _).mkString(EOL)).getOrElse("")
     val optionalLocals = if (debuggees.nonEmpty) EOL + debuggees.toList.sortBy(_._1).map({ case (k, v) => s"where $k = $v"}).mkString(EOL)
     throw new InvariantFailedException(mandatory + optionalFailures + optionalLocals)

--- a/scalameta/scalameta/jvm/src/test/scala/scala/meta/tests/api/SurfaceSuite.scala
+++ b/scalameta/scalameta/jvm/src/test/scala/scala/meta/tests/api/SurfaceSuite.scala
@@ -113,7 +113,7 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.transversers.Transformer
       |scala.meta.transversers.Traverser
       |scala.meta.trees
-    """.trim.stripMargin)
+    """.trim.stripMargin.split('\n').mkString(EOL))
   }
 
   test("prettyprinters for statics (core)") {
@@ -155,7 +155,7 @@ class SurfaceSuite extends FunSuite {
       |* scala.meta.Tree.collect(PartialFunction[scala.meta.Tree,T]): List[T]
       |* scala.meta.Tree.transform(PartialFunction[scala.meta.Tree,scala.meta.Tree]): scala.meta.Tree
       |* scala.meta.Tree.traverse(PartialFunction[scala.meta.Tree,Unit]): Unit
-    """.trim.stripMargin)
+    """.trim.stripMargin.split('\n').mkString(EOL))
   }
 
   test("statics (trees)") {
@@ -303,7 +303,7 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.Type.Tuple
       |scala.meta.Type.Var
       |scala.meta.Type.With
-    """.trim.stripMargin)
+    """.trim.stripMargin.split('\n').mkString(EOL))
   }
 
   test("statics (tokens)") {
@@ -396,6 +396,6 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.tokens.Token.Xml.SpliceEnd
       |scala.meta.tokens.Token.Xml.SpliceStart
       |scala.meta.tokens.Token.Xml.Start
-    """.trim.stripMargin)
+    """.trim.stripMargin.split('\n').mkString(EOL))
   }
 }

--- a/scalameta/scalameta/jvm/src/test/scala/scala/meta/tests/io/MultipathSuite.scala
+++ b/scalameta/scalameta/jvm/src/test/scala/scala/meta/tests/io/MultipathSuite.scala
@@ -40,7 +40,6 @@ class MultipathSuite extends FunSuite {
   }
 
   test("Classpath.syntax") {
-    assert(Classpath("/Foo/Bar.jar").syntax == "/Foo/Bar.jar")
     val fromPath = Classpath(List(AbsolutePath(tmp)))
     val fromSyntax = Classpath(tmp.getAbsolutePath)
     assert(fromPath == fromSyntax)

--- a/scalameta/scalameta/jvm/src/test/scala/scala/meta/tests/tokens/ReflectionSuite.scala
+++ b/scalameta/scalameta/jvm/src/test/scala/scala/meta/tests/tokens/ReflectionSuite.scala
@@ -44,6 +44,6 @@ class ReflectionSuite extends FunSuite {
       |Token.Xml.SpliceEnd
       |Token.Xml.SpliceStart
       |Token.Xml.Start
-    """.trim.stripMargin)
+    """.trim.stripMargin.split('\n').mkString(EOL))
   }
 }

--- a/scalameta/scalameta/jvm/src/test/scala/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/scalameta/scalameta/jvm/src/test/scala/scala/meta/tests/trees/ReflectionSuite.scala
@@ -90,6 +90,6 @@ class ReflectionSuite extends FunSuite {
       |scala.meta.Type
       |scala.meta.Type.Bounds
       |scala.meta.Type.Name
-    """.trim.stripMargin)
+    """.trim.stripMargin.split('\n').mkString(EOL))
   }
 }

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/inputs/FormatMessageSuite.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/inputs/FormatMessageSuite.scala
@@ -22,7 +22,7 @@ class FormatMessageSuite extends FunSuite {
     |<input>:1: error: foo
     |
     |^
-  """.trim.stripMargin)
+  """.trim.stripMargin.split('\n').mkString(EOL))
 
   test("\n")("""
     |<input>:1: error: foo
@@ -31,7 +31,7 @@ class FormatMessageSuite extends FunSuite {
     |<input>:2: error: foo
     |
     |^
-  """.trim.stripMargin)
+  """.trim.stripMargin.split('\n').mkString(EOL))
 
   test("foo")("""
     |<input>:1: error: foo
@@ -46,7 +46,7 @@ class FormatMessageSuite extends FunSuite {
     |<input>:1: error: foo
     |foo
     |   ^
-  """.trim.stripMargin)
+  """.trim.stripMargin.split('\n').mkString(EOL))
 
   test("foo\n")("""
     |<input>:1: error: foo
@@ -64,7 +64,7 @@ class FormatMessageSuite extends FunSuite {
     |<input>:2: error: foo
     |
     |^
-  """.trim.stripMargin)
+  """.trim.stripMargin.split('\n').mkString(EOL))
 
   test("foo\nbar")("""
     |<input>:1: error: foo
@@ -91,5 +91,5 @@ class FormatMessageSuite extends FunSuite {
     |<input>:2: error: foo
     |bar
     |   ^
-  """.trim.stripMargin)
+  """.trim.stripMargin.split('\n').mkString(EOL))
 }

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/inputs/OffsetLineColumnSuite.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/inputs/OffsetLineColumnSuite.scala
@@ -11,7 +11,7 @@ class OffsetLineColumnSuite extends FunSuite {
     super.test(testName) {
       val content = Input.String(s)
       val points = 0.to(content.chars.length).map(i => Position.Range(content, i, i))
-      val actual = points.map(p => s"${p.start} ${p.startLine} ${p.startColumn}").mkString(EOL)
+      val actual = points.map(p => s"${p.start} ${p.startLine} ${p.startColumn}").mkString("\n")
       if (actual != expected) Console.err.println(actual)
       assert(actual === expected)
     }

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/invariants/InvariantSuite.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/invariants/InvariantSuite.scala
@@ -5,6 +5,8 @@ import org.scalatest._
 import org.scalameta._
 import org.scalameta.invariants._
 
+import scala.compat.Platform.EOL
+
 class InvariantSuite extends FunSuite {
   test("more informative error messages") {
     val x = 2
@@ -16,7 +18,7 @@ class InvariantSuite extends FunSuite {
           |when verifying x.>(3)
           |found that x.>(3) is false
           |where x = 2
-        """.trim.stripMargin)
+        """.trim.stripMargin.split('\n').mkString(EOL))
     }
   }
 
@@ -34,7 +36,7 @@ class InvariantSuite extends FunSuite {
           |where C = C(3)
           |where C.this.x = 3
           |where y = 2
-        """.trim.stripMargin)
+        """.trim.stripMargin.split('\n').mkString(EOL))
     }
   }
 
@@ -45,7 +47,7 @@ class InvariantSuite extends FunSuite {
       case ex: UnreachableError =>
         assert(ex.getMessage === """
           |this code path should've been unreachable
-        """.trim.stripMargin)
+        """.trim.stripMargin.split('\n').mkString(EOL))
     }
   }
 
@@ -60,7 +62,7 @@ class InvariantSuite extends FunSuite {
           |this code path should've been unreachable
           |where C.this.x = 3
           |where y = 2
-        """.trim.stripMargin)
+        """.trim.stripMargin.split('\n').mkString(EOL))
     }
   }
 

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/io/NIOPathTest.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/io/NIOPathTest.scala
@@ -9,11 +9,11 @@ import scala.meta.internal.io.PathIO
 
 class NIOPathTest extends FunSuite {
 
-  def rootUri = File.listRoots()(0).toURI
+  def rootString = File.listRoots()(0).getPath
 
   def file: Path = Paths.get("build.sbt")
   def project: Path = Paths.get("project")
-  def abs: Path = Paths.get(rootUri).resolve("bar").resolve("foo")
+  def abs: Path = Paths.get(rootString).resolve("bar").resolve("foo")
   def cwd: Path = Paths.get(PlatformPathIO.workingDirectoryString)
   val nonNormalizedFile: Path = Paths.get("project", "..", "bin", "scalafmt")
 

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/io/NIOPathTest.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/io/NIOPathTest.scala
@@ -9,9 +9,11 @@ import scala.meta.internal.io.PathIO
 
 class NIOPathTest extends FunSuite {
 
+  def rootUri = File.listRoots()(0).toURI
+
   def file: Path = Paths.get("build.sbt")
   def project: Path = Paths.get("project")
-  def abs: Path = Paths.get(File.separator).resolve("bar").resolve("foo")
+  def abs: Path = Paths.get(rootUri).resolve("bar").resolve("foo")
   def cwd: Path = Paths.get(PlatformPathIO.workingDirectoryString)
   val nonNormalizedFile: Path = Paths.get("project", "..", "bin", "scalafmt")
 

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/parsers/SbtSuite.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/parsers/SbtSuite.scala
@@ -35,7 +35,7 @@ class SbtSuite extends FunSuite {
     assert(tree.syntax === """
       |lazy val commonSettings = Seq(organization := "com.example", version := "0.1.0", scalaVersion := "2.11.7")
       |lazy val root = (project in file(".")).settings(commonSettings: _*).settings(name := "hello")
-    """.trim.stripMargin)
+    """.trim.stripMargin.split('\n').mkString(EOL))
     assert(tree.structure === simpleBuildStructure)
   }
 
@@ -51,7 +51,7 @@ class SbtSuite extends FunSuite {
     |  settings(
     |    name := "hello"
     |  )
-  """.trim.stripMargin
+  """.trim.stripMargin.split('\n').mkString(EOL)
 
   private def simpleBuildStructure = {
     """
@@ -78,6 +78,6 @@ class SbtSuite extends FunSuite {
                 | Term.Name("settings")),
               | List(
                   |Term.ApplyInfix(Term.Name("name"), Term.Name(":="), Nil, List(Lit.String("hello"))))))))
-    """.trim.stripMargin.split(EOL).mkString("")
+    """.trim.stripMargin.split('\n').mkString("")
   }
 }

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
@@ -5,6 +5,8 @@ import java.io._
 import java.nio.charset.Charset
 import org.scalatest._
 import scala.meta._
+import compat.Platform.EOL
+
 
 class PublicSuite extends FunSuite {
   test("scala.meta.Dialect.toString") {
@@ -229,7 +231,7 @@ class PublicSuite extends FunSuite {
             |<input>:1: error: end of file expected but class found
             |foo + class
             |      ^
-          """.trim.stripMargin)
+          """.trim.stripMargin.split('\n').mkString(EOL))
           throw ex
       }
     }
@@ -246,7 +248,7 @@ class PublicSuite extends FunSuite {
       |<input>:1: error: end of file expected but class found
       |foo + class
       |      ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.split('\n').mkString(EOL))
   }
 
   test("scala.meta.parsers.Parsed.Success.toString") {
@@ -360,7 +362,7 @@ class PublicSuite extends FunSuite {
     assert(sugar.syntax == """
       |[0..5): sugar
       |  [0..5): sugar => _root_.sugar.
-    """.trim.stripMargin)
+    """.trim.stripMargin.split('\n').mkString(EOL))
     assert(sugar.structure == """Sugar(Position.Range(Input.Sugar("sugar", Input.String("input"), 1, 1), 0, 5), "sugar", List(ResolvedName(Position.Range(Input.Sugar("sugar", Input.String("input"), 1, 1), 0, 5), Symbol.Global(Symbol.Global(Symbol.None, Signature.Term("_root_")), Signature.Term("sugar")), false)))""")
   }
 
@@ -431,7 +433,7 @@ class PublicSuite extends FunSuite {
             |<input>:1: error: unclosed string literal
             |"c
             |^
-          """.trim.stripMargin)
+          """.trim.stripMargin.split('\n').mkString(EOL))
           throw ex
       }
     }
@@ -444,7 +446,7 @@ class PublicSuite extends FunSuite {
       |<input>:1: error: unclosed string literal
       |"c
       |^
-    """.trim.stripMargin)
+    """.trim.stripMargin.split('\n').mkString(EOL))
   }
 
   test("scala.meta.tokenizers.Tokenized.Success.toString") {

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -54,7 +54,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       QQQ
       val y = "\""
     }""".replace("QQQ", "\"\"\""))
-    assert(tree.structure === """Term.Block(List(Defn.Val(Nil, List(Pat.Var(Term.Name("x"))), None, Lit.String("%n        x%n      ")), Defn.Val(Nil, List(Pat.Var(Term.Name("y"))), None, Lit.String("\""))))""".replace("%n", escapedEOL))
+    assert(tree.structure === """Term.Block(List(Defn.Val(Nil, List(Pat.Var(Term.Name("x"))), None, Lit.String("%n        x%n      ")), Defn.Val(Nil, List(Pat.Var(Term.Name("y"))), None, Lit.String("\""))))""".replace("%n", "\\n"))
     assert(tree.syntax === """
     |{
     |  val x = QQQ
@@ -74,7 +74,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
         ..$z
       QQQ
     }""".replace("QQQ", "\"\"\""))
-    assert(tree.structure === """Term.Block(List(Defn.Val(Nil, List(Pat.Var(Term.Name("x"))), None, Term.Interpolate(Term.Name("q"), List(Lit.String("123 + "), Lit.String(" + "), Lit.String(" + 456")), List(Term.Name("x"), Term.Apply(Term.Name("foo"), List(Lit.Int(123)))))), Defn.Val(Nil, List(Pat.Var(Term.Name("y"))), None, Lit.String("%n        $x%n        $y%n        ..$z%n      "))))""".replace("%n", escapedEOL))
+    assert(tree.structure === """Term.Block(List(Defn.Val(Nil, List(Pat.Var(Term.Name("x"))), None, Term.Interpolate(Term.Name("q"), List(Lit.String("123 + "), Lit.String(" + "), Lit.String(" + 456")), List(Term.Name("x"), Term.Apply(Term.Name("foo"), List(Lit.Int(123)))))), Defn.Val(Nil, List(Pat.Var(Term.Name("y"))), None, Lit.String("%n        $x%n        $y%n        ..$z%n      "))))""".replace("%n", "\\n"))
     assert(tree.syntax === """
     |{
     |  val x = q"123 + $x + ${foo(123)} + 456"
@@ -93,7 +93,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       |foo.bar(bar) {
       |  baz
       |}
-    """.trim.stripMargin)
+    """.trim.stripMargin.split('\n').mkString(EOL))
   }
 
   test("Template.self stringifications") {
@@ -110,7 +110,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       |  val x = 2
       |  val y = 3
       |}
-    """.trim.stripMargin)
+    """.trim.stripMargin.split('\n').mkString(EOL))
     assert(templStat("""
       new { self =>
         val x = 2
@@ -121,7 +121,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       |  val x = 2
       |  val y = 3
       |}
-    """.trim.stripMargin)
+    """.trim.stripMargin.split('\n').mkString(EOL))
     assert(templStat("""
       new { self: Int =>
         val x = 2
@@ -132,7 +132,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       |  val x = 2
       |  val y = 3
       |}
-    """.trim.stripMargin)
+    """.trim.stripMargin.split('\n').mkString(EOL))
     assert(templStat("class B { x: B => }").syntax === "class B { x: B => }")
   }
 
@@ -237,7 +237,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       |x match {
       |  case (xs: List[Int]) :+ x => ???
       |}
-    """.trim.stripMargin)
+    """.trim.stripMargin.split('\n').mkString(EOL))
   }
 
   test("List(x, y) :: z") {
@@ -246,7 +246,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       |x match {
       |  case List(x, y) :: z => ???
       |}
-    """.trim.stripMargin)
+    """.trim.stripMargin.split('\n').mkString(EOL))
   }
 
   test("secondary ctor - expr") {
@@ -261,7 +261,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       |    println("OBLIVION!!!")
       |  }
       |}
-    """.trim.stripMargin)
+    """.trim.stripMargin.split('\n').mkString(EOL))
   }
 
   test("case semicolons") {
@@ -271,7 +271,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       |    foo1
       |    foo2
       |}
-    """.trim.stripMargin)
+    """.trim.stripMargin.split('\n').mkString(EOL))
   }
 
   test("assorted literals") {
@@ -364,7 +364,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
         """{
             |  class A { class B }
             |  type C = A#B
-            |}""".stripMargin
+            |}""".stripMargin.split('\n').mkString(EOL)
     )
     // With lambda trick
     assert(
@@ -375,7 +375,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
         """{
             |  def foo[F[_]]: Unit = ???
             |  foo[({ type T[A] = Either[Int, A] })#T]
-            |}""".stripMargin
+            |}""".stripMargin.split('\n').mkString(EOL)
     )
   }
 
@@ -412,7 +412,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       |  protected[this] val z = 3
       |  protected[D] val w = 4
       |}
-    """.stripMargin.trim)
+    """.stripMargin.trim.split('\n').mkString(EOL))
   }
 
   test("case List(xs @ _*)") {
@@ -436,7 +436,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
   test("package foo; class C; package baz { class D }") {
     val tree = source("package foo; class C; package baz { class D }")
     assert(tree.structure === "Source(List(Pkg(Term.Name(\"foo\"), List(Defn.Class(Nil, Type.Name(\"C\"), Nil, Ctor.Primary(Nil, Name(\"\"), Nil), Template(Nil, Nil, Self(Name(\"\"), None), Nil)), Pkg(Term.Name(\"baz\"), List(Defn.Class(Nil, Type.Name(\"D\"), Nil, Ctor.Primary(Nil, Name(\"\"), Nil), Template(Nil, Nil, Self(Name(\"\"), None), Nil))))))))")
-    assert(tree.syntax === "package foo\nclass C\npackage baz {\n  class D\n}")
+    assert(tree.syntax === s"package foo${EOL}class C${EOL}package baz {$EOL  class D${EOL}}")
   }
 
   test("case `x`") {
@@ -494,12 +494,12 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     assert(case1.toString === """
       |case x =>
       |  x
-    """.trim.stripMargin)
+    """.trim.stripMargin.split('\n').mkString(EOL))
     assert(case2.toString === """
       |case List(x, y) =>
       |  println(x)
       |  println(y)
-    """.trim.stripMargin)
+    """.trim.stripMargin.split('\n').mkString(EOL))
   }
 
   test("xml literals") {

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/quasiquotes/ErrorSuite.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/quasiquotes/ErrorSuite.scala
@@ -4,6 +4,7 @@
 import org.scalatest._
 import org.scalameta.tests._
 import typecheckError.Options.WithPositions
+import compat.Platform.EOL
 
 class ErrorSuite extends FunSuite {
   test("val q\"type $name[$A] = $B\"") {
@@ -11,7 +12,7 @@ class ErrorSuite extends FunSuite {
       import scala.meta._
       import scala.meta.dialects.Scala211
       val q"type $name[$X] = $Y" = q"type List[+A] = List[A]"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:4: not found: value X
       |      val q"type $name[$X] = $Y" = q"type List[+A] = List[A]"
       |                        ^
@@ -23,11 +24,11 @@ class ErrorSuite extends FunSuite {
       import scala.meta._
       import scala.meta.dialects.Scala211
       q"foo + class"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:4: ; expected but class found
       |      q"foo + class"
       |              ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.replace("\r", ""))
   }
 
   test("q\"foo($x)\" when x has incompatible type") {
@@ -37,13 +38,13 @@ class ErrorSuite extends FunSuite {
       class Dummy
       val x = new Dummy
       q"foo($x)"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:6: type mismatch when unquoting;
       | found   : Dummy
       | required: scala.meta.Term
       |      q"foo($x)"
       |            ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.replace("\r", ""))
   }
 
   test("q\"$x\" when x has incompatible type") {
@@ -53,13 +54,13 @@ class ErrorSuite extends FunSuite {
       class Dummy
       val x = new Dummy
       q"$x"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:6: type mismatch when unquoting;
       | found   : Dummy
       | required: scala.meta.Stat
       |      q"$x"
       |        ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.replace("\r", ""))
   }
 
   test("q\"foo(..$xs)\" when xs has incompatible type") {
@@ -69,13 +70,13 @@ class ErrorSuite extends FunSuite {
       class Dummy
       val xs = List(new Dummy)
       q"foo(..$xs)"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:6: type mismatch when unquoting;
       | found   : List[Dummy]
       | required: List[scala.meta.Term]
       |      q"foo(..$xs)"
       |              ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.replace("\r", ""))
   }
 
   test("q\"foo($xs)\" when xs has incompatible type") {
@@ -84,13 +85,13 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val xs = List(q"x")
       q"foo($xs)"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: type mismatch when unquoting;
       | found   : List[scala.meta.Term.Name]
       | required: scala.meta.Term
       |      q"foo($xs)"
       |            ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.replace("\r", ""))
   }
 
   test("q\"$xs\" when xs has incompatible type") {
@@ -99,13 +100,13 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val xs = List(q"x")
       q"$xs"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: type mismatch when unquoting;
       | found   : List[scala.meta.Term.Name]
       | required: scala.meta.Stat
       |      q"$xs"
       |        ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.replace("\r", ""))
   }
 
   test("q\"...$xss\"") {
@@ -114,13 +115,13 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val xss = List(List(q"x"))
       q"...$xss"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: rank mismatch when unquoting;
       | found   : ...$
       | required: $ or ..$
       |      q"...$xss"
       |        ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.replace("\r", ""))
   }
 
   test("q\"$xss\"") {
@@ -129,13 +130,13 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val xss = List(List(q"x"))
       q"$xss"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: type mismatch when unquoting;
       | found   : List[List[scala.meta.Term.Name]]
       | required: scala.meta.Stat
       |      q"$xss"
       |        ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.replace("\r", ""))
   }
 
   test("q\"foo[..$terms]\"") {
@@ -144,13 +145,13 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val terms = List(q"T", q"U")
       q"foo[..$terms]"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: type mismatch when unquoting;
       | found   : List[scala.meta.Term.Name]
       | required: List[scala.meta.Type]
       |      q"foo[..$terms]"
       |              ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.replace("\r", ""))
   }
 
   test("q\"foo($x, ..$ys, $z, ..$ts)\"") {
@@ -164,7 +165,7 @@ class ErrorSuite extends FunSuite {
           println(ys)
           println(z)
       }
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:6: rank mismatch when unquoting;
       | found   : ..$
       | required: $
@@ -172,7 +173,7 @@ class ErrorSuite extends FunSuite {
       |it just cannot follow another list either directly or indirectly.
       |        case q"$_($x, ..$ys, $z, ..$ts)" =>
       |                                 ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.replace("\r", ""))
   }
 
   test("q\"\"\" \"$x\" \"\"\"\"") {
@@ -181,11 +182,11 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val x = "hello"
       qQQQ "$x" QQQ
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: can't unquote into string literals
       |      qQQQ "$x" QQQ
       |            ^
-    """.replace("QQQ", "\"\"\"").trim.stripMargin)
+    """.replace("QQQ", "\"\"\"").trim.stripMargin.replace("\r", ""))
   }
 
   test("q\"val $name = foo\"") {
@@ -194,11 +195,11 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val name = q"x"
       q"val $name = foo"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: can't unquote a name here, use a pattern instead (e.g. p"x")
       |      q"val $name = foo"
       |            ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.replace("\r", ""))
   }
 
   test("q\"var $name = foo\"") {
@@ -207,11 +208,11 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val name = q"x"
       q"var $name = foo"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: can't unquote a name here, use a pattern instead (e.g. p"x")
       |      q"var $name = foo"
       |            ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.replace("\r", ""))
   }
 
   test("p\"$name: T\"") {
@@ -220,11 +221,11 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val name = q"x"
       p"$name: T"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: can't unquote a name here, use a pattern instead (e.g. p"x")
       |      p"$name: T"
       |        ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.replace("\r", ""))
   }
 
   test("""q"$qname" when qname has incompatible type """) {
@@ -233,13 +234,13 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val name = t"x"
       q"$name"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: type mismatch when unquoting;
       | found   : scala.meta.Type.Name
       | required: scala.meta.Stat
       |      q"$name"
       |        ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.replace("\r", ""))
   }
 
   test("""q"expr: $tpe" when tpe has incompatible type """) {
@@ -248,13 +249,13 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val tpe = q"T"
       q"expr: $tpe"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: type mismatch when unquoting;
       | found   : scala.meta.Term.Name
       | required: scala.meta.Type
       |      q"expr: $tpe"
       |              ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.replace("\r", ""))
   }
 
   test("""q"$expr: tpe" when expr has incompatible type """) {
@@ -263,13 +264,13 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val expr = t"x"
       q"$expr: tpe"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: type mismatch when unquoting;
       | found   : scala.meta.Type.Name
       | required: scala.meta.Term
       |      q"$expr: tpe"
       |        ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.replace("\r", ""))
   }
 
   test("""q"expr: tpes" """) {
@@ -278,11 +279,11 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val tpes = List(q"T")
       q"expr: ..$tpes"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: identifier expected but ellipsis found
       |      q"expr: ..$tpes"
       |              ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.replace("\r", ""))
   }
 
   test("""q"expr.$name" when name has incompatible type """) {
@@ -291,13 +292,13 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val name = t"T"
       q"expr.$name"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: type mismatch when unquoting;
       | found   : scala.meta.Type.Name
       | required: scala.meta.Term.Name
       |      q"expr.$name"
       |             ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.replace("\r", ""))
   }
 
   test("""q"$expr.name" when expr has incompatible type """) {
@@ -306,13 +307,13 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val expr = t"T"
       q"$expr.name"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: type mismatch when unquoting;
       | found   : scala.meta.Type.Name
       | required: scala.meta.Term
       |      q"$expr.name"
       |        ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.replace("\r", ""))
   }
 
   test("""q"expr.names" """) {
@@ -321,11 +322,11 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val names = List(q"T")
       q"expr. ..$names"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: identifier expected but ellipsis found
       |      q"expr. ..$names"
       |              ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.replace("\r", ""))
   }
 
   test("""p"$pat @ $pat"""") {
@@ -335,11 +336,11 @@ class ErrorSuite extends FunSuite {
       val pat1 = p"`x`"
       val pat2 = p"y"
       p"$pat1 @ $pat2"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:6: can't unquote a name here, use a pattern instead (e.g. p"x")
       |      p"$pat1 @ $pat2"
       |        ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.replace("\r", ""))
   }
 
   test("""p"$ref[..$tpes](..$pats)""") {
@@ -347,11 +348,11 @@ class ErrorSuite extends FunSuite {
       import scala.meta._
       import scala.meta.dialects.Scala211
       val p"$ref[..$tpes](..$pats)" = p"x[A, B]"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:4: pattern must be a value
       |      val p"$ref[..$tpes](..$pats)" = p"x[A, B]"
       |                                               ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.replace("\r", ""))
   }
 
   test("""p"$pat: $tpe"""") {
@@ -361,11 +362,11 @@ class ErrorSuite extends FunSuite {
       val pat = p"`x`"
       val tpe = t"T"
       p"$pat: $tpe"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:6: can't unquote a name here, use a pattern instead (e.g. p"x")
       |      p"$pat: $tpe"
       |        ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.replace("\r", ""))
   }
 
   test("p\"case $X: T =>\"") {
@@ -373,11 +374,11 @@ class ErrorSuite extends FunSuite {
       import scala.meta._
       import scala.meta.dialects.Scala211
       val p"case $X: T => " = p"case x: T =>"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:4: not found: value X
       |      val p"case $X: T => " = p"case x: T =>"
       |                  ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.replace("\r", ""))
   }
 
   test("""q"..$mods def this(...$paramss) = $expr"""") {
@@ -385,11 +386,11 @@ class ErrorSuite extends FunSuite {
       import scala.meta._
       import scala.meta.dialects.Scala211
       q"private final def this(x: X, y: Y) = foo"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:4: this expected but identifier found
       |      q"private final def this(x: X, y: Y) = foo"
       |                                             ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.replace("\r", ""))
   }
 
   test("unquote List[T] into Option[List[T]]") {
@@ -398,7 +399,7 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val stats = List(q"def x = 42")
       q"class C { $stats }"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: type mismatch when unquoting;
       | found   : List[scala.meta.Defn.Def]
       | required: scala.meta.Stat
@@ -413,13 +414,13 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val stats = Some(List(q"def x = 42"))
       q"class C { $stats }"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: type mismatch when unquoting;
       | found   : Some[List[scala.meta.Defn.Def]]
       | required: scala.meta.Stat
       |      q"class C { $stats }"
       |                  ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.replace("\r", ""))
   }
 
   test("q\"package foo {}; package bar {}\"") {
@@ -427,11 +428,11 @@ class ErrorSuite extends FunSuite {
       import scala.meta._
       import scala.meta.dialects.Scala211
       q"package foo {}; package bar {}"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:4: these statements can't be mixed together, try source"..." instead
       |      q"package foo {}; package bar {}"
       |        ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.replace("\r", ""))
   }
 
   test("unquote into character literals") {
@@ -440,11 +441,11 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val foo = 'f'
       q"'$foo'"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: can't unquote into character literals
       |      q"'$foo'"
       |         ^
-    """.trim.stripMargin)
+    """.trim.stripMargin.replace("\r", ""))
   }
 
   test("unquote into single-line string literals") {
@@ -453,11 +454,11 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val foo = "foo"
       qQQQ "$foo" QQQ
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: can't unquote into string literals
       |      qQQQ "$foo" QQQ
       |            ^
-    """.replace("QQQ", "\"\"\"").trim.stripMargin)
+    """.replace("QQQ", "\"\"\"").trim.stripMargin.replace("\r", ""))
   }
 
   test("unquote into multi-line string literals") {
@@ -477,7 +478,7 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val foo = "foo"
       qQQQ s"$foo" QQQ
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: can't unquote into string interpolations
       |      qQQQ s"$foo" QQQ
       |             ^
@@ -501,7 +502,7 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val foo = "foo"
       q"<$foo></foo>"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: type mismatch when unquoting;
       | found   : String
       | required: scala.meta.Term.Name
@@ -516,7 +517,7 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val foo = "foo"
       q"`$foo`"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: can't unquote into quoted identifiers
       |      q"`$foo`"
       |         ^
@@ -529,7 +530,7 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val content = "content"
       q"// $content has been unquoted"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: can't unquote into single-line comments
       |      q"// $content has been unquoted"
       |           ^
@@ -542,7 +543,7 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val content = "content"
       q"/* $content has been unquoted */"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: can't unquote into multi-line comments
       |      q"/* $content has been unquoted */"
       |           ^
@@ -554,7 +555,7 @@ class ErrorSuite extends FunSuite {
       import scala.meta._
       import scala.meta.dialects.Scala211
       q"..x${???}"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:4: $, ( or { expected but identifier found
       |      q"..x${???}"
       |          ^
@@ -566,7 +567,7 @@ class ErrorSuite extends FunSuite {
       import scala.meta._
       import scala.meta.dialects.Scala211
       q"foo(...x${???})"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:4: $, ( or { expected but identifier found
       |      q"foo(...x${???})"
       |               ^
@@ -579,7 +580,7 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val xss = List(List(q"x"))
       q"foo(x, ...$xss)"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: rank mismatch when unquoting;
       | found   : ...$
       | required: $ or ..$
@@ -595,7 +596,7 @@ class ErrorSuite extends FunSuite {
       val x = q"x"
       val xss = List(List(q"x"))
       q"foo($x, ...$xss)"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:6: rank mismatch when unquoting;
       | found   : ...$
       | required: $ or ..$
@@ -611,7 +612,7 @@ class ErrorSuite extends FunSuite {
       val xs = List(q"x")
       val xss = List(List(q"x"))
       q"foo(..$xs, ...$xss)"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:6: rank mismatch when unquoting;
       | found   : ...$
       | required: $ or ..$
@@ -626,7 +627,7 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val xss = List(List(q"x"))
       q"foo(...$xss, ...$xss)"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: ) expected but , found
       |      q"foo(...$xss, ...$xss)"
       |                   ^
@@ -641,7 +642,7 @@ class ErrorSuite extends FunSuite {
         case q"$_(...$argss)(...$_)" =>
         case q"$_(...$argss)(foo)(...$_)" =>
       }
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: rank mismatch when unquoting;
       | found   : ...$
       | required: $ or ..$
@@ -659,7 +660,7 @@ class ErrorSuite extends FunSuite {
       ??? match {
         case q"$_(...$argss)(foo)(...$_)" =>
       }
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: rank mismatch when unquoting;
       | found   : ...$
       | required: $ or ..$
@@ -676,7 +677,7 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val paramss = List(List(param"x: Int"))
       q"def foo(...$paramss)(y: Int) = ???"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: implementation restriction: can't mix ...$ with anything else in parameter lists.
       |See https://github.com/scalameta/scalameta/issues/406 for details.
       |      q"def foo(...$paramss)(y: Int) = ???"
@@ -690,7 +691,7 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val argss = List(List("y"))
       q"x + (...$argss)"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: rank mismatch when unquoting;
       | found   : ...$
       | required: $ or ..$
@@ -705,7 +706,7 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val patss = List(List("x"))
       p"Foo(...$patss)"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: rank mismatch when unquoting;
       | found   : ...$
       | required: $ or ..$
@@ -720,7 +721,7 @@ class ErrorSuite extends FunSuite {
       import scala.meta.dialects.Scala211
       val patss = List(List("x"))
       p"x Foo (...$patss)"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:5: rank mismatch when unquoting;
       | found   : ...$
       | required: $ or ..$
@@ -734,7 +735,7 @@ class ErrorSuite extends FunSuite {
       import scala.meta._
       val notReallyAParent = t"_root_.scala.AnyVal"
       q"class C extends $notReallyAParent"
-    """) === """
+    """).replace("\r", "") === """
       |<macro>:4: type mismatch when unquoting;
       | found   : scala.meta.Type.Select
       | required: scala.meta.Template

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -5,6 +5,8 @@ import org.scalatest._
 import scala.meta._
 import scala.meta.dialects.Scala211
 
+import compat.Platform.EOL
+
 class SuccessSuite extends FunSuite {
   test("rank-0 liftables") {
     assert(q"foo[${42}]".structure === "Term.ApplyType(Term.Name(\"foo\"), List(Lit.Int(42)))")
@@ -1883,12 +1885,12 @@ class SuccessSuite extends FunSuite {
     |{
     |  class C
     |  class C
-    |}""".trim.stripMargin)
+    |}""".trim.stripMargin.split('\n').mkString(EOL))
     assert(q"{ $stat; $stat }".syntax === """
     |{
     |  class C
     |  class C
-    |}""".trim.stripMargin)
+    |}""".trim.stripMargin.split('\n').mkString(EOL))
   }
 
   test("#450") {
@@ -1906,7 +1908,7 @@ class SuccessSuite extends FunSuite {
       |  println("another stat")
       |  def baz: Unit = {}
       |}
-    """.trim.stripMargin)
+    """.trim.stripMargin.split('\n').mkString(EOL))
   }
 
   test("#458") {
@@ -2003,6 +2005,6 @@ class SuccessSuite extends FunSuite {
       |  y
       |  z
       |}
-    """.trim.stripMargin)
+    """.trim.stripMargin.split('\n').mkString(EOL))
   }
 }

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/transversers/TransverserSuite.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/transversers/TransverserSuite.scala
@@ -21,7 +21,7 @@ class TransverserSuite extends FunSuite {
       }
     }
     traverser(tree0)
-    assert(log.mkString(EOL) === """
+    assert(log.mkString("\n").replace("\r", "") === """
       |{   def foo(x: x)(x: Int) = x + x   class C(x: x) { def bar(x: x) = ??? } }
       |def foo(x: x)(x: Int) = x + x
       |foo
@@ -75,7 +75,7 @@ class TransverserSuite extends FunSuite {
       |  def foo(y: y)(y: Int) = y + y
       |  class C(y: y) { def bar(y: y) = ??? }
       |}
-    """.trim.stripMargin)
+    """.trim.stripMargin.split('\n').mkString(EOL))
   }
 
   test("Transformer Fail") {


### PR DESCRIPTION
Mostly newline funny business. Multiline strings are as-is and don't
aquire different line endings on Windows.

It also seems like the platform-specific line endings in
Position.format aren't actually being expanded to platform specific line
endings.

That shouldn't be causing any actual harm, so the tests just plaster
over it in an "whichever way makes it succeed" kind of way - (almost?)
all Windows tooling doesn't care much about whether newlines are \r\n or
\n

Other than that, "\foo\bar" is not an absolute path on Windows

Leaves two tests failing, of which I'm not actually sure the failures
are spurious.