### PR TITLE
Make Denotation.members List[Signature] instead of Option[List[_]]

### DIFF
--- a/langmeta/shared/src/main/scala/org/langmeta/semanticdb/Denotation.scala
+++ b/langmeta/shared/src/main/scala/org/langmeta/semanticdb/Denotation.scala
@@ -9,15 +9,15 @@ final class Denotation(
     val name: String,
     val signature: String,
     val names: List[ResolvedName],
-    val members: Option[List[Signature]]
+    val members: List[Signature]
 ) extends HasFlags
     with Product
     with Serializable {
   def this(flags: Long, name: String, signature: String, names: List[ResolvedName]) =
-      this(flags, name, signature, names, None)
+      this(flags, name, signature, names, Nil)
 
   def syntax: String = {
-    val s_members = members.fold("")(members => s".{+${members.length} members}")
+    val s_members = if (members.isEmpty) "" else s".{+${members.length} members}"
     val s_info = if (signature != "") ": " + signature else ""
     val s_names = ResolvedName.syntax(names)
     // TODO(olafur) use more advances escaping.
@@ -65,7 +65,7 @@ final class Denotation(
   override def canEqual(that: Any): Boolean = that.isInstanceOf[Denotation]
 }
 object Denotation extends AbstractFunction4[Long, String, String, List[ResolvedName], Denotation] {
-  def apply(flags: Long, name: String, signature: String, names: List[ResolvedName], members: Option[List[Signature]]): Denotation =
+  def apply(flags: Long, name: String, signature: String, names: List[ResolvedName], members: List[Signature]): Denotation =
     new Denotation(flags, name, signature, names, members)
   def apply(flags: Long, name: String, signature: String, names: List[ResolvedName]): Denotation =
     new Denotation(flags, name, signature, names)

--- a/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/package.scala
+++ b/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/package.scala
@@ -67,15 +67,11 @@ package object semanticdb {
                   case other =>
                     sys.error(s"bad protobuf: unsupported name $other")
                 }.toList
-                val dmembers: Option[List[d.Signature]] =
-                  if (smembers.isEmpty) None
-                  else Some(
-                    smembers.toIterator.map { smember =>
-                      if (smember.endsWith("#")) d.Signature.Type(smember.stripSuffix("#"))
-                      else if (smember.endsWith(".")) d.Signature.Term(smember.stripSuffix("."))
-                      else sys.error(s"Unexpected signature $smember")
-                    }.toList
-                  )
+                val dmembers = smembers.toIterator.map { smember =>
+                  if (smember.endsWith("#")) d.Signature.Type(smember.stripSuffix("#"))
+                  else if (smember.endsWith(".")) d.Signature.Term(smember.stripSuffix("."))
+                  else sys.error(s"Unexpected signature $smember")
+                }.toList
                 val ddefn = d.Denotation(dflags, dname, dsignature, dnames, dmembers)
                 Some(d.ResolvedSymbol(dsym, ddefn))
               case other => sys.error(s"bad protobuf: unsupported denotation $other")
@@ -148,10 +144,7 @@ package object semanticdb {
                 case other =>
                   sys.error(s"bad database: unsupported position $other")
               }
-              val smembers = ddefn.members match {
-                case Some(dmembers) => dmembers.map(_.syntax)
-                case _ => Nil
-              }
+              val smembers = ddefn.members.map(_.syntax)
               Some(s.Denotation(flags, name, signature, snames, smembers))
             }
           }

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/DocumentOps.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/DocumentOps.scala
@@ -450,7 +450,7 @@ trait DocumentOps { self: DatabaseOps =>
         val symbols = denotations.map {
           case (sym, denot) =>
             val denotationWithMembers = members.get(sym).fold(denot) { members =>
-              new m.Denotation(denot.flags, denot.name, denot.signature, denot.names, Some(members))
+              new m.Denotation(denot.flags, denot.name, denot.signature, denot.names, members)
             }
             m.ResolvedSymbol(sym, denotationWithMembers)
         }.toList

--- a/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/DatabaseSuite.scala
+++ b/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/DatabaseSuite.scala
@@ -223,7 +223,7 @@ abstract class DatabaseSuite(mode: SemanticdbMode, members: MemberMode = MemberM
       val obtained = db.symbols
         .collect {
           case rs if rs.denotation.members.nonEmpty =>
-            s"${rs.symbol}{\n  ${rs.denotation.members.get.mkString("\n  ")}\n}"
+            s"${rs.symbol}{\n  ${rs.denotation.members.mkString("\n  ")}\n}"
         }
         .mkString("\n")
       // println(obtained)


### PR DESCRIPTION
The original idea with Option[_] was that

- None indicated members were not stored in the semanticdb
- Some(Nil) indicated members were stored in the semanticdb but this
  denotation had no members.

However, after some thinking how this would affect downstream users I
realized it's better to provide that bit of information (members are
persisted/not persisted) in a different place like
`Document.settings.members = all` (related https://github.com/scalameta/scalameta/issues/1151). By using Option[_], we open a can of
worms related to validating consistency, what happens for example if
one Denotation.member is Some(Nil) and another one in the same file is
None? Additionally, in protobuf, it's possible to distinguish None from
Some(Nil).