### PR TITLE
Bump npm version

### DIFF
--- a/scalameta/parsers/js/npm/package.json
+++ b/scalameta/parsers/js/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scalameta-parsers",
-  "version": "2.0.0-RC3",
+  "version": "2.0.1",
   "main": "index.js",
   "files": [
     "index.js"

--- a/scalameta/parsers/js/npm/package.json
+++ b/scalameta/parsers/js/npm/package.json
@@ -6,7 +6,7 @@
     "index.js"
   ],
   "scripts": {
-    "prepublish": "export current=$PWD && cd ../../../.. && sbt parsersJS/fullOptJS && cd $current && cp ../target/scala-2.11/parsers-opt.js index.js"
+    "prepublish": "export current=$PWD && cd ../../../.. && sbt parsersJS/fullOptJS && cd $current && cp ../target/scala-2.12/parsers-opt.js index.js"
   },
   "author": "scalameta",
   "license": "BSD-3-Clause"

--- a/scalameta/parsers/js/npm/package.json
+++ b/scalameta/parsers/js/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scalameta-parsers",
-  "version": "1.9.0-beta.3",
+  "version": "2.0.0-RC3",
   "main": "index.js",
   "files": [
     "index.js"


### PR DESCRIPTION
Published as 2.0.0-RC3 on https://www.npmjs.com/package/scalameta-parsers