### PR TITLE
Welcome Gabriele Petronella to the team!

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The current maintainers (people who can merge pull requests) are:
 * Mikhail Mutcianko - [`@mutcianm`](https://github.com/mutcianm)
 * Ólafur Páll Geirsson - [`@olafurpg`](https://github.com/olafurpg)
 * David Dudson - [`@DavidDudson`](https://github.com/DavidDudson)
+* Gabriele Petronella - [`@gabro`](https://github.com/gabro)
 
 An up-to-date list of contributors is available here: https://github.com/scalameta/scalameta/graphs/contributors.
 

--- a/build.sbt
+++ b/build.sbt
@@ -495,9 +495,24 @@ lazy val publishableSettings = Def.settings(
         <url>http://den.sh</url>
       </developer>
       <developer>
+        <id>mutcianm</id>
+        <name>Mikhail Mutcianko</name>
+        <url>https://github.com/mutcianm</url>
+      </developer>
+      <developer>
         <id>olafurpg</id>
         <name>Ólafur Páll Geirsson</name>
         <url>https://geirsson.com/</url>
+      </developer>
+      <developer>
+        <id>DavidDudson</id>
+        <name>David Dudson</name>
+        <url>https://daviddudson.github.io/</url>
+      </developer>
+      <developer>
+        <id>gabro</id>
+        <name>Gabriele Petronella</name>
+        <url>http://buildo.io</url>
       </developer>
     </developers>
   )


### PR DESCRIPTION
Gabriele Petronella has many valuable contributions to Scalafix and
Scalameta via PRs, issue discussions and presenting awesome talks about
it at conferences. It is long overdue that we officially recognize his
contributions to Scalameta!