### PR TITLE
Fix incorrect names in semanticdb for for-comprehensions

### DIFF
--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/DocumentOps.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/DocumentOps.scala
@@ -154,22 +154,15 @@ trait DocumentOps { self: DatabaseOps =>
                 // Instead of crashing with "unsupported file", we ignore these cases.
                 if (mtree.pos == m.Position.None) return
 
-                object DesugaredLoopMethod {
-                  def unapply(sym: m.Symbol): Option[String] = sym match {
-                    case m.Symbol.Global(_, m.Signature.Method(name, _)) => Some(name)
-                    case _ => None
-                  }
-                }
-
                 /*
                  * HACK for desugared for-comprehensions.
                  * See https://github.com/scalameta/scalameta/issues/1037
                  */
                 def keepExistingEntry = names.get(mtree.pos) match {
-                  case Some(DesugaredLoopMethod("foreach")) => false
-                  case Some(DesugaredLoopMethod("flatMap")) => false
-                  case Some(DesugaredLoopMethod("map")) => false
-                  case Some(DesugaredLoopMethod("withFilter")) => false
+                  case Some(MethodSymbol("foreach")) => false
+                  case Some(MethodSymbol("flatMap")) => false
+                  case Some(MethodSymbol("map")) => false
+                  case Some(MethodSymbol("withFilter")) => false
                   case Some(_) => true
                   case None => false
                 }

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/SymbolOps.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/SymbolOps.scala
@@ -80,4 +80,12 @@ trait SymbolOps { self: DatabaseOps =>
       m.Symbol.Global(owner, signature)
     }
   }
+
+  object MethodSymbol {
+    def unapply(sym: m.Symbol): Option[String] = sym match {
+      case m.Symbol.Global(_, m.Signature.Method(name, _)) => Some(name)
+      case _ => None
+    }
+  }
+
 }

--- a/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/SemanticSuite.scala
+++ b/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/SemanticSuite.scala
@@ -879,7 +879,7 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       assert(z1 == z2)
     }
   )
-  
+
   names(
     """
       |object flatmap {

--- a/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/SemanticSuite.scala
+++ b/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/SemanticSuite.scala
@@ -879,4 +879,41 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       assert(z1 == z2)
     }
   )
+  
+  names(
+    """
+      |object flatmap {
+      | for (x <- 1 to 10; y <- 0 until 10) println(x -> x)
+      | for (i <- 1 to 10; j <- 0 until 10) yield (i, j)
+      | for (i <- 1 to 10; j <- 0 until 10 if i % 2 == 0) yield (i, j)
+      |}
+  """.trim.stripMargin,
+    """
+      |[7..14): flatmap <= _empty_.flatmap.
+      |[23..24): x <= <...>@23..24
+      |[30..32): to => _root_.scala.runtime.RichInt#to(I)Lscala/collection/immutable/Range/Inclusive;.
+      |[37..38): y <= <...>@37..38
+      |[44..49): until => _root_.scala.runtime.RichInt#until(I)Lscala/collection/immutable/Range;.
+      |[54..61): println => _root_.scala.Predef.println(Ljava/lang/Object;)V.
+      |[62..63): x => <...>@23..24
+      |[64..66): -> => _root_.scala.Predef.ArrowAssoc#`->`(Ljava/lang/Object;)Lscala/Tuple2;.
+      |[67..68): x => <...>@23..24
+      |[76..77): i <= <...>@76..77
+      |[83..85): to => _root_.scala.runtime.RichInt#to(I)Lscala/collection/immutable/Range/Inclusive;.
+      |[90..91): j <= <...>@90..91
+      |[97..102): until => _root_.scala.runtime.RichInt#until(I)Lscala/collection/immutable/Range;.
+      |[114..115): i => <...>@76..77
+      |[117..118): j => <...>@90..91
+      |[126..127): i <= <...>@126..127
+      |[133..135): to => _root_.scala.runtime.RichInt#to(I)Lscala/collection/immutable/Range/Inclusive;.
+      |[140..141): j <= <...>@140..140
+      |[147..152): until => _root_.scala.runtime.RichInt#until(I)Lscala/collection/immutable/Range;.
+      |[159..160): i => <...>@126..127
+      |[161..162): % => _root_.scala.Int#`%`(I)I.
+      |[165..167): == => _root_.scala.Int#`==`(I)Z.
+      |[178..179): i => <...>@126..127
+      |[181..182): j => <...>@140..141
+  """.trim.stripMargin
+  )
+
 }


### PR DESCRIPTION
Fixes #1037

Adds a special case for the `foreach`/`map`/`flatMap`/`withFilter` symbols that are generated by desugaring of for-comprehensions.

We still add the synthetic symbol to the cache, but later we come along and replace it with the correct symbol.