### PR TITLE
Fix CI publish infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
     - CI_TEST: check
     - CI_TEST: ci-fast
       CI_SCALA_VERSION: 2.11.11
+      CI_PUBLISH: true
     - CI_TEST: ci-fast
       CI_SCALA_VERSION: 2.11.11
       CI_SCALA_JS: true
@@ -26,6 +27,7 @@ env:
       CI_SCALA_JS: true
     - CI_TEST: ci-langmeta
       CI_SCALA_VERSION: 2.10.6
+      CI_PUBLISH: true
 
 cache:
   directories:

--- a/bin/ci-publish.sh
+++ b/bin/ci-publish.sh
@@ -6,14 +6,7 @@ SECURE_VAR=${TRAVIS_SECURE_ENV_VARS:-false}
 if [[ "$TRAVIS_SECURE_ENV_VARS" == true && -n "$TRAVIS_TAG" && "$CI_PUBLISH" == true ]]; then
   git log | head -n 20
   echo "$PGP_SECRET" | base64 --decode | gpg --import
-  mkdir -p $HOME/.bintray
-  cat > $HOME/.bintray/.credentials <<EOF
-realm = Bintray API Realm
-host = api.bintray.com
-user = ${BINTRAY_USERNAME}
-password = ${BINTRAY_API_KEY}
-EOF
-  sbt "sonatypeOpen scalameta-$TRAVIS_TAG" ci-publish sonatypeReleaseAll
+  sbt ci-publish sonatypeReleaseAll
 else
   echo "Skipping publish, branch=$TRAVIS_BRANCH publish=$PUBLISH test=$CI_TEST"
 fi

--- a/build.sbt
+++ b/build.sbt
@@ -89,7 +89,6 @@ lazy val langmeta = crossProject
   .settings(
     publishableSettings,
     crossScalaVersions := List(LatestScala210, LatestScala211, LatestScala212),
-    organization := "org.langmeta",
     description := "Langmeta umbrella module that includes all public APIs",
     // Protobuf setup for binary serialization.
     PB.targets.in(Compile) := Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -36,11 +36,10 @@ commands += CiCommand("ci-slow")(
   "testkit/test:runMain scala.meta.testkit.ScalametaParserPropertyTest" ::
   Nil
 )
-commands += Command.command("ci-publish") { s =>
-  if (isCiPublish && isTagPush) s"very publishSigned" :: s
-  else if (isCiPublish) s"very publish" :: s
-  else s
-}
+commands += CiCommand("ci-publish")(
+  if (isTagPush) "publishSigned" :: Nil
+  else Nil
+)
 // NOTE: These tasks are aliased here in order to support running "tests/test"
 // from a command. Running "test" inside a command will trigger the `test` task
 // to run in all defined modules, including ones like inputs/io/dialects which


### PR DESCRIPTION
- Handle timeout by publishing by scala version in individual jobs
- Remove org.langmeta to please sbt-sonatype. @xeno-by We'll have to figure this out later, but I don't have time to deal with it right now.