### PR TITLE
Enable MiMa checks on every PR.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
     - CI_TEST: ci-langmeta
       CI_SCALA_VERSION: 2.10.6
       CI_PUBLISH: true
+    - CI_TEST: mima
 
 cache:
   directories:

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -1,0 +1,13 @@
+import com.typesafe.tools.mima.core._
+
+// More details about Mim:
+// https://github.com/typesafehub/migration-manager/wiki/sbt-plugin#basic-usage
+object Mima {
+  val ignoredABIProblems: Seq[ProblemFilter] = {
+    Seq(
+      ProblemFilters.exclude[Problem]("scala.meta.internal.*"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.meta.parsers.Parsed.*"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.meta.tokenizers.Tokenized.*")
+    )
+  }
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -26,3 +26,4 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "2.0.0")
 
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.15")


### PR DESCRIPTION
The changes in #1121 broke binary compatibility in 2.11 for potential
users who implement the sealed Tokenized/Parsed traits. Those should not
be extended, so we ignore the errors.