### PR TITLE
Show triple-quoted string on all line endings

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
 build_script:
   - sbt version # dummy step, a build_script step is required by appveyor.
 test_script:
-  - sbt testsJVM/test
+  - sbt testAll
 cache:
   - C:\Users\appveyor\.m2
   - C:\Users\appveyor\.ivy2

--- a/langmeta/js/src/main/scala/java/io/File.scala
+++ b/langmeta/js/src/main/scala/java/io/File.scala
@@ -22,10 +22,9 @@ class File(path: String) {
     NodeNIOPath(path)
   def toURI: URI = {
     val file = getAbsoluteFile.toString
-    val path =
-      if (isDirectory && !file.endsWith("/")) file + "/"
-      else file
-    new URI("file", null, path, null)
+    val uripath = if (file.startsWith("/")) file else "/" + file.replace(File.separator, "/")
+    val withslash = if (isDirectory && !uripath.endsWith("/")) uripath + "/" else uripath
+    new URI("file", null, withslash, null)
   }
   def getAbsoluteFile: File =
     toPath.toAbsolutePath.toFile

--- a/langmeta/js/src/main/scala/java/nio/file/Paths.scala
+++ b/langmeta/js/src/main/scala/java/nio/file/Paths.scala
@@ -1,6 +1,7 @@
 package java.nio.file
 
 import java.io.File
+import java.net.URI
 import org.langmeta.internal.io.JSPath
 import org.langmeta.internal.io.NodeNIOPath
 
@@ -14,5 +15,16 @@ object Paths {
       if (more.isEmpty) first
       else first + File.separator + more.mkString(File.separator)
     NodeNIOPath(path)
+  }
+
+  def get(uri: URI): Path = {
+    if(uri.getScheme != "file") throw new IllegalArgumentException("only file: URIs are supported")
+    val uripath = uri.getPath
+    val parts = uripath.split('/').toList
+    val (leading, trailing) = parts.span(_ == "")
+    trailing match {
+      case drive :: path if (drive.length == 2 && drive(1) == ':') => NodeNIOPath(trailing.mkString("\\"))
+      case _ => NodeNIOPath(uripath)
+    }
   }
 }

--- a/langmeta/js/src/main/scala/org/langmeta/internal/io/PlatformFileIO.scala
+++ b/langmeta/js/src/main/scala/org/langmeta/internal/io/PlatformFileIO.scala
@@ -4,6 +4,7 @@ import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.net.URI
 import java.nio.charset.Charset
+import java.nio.file.Paths
 import org.langmeta.io._
 
 object PlatformFileIO {
@@ -11,7 +12,10 @@ object PlatformFileIO {
     new ByteArrayInputStream(readAllBytes(uri))
 
   def readAllBytes(uri: URI): Array[Byte] =
-    if (uri.getScheme == "file") readAllBytes(AbsolutePath(uri.getPath))
+    if (uri.getScheme == "file") {
+      val filepath = Paths.get(uri)
+      readAllBytes(AbsolutePath(filepath.toString))
+    }
     else throw new UnsupportedOperationException(s"Can't read $uri as InputStream")
 
   def readAllBytes(path: AbsolutePath): Array[Byte] = JSIO.inNode {

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/io/NIOPathTest.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/io/NIOPathTest.scala
@@ -41,7 +41,7 @@ class NIOPathTest extends FunSuite {
     assert(abs.getParent.getFileName.toString == "bar")
   }
   test(".getNameCount") {
-    assert(Paths.get("/").getNameCount == 0)
+    assert(Paths.get(rootString).getNameCount == 0)
     assert(Paths.get("").getNameCount == 1)
     assert(abs.getNameCount == 2)
     assert(nonNormalizedFile.getNameCount == 4)

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
@@ -12,6 +12,14 @@ import org.scalameta.logger
 class ParseSuite extends FunSuite with CommonTrees {
   val EOL = scala.compat.Platform.EOL
   val escapedEOL = if (EOL == "\n") """\n""" else """\r\n"""
+
+
+  def assertSameLines(actual: String, expected: String) = {
+    val actualLines = actual.lines.toList
+    val expectedLines = expected.lines.toList
+    assert(actualLines === expectedLines)
+  }
+
   def stat(code: String)(implicit dialect: Dialect) = code.applyRule(_.parseStat())
   def term(code: String)(implicit dialect: Dialect) = code.parseRule(_.expr())
   def pat(code: String)(implicit dialect: Dialect) = code.parseRule(_.pattern())
@@ -40,6 +48,7 @@ class ParseSuite extends FunSuite with CommonTrees {
     test(logger.revealWhitespace(stat).take(50)) { interceptParseErrors(stat) }
   def checkOK(stat: String)(implicit dialect: Dialect) =
     test(logger.revealWhitespace(stat).take(50)) { templStat(stat) }
+
 }
 
 object MoreHelpers {

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
@@ -13,7 +13,7 @@ class ParseSuite extends FunSuite with CommonTrees {
   val EOL = scala.compat.Platform.EOL
   val escapedEOL = if (EOL == "\n") """\n""" else """\r\n"""
 
-
+  //This should eventually be replaced by DiffAssertions.assertNoDiff
   def assertSameLines(actual: String, expected: String) = {
     val actualLines = actual.lines.toList
     val expectedLines = expected.lines.toList

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
@@ -292,7 +292,7 @@ class PublicSuite extends FunSuite {
     val defIdentity = Denotation(DEF | FINAL, "identity", info, names)
     assert(defIdentity.toString ===
       """final def identity: [T](e: E)T
-        |  [7..8): E => _root_.E#""".stripMargin
+        |  [7..8): E => _root_.E#""".stripMargin.split('\n').mkString(EOL)
     )
   }
 

--- a/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/scalameta/scalameta/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -47,6 +47,22 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     assert(tree.syntax === "(x map y).foo")
   }
 
+  test("multi-line string literals") {
+    val tree = templStat("""{
+      val x = QQQ
+        x
+      QQQ
+    }""".replace("QQQ", "\"\"\""))
+
+    assertSameLines(tree.syntax, """
+    |{
+    |  val x = QQQ
+    |        x
+    |      QQQ
+    |}
+    """.trim.stripMargin.replace("QQQ", "\"\"\""))
+  }
+
   test("string literals with newlines and double quotes") {
     val tree = templStat("""{
       val x = QQQ
@@ -55,7 +71,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       val y = "\""
     }""".replace("QQQ", "\"\"\""))
     assert(tree.structure === """Term.Block(List(Defn.Val(Nil, List(Pat.Var(Term.Name("x"))), None, Lit.String("%n        x%n      ")), Defn.Val(Nil, List(Pat.Var(Term.Name("y"))), None, Lit.String("\""))))""".replace("%n", "\\n"))
-    assert(tree.syntax === """
+    assertSameLines(tree.syntax, """
     |{
     |  val x = QQQ
     |        x
@@ -75,7 +91,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       QQQ
     }""".replace("QQQ", "\"\"\""))
     assert(tree.structure === """Term.Block(List(Defn.Val(Nil, List(Pat.Var(Term.Name("x"))), None, Term.Interpolate(Term.Name("q"), List(Lit.String("123 + "), Lit.String(" + "), Lit.String(" + 456")), List(Term.Name("x"), Term.Apply(Term.Name("foo"), List(Lit.Int(123)))))), Defn.Val(Nil, List(Pat.Var(Term.Name("y"))), None, Lit.String("%n        $x%n        $y%n        ..$z%n      "))))""".replace("%n", "\\n"))
-    assert(tree.syntax === """
+    assertSameLines(tree.syntax, """
     |{
     |  val x = q"123 + $x + ${foo(123)} + 456"
     |  val y = QQQ
@@ -491,10 +507,10 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
 
   test("smart case printing - oneliner in multiple lines") {
     val Term.Match(_, case1 :: case2 :: Nil) = templStat("??? match { case x => x; case List(x, y) => println(x); println(y) }")
-    assert(case1.toString === """
+    assertSameLines(case1.toString, """
       |case x =>
       |  x
-    """.trim.stripMargin.split('\n').mkString(EOL))
+    """.trim.stripMargin)
     assert(case2.toString === """
       |case List(x, y) =>
       |  println(x)

--- a/scalameta/tests/shared/src/test/scala/scala/meta/tests/MirrorConstructionSuite.scala
+++ b/scalameta/tests/shared/src/test/scala/scala/meta/tests/MirrorConstructionSuite.scala
@@ -39,4 +39,5 @@ class MirrorConstructionSuite extends BaseSemanticSuite {
       assert(!sattrs.filename.contains('\\'))
     }
   }
+
 }

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -214,7 +214,7 @@ object TreeSyntax {
             case (part, id: Name) if !guessIsBackquoted(id) => s(part, "$", id.value)
             case (part, arg) => s(part, "${", p(Expr, arg), "}")
           }
-          val quote = if (parts.exists(s => s.contains(EOL) || s.contains("\""))) "\"\"\"" else "\""
+          val quote = if (parts.exists(s => s.contains("\n") || s.contains("\""))) "\"\"\"" else "\""
           m(SimpleExpr1, s(t.prefix, quote, r(zipped), parts.last, quote))
         case t: Term.Xml             =>
           if (!dialect.allowXmlLiterals) throw new UnsupportedOperationException(s"$dialect doesn't support xml literals")
@@ -415,7 +415,8 @@ object TreeSyntax {
             }
           }
         case Lit.Char(value)    => m(Literal, s(enquote(value.toString, SingleQuotes)))
-        case Lit.String(value)  => m(Literal, s(enquote(value.toString, if (value.contains(EOL)) TripleQuotes else DoubleQuotes)))
+        // Strings should be triple-quoted regardless of what newline style is used.
+        case Lit.String(value)  => m(Literal, s(enquote(value.toString, if (value.contains("\n")) TripleQuotes else DoubleQuotes)))
         case Lit.Symbol(value)  => m(Literal, s("'", value.name))
         case Lit.Null()         => m(Literal, s(kw("null")))
         case Lit.Unit()         => m(Literal, s("()"))


### PR DESCRIPTION
This is an "actual" change (even if it pertains only to pretty-printing) rather than a test change, bringing the windows implementation in line with the *nix implementation.

Also expanding the appveyor tests - all tests should now pass.

Review requested on the actual bug fix, whether assertSameLines is in the right place, and whether cleaning up the rest of the tests in terms of assertSameLines should be in this PR or in a separate one.

