### PR TITLE
Merging inferred args with calls to synthetics

### DIFF
--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/DocumentOps.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/DocumentOps.scala
@@ -320,7 +320,8 @@ trait DocumentOps { self: DatabaseOps =>
                 private def isForComprehensionSyntheticName(select: g.Select): Boolean = {
                   select.pos == select.qualifier.pos && (select.name == g.nme.map ||
                   select.name == g.nme.withFilter ||
-                  select.name == g.nme.flatMap)
+                  select.name == g.nme.flatMap ||
+                  select.name == g.nme.foreach)
                 }
 
                 private def findSelect(t: g.Tree): Option[g.Tree] = t match {

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/DocumentOps.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/DocumentOps.scala
@@ -316,6 +316,17 @@ trait DocumentOps { self: DatabaseOps =>
                 }
               }
 
+              object SyntheticApplyToImplicitArgs {
+                private def findSelect(t: g.Tree): Option[g.Tree] = t match {
+                  case g.Apply(fun, _) => findSelect(fun)
+                  case g.TypeApply(fun, _) => findSelect(fun)
+                  case s@g.Select(qual, _) if isSyntheticName(s) => Some(qual)
+                  case _ => None
+                }
+
+                def unapply(gfun: g.Apply): Option[g.Tree] = findSelect(gfun)
+              }
+
               gtree match {
                 case gview: g.ApplyImplicitView =>
                   val pos = gtree.pos.toMeta
@@ -323,17 +334,20 @@ trait DocumentOps { self: DatabaseOps =>
                   success(pos, _.copy(conversion = Some(syntax)))
                   isVisited += gview.fun
                 case gimpl: g.ApplyToImplicitArgs =>
+                  val args = S.mkString(gimpl.args.map(showSynthetic), ", ")
                   gimpl.fun match {
                     case gview: g.ApplyImplicitView =>
                       isVisited += gview
                       val pos = gtree.pos.toMeta
-                      val args = S.mkString(gimpl.args.map(showSynthetic), ", ")
                       val syntax = showSynthetic(gview.fun) + "(" + S.star + ")(" + args + ")"
                       success(pos, _.copy(conversion = Some(syntax)))
+                    case SyntheticApplyToImplicitArgs(qual) =>
+                      val morePrecisePos = qual.pos.withStart(qual.pos.end).toMeta
+                      val syntax = S("(") + S.star + ")" + "(" + args + ")"
+                      success(morePrecisePos, _.copy(args = Some(syntax)))
                     case gfun =>
-                      val fullyQualifiedArgs = S.mkString(gimpl.args.map(showSynthetic), ", ")
                       val morePrecisePos = gimpl.pos.withStart(gimpl.pos.end).toMeta
-                      val syntax = S("(") + fullyQualifiedArgs + ")"
+                      val syntax = S("(") + args + ")"
                       success(morePrecisePos, _.copy(args = Some(syntax)))
                   }
                 case g.TypeApply(fun, targs @ List(targ, _*)) =>

--- a/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/SemanticSuite.scala
+++ b/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/SemanticSuite.scala
@@ -248,14 +248,13 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |  CommandeerDSL(null.asInstanceOf[Foo])
       |}
     """.trim.stripMargin,
-    """|[324..324): *.apply[Foo, FooDSL]
+    """|[324..324): *.apply[Foo, FooDSL](*)(g.Foo.fooDSL)
        |  [0..1): * => _star_.
        |  [2..7): apply => _root_.g.CommandeerDSL.apply(Ljava/lang/Object;Lg/CommandeerDSL;)Lg/CommandeerDSL;.
        |  [8..11): Foo => _root_.g.Foo#
        |  [13..19): FooDSL => _root_.g.FooDSL#
-       |[348..348): *(g.Foo.fooDSL)
-       |  [0..1): * => _star_.
-       |  [8..14): fooDSL => _root_.g.Foo.fooDSL.
+       |  [21..22): * => _star_.
+       |  [30..36): fooDSL => _root_.g.Foo.fooDSL.
     """.trim.stripMargin
   )
 
@@ -949,7 +948,7 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |[76..77): scala.Predef.intWrapper(*)
       |  [13..23): intWrapper => _root_.scala.LowPriorityImplicits#intWrapper(I)I.
       |  [24..25): * => _star_.
-      |[83..83): *.flatMap[Tuple2[Int, Int], IndexedSeq[Tuple2[Int, Int]]]
+      |[83..83): *.flatMap[Tuple2[Int, Int], IndexedSeq[Tuple2[Int, Int]]](*)(scala.collection.immutable.IndexedSeq.canBuildFrom[Tuple2[Int, Int]])
       |  [0..1): * => _star_.
       |  [2..9): flatMap => _root_.scala.collection.TraversableLike#flatMap(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.
       |  [22..25): Int => _root_.scala.Int#
@@ -959,10 +958,15 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |  [39..45): Tuple2 => _root_.scala.Tuple2#
       |  [46..49): Int => _root_.scala.Int#
       |  [51..54): Int => _root_.scala.Int#
+      |  [58..59): * => _star_.
+      |  [112..118): Tuple2 => _root_.scala.Tuple2#
+      |  [119..122): Int => _root_.scala.Int#
+      |  [124..127): Int => _root_.scala.Int#
+      |  [99..111): canBuildFrom => _root_.scala.collection.immutable.IndexedSeq.canBuildFrom()Lscala/collection/generic/CanBuildFrom;.
       |[90..91): scala.Predef.intWrapper(*)
       |  [13..23): intWrapper => _root_.scala.LowPriorityImplicits#intWrapper(I)I.
       |  [24..25): * => _star_.
-      |[100..100): *.map[Tuple2[Int, Int], IndexedSeq[Tuple2[Int, Int]]]
+      |[100..100): *.map[Tuple2[Int, Int], IndexedSeq[Tuple2[Int, Int]]](*)(scala.collection.immutable.IndexedSeq.canBuildFrom[Tuple2[Int, Int]])
       |  [0..1): * => _star_.
       |  [2..5): map => _root_.scala.collection.TraversableLike#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.
       |  [18..21): Int => _root_.scala.Int#
@@ -972,16 +976,15 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |  [35..41): Tuple2 => _root_.scala.Tuple2#
       |  [42..45): Int => _root_.scala.Int#
       |  [47..50): Int => _root_.scala.Int#
-      |[114..114): *(scala.collection.immutable.IndexedSeq.canBuildFrom[Tuple2[Int, Int]])
-      |  [0..1): * => _star_.
-      |  [53..59): Tuple2 => _root_.scala.Tuple2#
-      |  [60..63): Int => _root_.scala.Int#
-      |  [65..68): Int => _root_.scala.Int#
-      |  [40..52): canBuildFrom => _root_.scala.collection.immutable.IndexedSeq.canBuildFrom()Lscala/collection/generic/CanBuildFrom;.
+      |  [54..55): * => _star_.
+      |  [108..114): Tuple2 => _root_.scala.Tuple2#
+      |  [115..118): Int => _root_.scala.Int#
+      |  [120..123): Int => _root_.scala.Int#
+      |  [95..107): canBuildFrom => _root_.scala.collection.immutable.IndexedSeq.canBuildFrom()Lscala/collection/generic/CanBuildFrom;.
       |[126..127): scala.Predef.intWrapper(*)
       |  [13..23): intWrapper => _root_.scala.LowPriorityImplicits#intWrapper(I)I.
       |  [24..25): * => _star_.
-      |[133..133): *.flatMap[Tuple2[Int, Int], IndexedSeq[Tuple2[Int, Int]]]
+      |[133..133): *.flatMap[Tuple2[Int, Int], IndexedSeq[Tuple2[Int, Int]]](*)(scala.collection.immutable.IndexedSeq.canBuildFrom[Tuple2[Int, Int]])
       |  [0..1): * => _star_.
       |  [2..9): flatMap => _root_.scala.collection.TraversableLike#flatMap(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.
       |  [22..25): Int => _root_.scala.Int#
@@ -991,13 +994,18 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |  [39..45): Tuple2 => _root_.scala.Tuple2#
       |  [46..49): Int => _root_.scala.Int#
       |  [51..54): Int => _root_.scala.Int#
+      |  [58..59): * => _star_.
+      |  [112..118): Tuple2 => _root_.scala.Tuple2#
+      |  [119..122): Int => _root_.scala.Int#
+      |  [124..127): Int => _root_.scala.Int#
+      |  [99..111): canBuildFrom => _root_.scala.collection.immutable.IndexedSeq.canBuildFrom()Lscala/collection/generic/CanBuildFrom;.
       |[140..141): scala.Predef.intWrapper(*)
       |  [13..23): intWrapper => _root_.scala.LowPriorityImplicits#intWrapper(I)I.
       |  [24..25): * => _star_.
       |[150..150): *.withFilter
       |  [0..1): * => _star_.
       |  [2..12): withFilter => _root_.scala.collection.TraversableLike#withFilter(Lscala/Function1;)Lscala/collection/generic/FilterMonadic;.
-      |[164..164): *.map[Tuple2[Int, Int], IndexedSeq[Tuple2[Int, Int]]]
+      |[164..164): *.map[Tuple2[Int, Int], IndexedSeq[Tuple2[Int, Int]]](*)(scala.collection.immutable.IndexedSeq.canBuildFrom[Tuple2[Int, Int]])
       |  [0..1): * => _star_.
       |  [2..5): map => _root_.scala.collection.generic.FilterMonadic#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.
       |  [18..21): Int => _root_.scala.Int#
@@ -1007,12 +1015,55 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |  [35..41): Tuple2 => _root_.scala.Tuple2#
       |  [42..45): Int => _root_.scala.Int#
       |  [47..50): Int => _root_.scala.Int#
-      |[178..178): *(scala.collection.immutable.IndexedSeq.canBuildFrom[Tuple2[Int, Int]])
-      |  [0..1): * => _star_.
-      |  [53..59): Tuple2 => _root_.scala.Tuple2#
-      |  [60..63): Int => _root_.scala.Int#
-      |  [65..68): Int => _root_.scala.Int#
-      |  [40..52): canBuildFrom => _root_.scala.collection.immutable.IndexedSeq.canBuildFrom()Lscala/collection/generic/CanBuildFrom;.
+      |  [54..55): * => _star_.
+      |  [108..114): Tuple2 => _root_.scala.Tuple2#
+      |  [115..118): Int => _root_.scala.Int#
+      |  [120..123): Int => _root_.scala.Int#
+      |  [95..107): canBuildFrom => _root_.scala.collection.immutable.IndexedSeq.canBuildFrom()Lscala/collection/generic/CanBuildFrom;.
     """.trim.stripMargin
   )
+
+  synthetics(
+    """
+      |object ForCompFuture {
+      |  import scala.concurrent.ExecutionContext.Implicits.global
+      |  val f1 = scala.concurrent.Future {1}
+      |  val f2 = scala.concurrent.Future {2}
+      |
+      |  for (v1 <- f1; v2 <- f2 if v1 > v2) yield v1+v2
+      |}
+    """.trim.stripMargin,
+    """
+      |[109..109): *.apply[Int](*)(scala.concurrent.ExecutionContext.Implicits.global)
+      |  [0..1): * => _star_.
+      |  [2..7): apply => _root_.scala.concurrent.Future.apply(Lscala/Function0;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
+      |  [8..11): Int => _root_.scala.Int#
+      |  [13..14): * => _star_.
+      |  [60..66): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
+      |[148..148): *.apply[Int](*)(scala.concurrent.ExecutionContext.Implicits.global)
+      |  [0..1): * => _star_.
+      |  [2..7): apply => _root_.scala.concurrent.Future.apply(Lscala/Function0;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
+      |  [8..11): Int => _root_.scala.Int#
+      |  [13..14): * => _star_.
+      |  [60..66): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
+      |[169..169): *.flatMap[Int](*)(scala.concurrent.ExecutionContext.Implicits.global)
+      |  [0..1): * => _star_.
+      |  [2..9): flatMap => _root_.scala.concurrent.Future#flatMap(Lscala/Function1;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
+      |  [10..13): Int => _root_.scala.Int#
+      |  [15..16): * => _star_.
+      |  [62..68): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
+      |[179..179): *.withFilter(*)(scala.concurrent.ExecutionContext.Implicits.global)
+      |  [0..1): * => _star_.
+      |  [2..12): withFilter => _root_.scala.concurrent.Future#withFilter(Lscala/Function1;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
+      |  [13..14): * => _star_.
+      |  [60..66): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
+      |[190..190): *.map[Int](*)(scala.concurrent.ExecutionContext.Implicits.global)
+      |  [0..1): * => _star_.
+      |  [2..5): map => _root_.scala.concurrent.Future#map(Lscala/Function1;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
+      |  [6..9): Int => _root_.scala.Int#
+      |  [11..12): * => _star_.
+      |  [58..64): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
+    """.trim.stripMargin
+  )
+
 }

--- a/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/SemanticSuite.scala
+++ b/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/SemanticSuite.scala
@@ -1026,86 +1026,61 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
 
   synthetics(
     """
-      |object ForCompFuture {
+      |object ForCompImplicits {
       |  import scala.concurrent.ExecutionContext.Implicits.global
-      |  val f1 = scala.concurrent.Future {1}
-      |  val f2 = scala.concurrent.Future {2}
-      |
-      |  for (v1 <- f1; v2 <- f2 if v1 > v2) yield v1+v2
+      |  for {
+      |    a <- scala.concurrent.Future.successful(1)
+      |    b <- scala.concurrent.Future.successful(2)
+      |  } println(a)
+      |  for {
+      |    a <- scala.concurrent.Future.successful(1)
+      |    b <- scala.concurrent.Future.successful(2)
+      |    if a < b
+      |  } yield a
       |}
     """.trim.stripMargin,
     """
-    |[117..117): *.apply[Int]
-    |  [0..1): * => _star_.
-    |  [2..7): apply => _root_.scala.concurrent.Future.apply(Lscala/Function0;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
-    |  [8..11): Int => _root_.scala.Int#
-    |[121..121): *(scala.concurrent.ExecutionContext.Implicits.global)
-    |  [0..1): * => _star_.
-    |  [46..52): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
-    |[156..156): *.apply[Int]
-    |  [0..1): * => _star_.
-    |  [2..7): apply => _root_.scala.concurrent.Future.apply(Lscala/Function0;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
-    |  [8..11): Int => _root_.scala.Int#
-    |[160..160): *(scala.concurrent.ExecutionContext.Implicits.global)
-    |  [0..1): * => _star_.
-    |  [46..52): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
-    |[177..177): *.flatMap[Int](*)(scala.concurrent.ExecutionContext.Implicits.global)
-    |  [0..1): * => _star_.
-    |  [2..9): flatMap => _root_.scala.concurrent.Future#flatMap(Lscala/Function1;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
-    |  [10..13): Int => _root_.scala.Int#
-    |  [15..16): * => _star_.
-    |  [62..68): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
-    |[187..187): *.withFilter(*)(scala.concurrent.ExecutionContext.Implicits.global)
-    |  [0..1): * => _star_.
-    |  [2..12): withFilter => _root_.scala.concurrent.Future#withFilter(Lscala/Function1;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
-    |  [13..14): * => _star_.
-    |  [60..66): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
-    |[198..198): *.map[Int](*)(scala.concurrent.ExecutionContext.Implicits.global)
-    |  [0..1): * => _star_.
-    |  [2..5): map => _root_.scala.concurrent.Future#map(Lscala/Function1;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
-    |  [6..9): Int => _root_.scala.Int#
-    |  [11..12): * => _star_.
-    |  [58..64): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
-   """.trim.stripMargin
-  )
-
-  synthetics(
-    """
-      |object ForeachFuture {
-      |  import scala.concurrent.ExecutionContext.Implicits.global
-      |  val f1 = scala.concurrent.Future {1}
-      |  val f2 = scala.concurrent.Future {2}
-      |
-      |  for (v1 <- f1; v2 <- f2) println(v1+v2)
-      |}
-    """.trim.stripMargin,
-    """
-      |[117..117): *.apply[Int]
+      |[137..137): *[Int]
       |  [0..1): * => _star_.
-      |  [2..7): apply => _root_.scala.concurrent.Future.apply(Lscala/Function0;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
-      |  [8..11): Int => _root_.scala.Int#
-      |[121..121): *(scala.concurrent.ExecutionContext.Implicits.global)
-      |  [0..1): * => _star_.
-      |  [46..52): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
-      |[156..156): *.apply[Int]
-      |  [0..1): * => _star_.
-      |  [2..7): apply => _root_.scala.concurrent.Future.apply(Lscala/Function0;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
-      |  [8..11): Int => _root_.scala.Int#
-      |[160..160): *(scala.concurrent.ExecutionContext.Implicits.global)
-      |  [0..1): * => _star_.
-      |  [46..52): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
-      |[177..177): *.foreach[Unit](*)(scala.concurrent.ExecutionContext.Implicits.global)
+      |  [2..5): Int => _root_.scala.Int#
+      |[140..140): *.foreach[Unit](*)(scala.concurrent.ExecutionContext.Implicits.global)
       |  [0..1): * => _star_.
       |  [2..9): foreach => _root_.scala.concurrent.Future#foreach(Lscala/Function1;Lscala/concurrent/ExecutionContext;)V.
       |  [10..14): Unit => _root_.scala.Unit#
       |  [16..17): * => _star_.
       |  [63..69): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
+      |[184..184): *[Int]
+      |  [0..1): * => _star_.
+      |  [2..5): Int => _root_.scala.Int#
       |[187..187): *.foreach[Unit](*)(scala.concurrent.ExecutionContext.Implicits.global)
       |  [0..1): * => _star_.
       |  [2..9): foreach => _root_.scala.concurrent.Future#foreach(Lscala/Function1;Lscala/concurrent/ExecutionContext;)V.
       |  [10..14): Unit => _root_.scala.Unit#
       |  [16..17): * => _star_.
       |  [63..69): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
-    """.trim.stripMargin
+      |[254..254): *[Int]
+      |  [0..1): * => _star_.
+      |  [2..5): Int => _root_.scala.Int#
+      |[257..257): *.flatMap[Int](*)(scala.concurrent.ExecutionContext.Implicits.global)
+      |  [0..1): * => _star_.
+      |  [2..9): flatMap => _root_.scala.concurrent.Future#flatMap(Lscala/Function1;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
+      |  [10..13): Int => _root_.scala.Int#
+      |  [15..16): * => _star_.
+      |  [62..68): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
+      |[301..301): *[Int]
+      |  [0..1): * => _star_.
+      |  [2..5): Int => _root_.scala.Int#
+      |[304..304): *.withFilter(*)(scala.concurrent.ExecutionContext.Implicits.global)
+      |  [0..1): * => _star_.
+      |  [2..12): withFilter => _root_.scala.concurrent.Future#withFilter(Lscala/Function1;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
+      |  [13..14): * => _star_.
+      |  [60..66): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
+      |[317..317): *.map[Int](*)(scala.concurrent.ExecutionContext.Implicits.global)
+      |  [0..1): * => _star_.
+      |  [2..5): map => _root_.scala.concurrent.Future#map(Lscala/Function1;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
+      |  [6..9): Int => _root_.scala.Int#
+      |  [11..12): * => _star_.
+      |  [58..64): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
+   """.trim.stripMargin
   )
 }

--- a/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/SemanticSuite.scala
+++ b/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/SemanticSuite.scala
@@ -248,13 +248,14 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |  CommandeerDSL(null.asInstanceOf[Foo])
       |}
     """.trim.stripMargin,
-    """|[324..324): *.apply[Foo, FooDSL](*)(g.Foo.fooDSL)
+    """|[324..324): *.apply[Foo, FooDSL]
        |  [0..1): * => _star_.
        |  [2..7): apply => _root_.g.CommandeerDSL.apply(Ljava/lang/Object;Lg/CommandeerDSL;)Lg/CommandeerDSL;.
        |  [8..11): Foo => _root_.g.Foo#
        |  [13..19): FooDSL => _root_.g.FooDSL#
-       |  [21..22): * => _star_.
-       |  [30..36): fooDSL => _root_.g.Foo.fooDSL.
+       |[348..348): *(g.Foo.fooDSL)
+       |  [0..1): * => _star_.
+       |  [8..14): fooDSL => _root_.g.Foo.fooDSL.
     """.trim.stripMargin
   )
 
@@ -1034,36 +1035,38 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |}
     """.trim.stripMargin,
     """
-      |[109..109): *.apply[Int](*)(scala.concurrent.ExecutionContext.Implicits.global)
-      |  [0..1): * => _star_.
-      |  [2..7): apply => _root_.scala.concurrent.Future.apply(Lscala/Function0;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
-      |  [8..11): Int => _root_.scala.Int#
-      |  [13..14): * => _star_.
-      |  [60..66): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
-      |[148..148): *.apply[Int](*)(scala.concurrent.ExecutionContext.Implicits.global)
-      |  [0..1): * => _star_.
-      |  [2..7): apply => _root_.scala.concurrent.Future.apply(Lscala/Function0;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
-      |  [8..11): Int => _root_.scala.Int#
-      |  [13..14): * => _star_.
-      |  [60..66): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
-      |[169..169): *.flatMap[Int](*)(scala.concurrent.ExecutionContext.Implicits.global)
-      |  [0..1): * => _star_.
-      |  [2..9): flatMap => _root_.scala.concurrent.Future#flatMap(Lscala/Function1;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
-      |  [10..13): Int => _root_.scala.Int#
-      |  [15..16): * => _star_.
-      |  [62..68): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
-      |[179..179): *.withFilter(*)(scala.concurrent.ExecutionContext.Implicits.global)
-      |  [0..1): * => _star_.
-      |  [2..12): withFilter => _root_.scala.concurrent.Future#withFilter(Lscala/Function1;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
-      |  [13..14): * => _star_.
-      |  [60..66): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
-      |[190..190): *.map[Int](*)(scala.concurrent.ExecutionContext.Implicits.global)
-      |  [0..1): * => _star_.
-      |  [2..5): map => _root_.scala.concurrent.Future#map(Lscala/Function1;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
-      |  [6..9): Int => _root_.scala.Int#
-      |  [11..12): * => _star_.
-      |  [58..64): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
-    """.trim.stripMargin
+    |[117..117): *.apply[Int]
+    |  [0..1): * => _star_.
+    |  [2..7): apply => _root_.scala.concurrent.Future.apply(Lscala/Function0;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
+    |  [8..11): Int => _root_.scala.Int#
+    |[121..121): *(scala.concurrent.ExecutionContext.Implicits.global)
+    |  [0..1): * => _star_.
+    |  [46..52): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
+    |[156..156): *.apply[Int]
+    |  [0..1): * => _star_.
+    |  [2..7): apply => _root_.scala.concurrent.Future.apply(Lscala/Function0;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
+    |  [8..11): Int => _root_.scala.Int#
+    |[160..160): *(scala.concurrent.ExecutionContext.Implicits.global)
+    |  [0..1): * => _star_.
+    |  [46..52): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
+    |[177..177): *.flatMap[Int](*)(scala.concurrent.ExecutionContext.Implicits.global)
+    |  [0..1): * => _star_.
+    |  [2..9): flatMap => _root_.scala.concurrent.Future#flatMap(Lscala/Function1;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
+    |  [10..13): Int => _root_.scala.Int#
+    |  [15..16): * => _star_.
+    |  [62..68): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
+    |[187..187): *.withFilter(*)(scala.concurrent.ExecutionContext.Implicits.global)
+    |  [0..1): * => _star_.
+    |  [2..12): withFilter => _root_.scala.concurrent.Future#withFilter(Lscala/Function1;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
+    |  [13..14): * => _star_.
+    |  [60..66): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
+    |[198..198): *.map[Int](*)(scala.concurrent.ExecutionContext.Implicits.global)
+    |  [0..1): * => _star_.
+    |  [2..5): map => _root_.scala.concurrent.Future#map(Lscala/Function1;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
+    |  [6..9): Int => _root_.scala.Int#
+    |  [11..12): * => _star_.
+    |  [58..64): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
+   """.trim.stripMargin
   )
 
 }

--- a/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/SemanticSuite.scala
+++ b/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/SemanticSuite.scala
@@ -1069,4 +1069,43 @@ class SemanticSuite extends DatabaseSuite(SemanticdbMode.Slim) {
    """.trim.stripMargin
   )
 
+  synthetics(
+    """
+      |object ForeachFuture {
+      |  import scala.concurrent.ExecutionContext.Implicits.global
+      |  val f1 = scala.concurrent.Future {1}
+      |  val f2 = scala.concurrent.Future {2}
+      |
+      |  for (v1 <- f1; v2 <- f2) println(v1+v2)
+      |}
+    """.trim.stripMargin,
+    """
+      |[117..117): *.apply[Int]
+      |  [0..1): * => _star_.
+      |  [2..7): apply => _root_.scala.concurrent.Future.apply(Lscala/Function0;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
+      |  [8..11): Int => _root_.scala.Int#
+      |[121..121): *(scala.concurrent.ExecutionContext.Implicits.global)
+      |  [0..1): * => _star_.
+      |  [46..52): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
+      |[156..156): *.apply[Int]
+      |  [0..1): * => _star_.
+      |  [2..7): apply => _root_.scala.concurrent.Future.apply(Lscala/Function0;Lscala/concurrent/ExecutionContext;)Lscala/concurrent/Future;.
+      |  [8..11): Int => _root_.scala.Int#
+      |[160..160): *(scala.concurrent.ExecutionContext.Implicits.global)
+      |  [0..1): * => _star_.
+      |  [46..52): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
+      |[177..177): *.foreach[Unit](*)(scala.concurrent.ExecutionContext.Implicits.global)
+      |  [0..1): * => _star_.
+      |  [2..9): foreach => _root_.scala.concurrent.Future#foreach(Lscala/Function1;Lscala/concurrent/ExecutionContext;)V.
+      |  [10..14): Unit => _root_.scala.Unit#
+      |  [16..17): * => _star_.
+      |  [63..69): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
+      |[187..187): *.foreach[Unit](*)(scala.concurrent.ExecutionContext.Implicits.global)
+      |  [0..1): * => _star_.
+      |  [2..9): foreach => _root_.scala.concurrent.Future#foreach(Lscala/Function1;Lscala/concurrent/ExecutionContext;)V.
+      |  [10..14): Unit => _root_.scala.Unit#
+      |  [16..17): * => _star_.
+      |  [63..69): global => _root_.scala.concurrent.ExecutionContext.Implicits.global.
+    """.trim.stripMargin
+  )
 }


### PR DESCRIPTION
This is a possible fix to #1133. 

For
```scala
import scala.concurrent.ExecutionContext.Implicits.global
val f1 = scala.concurrent.Future {1}
val f2 = scala.concurrent.Future {2}

for (v1 <- f1; v2 <- f2 if v1 > v2) yield v1+v2
```
it generates:
```
[169..169): *.flatMap[Int](*)(scala.concurrent.ExecutionContext.Implicits.global)
...
[179..179): *.withFilter(*)(scala.concurrent.ExecutionContext.Implicits.global)
...
[190..190): *.map[Int](*)(scala.concurrent.ExecutionContext.Implicits.global)
...
```

