### PR TITLE
Adapt semanticdb-scalac to new Type.Lambda/Type.Method syntax.

### DIFF
--- a/langmeta/shared/src/main/scala/org/langmeta/internal/inputs/package.scala
+++ b/langmeta/shared/src/main/scala/org/langmeta/internal/inputs/package.scala
@@ -32,6 +32,7 @@ package object inputs {
       case Input.None => "<none>"
       case Input.File(path, _) => path.toString
       case Input.VirtualFile(path, _) => path
+      case Input.Denotation(_, symbol) => symbol.syntax
       case _ => "<input>"
     }
     def structure: String = input.toString

--- a/langmeta/shared/src/main/scala/org/langmeta/semanticdb/ResolvedSymbol.scala
+++ b/langmeta/shared/src/main/scala/org/langmeta/semanticdb/ResolvedSymbol.scala
@@ -2,6 +2,7 @@ package org.langmeta
 package semanticdb
 
 final case class ResolvedSymbol(symbol: Symbol, denotation: Denotation) {
+  def input: Input = Input.Denotation(denotation.signature, symbol)
   def syntax = s"${symbol.syntax} => ${denotation.syntax}"
   def structure = s"""ResolvedSymbol(${symbol.structure}, ${denotation.structure})"""
   override def toString = syntax

--- a/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/SemanticSuite.scala
+++ b/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/SemanticSuite.scala
@@ -134,103 +134,100 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |package object F {
       |}
   """.trim.stripMargin,
-    """
-      |_root_.F.package. => packageobject package
-      |_root_.f. => package f
-      |_root_.f.C1# => class C1
-      |_root_.f.C1#(p1) => param p1: scala.Int
-      |  [6..9): Int => _root_.scala.Int#
-      |_root_.f.C1#(p2) => val param p2: scala.Int
-      |  [6..9): Int => _root_.scala.Int#
-      |_root_.f.C1#(p3) => var param p3_=: (x$1: scala.Int)scala.Unit
-      |  [12..15): Int => _root_.scala.Int#
-      |  [22..26): Unit => _root_.scala.Unit#
-      |_root_.f.C1#T1# => abstract type T1:  <: Int
-      |_root_.f.C1#T2# => type T2: scala.Int
-      |  [6..9): Int => _root_.scala.Int#
-      |_root_.f.C1#`<init>`()V. => secondaryctor <init>: ()f.C1
-      |  [4..6): C1 => _root_.f.C1#
-      |_root_.f.C1#`<init>`(III)V. => primaryctor <init>: (p1: scala.Int,p2: scala.Int,p3: scala.Int)f.C1
-      |  [11..14): Int => _root_.scala.Int#
-      |  [25..28): Int => _root_.scala.Int#
-      |  [39..42): Int => _root_.scala.Int#
-      |  [45..47): C1 => _root_.f.C1#
-      |_root_.f.C1#f1. => val f1: scala.Nothing
-      |  [6..13): Nothing => _root_.scala.Nothing#
-      |_root_.f.C1#f1.l1. => val l1: scala.Nothing
-      |  [6..13): Nothing => _root_.scala.Nothing#
-      |_root_.f.C1#f1.l2. => var l2: scala.Nothing
-      |  [6..13): Nothing => _root_.scala.Nothing#
-      |_root_.f.C1#f2. => var f2_=: (x$1: scala.Nothing)scala.Unit
-      |  [12..19): Nothing => _root_.scala.Nothing#
-      |  [26..30): Unit => _root_.scala.Unit#
-      |_root_.f.C1#m1(I)I. => def m1: [T](x: scala.Int)scala.Int
-      |  [13..16): Int => _root_.scala.Int#
-      |  [23..26): Int => _root_.scala.Int#
-      |_root_.f.C1#m1(I)I.(x) => param x: scala.Int
-      |  [6..9): Int => _root_.scala.Int#
-      |_root_.f.C1#m1(I)I.T# => typeparam T
-      |_root_.f.C1#m2()Lscala/Nothing;. => macro m2: scala.Nothing
-      |  [6..13): Nothing => _root_.scala.Nothing#
-      |_root_.f.C2# => abstract class C2
-      |_root_.f.C2#`<init>`()V. => primaryctor <init>: ()f.C2
-      |  [4..6): C2 => _root_.f.C2#
-      |_root_.f.C2#m3()I. => abstract def m3: scala.Int
-      |  [6..9): Int => _root_.scala.Int#
-      |_root_.f.C2#m4()Lscala/Nothing;. => final def m4: scala.Nothing
-      |  [6..13): Nothing => _root_.scala.Nothing#
-      |_root_.f.C3# => sealed class C3
-      |_root_.f.C3#`<init>`()V. => primaryctor <init>: ()f.C3
-      |  [4..6): C3 => _root_.f.C3#
-      |_root_.f.C3#m3()I. => def m3: scala.Int
-      |  [6..9): Int => _root_.scala.Int#
-      |_root_.f.C3#toString()Ljava/lang/String;. => def toString: ()java.lang.String
-      |  [12..18): String => _root_.java.lang.String#
-      |_root_.f.M. => final object M
-      |_root_.f.M.C1# => case class C1
-      |_root_.f.M.C1#`<init>`()V. => primaryctor <init>: ()f.M.C1
-      |  [6..8): C1 => _root_.f.M.C1#
-      |_root_.f.M.C2# => class C2
-      |_root_.f.M.C2#[T] => covariant typeparam T
-      |_root_.f.M.C2#[U] => contravariant typeparam U
-      |_root_.f.M.C2#`<init>`()V. => primaryctor <init>: ()f.M.C2[T,U]
-      |  [6..8): C2 => _root_.f.M.C2#
-      |  [9..10): T => _root_.f.M.C2#[T]
-      |  [11..12): U => _root_.f.M.C2#[U]
-      |_root_.f.M.i1()Lscala/Nothing;. => implicit def i1: scala.Nothing
-      |  [6..13): Nothing => _root_.scala.Nothing#
-      |_root_.f.M.l1. => lazy val l1: scala.Nothing
-      |  [6..13): Nothing => _root_.scala.Nothing#
-      |_root_.f.T# => trait T
-      |_root_.f.T#$init$()V. => primaryctor $init$: ()scala.Unit
-      |  [8..12): Unit => _root_.scala.Unit#
-      |_root_.f.T#f1. => private val f1: scala.Nothing
-      |  [6..13): Nothing => _root_.scala.Nothing#
-      |_root_.f.T#f2. => private val f2: scala.Nothing
-      |  [6..13): Nothing => _root_.scala.Nothing#
-      |_root_.f.T#f3. => private val f3: scala.Nothing
-      |  [6..13): Nothing => _root_.scala.Nothing#
-      |_root_.f.T#f4. => protected var f4_=: (x$1: scala.Nothing)scala.Unit
-      |  [12..19): Nothing => _root_.scala.Nothing#
-      |  [26..30): Unit => _root_.scala.Unit#
-      |_root_.f.T#f5. => protected var f5_=: (x$1: scala.Nothing)scala.Unit
-      |  [12..19): Nothing => _root_.scala.Nothing#
-      |  [26..30): Unit => _root_.scala.Unit#
-      |_root_.f.T#f6. => protected var f6_=: (x$1: scala.Nothing)scala.Unit
-      |  [12..19): Nothing => _root_.scala.Nothing#
-      |  [26..30): Unit => _root_.scala.Unit#
-      |_root_.scala. => package scala
-      |_root_.scala.Int# => abstract final class Int
-      |_root_.scala.Int#`<init>`()V. => primaryctor <init>: ()scala.Int
-      |  [8..11): Int => _root_.scala.Int#
-      |_root_.scala.Predef.`???`()Lscala/Nothing;. => def ???: scala.Nothing
-      |  [6..13): Nothing => _root_.scala.Nothing#
-      |_root_.scala.language. => final object language
-      |_root_.scala.language.experimental. => final object experimental
-      |_root_.scala.language.experimental.macros. => implicit lazy val macros: scala.languageFeature.experimental.macros
-      |  [6..21): languageFeature => _root_.scala.languageFeature.
-      |  [22..34): experimental => _root_.scala.languageFeature.experimental.
-      |  [35..41): macros => _root_.scala.languageFeature.experimental.macros#
+    """|_root_.F.package. => packageobject package
+       |_root_.f. => package f
+       |_root_.f.C1# => class C1
+       |_root_.f.C1#(p1) => param p1: Int
+       |  [0..3): Int => _root_.scala.Int#
+       |_root_.f.C1#(p2) => val param p2: Int
+       |  [0..3): Int => _root_.scala.Int#
+       |_root_.f.C1#(p3) => var param p3_=: (x$1: Int): Unit
+       |  [6..9): Int => _root_.scala.Int#
+       |  [12..16): Unit => _root_.scala.Unit#
+       |_root_.f.C1#T1# => abstract type T1
+       |_root_.f.C1#T2# => type T2: Int
+       |  [0..3): Int => _root_.scala.Int#
+       |_root_.f.C1#`<init>`()V. => secondaryctor <init>: (): C1
+       |  [4..6): C1 => _root_.f.C1#
+       |_root_.f.C1#`<init>`(III)V. => primaryctor <init>: (p1: Int, p2: Int, p3: Int): C1
+       |  [5..8): Int => _root_.scala.Int#
+       |  [14..17): Int => _root_.scala.Int#
+       |  [23..26): Int => _root_.scala.Int#
+       |  [29..31): C1 => _root_.f.C1#
+       |_root_.f.C1#f1. => val f1: Nothing
+       |  [0..7): Nothing => _root_.scala.Nothing#
+       |_root_.f.C1#f1.l1. => val l1: Nothing
+       |  [0..7): Nothing => _root_.scala.Nothing#
+       |_root_.f.C1#f1.l2. => var l2: Nothing
+       |  [0..7): Nothing => _root_.scala.Nothing#
+       |_root_.f.C1#f2. => var f2_=: (x$1: Nothing): Unit
+       |  [6..13): Nothing => _root_.scala.Nothing#
+       |  [16..20): Unit => _root_.scala.Unit#
+       |_root_.f.C1#m1(I)I. => def m1: [T] => (x: Int): Int
+       |  [11..14): Int => _root_.scala.Int#
+       |  [17..20): Int => _root_.scala.Int#
+       |_root_.f.C1#m1(I)I.(x) => param x: Int
+       |  [0..3): Int => _root_.scala.Int#
+       |_root_.f.C1#m1(I)I.T# => typeparam T
+       |_root_.f.C1#m2()Lscala/Nothing;. => macro m2: Nothing
+       |  [0..7): Nothing => _root_.scala.Nothing#
+       |_root_.f.C2# => abstract class C2
+       |_root_.f.C2#`<init>`()V. => primaryctor <init>: (): C2
+       |  [4..6): C2 => _root_.f.C2#
+       |_root_.f.C2#m3()I. => abstract def m3: Int
+       |  [0..3): Int => _root_.scala.Int#
+       |_root_.f.C2#m4()Lscala/Nothing;. => final def m4: Nothing
+       |  [0..7): Nothing => _root_.scala.Nothing#
+       |_root_.f.C3# => sealed class C3
+       |_root_.f.C3#`<init>`()V. => primaryctor <init>: (): C3
+       |  [4..6): C3 => _root_.f.C3#
+       |_root_.f.C3#m3()I. => def m3: Int
+       |  [0..3): Int => _root_.scala.Int#
+       |_root_.f.C3#toString()Ljava/lang/String;. => def toString: (): String
+       |  [4..10): String => _root_.java.lang.String#
+       |_root_.f.M. => final object M
+       |_root_.f.M.C1# => case class C1
+       |_root_.f.M.C1#`<init>`()V. => primaryctor <init>: (): C1
+       |  [4..6): C1 => _root_.f.M.C1#
+       |_root_.f.M.C2# => class C2
+       |_root_.f.M.C2#[T] => covariant typeparam T
+       |_root_.f.M.C2#[U] => contravariant typeparam U
+       |_root_.f.M.C2#`<init>`()V. => primaryctor <init>: (): C2[T, U]
+       |  [4..6): C2 => _root_.f.M.C2#
+       |  [7..8): T => _root_.f.M.C2#[T]
+       |  [10..11): U => _root_.f.M.C2#[U]
+       |_root_.f.M.i1()Lscala/Nothing;. => implicit def i1: Nothing
+       |  [0..7): Nothing => _root_.scala.Nothing#
+       |_root_.f.M.l1. => lazy val l1: Nothing
+       |  [0..7): Nothing => _root_.scala.Nothing#
+       |_root_.f.T# => trait T
+       |_root_.f.T#$init$()V. => primaryctor $init$: (): Unit
+       |  [4..8): Unit => _root_.scala.Unit#
+       |_root_.f.T#f1. => private val f1: Nothing
+       |  [0..7): Nothing => _root_.scala.Nothing#
+       |_root_.f.T#f2. => private val f2: Nothing
+       |  [0..7): Nothing => _root_.scala.Nothing#
+       |_root_.f.T#f3. => private val f3: Nothing
+       |  [0..7): Nothing => _root_.scala.Nothing#
+       |_root_.f.T#f4. => protected var f4_=: (x$1: Nothing): Unit
+       |  [6..13): Nothing => _root_.scala.Nothing#
+       |  [16..20): Unit => _root_.scala.Unit#
+       |_root_.f.T#f5. => protected var f5_=: (x$1: Nothing): Unit
+       |  [6..13): Nothing => _root_.scala.Nothing#
+       |  [16..20): Unit => _root_.scala.Unit#
+       |_root_.f.T#f6. => protected var f6_=: (x$1: Nothing): Unit
+       |  [6..13): Nothing => _root_.scala.Nothing#
+       |  [16..20): Unit => _root_.scala.Unit#
+       |_root_.scala. => package scala
+       |_root_.scala.Int# => abstract final class Int
+       |_root_.scala.Int#`<init>`()V. => primaryctor <init>: (): Int
+       |  [4..7): Int => _root_.scala.Int#
+       |_root_.scala.Predef.`???`()Lscala/Nothing;. => def ???: Nothing
+       |  [0..7): Nothing => _root_.scala.Nothing#
+       |_root_.scala.language. => final object language
+       |_root_.scala.language.experimental. => final object experimental
+       |_root_.scala.language.experimental.macros. => implicit lazy val macros: macros
+       |  [0..6): macros => _root_.scala.languageFeature.experimental.macros#
   """.trim.stripMargin
   )
 
@@ -251,15 +248,14 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |  CommandeerDSL(null.asInstanceOf[Foo])
       |}
     """.trim.stripMargin,
-    """
-      |[324..324): *.apply[g.Foo, g.FooDSL]
-      |  [0..1): * => _star_.
-      |  [2..7): apply => _root_.g.CommandeerDSL.apply(Ljava/lang/Object;Lg/CommandeerDSL;)Lg/CommandeerDSL;.
-      |  [10..13): Foo => _root_.g.Foo#
-      |  [17..23): FooDSL => _root_.g.FooDSL#
-      |[348..348): *(g.Foo.fooDSL)
-      |  [0..1): * => _star_.
-      |  [8..14): fooDSL => _root_.g.Foo.fooDSL.
+    """|[324..324): *.apply[Foo, FooDSL]
+       |  [0..1): * => _star_.
+       |  [2..7): apply => _root_.g.CommandeerDSL.apply(Ljava/lang/Object;Lg/CommandeerDSL;)Lg/CommandeerDSL;.
+       |  [8..11): Foo => _root_.g.Foo#
+       |  [13..19): FooDSL => _root_.g.FooDSL#
+       |[348..348): *(g.Foo.fooDSL)
+       |  [0..1): * => _star_.
+       |  [8..14): fooDSL => _root_.g.Foo.fooDSL.
     """.trim.stripMargin
   )
 
@@ -290,30 +286,29 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |  i(new C[Int])
       |}
   """.trim.stripMargin,
-    """
-      |[201..201): *[scala.Int, scala.collection.immutable.List[scala.Int]]
-      |  [0..1): * => _star_.
-      |  [8..11): Int => _root_.scala.Int#
-      |  [40..44): List => _root_.scala.collection.immutable.List#
-      |  [51..54): Int => _root_.scala.Int#
-      |[209..209): *(scala.collection.immutable.List.canBuildFrom[scala.Int])
-      |  [0..1): * => _star_.
-      |  [34..46): canBuildFrom => _root_.scala.collection.immutable.List.canBuildFrom()Lscala/collection/generic/CanBuildFrom;.
-      |  [53..56): Int => _root_.scala.Int#
-      |[247..247): *(h.C.list[scala.Int](h.C.int))
-      |  [0..1): * => _star_.
-      |  [17..20): Int => _root_.scala.Int#
-      |  [26..29): int => _root_.h.C.int()Lh/C;.
-      |  [6..10): list => _root_.h.C.list(Lh/C;)Lh/C;.
-      |[273..275): h.X.cvt[scala.Int](*)(h.C.int)
-      |  [4..7): cvt => _root_.h.X.cvt(Ljava/lang/Object;Lh/C;)Lh/X;.
-      |  [14..17): Int => _root_.scala.Int#
-      |  [19..20): * => _star_.
-      |  [26..29): int => _root_.h.C.int()Lh/C;.
-      |[304..304): *[h.C[scala.Int]]
-      |  [0..1): * => _star_.
-      |  [4..5): C => _root_.h.C#
-      |  [12..15): Int => _root_.scala.Int#
+    """|[201..201): *[Int, List[Int]]
+       |  [0..1): * => _star_.
+       |  [2..5): Int => _root_.scala.Int#
+       |  [12..15): Int => _root_.scala.Int#
+       |  [7..11): List => _root_.scala.collection.immutable.List#
+       |[209..209): *(scala.collection.immutable.List.canBuildFrom[Int])
+       |  [0..1): * => _star_.
+       |  [47..50): Int => _root_.scala.Int#
+       |  [34..46): canBuildFrom => _root_.scala.collection.immutable.List.canBuildFrom()Lscala/collection/generic/CanBuildFrom;.
+       |[247..247): *(h.C.list[Int](h.C.int))
+       |  [0..1): * => _star_.
+       |  [11..14): Int => _root_.scala.Int#
+       |  [6..10): list => _root_.h.C.list(Lh/C;)Lh/C;.
+       |  [20..23): int => _root_.h.C.int()Lh/C;.
+       |[273..275): h.X.cvt[Int](*)(h.C.int)
+       |  [8..11): Int => _root_.scala.Int#
+       |  [4..7): cvt => _root_.h.X.cvt(Ljava/lang/Object;Lh/C;)Lh/X;.
+       |  [13..14): * => _star_.
+       |  [20..23): int => _root_.h.C.int()Lh/C;.
+       |[304..304): *[C[Int]]
+       |  [0..1): * => _star_.
+       |  [4..7): Int => _root_.scala.Int#
+       |  [2..3): C => _root_.h.C#
   """.trim.stripMargin
   )
 
@@ -343,75 +338,71 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |  }
       |}
     """.stripMargin,
-    """
-      |<...>@359..375 => val result: b.X
-      |  [0..1): b => _root_.i.a.foo(Li/B;)Ljava/lang/Object;.(b)
-      |  [2..3): X => _root_.i.B#X#
-      |_root_.i. => package i
-      |_root_.i.B# => trait B
-      |_root_.i.B#X# => abstract type X
-      |_root_.i.B#x()Ljava/lang/Object;. => abstract def x: B.this.X
-      |  [7..8): X => _root_.i.B#X#
-      |_root_.i.D# => class D
-      |_root_.i.D#X# => type X: scala.collection.mutable.HashSet[scala.Int]
-      |  [25..32): HashSet => _root_.scala.collection.mutable.HashSet#
-      |  [39..42): Int => _root_.scala.Int#
-      |_root_.i.D#`<init>`()V. => primaryctor <init>: ()i.D
-      |  [4..5): D => _root_.i.D#
-      |_root_.i.D#x()Lscala/collection/mutable/HashSet;. => def x: scala.collection.mutable.HashSet[scala.Int]
-      |  [25..32): HashSet => _root_.scala.collection.mutable.HashSet#
-      |  [39..42): Int => _root_.scala.Int#
-      |_root_.i.E# => class E
-      |_root_.i.E#X# => type X: scala.collection.mutable.ListBuffer[scala.Int]
-      |  [25..35): ListBuffer => _root_.scala.collection.mutable.ListBuffer#
-      |  [42..45): Int => _root_.scala.Int#
-      |_root_.i.E#`<init>`()V. => primaryctor <init>: ()i.E
-      |  [4..5): E => _root_.i.E#
-      |_root_.i.E#x()Lscala/collection/mutable/ListBuffer;. => def x: scala.collection.mutable.ListBuffer[scala.Int]
-      |  [25..35): ListBuffer => _root_.scala.collection.mutable.ListBuffer#
-      |  [42..45): Int => _root_.scala.Int#
-      |_root_.i.a. => final object a
-      |_root_.i.a.foo(Li/B;)Ljava/lang/Object;. => def foo: (implicit b: i.B)b.X
-      |  [15..16): B => _root_.i.B#
-      |  [17..18): b => _root_.i.a.foo(Li/B;)Ljava/lang/Object;.(b)
-      |  [19..20): X => _root_.i.B#X#
-      |_root_.i.a.foo(Li/B;)Ljava/lang/Object;.(b) => implicit param b: i.B
-      |  [2..3): B => _root_.i.B#
-      |_root_.i.a.x. => val x: scala.collection.mutable.ListBuffer[scala.Int]
-      |  [25..35): ListBuffer => _root_.scala.collection.mutable.ListBuffer#
-      |  [42..45): Int => _root_.scala.Int#
-      |_root_.i.a.y. => val y: scala.collection.mutable.HashSet[scala.Int]
-      |  [25..32): HashSet => _root_.scala.collection.mutable.HashSet#
-      |  [39..42): Int => _root_.scala.Int#
-      |_root_.java.lang.Object#`<init>`()V. => primaryctor <init>: ()java.lang.Object
-      |  [12..18): Object => _root_.java.lang.Object#
-      |_root_.scala. => package scala
-      |_root_.scala.Int# => abstract final class Int
-      |_root_.scala.Int#`<init>`()V. => primaryctor <init>: ()scala.Int
-      |  [8..11): Int => _root_.scala.Int#
-      |_root_.scala.collection. => package collection
-      |_root_.scala.collection.generic.GenericCompanion#empty()Lscala/collection/GenTraversable;. => def empty: [A]CC[A]
-      |  [3..5): CC => _root_.scala.collection.generic.GenericCompanion#[CC]
-      |  [6..7): A => _root_.scala.collection.generic.GenericCompanion#empty()Lscala/collection/GenTraversable;.[A]
-      |_root_.scala.collection.mutable. => package mutable
-      |_root_.scala.collection.mutable.HashSet# => class HashSet
-      |_root_.scala.collection.mutable.HashSet#`<init>`(Lscala/collection/mutable/FlatHashTable/Contents;)V. => private primaryctor <init>: (contents: scala.collection.mutable.FlatHashTable.Contents[A])scala.collection.mutable.HashSet[A]
-      |  [36..49): FlatHashTable => _root_.scala.collection.mutable.FlatHashTable.
-      |  [50..58): Contents => _root_.scala.collection.mutable.FlatHashTable.Contents#
-      |  [59..60): A => _root_.scala.collection.mutable.HashSet#[A]
-      |  [87..94): HashSet => _root_.scala.collection.mutable.HashSet#
-      |  [95..96): A => _root_.scala.collection.mutable.HashSet#[A]
-      |_root_.scala.collection.mutable.HashSet. => final object HashSet
-      |_root_.scala.collection.mutable.HashSet.;_root_.scala.collection.mutable.HashSet# => val <import scala.collection.mutable.HashSet>: scala.collection.mutable.HashSet.type <and> scala.collection.mutable.HashSet
-      |_root_.scala.collection.mutable.HashSet.empty()Lscala/collection/mutable/HashSet;. => def empty: [A]scala.collection.mutable.HashSet[A]
-      |  [28..35): HashSet => _root_.scala.collection.mutable.HashSet#
-      |  [36..37): A => _root_.scala.collection.mutable.HashSet.empty()Lscala/collection/mutable/HashSet;.[A]
-      |_root_.scala.collection.mutable.ListBuffer# => final class ListBuffer
-      |_root_.scala.collection.mutable.ListBuffer#`<init>`()V. => primaryctor <init>: ()scala.collection.mutable.ListBuffer[A]
-      |  [27..37): ListBuffer => _root_.scala.collection.mutable.ListBuffer#
-      |  [38..39): A => _root_.scala.collection.mutable.ListBuffer#[A]
-      |_root_.scala.collection.mutable.ListBuffer. => final object ListBuffer
-      |_root_.scala.collection.mutable.ListBuffer.;_root_.scala.collection.mutable.ListBuffer# => val <import scala.collection.mutable.ListBuffer>: scala.collection.mutable.ListBuffer.type <and> scala.collection.mutable.ListBuffer
+    """|<...>@359..375 => val result: X
+       |  [0..1): X => _root_.i.B#X#
+       |_root_.i. => package i
+       |_root_.i.B# => trait B
+       |_root_.i.B#X# => abstract type X
+       |_root_.i.B#x()Ljava/lang/Object;. => abstract def x: X
+       |  [0..1): X => _root_.i.B#X#
+       |_root_.i.D# => class D
+       |_root_.i.D#X# => type X: HashSet[Int]
+       |  [0..7): HashSet => _root_.scala.collection.mutable.HashSet#
+       |  [8..11): Int => _root_.scala.Int#
+       |_root_.i.D#`<init>`()V. => primaryctor <init>: (): D
+       |  [4..5): D => _root_.i.D#
+       |_root_.i.D#x()Lscala/collection/mutable/HashSet;. => def x: HashSet[Int]
+       |  [0..7): HashSet => _root_.scala.collection.mutable.HashSet#
+       |  [8..11): Int => _root_.scala.Int#
+       |_root_.i.E# => class E
+       |_root_.i.E#X# => type X: ListBuffer[Int]
+       |  [0..10): ListBuffer => _root_.scala.collection.mutable.ListBuffer#
+       |  [11..14): Int => _root_.scala.Int#
+       |_root_.i.E#`<init>`()V. => primaryctor <init>: (): E
+       |  [4..5): E => _root_.i.E#
+       |_root_.i.E#x()Lscala/collection/mutable/ListBuffer;. => def x: ListBuffer[Int]
+       |  [0..10): ListBuffer => _root_.scala.collection.mutable.ListBuffer#
+       |  [11..14): Int => _root_.scala.Int#
+       |_root_.i.a. => final object a
+       |_root_.i.a.foo(Li/B;)Ljava/lang/Object;. => def foo: (implicit b: B): X
+       |  [13..14): B => _root_.i.B#
+       |  [17..18): X => _root_.i.B#X#
+       |_root_.i.a.foo(Li/B;)Ljava/lang/Object;.(b) => implicit param b: B
+       |  [0..1): B => _root_.i.B#
+       |_root_.i.a.x. => val x: ListBuffer[Int]
+       |  [0..10): ListBuffer => _root_.scala.collection.mutable.ListBuffer#
+       |  [11..14): Int => _root_.scala.Int#
+       |_root_.i.a.y. => val y: HashSet[Int]
+       |  [0..7): HashSet => _root_.scala.collection.mutable.HashSet#
+       |  [8..11): Int => _root_.scala.Int#
+       |_root_.java.lang.Object#`<init>`()V. => primaryctor <init>: (): Object
+       |  [4..10): Object => _root_.java.lang.Object#
+       |_root_.scala. => package scala
+       |_root_.scala.Int# => abstract final class Int
+       |_root_.scala.Int#`<init>`()V. => primaryctor <init>: (): Int
+       |  [4..7): Int => _root_.scala.Int#
+       |_root_.scala.collection. => package collection
+       |_root_.scala.collection.generic.GenericCompanion#empty()Lscala/collection/GenTraversable;. => def empty: [A] => CC[A]
+       |  [7..9): CC => _root_.scala.collection.generic.GenericCompanion#[CC]
+       |  [10..11): A => _root_.scala.collection.generic.GenericCompanion#empty()Lscala/collection/GenTraversable;.[A]
+       |_root_.scala.collection.mutable. => package mutable
+       |_root_.scala.collection.mutable.HashSet# => class HashSet
+       |_root_.scala.collection.mutable.HashSet#`<init>`(Lscala/collection/mutable/FlatHashTable/Contents;)V. => private primaryctor <init>: (contents: Contents[A]): HashSet[A]
+       |  [11..19): Contents => _root_.scala.collection.mutable.FlatHashTable.Contents#
+       |  [20..21): A => _root_.scala.collection.mutable.HashSet#[A]
+       |  [25..32): HashSet => _root_.scala.collection.mutable.HashSet#
+       |  [33..34): A => _root_.scala.collection.mutable.HashSet#[A]
+       |_root_.scala.collection.mutable.HashSet. => final object HashSet
+       |_root_.scala.collection.mutable.HashSet.;_root_.scala.collection.mutable.HashSet# => val <import scala.collection.mutable.HashSet>: scala.collection.mutable.HashSet.type <and> scala.collection.mutable.HashSet
+       |_root_.scala.collection.mutable.HashSet.empty()Lscala/collection/mutable/HashSet;. => def empty: [A] => HashSet[A]
+       |  [7..14): HashSet => _root_.scala.collection.mutable.HashSet#
+       |  [15..16): A => _root_.scala.collection.mutable.HashSet.empty()Lscala/collection/mutable/HashSet;.[A]
+       |_root_.scala.collection.mutable.ListBuffer# => final class ListBuffer
+       |_root_.scala.collection.mutable.ListBuffer#`<init>`()V. => primaryctor <init>: (): ListBuffer[A]
+       |  [4..14): ListBuffer => _root_.scala.collection.mutable.ListBuffer#
+       |  [15..16): A => _root_.scala.collection.mutable.ListBuffer#[A]
+       |_root_.scala.collection.mutable.ListBuffer. => final object ListBuffer
+       |_root_.scala.collection.mutable.ListBuffer.;_root_.scala.collection.mutable.ListBuffer# => val <import scala.collection.mutable.ListBuffer>: scala.collection.mutable.ListBuffer.type <and> scala.collection.mutable.ListBuffer
     """.stripMargin.trim
   )
 
@@ -524,21 +515,20 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |  List.newBuilder[Int].result
       |  List(1).head
       |}""".stripMargin,
-    """
-      |_empty_.o. => final object o
-      |_root_.scala.Int# => abstract final class Int
-      |_root_.scala.Int#`<init>`()V. => primaryctor <init>: ()scala.Int
-      |  [8..11): Int => _root_.scala.Int#
-      |_root_.scala.collection.IterableLike#head()Ljava/lang/Object;. => def head: A
-      |  [0..1): A => _root_.scala.collection.IterableLike#[A]
-      |_root_.scala.collection.immutable.List. => final object List
-      |_root_.scala.collection.immutable.List.newBuilder()Lscala/collection/mutable/Builder;. => def newBuilder: [A]scala.collection.mutable.Builder[A,scala.collection.immutable.List[A]]
-      |  [28..35): Builder => _root_.scala.collection.mutable.Builder#
-      |  [36..37): A => _root_.scala.collection.immutable.List.newBuilder()Lscala/collection/mutable/Builder;.[A]
-      |  [65..69): List => _root_.scala.collection.immutable.List#
-      |  [70..71): A => _root_.scala.collection.immutable.List.newBuilder()Lscala/collection/mutable/Builder;.[A]
-      |_root_.scala.collection.mutable.Builder#result()Ljava/lang/Object;. => abstract def result: ()To
-      |  [2..4): To => _root_.scala.collection.mutable.Builder#[To]
+    """|_empty_.o. => final object o
+       |_root_.scala.Int# => abstract final class Int
+       |_root_.scala.Int#`<init>`()V. => primaryctor <init>: (): Int
+       |  [4..7): Int => _root_.scala.Int#
+       |_root_.scala.collection.IterableLike#head()Ljava/lang/Object;. => def head: A
+       |  [0..1): A => _root_.scala.collection.IterableLike#[A]
+       |_root_.scala.collection.immutable.List. => final object List
+       |_root_.scala.collection.immutable.List.newBuilder()Lscala/collection/mutable/Builder;. => def newBuilder: [A] => Builder[A, List[A]]
+       |  [7..14): Builder => _root_.scala.collection.mutable.Builder#
+       |  [15..16): A => _root_.scala.collection.immutable.List.newBuilder()Lscala/collection/mutable/Builder;.[A]
+       |  [18..22): List => _root_.scala.collection.immutable.List#
+       |  [23..24): A => _root_.scala.collection.immutable.List.newBuilder()Lscala/collection/mutable/Builder;.[A]
+       |_root_.scala.collection.mutable.Builder#result()Ljava/lang/Object;. => abstract def result: (): To
+       |  [4..6): To => _root_.scala.collection.mutable.Builder#[To]
     """.stripMargin.trim
   )
 
@@ -564,16 +554,15 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
        |  List(1) + "blaH"
        |}
     """.stripMargin,
-    """|
-       |[13..20): scala.Predef.any2stringadd[scala.collection.immutable.List[scala.Int]](*)
+    """|[13..20): scala.Predef.any2stringadd[List[Int]](*)
+       |  [27..31): List => _root_.scala.collection.immutable.List#
        |  [13..26): any2stringadd => _root_.scala.Predef.any2stringadd(Ljava/lang/Object;)Ljava/lang/Object;.
-       |  [65..68): Int => _root_.scala.Int#
-       |  [54..58): List => _root_.scala.collection.immutable.List#
-       |  [71..72): * => _star_.
-       |[17..17): *.apply[scala.Int]
+       |  [32..35): Int => _root_.scala.Int#
+       |  [38..39): * => _star_.
+       |[17..17): *.apply[Int]
        |  [0..1): * => _star_.
        |  [2..7): apply => _root_.scala.collection.immutable.List.apply(Lscala/collection/Seq;)Lscala/collection/immutable/List;.
-       |  [14..17): Int => _root_.scala.Int#
+       |  [8..11): Int => _root_.scala.Int#
        |""".stripMargin
   )
 
@@ -584,11 +573,11 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
        |  val x: Ordered[F] = new F
        |}
     """.stripMargin,
-    """|[86..91): scala.math.Ordered.orderingToOrdered[r.F](*)(r.this.ordering)
+    """|[86..91): scala.math.Ordered.orderingToOrdered[F](*)(r.this.ordering)
        |  [19..36): orderingToOrdered => _root_.scala.math.Ordered.orderingToOrdered(Ljava/lang/Object;Lscala/math/Ordering;)Lscala/math/Ordered;.
-       |  [39..40): F => _empty_.r.F#
-       |  [42..43): * => _star_.
-       |  [52..60): ordering => _empty_.r.ordering.
+       |  [37..38): F => _empty_.r.F#
+       |  [40..41): * => _star_.
+       |  [50..58): ordering => _empty_.r.ordering.
        |""".stripMargin
   )
 
@@ -628,10 +617,10 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       assert(first == Symbol("_empty_.u.unapply(Lu;)Lscala/Option;."))
       assertNoDiff(
         denotation.toString,
-        """case def unapply: (x$0: u)scala.Option[scala.Int]
+        """case def unapply: (x$0: u): Option[Int]
           |  [6..7): u => _empty_.u#
-          |  [14..20): Option => _root_.scala.Option#
-          |  [27..30): Int => _root_.scala.Int#
+          |  [10..16): Option => _root_.scala.Option#
+          |  [17..20): Int => _root_.scala.Int#
         """.stripMargin
       )
     }
@@ -663,10 +652,10 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       def check(symbol: Symbol, info: String) = {
         assertNoDiff(db.symbols.find(_.symbol == symbol).get.denotation.signature, info)
       }
-      check(a, "java.lang.StringBuilder")
-      check(b, "scala.collection.mutable.StringBuilder")
-      check(c, "scala.package.Traversable[scala.Int]")
-      check(d, "scala.collection.immutable.Map[scala.Int,scala.Int]")
+      check(a, "StringBuilder")
+      check(b, "StringBuilder")
+      check(c, "Traversable[Int]")
+      check(d, "Map[Int, Int]")
     }
   )
 

--- a/scalameta/tests/jvm/src/test/resources/semanticdb.expect
+++ b/scalameta/tests/jvm/src/test/resources/semanticdb.expect
@@ -34,62 +34,58 @@ Messages:
 Symbols:
 _root_.example. => package example
 _root_.example.Example. => final object Example
-_root_.example.Example.main([Ljava/lang/String;)V. => def main: (args: scala.Array[scala.Predef.String])scala.Unit
-  [13..18): Array => _root_.scala.Array#
-  [19..24): scala => _root_.scala.
-  [25..31): Predef => _root_.scala.Predef.
-  [32..38): String => _root_.scala.Predef.String#
-  [46..50): Unit => _root_.scala.Unit#
-_root_.example.Example.main([Ljava/lang/String;)V.(args) => param args: scala.Array[scala.Predef.String]
-  [6..11): Array => _root_.scala.Array#
-  [12..17): scala => _root_.scala.
-  [18..24): Predef => _root_.scala.Predef.
-  [25..31): String => _root_.scala.Predef.String#
-_root_.example.Example.x. => val x: scala.reflect.ClassTag[scala.Int]
-  [14..22): ClassTag => _root_.scala.reflect.ClassTag#
-  [29..32): Int => _root_.scala.Int#
+_root_.example.Example.main([Ljava/lang/String;)V. => def main: (args: Array[String]): Unit
+  [7..12): Array => _root_.scala.Array#
+  [13..19): String => _root_.scala.Predef.String#
+  [23..27): Unit => _root_.scala.Unit#
+_root_.example.Example.main([Ljava/lang/String;)V.(args) => param args: Array[String]
+  [0..5): Array => _root_.scala.Array#
+  [6..12): String => _root_.scala.Predef.String#
+_root_.example.Example.x. => val x: ClassTag[Int]
+  [0..8): ClassTag => _root_.scala.reflect.ClassTag#
+  [9..12): Int => _root_.scala.Int#
 _root_.scala. => package scala
 _root_.scala.Array# => final class Array
-_root_.scala.Array#`<init>`(I)V. => primaryctor <init>: (_length: scala.Int)scala.Array[T]
-  [16..19): Int => _root_.scala.Int#
-  [26..31): Array => _root_.scala.Array#
-  [32..33): T => _root_.scala.Array#[T]
+_root_.scala.Array#`<init>`(I)V. => primaryctor <init>: (_length: Int): Array[T]
+  [10..13): Int => _root_.scala.Int#
+  [16..21): Array => _root_.scala.Array#
+  [22..23): T => _root_.scala.Array#[T]
 _root_.scala.Int# => abstract final class Int
-_root_.scala.Int#`<init>`()V. => primaryctor <init>: ()scala.Int
-  [8..11): Int => _root_.scala.Int#
-_root_.scala.Predef.String# => type String: java.lang.String
-  [10..16): String => _root_.java.lang.String#
-_root_.scala.Predef.println(Ljava/lang/Object;)V. => def println: (x: scala.Any)scala.Unit
-  [10..13): Any => _root_.scala.Any#
-  [20..24): Unit => _root_.scala.Unit#
+_root_.scala.Int#`<init>`()V. => primaryctor <init>: (): Int
+  [4..7): Int => _root_.scala.Int#
+_root_.scala.Predef.String# => type String: String
+  [0..6): String => _root_.java.lang.String#
+_root_.scala.Predef.println(Ljava/lang/Object;)V. => def println: (x: Any): Unit
+  [4..7): Any => _root_.scala.Any#
+  [10..14): Unit => _root_.scala.Unit#
 _root_.scala.Unit# => abstract final class Unit
-_root_.scala.Unit#`<init>`()V. => primaryctor <init>: ()scala.Unit
-  [8..12): Unit => _root_.scala.Unit#
+_root_.scala.Unit#`<init>`()V. => primaryctor <init>: (): Unit
+  [4..8): Unit => _root_.scala.Unit#
 _root_.scala.collection. => package collection
 _root_.scala.collection.mutable. => package mutable
 _root_.scala.collection.mutable.Stack# => class Stack
-_root_.scala.collection.mutable.Stack#`<init>`()V. => secondaryctor <init>: ()scala.collection.mutable.Stack[A]
-  [27..32): Stack => _root_.scala.collection.mutable.Stack#
-  [33..34): A => _root_.scala.collection.mutable.Stack#[A]
-_root_.scala.collection.mutable.Stack#`<init>`(Lscala/collection/immutable/List;)V. => private primaryctor <init>: (elems: scala.collection.immutable.List[A])scala.collection.mutable.Stack[A]
-  [35..39): List => _root_.scala.collection.immutable.List#
-  [40..41): A => _root_.scala.collection.mutable.Stack#[A]
-  [68..73): Stack => _root_.scala.collection.mutable.Stack#
-  [74..75): A => _root_.scala.collection.mutable.Stack#[A]
+_root_.scala.collection.mutable.Stack#`<init>`()V. => secondaryctor <init>: (): Stack[A]
+  [4..9): Stack => _root_.scala.collection.mutable.Stack#
+  [10..11): A => _root_.scala.collection.mutable.Stack#[A]
+_root_.scala.collection.mutable.Stack#`<init>`(Lscala/collection/immutable/List;)V. => private primaryctor <init>: (elems: List[A]): Stack[A]
+  [8..12): List => _root_.scala.collection.immutable.List#
+  [13..14): A => _root_.scala.collection.mutable.Stack#[A]
+  [18..23): Stack => _root_.scala.collection.mutable.Stack#
+  [24..25): A => _root_.scala.collection.mutable.Stack#[A]
 _root_.scala.concurrent. => package concurrent
 _root_.scala.concurrent.Future.;_root_.scala.concurrent.Future# => val <import scala.concurrent.Future>: scala.concurrent.Future.type <and> scala.concurrent.Future
 _root_.scala.reflect. => package reflect
-_root_.scala.reflect.package.classTag(Lscala/reflect/ClassTag;)Lscala/reflect/ClassTag;. => def classTag: [T](implicit ctag: scala.reflect.ClassTag[T])scala.reflect.ClassTag[T]
-  [33..41): ClassTag => _root_.scala.reflect.ClassTag#
-  [42..43): T => _root_.scala.reflect.package.classTag(Lscala/reflect/ClassTag;)Lscala/reflect/ClassTag;.[T]
-  [59..67): ClassTag => _root_.scala.reflect.ClassTag#
-  [68..69): T => _root_.scala.reflect.package.classTag(Lscala/reflect/ClassTag;)Lscala/reflect/ClassTag;.[T]
+_root_.scala.reflect.package.classTag(Lscala/reflect/ClassTag;)Lscala/reflect/ClassTag;. => def classTag: [T] => (implicit ctag: ClassTag[T]): ClassTag[T]
+  [23..31): ClassTag => _root_.scala.reflect.ClassTag#
+  [32..33): T => _root_.scala.reflect.package.classTag(Lscala/reflect/ClassTag;)Lscala/reflect/ClassTag;.[T]
+  [37..45): ClassTag => _root_.scala.reflect.ClassTag#
+  [46..47): T => _root_.scala.reflect.package.classTag(Lscala/reflect/ClassTag;)Lscala/reflect/ClassTag;.[T]
 
 Synthetics:
-[208..208): *(((ClassTag.Int): scala.reflect.ClassTag[scala.Int]))
+[208..208): *(((ClassTag.Int): ClassTag[Int]))
   [0..1): * => _star_.
-  [48..51): Int => _root_.scala.Int#
-  [33..41): ClassTag => _root_.scala.reflect.ClassTag#
+  [28..31): Int => _root_.scala.Int#
+  [19..27): ClassTag => _root_.scala.reflect.ClassTag#
   [13..16): Int => _root_.scala.reflect.ClassTag.Int.
 
 
@@ -114,61 +110,59 @@ Names:
 Symbols:
 _root_.example. => package example
 _root_.example.Synthetic# => class Synthetic
-_root_.example.Synthetic#`<init>`()V. => primaryctor <init>: ()example.Synthetic
-  [10..19): Synthetic => _root_.example.Synthetic#
+_root_.example.Synthetic#`<init>`()V. => primaryctor <init>: (): Synthetic
+  [4..13): Synthetic => _root_.example.Synthetic#
 _root_.scala.Array. => final object Array
-_root_.scala.Array.empty(Lscala/reflect/ClassTag;)Ljava/lang/Object;. => def empty: [T](implicit evidence$1: scala.reflect.ClassTag[T])scala.Array[T]
-  [39..47): ClassTag => _root_.scala.reflect.ClassTag#
-  [48..49): T => _root_.scala.Array.empty(Lscala/reflect/ClassTag;)Ljava/lang/Object;.[T]
-  [57..62): Array => _root_.scala.Array#
-  [63..64): T => _root_.scala.Array.empty(Lscala/reflect/ClassTag;)Ljava/lang/Object;.[T]
+_root_.scala.Array.empty(Lscala/reflect/ClassTag;)Ljava/lang/Object;. => def empty: [T] => (implicit evidence$1: ClassTag[T]): Array[T]
+  [29..37): ClassTag => _root_.scala.reflect.ClassTag#
+  [38..39): T => _root_.scala.Array.empty(Lscala/reflect/ClassTag;)Ljava/lang/Object;.[T]
+  [43..48): Array => _root_.scala.Array#
+  [49..50): T => _root_.scala.Array.empty(Lscala/reflect/ClassTag;)Ljava/lang/Object;.[T]
 _root_.scala.Int# => abstract final class Int
-_root_.scala.Int#`+`(I)I. => abstract def +: (x: scala.Int)scala.Int
+_root_.scala.Int#`+`(I)I. => abstract def +: (x: Int): Int
+  [4..7): Int => _root_.scala.Int#
   [10..13): Int => _root_.scala.Int#
-  [20..23): Int => _root_.scala.Int#
-_root_.scala.Int#`<init>`()V. => primaryctor <init>: ()scala.Int
-  [8..11): Int => _root_.scala.Int#
-_root_.scala.collection.TraversableLike#headOption()Lscala/Option;. => def headOption: scala.Option[A]
-  [6..12): Option => _root_.scala.Option#
-  [13..14): A => _root_.scala.collection.TraversableLike#[A]
-_root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;. => final def map: [B,That](f: scala.Function1[A,B])(implicit bf: scala.collection.generic.CanBuildFrom[scala.collection.immutable.List[A],B,That])That
-  [18..27): Function1 => _root_.scala.Function1#
-  [28..29): A => _root_.scala.collection.immutable.List#[A]
+_root_.scala.Int#`<init>`()V. => primaryctor <init>: (): Int
+  [4..7): Int => _root_.scala.Int#
+_root_.scala.collection.TraversableLike#headOption()Lscala/Option;. => def headOption: Option[A]
+  [0..6): Option => _root_.scala.Option#
+  [7..8): A => _root_.scala.collection.TraversableLike#[A]
+_root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;. => final def map: [B, That] => (f: Function1[A, B])(implicit bf: CanBuildFrom[List[A], B, That]): That
+  [17..26): Function1 => _root_.scala.Function1#
+  [27..28): A => _root_.scala.collection.immutable.List#[A]
   [30..31): B => _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.[B]
-  [72..84): CanBuildFrom => _root_.scala.collection.generic.CanBuildFrom#
-  [112..116): List => _root_.scala.collection.immutable.List#
-  [117..118): A => _root_.scala.collection.immutable.List#[A]
-  [120..121): B => _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.[B]
-  [122..126): That => _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.[That]
-  [128..132): That => _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.[That]
+  [47..59): CanBuildFrom => _root_.scala.collection.generic.CanBuildFrom#
+  [60..64): List => _root_.scala.collection.immutable.List#
+  [65..66): A => _root_.scala.collection.immutable.List#[A]
+  [69..70): B => _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.[B]
+  [72..76): That => _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.[That]
+  [80..84): That => _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.[That]
 _root_.scala.collection.immutable.List. => final object List
-_root_.scala.collection.immutable.StringLike#stripPrefix(Ljava/lang/String;)Ljava/lang/String;. => def stripPrefix: (prefix: scala.Predef.String)java.lang.String
-  [9..14): scala => _root_.scala.
-  [15..21): Predef => _root_.scala.Predef.
-  [22..28): String => _root_.scala.Predef.String#
-  [39..45): String => _root_.java.lang.String#
+_root_.scala.collection.immutable.StringLike#stripPrefix(Ljava/lang/String;)Ljava/lang/String;. => def stripPrefix: (prefix: String): String
+  [9..15): String => _root_.scala.Predef.String#
+  [18..24): String => _root_.java.lang.String#
 
 Synthetics:
-[41..41): *.apply[scala.Int]
+[41..41): *.apply[Int]
   [0..1): * => _star_.
   [2..7): apply => _root_.scala.collection.immutable.List.apply(Lscala/collection/Seq;)Lscala/collection/immutable/List;.
-  [14..17): Int => _root_.scala.Int#
-[48..48): *[scala.Int, scala.collection.immutable.List[scala.Int]]
-  [0..1): * => _star_.
   [8..11): Int => _root_.scala.Int#
-  [40..44): List => _root_.scala.collection.immutable.List#
-  [51..54): Int => _root_.scala.Int#
-[55..55): *(scala.collection.immutable.List.canBuildFrom[scala.Int])
+[48..48): *[Int, List[Int]]
   [0..1): * => _star_.
+  [2..5): Int => _root_.scala.Int#
+  [12..15): Int => _root_.scala.Int#
+  [7..11): List => _root_.scala.collection.immutable.List#
+[55..55): *(scala.collection.immutable.List.canBuildFrom[Int])
+  [0..1): * => _star_.
+  [47..50): Int => _root_.scala.Int#
   [34..46): canBuildFrom => _root_.scala.collection.immutable.List.canBuildFrom()Lscala/collection/generic/CanBuildFrom;.
-  [53..56): Int => _root_.scala.Int#
 [58..74): scala.Predef.intArrayOps(*)
   [13..24): intArrayOps => _root_.scala.Predef.intArrayOps([I)[I.
   [25..26): * => _star_.
-[74..74): *(((ClassTag.Int): scala.reflect.ClassTag[scala.Int]))
+[74..74): *(((ClassTag.Int): ClassTag[Int]))
   [0..1): * => _star_.
-  [48..51): Int => _root_.scala.Int#
-  [33..41): ClassTag => _root_.scala.reflect.ClassTag#
+  [28..31): Int => _root_.scala.Int#
+  [19..27): ClassTag => _root_.scala.reflect.ClassTag#
   [13..16): Int => _root_.scala.reflect.ClassTag.Int.
 [88..94): scala.Predef.augmentString(*)
   [13..26): augmentString => _root_.scala.Predef.augmentString(Ljava/lang/String;)Ljava/lang/String;.

--- a/scalameta/tests/shared/src/test/scala/scala/meta/tests/SyntheticSuite.scala
+++ b/scalameta/tests/shared/src/test/scala/scala/meta/tests/SyntheticSuite.scala
@@ -11,7 +11,7 @@ class SyntheticSuite extends BaseSemanticSuite {
       case t: Defn.Def if t.name.value == "main" =>
         val symbol = entry.names.find(_.position == t.name.pos).get.symbol
         val expectedInput =
-          Input.Denotation("(args: scala.Array[scala.Predef.String])scala.Unit", symbol)
+          Input.Denotation("(args: Array[String]): Unit", symbol)
         val infoSymbols = entry.symbols.find(_.symbol == symbol).get.denotation.names
         assert(infoSymbols.nonEmpty)
         infoSymbols.foreach {


### PR DESCRIPTION
- `def x[T](e: Int): T`.signature is `[T] => (e: Int): T`
- Denotation.signature no longer include redundant fully qualified paths,
  to fully qualify use the resolved symbols instead.