### PR TITLE
Finish remaining pieces from hackweek

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ env:
   matrix:
     - CI_TEST: check
     - CI_TEST: ci-fast
-      CI_SCALA_VERSION: 2.11.11
+      CI_SCALA_VERSION: 2.11.12
       CI_PUBLISH: true
     - CI_TEST: ci-fast
-      CI_SCALA_VERSION: 2.11.11
+      CI_SCALA_VERSION: 2.11.12
       CI_SCALA_JS: true
     - CI_TEST: ci-fast
       CI_SCALA_VERSION: 2.12.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ env:
       CI_SCALA_VERSION: 2.11.11
       CI_SCALA_JS: true
     - CI_TEST: ci-fast
-      CI_SCALA_VERSION: 2.12.3
+      CI_SCALA_VERSION: 2.12.4
       CI_PUBLISH: true
     - CI_TEST: ci-fast
-      CI_SCALA_VERSION: 2.12.3
+      CI_SCALA_VERSION: 2.12.4
       CI_SCALA_JS: true
     - CI_TEST: ci-langmeta
       CI_SCALA_VERSION: 2.10.6

--- a/build.sbt
+++ b/build.sbt
@@ -315,6 +315,7 @@ lazy val semanticdbIntegration = project
         s"-P:semanticdb:sourceroot:${baseDirectory.in(ThisBuild).value}",
         s"-P:semanticdb:failures:error", // fail fast during development.
         s"-P:semanticdb:members:all",
+        s"-P:semanticdb:exclude:Exclude.scala",
         "-Xplugin-require:semanticdb"
       )
     }

--- a/langmeta/shared/src/main/scala/org/langmeta/semanticdb/Database.scala
+++ b/langmeta/shared/src/main/scala/org/langmeta/semanticdb/Database.scala
@@ -49,7 +49,7 @@ object Database {
 
   def load(bytes: Array[Byte]): Database = {
     val sdb = s.Database.parseFrom(bytes)
-    val mdb = sdb.toDb(None)
+    val mdb = sdb.mergeMessageOnlyDocuments.toDb(None)
     mdb
   }
 }

--- a/langmeta/shared/src/main/scala/org/langmeta/semanticdb/Database.scala
+++ b/langmeta/shared/src/main/scala/org/langmeta/semanticdb/Database.scala
@@ -15,7 +15,10 @@ final case class Database(documents: Seq[Document]) {
   lazy val synthetics: Seq[Synthetic] = documents.flatMap(_.synthetics)
 
   def save(targetroot: AbsolutePath, sourceroot: AbsolutePath): Unit = {
-    this.toSchema(sourceroot).toVfs(targetroot).save()
+    this.toSchema(sourceroot).toVfs(targetroot).save(append = false)
+  }
+  def append(targetroot: AbsolutePath, sourceroot: AbsolutePath): Unit = {
+    this.toSchema(sourceroot).toVfs(targetroot).save(append = true)
   }
 
   def syntax: String = {

--- a/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/package.scala
+++ b/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/package.scala
@@ -170,6 +170,16 @@ package object semanticdb {
                 None
             }
           }
+          object dSeverity {
+            def unapply(dseverity: d.Severity): Option[s.Message.Severity] = {
+              dseverity match {
+                case d.Severity.Info => Some(s.Message.Severity.INFO)
+                case d.Severity.Warning => Some(s.Message.Severity.WARNING)
+                case d.Severity.Error => Some(s.Message.Severity.ERROR)
+                case _ => None
+              }
+            }
+          }
           object dDenotation {
             def unapply(ddefn: d.Denotation): Option[s.Denotation] = {
               import ddefn._
@@ -230,31 +240,4 @@ package object semanticdb {
     }
   }
 
-  implicit class XtensionMetaMessagesAppend(mmessages: List[d.Message]) {
-    private def toSchema: List[s.Message] = mmessages.collect {
-      case d.Message(pos, dSeverity(severity), msg) =>
-        s.Message(Some(s.Position(pos.start, pos.end)),severity, msg)
-    }
-    def append(filename: AbsolutePath, sourceroot: AbsolutePath, targetroot: AbsolutePath): Unit = {
-      val relpath = v.SemanticdbPaths.fromScala(filename.toRelative(sourceroot))
-      val semanticdbpath = targetroot.resolve(relpath)
-      val out = new RandomAccessFile(semanticdbpath.toFile, "rw")
-      try {
-        out.setLength(out.length() - 1)
-        s.Database().writeTo(???)
-        out.write(s.Database(s.Document(messages = toSchema) :: Nil).toByteArray)
-      } finally out.close()
-    }
-  }
-
-  private object dSeverity {
-    def unapply(dseverity: d.Severity): Option[s.Message.Severity] = {
-      dseverity match {
-        case d.Severity.Info => Some(s.Message.Severity.INFO)
-        case d.Severity.Warning => Some(s.Message.Severity.WARNING)
-        case d.Severity.Error => Some(s.Message.Severity.ERROR)
-        case _ => None
-      }
-    }
-  }
 }

--- a/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/vfs/Database.scala
+++ b/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/vfs/Database.scala
@@ -4,6 +4,7 @@ package vfs
 
 import java.io.File
 import java.io.FileOutputStream
+import org.langmeta.internal.semanticdb.schema.Document
 import org.langmeta.io._
 import org.langmeta.internal.semanticdb.{vfs => v}
 import org.langmeta.internal.semanticdb.{schema => s}
@@ -20,16 +21,43 @@ final case class Database(entries: List[Entry]) {
   def toSchema: s.Database = {
     val sentries = entries.flatMap { ventry =>
       val sdb = s.Database.parseFrom(ventry.bytes)
-      sdb.documents
+      // returns true if this document contains only messages and nothing else.
+      // deprecation messages are reported in refchecks and get persisted
+      // as standalone documents that need to be merged with their typer-phase
+      // document during loading. It seems there's no way to merge the documents
+      // during compilation without introducing a lot of memory pressure.
+      def isOnlyMessages(sdocument: s.Document): Boolean =
+        sdocument.messages.nonEmpty &&
+          sdocument.contents.isEmpty &&
+          sdocument.names.isEmpty &&
+          sdocument.synthetics.isEmpty &&
+          sdocument.symbols.isEmpty
+      val sdocsMerged: Seq[Document] = {
+        if (sdb.documents.length <= 1) {
+          // NOTE(olafur) the most common case is that there is only a single database
+          // per document so we short-circuit here if that's the case.
+          sdb.documents
+        } else {
+          sdb.documents match {
+            case Seq(doc, messages)
+                if doc.filename == messages.filename &&
+                  isOnlyMessages(messages) =>
+              val x = doc.addMessages(messages.messages: _*)
+              x :: Nil
+            case _ => sdb.documents
+          }
+        }
+      }
+      sdocsMerged
     }
     s.Database(sentries)
   }
 
-  def save(): Unit = {
+  def save(append: Boolean): Unit = {
     entries.foreach(ventry => {
       val file = new File(ventry.uri)
       file.getParentFile.mkdirs()
-      val fos = new FileOutputStream(file)
+      val fos = new FileOutputStream(file, append)
       try fos.write(ventry.bytes)
       finally fos.close()
     })

--- a/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/vfs/Database.scala
+++ b/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/vfs/Database.scala
@@ -4,7 +4,6 @@ package vfs
 
 import java.io.File
 import java.io.FileOutputStream
-import org.langmeta.internal.semanticdb.schema.Document
 import org.langmeta.io._
 import org.langmeta.internal.semanticdb.{vfs => v}
 import org.langmeta.internal.semanticdb.{schema => s}
@@ -21,34 +20,7 @@ final case class Database(entries: List[Entry]) {
   def toSchema: s.Database = {
     val sentries = entries.flatMap { ventry =>
       val sdb = s.Database.parseFrom(ventry.bytes)
-      // returns true if this document contains only messages and nothing else.
-      // deprecation messages are reported in refchecks and get persisted
-      // as standalone documents that need to be merged with their typer-phase
-      // document during loading. It seems there's no way to merge the documents
-      // during compilation without introducing a lot of memory pressure.
-      def isOnlyMessages(sdocument: s.Document): Boolean =
-        sdocument.messages.nonEmpty &&
-          sdocument.contents.isEmpty &&
-          sdocument.names.isEmpty &&
-          sdocument.synthetics.isEmpty &&
-          sdocument.symbols.isEmpty
-      val sdocsMerged: Seq[Document] = {
-        if (sdb.documents.length <= 1) {
-          // NOTE(olafur) the most common case is that there is only a single database
-          // per document so we short-circuit here if that's the case.
-          sdb.documents
-        } else {
-          sdb.documents match {
-            case Seq(doc, messages)
-                if doc.filename == messages.filename &&
-                  isOnlyMessages(messages) =>
-              val x = doc.addMessages(messages.messages: _*)
-              x :: Nil
-            case _ => sdb.documents
-          }
-        }
-      }
-      sdocsMerged
+      sdb.mergeMessageOnlyDocuments.documents
     }
     s.Database(sentries)
   }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,5 +1,5 @@
 object Versions {
   val LatestScala210 = "2.10.6"
-  val LatestScala211 = "2.11.11"
+  val LatestScala211 = "2.11.12"
   val LatestScala212 = "2.12.4"
 }

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -161,8 +161,8 @@ package object dialects {
   )
 
   implicit val Scala212 = Scala211.copy(
-    // NOTE: support for literal types is tentatively scheduled for 2.12.3
-    // https://github.com/scala/scala/pull/5310#issuecomment-290617202
+    // NOTE: support for literal types is tentatively scheduled for 2.12.5
+    // https://github.com/scala/scala/pull/5311#issuecomment-290617202
     allowLiteralTypes = false,
     allowTrailingCommas = true
   )

--- a/scalameta/semanticdb-integration/src/main/scala/example/Exclude.scala
+++ b/scalameta/semanticdb-integration/src/main/scala/example/Exclude.scala
@@ -1,0 +1,4 @@
+package exclude
+
+// This class should not be excluded by semanticdb.
+class Exclude

--- a/scalameta/semanticdb-integration/src/main/scala/example/Exclude.scala
+++ b/scalameta/semanticdb-integration/src/main/scala/example/Exclude.scala
@@ -1,4 +1,4 @@
 package exclude
 
-// This class should not be excluded by semanticdb.
+// This class should be excluded by semanticdb.
 class Exclude

--- a/scalameta/semanticdb-scalac/src/main/scala-2.11.12/scala/meta/internal/SemanticdbAnalyzer.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala-2.11.12/scala/meta/internal/SemanticdbAnalyzer.scala
@@ -1,0 +1,1098 @@
+// NOTE: has to be this package or otherwise we won't be able to access private[typechecker] methods
+package scala
+package tools.nsc
+package typechecker
+
+import scala.tools.nsc.typechecker.{Analyzer => NscAnalyzer}
+import scala.reflect.internal.Mode._
+import scala.reflect.internal.util._
+import scala.reflect.internal.Flags._
+import scala.meta.internal.ReflectionToolkit
+
+// NOTE: grep for "scalac deviation" to see what exactly has been changed
+// I had to copy/paste a lot of code from Namers and Typers, but only a small percentage is actually relevant
+
+trait SemanticdbAnalyzer extends NscAnalyzer with ReflectionToolkit {
+  import global._
+  import definitions._
+  import TypersStats._
+
+  override def newNamer(context: Context) = new SemanticdbNamer(context)
+  class SemanticdbNamer(context0: Context) extends Namer(context0) {
+    override def selfTypeCompleter(tree: Tree) = mkTypeCompleter(tree) { sym =>
+      val tree1 = typer.typedType(tree)
+      //+scalac deviation
+      tree.rememberSelfTypeOf(tree1.asInstanceOf[TypeTree].original)
+      //-scalac deviation
+      val selftpe = tree1.tpe
+      sym setInfo {
+        if (selftpe.typeSymbol isNonBottomSubClass sym.owner) selftpe
+        else intersectionType(List(sym.owner.tpe, selftpe))
+      }
+    }
+  }
+
+  override def newTyper(context: Context) = new SemanticdbTyper(context)
+  class SemanticdbTyper(context0: Context) extends Typer(context0) {
+    import infer._
+    import TyperErrorGen._
+    import typeDebug.ptTree
+    import runDefinitions._
+
+    // TODO: No idea whether this is gonna work well in the batch compilation mode.
+    override def canTranslateEmptyListToNil = false
+
+    override def typed1(tree: Tree, mode: Mode, pt: Type): Tree = {
+      def typedSingletonTypeTree(tree: SingletonTypeTree) = {
+        val refTyped =
+          context.withImplicitsDisabled {
+            typed(tree.ref, MonoQualifierModes | mode.onlyTypePat, AnyRefTpe)
+          }
+
+        if (refTyped.isErrorTyped) {
+          setError(tree)
+        } else {
+          //+scalac deviation
+          tree setType refTyped.tpe.resultType rememberSingletonTypeTreeOf refTyped
+          //-scalac deviation
+          if (refTyped.isErrorTyped || treeInfo.admitsTypeSelection(refTyped)) tree
+          else UnstableTreeError(tree)
+        }
+      }
+
+      def tryTypedArgs(args: List[Tree], mode: Mode): Option[List[Tree]] = {
+        val c = context.makeSilent(reportAmbiguousErrors = false)
+        c.retyping = true
+        try {
+          val res = newTyper(c).typedArgs(args, mode)
+          if (c.reporter.hasErrors) None else Some(res)
+        } catch {
+          case ex: CyclicReference =>
+            throw ex
+          case te: TypeError =>
+            // @H some of typer errors can still leak,
+            // for instance in continuations
+            None
+        }
+      }
+
+      /* Try to apply function to arguments; if it does not work, try to convert Java raw to existentials, or try to
+       * insert an implicit conversion.
+       */
+      def tryTypedApply(fun: Tree, args: List[Tree]): Tree = {
+        val start = if (Statistics.canEnable) Statistics.startTimer(failedApplyNanos) else null
+
+        def onError(typeErrors: Seq[AbsTypeError], warnings: Seq[(Position, String)]): Tree = {
+          if (Statistics.canEnable) Statistics.stopTimer(failedApplyNanos, start)
+
+          // If the problem is with raw types, convert to existentials and try again.
+          // See #4712 for a case where this situation arises,
+          if ((fun.symbol ne null) && fun.symbol.isJavaDefined) {
+            val newtpe = rawToExistential(fun.tpe)
+            if (fun.tpe ne newtpe) {
+              // println("late cooking: "+fun+":"+fun.tpe) // DEBUG
+              return tryTypedApply(fun setType newtpe, args)
+            }
+          }
+          def treesInResult(tree: Tree): List[Tree] = tree :: (tree match {
+            case Block(_, r)                        => treesInResult(r)
+            case Match(_, cases)                    => cases
+            case CaseDef(_, _, r)                   => treesInResult(r)
+            case Annotated(_, r)                    => treesInResult(r)
+            case If(_, t, e)                        => treesInResult(t) ++ treesInResult(e)
+            case Try(b, catches, _)                 => treesInResult(b) ++ catches
+            case Typed(r, Function(Nil, EmptyTree)) => treesInResult(r) // a method value
+            case Select(qual, name)                 => treesInResult(qual)
+            case Apply(fun, args)                   => treesInResult(fun) ++ args.flatMap(treesInResult)
+            case TypeApply(fun, args)               => treesInResult(fun) ++ args.flatMap(treesInResult)
+            case _                                  => Nil
+          })
+          def errorInResult(tree: Tree) = treesInResult(tree) exists (err => typeErrors.exists(_.errPos == err.pos))
+
+          val retry = (typeErrors.forall(_.errPos != null)) && (fun :: tree :: args exists errorInResult)
+          typingStack.printTyping({
+            val funStr = ptTree(fun) + " and " + (args map ptTree mkString ", ")
+            if (retry) "second try: " + funStr
+            else "no second try: " + funStr + " because error not in result: " + typeErrors.head.errPos+"!="+tree.pos
+          })
+          if (retry) {
+            val Select(qual, name) = fun
+            tryTypedArgs(args, forArgMode(fun, mode)) match {
+              case Some(args1) if !args1.exists(arg => arg.exists(_.isErroneous)) =>
+                val qual1 =
+                  if (!pt.isError) adaptToArguments(qual, name, args1, pt, reportAmbiguous = true, saveErrors = true)
+                  else qual
+                if (qual1 ne qual) {
+                  val tree1 = Apply(Select(qual1, name) setPos fun.pos, args1) setPos tree.pos
+                  return context withinSecondTry typed1(tree1, mode, pt)
+                }
+              case _ => ()
+            }
+          }
+          typeErrors foreach context.issue
+          warnings foreach { case (p, m) => context.warning(p, m) }
+          setError(treeCopy.Apply(tree, fun, args))
+        }
+
+        silent(_.doTypedApply(tree, fun, args, mode, pt)) match {
+          case SilentResultValue(value) => value
+          case e: SilentTypeError => onError(e.errors, e.warnings)
+        }
+      }
+
+      def normalTypedApply(tree: Tree, fun: Tree, args: List[Tree]) = {
+        // TODO: replace `fun.symbol.isStable` by `treeInfo.isStableIdentifierPattern(fun)`
+        val stableApplication = (fun.symbol ne null) && fun.symbol.isMethod && fun.symbol.isStable
+        val funpt = if (mode.inPatternMode) pt else WildcardType
+        val appStart = if (Statistics.canEnable) Statistics.startTimer(failedApplyNanos) else null
+        val opeqStart = if (Statistics.canEnable) Statistics.startTimer(failedOpEqNanos) else null
+
+        def isConversionCandidate(qual: Tree, name: Name): Boolean =
+          !mode.inPatternMode && nme.isOpAssignmentName(TermName(name.decode)) && !qual.exists(_.isErroneous)
+
+        def reportError(error: SilentTypeError): Tree = {
+          error.reportableErrors foreach context.issue
+          error.warnings foreach { case (p, m) => context.warning(p, m) }
+          args foreach (arg => typed(arg, mode, ErrorType))
+          setError(tree)
+        }
+        def advice1(convo: Tree, errors: List[AbsTypeError], err: SilentTypeError): List[AbsTypeError] =
+          errors.map { e =>
+            if (e.errPos == tree.pos) {
+              val header = f"${e.errMsg}%n  Expression does not convert to assignment because:%n    "
+              val expansion = f"%n    expansion: ${show(convo)}"
+              NormalTypeError(tree, err.errors.flatMap(_.errMsg.lines.toList).mkString(header, f"%n    ", expansion))
+            } else e
+          }
+        def advice2(errors: List[AbsTypeError]): List[AbsTypeError] =
+          errors.map { e =>
+            if (e.errPos == tree.pos) {
+              val msg = f"${e.errMsg}%n  Expression does not convert to assignment because receiver is not assignable."
+              NormalTypeError(tree, msg)
+            } else e
+          }
+        def onError(error: SilentTypeError): Tree = fun match {
+          case Select(qual, name) if isConversionCandidate(qual, name) =>
+            val qual1 = typedQualifier(qual)
+            if (treeInfo.isVariableOrGetter(qual1)) {
+              if (Statistics.canEnable) Statistics.stopTimer(failedOpEqNanos, opeqStart)
+              val erred = qual1.isErroneous || args.exists(_.isErroneous)
+              if (erred) reportError(error) else {
+                val convo = convertToAssignment(fun, qual1, name, args)
+                silent(op = _.typed1(convo, mode, pt)) match {
+                  case SilentResultValue(t) => t
+                  case err: SilentTypeError => reportError(SilentTypeError(advice1(convo, error.errors, err), error.warnings))
+                }
+              }
+            }
+            else {
+              if (Statistics.canEnable) Statistics.stopTimer(failedApplyNanos, appStart)
+              val Apply(Select(qual2, _), args2) = tree
+              val erred = qual2.isErroneous || args2.exists(_.isErroneous)
+              reportError {
+                if (erred) error else SilentTypeError(advice2(error.errors), error.warnings)
+              }
+            }
+          case _ =>
+            if (Statistics.canEnable) Statistics.stopTimer(failedApplyNanos, appStart)
+            reportError(error)
+        }
+        val silentResult = silent(
+          op                    = _.typed(fun, mode.forFunMode, funpt),
+          reportAmbiguousErrors = !mode.inExprMode && context.ambiguousErrors,
+          newtree               = if (mode.inExprMode) tree else context.tree
+        )
+        silentResult match {
+          case SilentResultValue(fun1) =>
+            val fun2 = if (stableApplication) stabilizeFun(fun1, mode, pt) else fun1
+            if (Statistics.canEnable) Statistics.incCounter(typedApplyCount)
+            val noSecondTry = (
+                 isPastTyper
+              || context.inSecondTry
+              || (fun2.symbol ne null) && fun2.symbol.isConstructor
+              || isImplicitMethodType(fun2.tpe)
+            )
+            val isFirstTry = fun2 match {
+              case Select(_, _) => !noSecondTry && mode.inExprMode
+              case _            => false
+            }
+            if (isFirstTry)
+              tryTypedApply(fun2, args)
+            else
+              doTypedApply(tree, fun2, args, mode, pt)
+          case err: SilentTypeError => onError(err)
+        }
+      }
+
+      // convert new Array[T](len) to evidence[ClassTag[T]].newArray(len)
+      // convert new Array^N[T](len) for N > 1 to evidence[ClassTag[Array[...Array[T]...]]].newArray(len)
+      // where Array HK gets applied (N-1) times
+      object ArrayInstantiation {
+        def unapply(tree: Apply) = tree match {
+          case Apply(Select(New(tpt), name), arg :: Nil) if tpt.tpe != null && tpt.tpe.typeSymbol == ArrayClass =>
+            Some(tpt.tpe) collect {
+              case erasure.GenericArray(level, componentType) =>
+                val tagType = (1 until level).foldLeft(componentType)((res, _) => arrayType(res))
+
+                resolveClassTag(tree.pos, tagType) match {
+                  case EmptyTree => MissingClassTagError(tree, tagType)
+                  case tag       => atPos(tree.pos)(new ApplyToImplicitArgs(Select(tag, nme.newArray), arg :: Nil))
+                }
+            }
+          case _ => None
+        }
+      }
+
+      def typedApply(tree: Apply) = tree match {
+        case Apply(Block(stats, expr), args) =>
+          typed1(atPos(tree.pos)(Block(stats, Apply(expr, args) setPos tree.pos.makeTransparent)), mode, pt)
+        case Apply(fun, args) =>
+          normalTypedApply(tree, fun, args) match {
+            case tree1 @ ArrayInstantiation(tree2) =>
+              if (tree2.isErrorTyped) tree2
+              //+scalac deviation
+              else typed(tree2, mode, pt).rememberNewArrayOf(tree1)
+              //-scalac deviation
+            case Apply(Select(fun, nme.apply), _) if treeInfo.isSuperConstrCall(fun) =>
+              TooManyArgumentListsForConstructor(tree) //SI-5696
+            case tree1 =>
+              tree1
+          }
+      }
+
+      def convertToAssignment(fun: Tree, qual: Tree, name: Name, args: List[Tree]): Tree = {
+        val prefix = name.toTermName stripSuffix nme.EQL
+        def mkAssign(vble: Tree): Tree =
+          Assign(
+            vble,
+            Apply(
+              Select(vble.duplicate, prefix) setPos fun.pos.focus, args) setPos tree.pos.makeTransparent
+          ) setPos tree.pos
+
+        def mkUpdate(table: Tree, indices: List[Tree]) =
+          gen.evalOnceAll(table :: indices, context.owner, context.unit) {
+            case tab :: is =>
+              def mkCall(name: Name, extraArgs: Tree*) = (
+                Apply(
+                  Select(tab(), name) setPos table.pos,
+                  is.map(i => i()) ++ extraArgs
+                ) setPos tree.pos
+              )
+              mkCall(
+                nme.update,
+                Apply(Select(mkCall(nme.apply), prefix) setPos fun.pos, args) setPos tree.pos
+              )
+            case _ => EmptyTree
+          }
+
+        val assignment = qual match {
+          case Ident(_) =>
+            mkAssign(qual)
+
+          case Select(qualqual, vname) =>
+            gen.evalOnce(qualqual, context.owner, context.unit) { qq =>
+              val qq1 = qq()
+              mkAssign(Select(qq1, vname) setPos qual.pos)
+            }
+
+          case Apply(fn, indices) =>
+            fn match {
+              case treeInfo.Applied(Select(table, nme.apply), _, _) => mkUpdate(table, indices)
+              case _  => UnexpectedTreeAssignmentConversionError(qual)
+            }
+        }
+        assignment
+      }
+
+      def typedAnnotated(atd: Annotated): Tree = {
+        val ann = atd.annot
+        val arg1 = typed(atd.arg, mode, pt)
+        /* mode for typing the annotation itself */
+        val annotMode = (mode &~ TYPEmode) | EXPRmode
+
+        def resultingTypeTree(tpe: Type) = {
+          // we need symbol-ful originals for reification
+          // hence we go the extra mile to hand-craft this guy
+          val original = arg1 match {
+            case tt @ TypeTree() if tt.original != null => Annotated(ann, tt.original)
+            // this clause is needed to correctly compile stuff like "new C @D" or "@(inline @getter)"
+            case _ => Annotated(ann, arg1)
+          }
+          original setType ann.tpe
+          val result = TypeTree(tpe) setOriginal original setPos tree.pos.focus
+          //+scalac deviation
+          result rememberAnnotatedOf treeCopy.Annotated(atd, tpe.annotations.head.original, arg1)
+          //-scalac deviation
+        }
+
+        if (arg1.isType) {
+          // make sure the annotation is only typechecked once
+          if (ann.tpe == null) {
+            val ainfo = typedAnnotation(ann, annotMode)
+            val atype = arg1.tpe.withAnnotation(ainfo)
+
+            if (ainfo.isErroneous)
+              // Erroneous annotations were already reported in typedAnnotation
+              arg1  // simply drop erroneous annotations
+            else {
+              ann setType atype
+              resultingTypeTree(atype)
+            }
+          } else {
+            // the annotation was typechecked before
+            resultingTypeTree(ann.tpe)
+          }
+        }
+        else {
+          if (ann.tpe == null) {
+            val annotInfo = typedAnnotation(ann, annotMode)
+            ann setType arg1.tpe.withAnnotation(annotInfo)
+          }
+          val atype = ann.tpe
+          Typed(arg1, resultingTypeTree(atype)) setPos tree.pos setType atype
+        }
+      }
+
+      // Lookup in the given class using the root mirror.
+      def lookupInOwner(owner: Symbol, name: Name): Symbol =
+        if (mode.inQualMode) rootMirror.missingHook(owner, name) else NoSymbol
+
+      // Lookup in the given qualifier.  Used in last-ditch efforts by typedIdent and typedSelect.
+      def lookupInRoot(name: Name): Symbol  = lookupInOwner(rootMirror.RootClass, name)
+      def lookupInEmpty(name: Name): Symbol = rootMirror.EmptyPackageClass.info member name
+
+      def lookupInQualifier(qual: Tree, name: Name): Symbol = (
+        if (name == nme.ERROR || qual.tpe.widen.isErroneous)
+          NoSymbol
+        else lookupInOwner(qual.tpe.typeSymbol, name) orElse {
+          NotAMemberError(tree, qual, name)
+          NoSymbol
+        }
+      )
+
+      /* Attribute a selection where `tree` is `qual.name`.
+       * `qual` is already attributed.
+       */
+      def typedSelect(tree: Tree, qual: Tree, name: Name): Tree = {
+        val t = typedSelectInternal(tree, qual, name)
+        // Checking for OverloadedTypes being handed out after overloading
+        // resolution has already happened.
+        if (isPastTyper) t.tpe match {
+          case OverloadedType(pre, alts) =>
+            if (alts forall (s => (s.owner == ObjectClass) || (s.owner == AnyClass) || isPrimitiveValueClass(s.owner))) ()
+            else if (settings.debug) printCaller(
+              s"""|Select received overloaded type during $phase, but typer is over.
+                  |If this type reaches the backend, we are likely doomed to crash.
+                  |$t has these overloads:
+                  |${alts map (s => "  " + s.defStringSeenAs(pre memberType s)) mkString "\n"}
+                  |""".stripMargin
+            )("")
+          case _ =>
+        }
+        t
+      }
+
+      def typedSelectInternal(tree: Tree, qual: Tree, name: Name): Tree = {
+        def asDynamicCall = dyna.mkInvoke(context, tree, qual, name) map { t =>
+          dyna.wrapErrors(t, (_.typed1(t, mode, pt)))
+        }
+
+        val sym = tree.symbol orElse member(qual, name) orElse {
+          // symbol not found? --> try to convert implicitly to a type that does have the required
+          // member.  Added `| PATTERNmode` to allow enrichment in patterns (so we can add e.g., an
+          // xml member to StringContext, which in turn has an unapply[Seq] method)
+          if (name != nme.CONSTRUCTOR && mode.inAny(EXPRmode | PATTERNmode)) {
+            val qual1 = adaptToMemberWithArgs(tree, qual, name, mode, reportAmbiguous = true, saveErrors = true)
+            if ((qual1 ne qual) && !qual1.isErrorTyped)
+              return typed(treeCopy.Select(tree, qual1, name), mode, pt)
+          }
+          NoSymbol
+        }
+        if (phase.erasedTypes && qual.isInstanceOf[Super] && tree.symbol != NoSymbol)
+          qual setType tree.symbol.owner.tpe
+
+        if (!reallyExists(sym)) {
+          def handleMissing: Tree = {
+            def errorTree = missingSelectErrorTree(tree, qual, name)
+            def asTypeSelection = (
+              if (context.unit.isJava && name.isTypeName) {
+                // SI-3120 Java uses the same syntax, A.B, to express selection from the
+                // value A and from the type A. We have to try both.
+                atPos(tree.pos)(gen.convertToSelectFromType(qual, name)) match {
+                  case EmptyTree => None
+                  case tree1     => Some(typed1(tree1, mode, pt))
+                }
+              }
+              else None
+            )
+            debuglog(s"""
+              |qual=$qual:${qual.tpe}
+              |symbol=${qual.tpe.termSymbol.defString}
+              |scope-id=${qual.tpe.termSymbol.info.decls.hashCode}
+              |members=${qual.tpe.members mkString ", "}
+              |name=$name
+              |found=$sym
+              |owner=${context.enclClass.owner}
+              """.stripMargin)
+
+            // 1) Try converting a term selection on a java class into a type selection.
+            // 2) Try expanding according to Dynamic rules.
+            // 3) Try looking up the name in the qualifier.
+            asTypeSelection orElse asDynamicCall getOrElse (lookupInQualifier(qual, name) match {
+              case NoSymbol => setError(errorTree)
+              case found    => typed1(tree setSymbol found, mode, pt)
+            })
+          }
+          handleMissing
+        }
+        else {
+          val tree1 = tree match {
+            case Select(_, _) => treeCopy.Select(tree, qual, name)
+            case SelectFromTypeTree(_, _) => treeCopy.SelectFromTypeTree(tree, qual, name)
+          }
+          val (result, accessibleError) = silent(_.asInstanceOf[SemanticdbTyper].makeAccessible(tree1, sym, qual.tpe, qual)) match {
+            case SilentTypeError(err: AccessTypeError) =>
+              (tree1, Some(err))
+            case SilentTypeError(err) =>
+              SelectWithUnderlyingError(tree, err)
+              return tree
+            case SilentResultValue(treeAndPre) =>
+              (stabilize(treeAndPre._1, treeAndPre._2, mode, pt), None)
+          }
+
+          result match {
+            // could checkAccessible (called by makeAccessible) potentially have skipped checking a type application in qual?
+            case SelectFromTypeTree(qual@TypeTree(), name) if qual.tpe.typeArgs.nonEmpty => // TODO: somehow the new qual is not checked in refchecks
+              treeCopy.SelectFromTypeTree(
+                result,
+                (TypeTreeWithDeferredRefCheck(){ () => val tp = qual.tpe; val sym = tp.typeSymbolDirect
+                  // will execute during refchecks -- TODO: make private checkTypeRef in refchecks public and call that one?
+                  checkBounds(qual, tp.prefix, sym.owner, sym.typeParams, tp.typeArgs, "")
+                  qual // you only get to see the wrapped tree after running this check :-p
+                }) setType qual.tpe setPos qual.pos,
+                name)
+            case _ if accessibleError.isDefined =>
+              // don't adapt constructor, SI-6074
+              val qual1 = if (name == nme.CONSTRUCTOR) qual
+                          else adaptToMemberWithArgs(tree, qual, name, mode, reportAmbiguous = false, saveErrors = false)
+              if (!qual1.isErrorTyped && (qual1 ne qual))
+                typed(Select(qual1, name) setPos tree.pos, mode, pt)
+              else
+                // before failing due to access, try a dynamic call.
+                asDynamicCall getOrElse {
+                  context.issue(accessibleError.get)
+                  setError(tree)
+                }
+            case _ =>
+              result
+          }
+        }
+      }
+
+      // the qualifier type of a supercall constructor is its first parent class
+      def typedSelectOrSuperQualifier(qual: Tree) =
+        context withinSuperInit typed(qual, PolyQualifierModes)
+
+      // temporarily use `filter` as an alternative for `withFilter`
+      def tryWithFilterAndFilter(tree: Select, qual: Tree): Tree = {
+        def warn(sym: Symbol) = context.deprecationWarning(tree.pos, sym, s"`withFilter' method does not yet exist on ${qual.tpe.widen}, using `filter' method instead")
+        silent(_ => typedSelect(tree, qual, nme.withFilter)) orElse { _ =>
+          silent(_ => typed1(Select(qual, nme.filter) setPos tree.pos, mode, pt)) match {
+            case SilentResultValue(res) => warn(res.symbol) ; res
+            case SilentTypeError(err)   => WithFilterError(tree, err)
+          }
+        }
+      }
+
+      def typedSelectOrSuperCall(tree: Select) = tree match {
+        case Select(qual @ Super(_, _), nme.CONSTRUCTOR) =>
+          // the qualifier type of a supercall constructor is its first parent class
+          typedSelect(tree, typedSelectOrSuperQualifier(qual), nme.CONSTRUCTOR)
+        case Select(qual, name) =>
+          if (Statistics.canEnable) Statistics.incCounter(typedSelectCount)
+          val qualTyped = checkDead(typedQualifier(qual, mode))
+          val qualStableOrError = (
+            if (qualTyped.isErrorTyped || !name.isTypeName || treeInfo.admitsTypeSelection(qualTyped))
+              qualTyped
+            else
+              UnstableTreeError(qualTyped)
+          )
+          val tree1 = name match {
+            case nme.withFilter if !settings.future => tryWithFilterAndFilter(tree, qualStableOrError)
+            case _              => typedSelect(tree, qualStableOrError, name)
+          }
+          def sym = tree1.symbol
+          if (tree.isInstanceOf[PostfixSelect])
+            checkFeature(tree.pos, PostfixOpsFeature, name.decode)
+          if (sym != null && sym.isOnlyRefinementMember && !sym.isMacro)
+            checkFeature(tree1.pos, ReflectiveCallsFeature, sym.toString)
+
+          qualStableOrError.symbol match {
+            //+scalac deviation
+            case s: Symbol if s.isRootPackage => treeCopy.Ident(tree1, name).rememberSelectOf(tree1)
+            case _                            => tree1
+            //-scalac deviation
+          }
+      }
+
+      tree match {
+        case tree: SingletonTypeTree => typedSingletonTypeTree(tree)
+        case tree: Apply => typedApply(tree)
+        case tree: Annotated => typedAnnotated(tree)
+        case tree: Select => typedSelectOrSuperCall(tree)
+        case _ => super.typed1(tree, mode, pt)
+      }
+    }
+
+    /** Make symbol accessible. This means:
+     *  If symbol refers to package object, insert `.package` as second to last selector.
+     *  (exception for some symbols in scala package which are dealiased immediately)
+     *  Call checkAccessible, which sets tree's attributes.
+     *  Also note that checkAccessible looks up sym on pre without checking that pre is well-formed
+     *  (illegal type applications in pre will be skipped -- that's why typedSelect wraps the resulting tree in a TreeWithDeferredChecks)
+     *  @return modified tree and new prefix type
+     */
+    private def makeAccessible(tree: Tree, sym: Symbol, pre: Type, site: Tree): (Tree, Type) =
+      if (context.isInPackageObject(sym, pre.typeSymbol)) {
+        if (pre.typeSymbol == ScalaPackageClass && sym.isTerm) {
+          // short cut some aliases. It seems pattern matching needs this
+          // to notice exhaustiveness and to generate good code when
+          // List extractors are mixed with :: patterns. See Test5 in lists.scala.
+          //
+          // TODO SI-6609 Eliminate this special case once the old pattern matcher is removed.
+          def dealias(sym: Symbol) = {
+            //+scalac deviation
+            val tree1 = atPos(tree.pos.makeTransparent) {gen.mkAttributedRef(sym)} setPos tree.pos
+            tree1.rememberSelectOf(tree)
+            (tree1, sym.owner.thisType)
+            //-scalac deviation
+          }
+          sym.name match {
+            case nme.List => return dealias(ListModule)
+            case nme.Seq  => return dealias(SeqModule)
+            case nme.Nil  => return dealias(NilModule)
+            case _ =>
+          }
+        }
+        val qual = typedQualifier { atPos(tree.pos.makeTransparent) {
+          tree match {
+            case Ident(_) => Ident(rootMirror.getPackageObjectWithMember(pre, sym))
+            case Select(qual, _) => Select(qual, nme.PACKAGEkw)
+            case SelectFromTypeTree(qual, _) => Select(qual, nme.PACKAGEkw)
+          }
+        }}
+        val tree1 = atPos(tree.pos) {
+          tree match {
+            case Ident(name) => Select(qual, name)
+            case Select(_, name) => Select(qual, name)
+            case SelectFromTypeTree(_, name) => SelectFromTypeTree(qual, name)
+          }
+        }
+        (checkAccessible(tree1, sym, qual.tpe, qual), qual.tpe)
+      } else {
+        (checkAccessible(tree, sym, pre, site), pre)
+      }
+
+    override protected def typedTypeApply(tree: Tree, mode: Mode, fun: Tree, args: List[Tree]): Tree = fun.tpe match {
+      case OverloadedType(pre, alts) =>
+        inferPolyAlternatives(fun, mapList(args)(treeTpe))
+
+        // SI-8267 `memberType` can introduce existentials *around* a PolyType/MethodType, see AsSeenFromMap#captureThis.
+        //         If we had selected a non-overloaded symbol, `memberType` would have been called in `makeAccessible`
+        //         and the resulting existential type would have been skolemized in `adapt` *before* we typechecked
+        //         the enclosing type-/ value- application.
+        //
+        //         However, if the selection is overloaded, we defer calling `memberType` until we can select a single
+        //         alternative here. It is therefore necessary to skolemize the existential here.
+        //
+        val fun1 = adaptAfterOverloadResolution(fun, mode.forFunMode | TAPPmode)
+
+        val tparams = fun1.symbol.typeParams //@M TODO: fun.symbol.info.typeParams ? (as in typedAppliedTypeTree)
+        val args1 = if (sameLength(args, tparams)) {
+          //@M: in case TypeApply we can't check the kind-arities of the type arguments,
+          // as we don't know which alternative to choose... here we do
+          map2Conserve(args, tparams) {
+            //@M! the polytype denotes the expected kind
+            (arg, tparam) => typedHigherKindedType(arg, mode, Kind.FromParams(tparam.typeParams))
+          }
+        } else // @M: there's probably something wrong when args.length != tparams.length... (triggered by bug #320)
+         // Martin, I'm using fake trees, because, if you use args or arg.map(typedType),
+         // inferPolyAlternatives loops...  -- I have no idea why :-(
+         // ...actually this was looping anyway, see bug #278.
+          return TypedApplyWrongNumberOfTpeParametersError(fun, fun)
+
+        typedTypeApply(tree, mode, fun1, args1)
+      case SingleType(_, _) =>
+        typedTypeApply(tree, mode, fun setType fun.tpe.widen, args)
+      case PolyType(tparams, restpe) if tparams.nonEmpty =>
+        if (sameLength(tparams, args)) {
+          val targs = mapList(args)(treeTpe)
+          checkBounds(tree, NoPrefix, NoSymbol, tparams, targs, "")
+          if (isPredefClassOf(fun.symbol)) {
+            //+scalac deviation
+            val result = typedClassOf(tree, args.head, noGen = true)
+            val original = atPos(tree.pos)(TypeApply(fun, args))
+            result.rememberClassOf(original)
+            //-scalac deviation
+          } else {
+            if (!isPastTyper && fun.symbol == Any_isInstanceOf && targs.nonEmpty) {
+              val scrutineeType = fun match {
+                case Select(qual, _) => qual.tpe
+                case _               => AnyTpe
+              }
+              checkCheckable(tree, targs.head, scrutineeType, inPattern = false)
+            }
+            val resultpe = restpe.instantiateTypeParams(tparams, targs)
+            //@M substitution in instantiateParams needs to be careful!
+            //@M example: class Foo[a] { def foo[m[x]]: m[a] = error("") } (new Foo[Int]).foo[List] : List[Int]
+            //@M    --> first, m[a] gets changed to m[Int], then m gets substituted for List,
+            //          this must preserve m's type argument, so that we end up with List[Int], and not List[a]
+            //@M related bug: #1438
+            //println("instantiating type params "+restpe+" "+tparams+" "+targs+" = "+resultpe)
+            treeCopy.TypeApply(tree, fun, args) setType resultpe
+          }
+        }
+        else {
+          TypedApplyWrongNumberOfTpeParametersError(tree, fun)
+        }
+      case ErrorType =>
+        setError(treeCopy.TypeApply(tree, fun, args))
+      case _ =>
+        fun match {
+          // drop the application for an applyDynamic or selectDynamic call since it has been pushed down
+          case treeInfo.DynamicApplication(_, _) => fun
+          case _ => TypedApplyDoesNotTakeTpeParametersError(tree, fun)
+        }
+    }
+
+    override protected def typedExistentialTypeTree(tree: ExistentialTypeTree, mode: Mode): Tree = {
+      for (wc <- tree.whereClauses)
+        if (wc.symbol == NoSymbol) { namer enterSym wc; wc.symbol setFlag EXISTENTIAL }
+        else context.scope enter wc.symbol
+      val whereClauses1 = typedStats(tree.whereClauses, context.owner)
+      for (vd @ ValDef(_, _, _, _) <- whereClauses1)
+        if (vd.symbol.tpe.isVolatile)
+          AbstractionFromVolatileTypeError(vd)
+      val tpt1 = typedType(tree.tpt, mode)
+      existentialTransform(whereClauses1 map (_.symbol), tpt1.tpe)((tparams, tp) => {
+        val original = tpt1 match {
+          case tpt : TypeTree => atPos(tree.pos)(ExistentialTypeTree(tpt.original, tree.whereClauses))
+          case _ => {
+            debuglog(s"cannot reconstruct the original for $tree, because $tpt1 is not a TypeTree")
+            tree
+          }
+        }
+        val result = TypeTree(newExistentialType(tparams, tp)) setOriginal original
+        //+scalac deviation
+        result.rememberExistentialTypeTreeOf(treeCopy.ExistentialTypeTree(tree, tpt1, whereClauses1.asInstanceOf[List[MemberDef]]))
+        //-scalac deviation
+      }
+      )
+    }
+
+    /** Perform the following adaptations of expression, pattern or type `tree` wrt to
+     *  given mode `mode` and given prototype `pt`:
+     *  (-1) For expressions with annotated types, let AnnotationCheckers decide what to do
+     *  (0) Convert expressions with constant types to literals (unless in interactive/scaladoc mode)
+     *  (1) Resolve overloading, unless mode contains FUNmode
+     *  (2) Apply parameterless functions
+     *  (3) Apply polymorphic types to fresh instances of their type parameters and
+     *      store these instances in context.undetparams,
+     *      unless followed by explicit type application.
+     *  (4) Do the following to unapplied methods used as values:
+     *  (4.1) If the method has only implicit parameters pass implicit arguments
+     *  (4.2) otherwise, if `pt` is a function type and method is not a constructor,
+     *        convert to function by eta-expansion,
+     *  (4.3) otherwise, if the method is nullary with a result type compatible to `pt`
+     *        and it is not a constructor, apply it to ()
+     *  otherwise issue an error
+     *  (5) Convert constructors in a pattern as follows:
+     *  (5.1) If constructor refers to a case class factory, set tree's type to the unique
+     *        instance of its primary constructor that is a subtype of the expected type.
+     *  (5.2) If constructor refers to an extractor, convert to application of
+     *        unapply or unapplySeq method.
+     *
+     *  (6) Convert all other types to TypeTree nodes.
+     *  (7) When in TYPEmode but not FUNmode or HKmode, check that types are fully parameterized
+     *      (7.1) In HKmode, higher-kinded types are allowed, but they must have the expected kind-arity
+     *  (8) When in both EXPRmode and FUNmode, add apply method calls to values of object type.
+     *  (9) If there are undetermined type variables and not POLYmode, infer expression instance
+     *  Then, if tree's type is not a subtype of expected type, try the following adaptations:
+     *  (10) If the expected type is Byte, Short or Char, and the expression
+     *      is an integer fitting in the range of that type, convert it to that type.
+     *  (11) Widen numeric literals to their expected type, if necessary
+     *  (12) When in mode EXPRmode, convert E to { E; () } if expected type is scala.Unit.
+     *  (13) When in mode EXPRmode, apply AnnotationChecker conversion if expected type is annotated.
+     *  (14) When in mode EXPRmode, apply a view
+     *  If all this fails, error
+     */
+    override protected def adapt(tree: Tree, mode: Mode, pt: Type, original: Tree = EmptyTree): Tree = {
+      def hasUndets           = context.undetparams.nonEmpty
+      def hasUndetsInMonoMode = hasUndets && !mode.inPolyMode
+
+      def adaptToImplicitMethod(mt: MethodType): Tree = {
+        if (hasUndets) { // (9) -- should revisit dropped condition `hasUndetsInMonoMode`
+          // dropped so that type args of implicit method are inferred even if polymorphic expressions are allowed
+          // needed for implicits in 2.8 collection library -- maybe once #3346 is fixed, we can reinstate the condition?
+            context.undetparams = inferExprInstance(tree, context.extractUndetparams(), pt,
+              // approximate types that depend on arguments since dependency on implicit argument is like dependency on type parameter
+              mt.approximate,
+              keepNothings = false,
+              useWeaklyCompatible = true) // #3808
+        }
+
+        // avoid throwing spurious DivergentImplicit errors
+        if (context.reporter.hasErrors)
+          setError(tree)
+        else
+          withCondConstrTyper(treeInfo.isSelfOrSuperConstrCall(tree))(typer1 =>
+            if (original != EmptyTree && pt != WildcardType) (
+              typer1 silent { tpr =>
+                val withImplicitArgs = tpr.applyImplicitArgs(tree)
+                if (tpr.context.reporter.hasErrors) tree // silent will wrap it in SilentTypeError anyway
+                else tpr.typed(withImplicitArgs, mode, pt)
+              }
+              orElse { _ =>
+                val resetTree = resetAttrs(original)
+                resetTree match {
+                  case treeInfo.Applied(fun, targs, args) =>
+                    if (fun.symbol != null && fun.symbol.isError)
+                      // SI-9041 Without this, we leak error symbols past the typer!
+                      // because the fallback typechecking notices the error-symbol,
+                      // refuses to re-attempt typechecking, and presumes that someone
+                      // else was responsible for issuing the related type error!
+                      fun.setSymbol(NoSymbol)
+                  case _ =>
+                }
+                debuglog(s"fallback on implicits: ${tree}/$resetTree")
+                val tree1 = typed(resetTree, mode)
+                // Q: `typed` already calls `pluginsTyped` and `adapt`. the only difference here is that
+                // we pass `EmptyTree` as the `original`. intended? added in 2009 (53d98e7d42) by martin.
+                tree1 setType pluginsTyped(tree1.tpe, this, tree1, mode, pt)
+                if (tree1.isEmpty) tree1 else adapt(tree1, mode, pt, EmptyTree)
+              }
+            )
+            else
+              typer1.typed(typer1.applyImplicitArgs(tree), mode, pt)
+          )
+      }
+
+      def instantiateToMethodType(mt: MethodType): Tree = {
+        val meth = tree match {
+          // a partial named application is a block (see comment in EtaExpansion)
+          case Block(_, tree1) => tree1.symbol
+          case _               => tree.symbol
+        }
+        if (!meth.isConstructor && (isFunctionType(pt) || samOf(pt).exists)) { // (4.2)
+          debuglog(s"eta-expanding $tree: ${tree.tpe} to $pt")
+          checkParamsConvertible(tree, tree.tpe)
+          val tree0 = etaExpand(context.unit, tree, this)
+
+          // #2624: need to infer type arguments for eta expansion of a polymorphic method
+          // context.undetparams contains clones of meth.typeParams (fresh ones were generated in etaExpand)
+          // need to run typer on tree0, since etaExpansion sets the tpe's of its subtrees to null
+          // can't type with the expected type, as we can't recreate the setup in (3) without calling typed
+          // (note that (3) does not call typed to do the polymorphic type instantiation --
+          //  it is called after the tree has been typed with a polymorphic expected result type)
+          if (hasUndets)
+            instantiate(typed(tree0, mode), mode, pt)
+          else
+            typed(tree0, mode, pt)
+        }
+        else if (!meth.isConstructor && mt.params.isEmpty) // (4.3)
+          adapt(typed(Apply(tree, Nil) setPos tree.pos), mode, pt, original)
+        else if (context.implicitsEnabled)
+          MissingArgsForMethodTpeError(tree, meth)
+        else
+          setError(tree)
+      }
+
+      def adaptType(): Tree = {
+        // @M When not typing a type constructor (!context.inTypeConstructorAllowed)
+        // or raw type, types must be of kind *,
+        // and thus parameterized types must be applied to their type arguments
+        // @M TODO: why do kind-* tree's have symbols, while higher-kinded ones don't?
+        def properTypeRequired = (
+             tree.hasSymbolField
+          && !context.inTypeConstructorAllowed
+          && !context.unit.isJava
+        )
+        // @M: don't check tree.tpe.symbol.typeParams. check tree.tpe.typeParams!!!
+        // (e.g., m[Int] --> tree.tpe.symbol.typeParams.length == 1, tree.tpe.typeParams.length == 0!)
+        // @M: removed check for tree.hasSymbolField and replace tree.symbol by tree.tpe.symbol
+        // (TypeTree's must also be checked here, and they don't directly have a symbol)
+        def kindArityMismatch = (
+             context.inTypeConstructorAllowed
+          && !sameLength(tree.tpe.typeParams, pt.typeParams)
+        )
+        // Note that we treat Any and Nothing as kind-polymorphic.
+        // We can't perform this check when typing type arguments to an overloaded method before the overload is resolved
+        // (or in the case of an error type) -- this is indicated by pt == WildcardType (see case TypeApply in typed1).
+        def kindArityMismatchOk = tree.tpe.typeSymbol match {
+          case NothingClass | AnyClass => true
+          case _                       => pt == WildcardType
+        }
+
+        // todo. It would make sense when mode.inFunMode to instead use
+        //    tree setType tree.tpe.normalize
+        // when typechecking, say, TypeApply(Ident(`some abstract type symbol`), List(...))
+        // because otherwise Ident will have its tpe set to a TypeRef, not to a PolyType, and `typedTypeApply` will fail
+        // but this needs additional investigation, because it crashes t5228, gadts1 and maybe something else
+        if (mode.inFunMode)
+          tree
+        else if (properTypeRequired && tree.symbol.typeParams.nonEmpty)  // (7)
+          MissingTypeParametersError(tree)
+        else if (kindArityMismatch && !kindArityMismatchOk)  // (7.1) @M: check kind-arity
+          KindArityMismatchError(tree, pt)
+        else tree match { // (6)
+          case TypeTree() => tree
+          case _          => TypeTree(tree.tpe) setOriginal tree
+        }
+      }
+
+      def insertApply(): Tree = {
+        assert(!context.inTypeConstructorAllowed, mode) //@M
+        val adapted = adaptToName(tree, nme.apply)
+        def stabilize0(pre: Type): Tree = stabilize(adapted, pre, MonoQualifierModes, WildcardType)
+
+        // TODO reconcile the overlap between Typers#stablize and TreeGen.stabilize
+        val qual = adapted match {
+          case This(_) =>
+            gen.stabilize(adapted)
+          case Ident(_) =>
+            val owner = adapted.symbol.owner
+            val pre =
+              if (owner.isPackageClass) owner.thisType
+              else if (owner.isClass) context.enclosingSubClassContext(owner).prefix
+              else NoPrefix
+            stabilize0(pre)
+          case Select(qualqual, _) =>
+            stabilize0(qualqual.tpe)
+          case other =>
+            other
+        }
+        typedPos(tree.pos, mode, pt) {
+          Select(qual setPos tree.pos.makeTransparent, nme.apply)
+        }
+      }
+      def adaptConstant(value: Constant): Tree = {
+        val sym = tree.symbol
+        if (sym != null && sym.isDeprecated)
+          context.deprecationWarning(tree.pos, sym)
+
+        val result = treeCopy.Literal(tree, value)
+        //+scalac deviation
+        result.rememberConstfoldOf(tree)
+        //-scalac deviation
+      }
+
+      // Ignore type errors raised in later phases that are due to mismatching types with existential skolems
+      // We have lift crashing in 2.9 with an adapt failure in the pattern matcher.
+      // Here's my hypothesis why this happens. The pattern matcher defines a variable of type
+      //
+      //   val x: T = expr
+      //
+      // where T is the type of expr, but T contains existential skolems ts.
+      // In that case, this value definition does not typecheck.
+      // The value definition
+      //
+      //   val x: T forSome { ts } = expr
+      //
+      // would typecheck. Or one can simply leave out the type of the `val`:
+      //
+      //   val x = expr
+      //
+      // SI-6029 shows another case where we also fail (in uncurry), but this time the expected
+      // type is an existential type.
+      //
+      // The reason for both failures have to do with the way we (don't) transform
+      // skolem types along with the trees that contain them. We'd need a
+      // radically different approach to do it. But before investing a lot of time to
+      // to do this (I have already sunk 3 full days with in the end futile attempts
+      // to consistently transform skolems and fix 6029), I'd like to
+      // investigate ways to avoid skolems completely.
+      //
+      // upd. The same problem happens when we try to typecheck the result of macro expansion against its expected type
+      // (which is the return type of the macro definition instantiated in the context of expandee):
+      //
+      //   Test.scala:2: error: type mismatch;
+      //     found   : $u.Expr[Class[_ <: Object]]
+      //     required: reflect.runtime.universe.Expr[Class[?0(in value <local Test>)]] where type ?0(in value <local Test>) <: Object
+      //     scala.reflect.runtime.universe.reify(new Object().getClass)
+      //                                         ^
+      // Therefore following Martin's advice I use this logic to recover from skolem errors after macro expansions
+      // (by adding the ` || tree.attachments.get[MacroExpansionAttachment].isDefined` clause to the conditional above).
+      //
+      def adaptMismatchedSkolems() = {
+        def canIgnoreMismatch = (
+             !context.reportErrors && isPastTyper
+          || tree.hasAttachment[MacroExpansionAttachment]
+        )
+        def bound = pt match {
+          case ExistentialType(qs, _) => qs
+          case _                      => Nil
+        }
+        def msg = sm"""
+          |Recovering from existential or skolem type error in
+          |  $tree
+          |with type: ${tree.tpe}
+          |       pt: $pt
+          |  context: ${context.tree}
+          |  adapted
+          """.trim
+
+        val boundOrSkolems = if (canIgnoreMismatch) bound ++ pt.skolemsExceptMethodTypeParams else Nil
+        boundOrSkolems match {
+          case Nil => AdaptTypeError(tree, tree.tpe, pt) ; setError(tree)
+          case _   => logResult(msg)(adapt(tree, mode, deriveTypeWithWildcards(boundOrSkolems)(pt)))
+        }
+      }
+
+      def fallbackAfterVanillaAdapt(): Tree = {
+        def isPopulatedPattern = {
+          if ((tree.symbol ne null) && tree.symbol.isModule)
+            inferModulePattern(tree, pt)
+
+          isPopulated(tree.tpe, approximateAbstracts(pt))
+        }
+        if (mode.inPatternMode && isPopulatedPattern)
+          return tree
+
+        val tree1 = constfold(tree, pt) // (10) (11)
+        if (tree1.tpe <:< pt)
+          return adapt(tree1, mode, pt, original)
+
+        if (mode.typingExprNotFun) {
+          // The <: Any requirement inhibits attempts to adapt continuation types
+          // to non-continuation types.
+          if (tree.tpe <:< AnyTpe) pt.dealias match {
+            case TypeRef(_, UnitClass, _) => // (12)
+              if (!isPastTyper && settings.warnValueDiscard)
+                context.warning(tree.pos, "discarded non-Unit value")
+              return typedPos(tree.pos, mode, pt)(Block(List(tree), Literal(Constant(()))))
+            case TypeRef(_, sym, _) if isNumericValueClass(sym) && isNumericSubType(tree.tpe, pt) =>
+              if (!isPastTyper && settings.warnNumericWiden)
+                context.warning(tree.pos, "implicit numeric widening")
+              return typedPos(tree.pos, mode, pt)(Select(tree, "to" + sym.name))
+            case _ =>
+          }
+          if (pt.dealias.annotations.nonEmpty && canAdaptAnnotations(tree, this, mode, pt)) // (13)
+            return typed(adaptAnnotations(tree, this, mode, pt), mode, pt)
+
+          if (hasUndets)
+            return instantiate(tree, mode, pt)
+
+          if (context.implicitsEnabled && !pt.isError && !tree.isErrorTyped) {
+            // (14); the condition prevents chains of views
+            debuglog("inferring view from " + tree.tpe + " to " + pt)
+            inferView(tree, tree.tpe, pt, reportAmbiguous = true) match {
+              case EmptyTree =>
+              case coercion  =>
+                def msg = "inferred view from " + tree.tpe + " to " + pt + " = " + coercion + ":" + coercion.tpe
+                if (settings.logImplicitConv)
+                  context.echo(tree.pos, msg)
+
+                debuglog(msg)
+                val silentContext = context.makeImplicit(context.ambiguousErrors)
+                val res = newTyper(silentContext).typed(
+                  new ApplyImplicitView(coercion, List(tree)) setPos tree.pos, mode, pt)
+                silentContext.reporter.firstError match {
+                  case Some(err) => context.issue(err)
+                  case None      => return res
+                }
+            }
+          }
+        }
+
+        debuglog("error tree = " + tree)
+        if (settings.debug && settings.explaintypes)
+          explainTypes(tree.tpe, pt)
+
+        if (tree.tpe.isErroneous || pt.isErroneous)
+          setError(tree)
+        else
+          adaptMismatchedSkolems()
+      }
+
+      def vanillaAdapt(tree: Tree) = {
+        def applyPossible = {
+          def applyMeth = member(adaptToName(tree, nme.apply), nme.apply)
+          def hasPolymorphicApply = applyMeth.alternatives exists (_.tpe.typeParams.nonEmpty)
+          def hasMonomorphicApply = applyMeth.alternatives exists (_.tpe.paramSectionCount > 0)
+
+          dyna.acceptsApplyDynamic(tree.tpe) || (
+            if (mode.inTappMode)
+              tree.tpe.typeParams.isEmpty && hasPolymorphicApply
+            else
+              hasMonomorphicApply
+          )
+        }
+        def shouldInsertApply(tree: Tree) = mode.typingExprFun && {
+          tree.tpe match {
+            case _: MethodType | _: OverloadedType | _: PolyType => false
+            case _                                               => applyPossible
+          }
+        }
+        if (tree.isType)
+          adaptType()
+        else if (mode.typingExprNotFun && treeInfo.isMacroApplication(tree) && !isMacroExpansionSuppressed(tree))
+          macroExpand(this, tree, mode, pt)
+        else if (mode.typingConstructorPattern)
+          typedConstructorPattern(tree, pt)
+        else if (shouldInsertApply(tree))
+          insertApply()
+        else if (hasUndetsInMonoMode) { // (9)
+          assert(!context.inTypeConstructorAllowed, context) //@M
+          instantiatePossiblyExpectingUnit(tree, mode, pt)
+        }
+        else if (tree.tpe <:< pt)
+          tree
+        else
+          fallbackAfterVanillaAdapt()
+      }
+
+      // begin adapt
+      if (isMacroImplRef(tree)) {
+        if (treeInfo.isMacroApplication(tree)) adapt(unmarkMacroImplRef(tree), mode, pt, original)
+        else tree
+      } else tree.tpe match {
+        case atp @ AnnotatedType(_, _) if canAdaptAnnotations(tree, this, mode, pt) => // (-1)
+          adaptAnnotations(tree, this, mode, pt)
+        case ct @ ConstantType(value) if mode.inNone(TYPEmode | FUNmode) && (ct <:< pt) && canAdaptConstantTypeToLiteral => // (0)
+          adaptConstant(value)
+        case OverloadedType(pre, alts) if !mode.inFunMode => // (1)
+          inferExprAlternative(tree, pt)
+          adaptAfterOverloadResolution(tree, mode, pt, original)
+        case NullaryMethodType(restpe) => // (2)
+          adapt(tree setType restpe, mode, pt, original)
+        case TypeRef(_, ByNameParamClass, arg :: Nil) if mode.inExprMode => // (2)
+          adapt(tree setType arg, mode, pt, original)
+        case tp if mode.typingExprNotLhs && isExistentialType(tp) =>
+          adapt(tree setType tp.dealias.skolemizeExistential(context.owner, tree), mode, pt, original)
+        case PolyType(tparams, restpe) if mode.inNone(TAPPmode | PATTERNmode) && !context.inTypeConstructorAllowed => // (3)
+          // assert((mode & HKmode) == 0) //@M a PolyType in HKmode represents an anonymous type function,
+          // we're in HKmode since a higher-kinded type is expected --> hence, don't implicitly apply it to type params!
+          // ticket #2197 triggered turning the assert into a guard
+          // I guess this assert wasn't violated before because type aliases weren't expanded as eagerly
+          //  (the only way to get a PolyType for an anonymous type function is by normalisation, which applies eta-expansion)
+          // -- are we sure we want to expand aliases this early?
+          // -- what caused this change in behaviour??
+          val tparams1 = cloneSymbols(tparams)
+          val tree1 = (
+            if (tree.isType) tree
+            else TypeApply(tree, tparams1 map (tparam => TypeTree(tparam.tpeHK) setPos tree.pos.focus)) setPos tree.pos
+          )
+          context.undetparams ++= tparams1
+          notifyUndetparamsAdded(tparams1)
+          adapt(tree1 setType restpe.substSym(tparams, tparams1), mode, pt, original)
+
+        case mt: MethodType if mode.typingExprNotFunNotLhs && mt.isImplicit => // (4.1)
+          adaptToImplicitMethod(mt)
+        case mt: MethodType if mode.typingExprNotFunNotLhs && !hasUndetsInMonoMode && !treeInfo.isMacroApplicationOrBlock(tree) =>
+          instantiateToMethodType(mt)
+        case _ =>
+          vanillaAdapt(tree)
+      }
+    }
+  }
+}

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/SemanticdbPipeline.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/SemanticdbPipeline.scala
@@ -46,6 +46,8 @@ trait SemanticdbPipeline extends DatabaseOps { self: SemanticdbPlugin =>
       override def apply(unit: g.CompilationUnit): Unit = {
         try {
           if (config.mode.isDisabled || !unit.source.file.name.endsWith(".scala")) return
+          val fullName = unit.source.file.file.getAbsolutePath
+          if (!config.fileFilter.matches(fullName)) return
           val mattrs = unit.toDocument
           unit.body.updateAttachment(mattrs)
         } catch handleError(unit)

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/SemanticdbPipeline.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/SemanticdbPipeline.scala
@@ -74,7 +74,7 @@ trait SemanticdbPipeline extends DatabaseOps { self: SemanticdbPlugin =>
         try {
           unit.body.attachments.get[m.Document].foreach { mattrs =>
             unit.body.removeAttachment[m.Document]
-            val messages = unit.reportedMessages
+            val messages = if (config.messages.saveMessages) unit.reportedMessages else Nil
             val mminidb = m.Database(List(mattrs.copy(messages = messages)))
             mminidb.save(scalametaTargetroot, config.sourceroot)
           }

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/SemanticdbPipeline.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/SemanticdbPipeline.scala
@@ -75,7 +75,7 @@ trait SemanticdbPipeline extends DatabaseOps { self: SemanticdbPlugin =>
     override val runsRightAfter = Some("jvm")
     val phaseName = "semanticdb-jvm"
     override val description =
-      "compute and persist semanticdb information after typer (most commonly messages)"
+      "compute and persist additional semanticdb entries created after typer"
     def newPhase(_prev: Phase) = new PersistSemanticdbPhase(_prev)
     class PersistSemanticdbPhase(prev: Phase) extends StdPhase(prev) {
       override def apply(unit: g.CompilationUnit): Unit = {

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/SemanticdbPlugin.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/SemanticdbPlugin.scala
@@ -1,8 +1,6 @@
 package scala.meta.internal
 
-import scala.meta.internal.semanticdb.FailureMode
-import scala.meta.internal.semanticdb.MemberMode
-import scala.meta.internal.semanticdb.SemanticdbMode
+import scala.meta.internal.semanticdb._
 import scala.meta.io.AbsolutePath
 import scala.tools.nsc.Global
 import scala.tools.nsc.plugins.{Plugin, PluginComponent}
@@ -38,6 +36,10 @@ class SemanticdbPlugin(val global: Global)
         config.setMembers(members)
       case SetMode(els) =>
         err(s"Unknown mode $els. Expected one of: ${SemanticdbMode.all.mkString(", ")} ")
+      case SetFailures(FailureMode(severity)) =>
+        config.setFailures(severity)
+      case SetDenotations(DenotationMode(denotations)) =>
+        config.setDenotations(denotations)
       case els =>
         err(s"Ignoring unknown option $els")
     }

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/SemanticdbPlugin.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/SemanticdbPlugin.scala
@@ -46,6 +46,10 @@ class SemanticdbPlugin(val global: Global)
         config.setInclude(include)
       case SetExclude(exclude) =>
         config.setExclude(exclude)
+      case SetMessages(MessageMode(messages)) =>
+        config.setMessages(messages)
+      case SetSynthetics(SyntheticMode(synthetics)) =>
+        config.setSynthetics(synthetics)
       case els =>
         err(s"Ignoring unknown option $els")
     }

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/SemanticdbPlugin.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/SemanticdbPlugin.scala
@@ -42,6 +42,10 @@ class SemanticdbPlugin(val global: Global)
         config.setDenotations(denotations)
       case SetProfiling(ProfilingMode(profiling)) =>
         config.setProfiling(profiling)
+      case SetInclude(include) =>
+        config.setInclude(include)
+      case SetExclude(exclude) =>
+        config.setExclude(exclude)
       case els =>
         err(s"Ignoring unknown option $els")
     }

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/SemanticdbPlugin.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/SemanticdbPlugin.scala
@@ -40,6 +40,8 @@ class SemanticdbPlugin(val global: Global)
         config.setFailures(severity)
       case SetDenotations(DenotationMode(denotations)) =>
         config.setDenotations(denotations)
+      case SetProfiling(ProfilingMode(profiling)) =>
+        config.setProfiling(profiling)
       case els =>
         err(s"Ignoring unknown option $els")
     }

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/SemanticdbPlugin.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/SemanticdbPlugin.scala
@@ -16,7 +16,7 @@ class SemanticdbPlugin(val global: Global)
   hijackAnalyzer()
   hijackReporter()
   val components = {
-    if (isBatchCompiler) List(ComputeSemanticdbComponent, PersistSemanticdbComponent)
+    if (isBatchCompiler) List(SemanticdbTyperComponent, SemanticdbJvmComponent)
     else Nil
   }
 

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/ConfigOps.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/ConfigOps.scala
@@ -23,9 +23,9 @@ case class SemanticdbConfig(
       s"-P:${SemanticdbPlugin.name}:denotations:${denotations.name} " +
       s"-P:${SemanticdbPlugin.name}:profiling:${profiling.name} " +
       s"-P:${SemanticdbPlugin.name}:include:${fileFilter.include} " +
-      s"-P:${SemanticdbPlugin.name}:exclude:${fileFilter.exclude} "
-  s"-P:${SemanticdbPlugin.name}:messages:${messages.name} " +
-    s"-P:${SemanticdbPlugin.name}:synthetics:${synthetics.name} "
+      s"-P:${SemanticdbPlugin.name}:exclude:${fileFilter.exclude} " +
+      s"-P:${SemanticdbPlugin.name}:messages:${messages.name} " +
+      s"-P:${SemanticdbPlugin.name}:synthetics:${synthetics.name} "
 }
 object SemanticdbConfig {
   def default = SemanticdbConfig(

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/ConfigOps.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/ConfigOps.scala
@@ -24,8 +24,8 @@ case class SemanticdbConfig(
       s"-P:${SemanticdbPlugin.name}:profiling:${profiling.name} " +
       s"-P:${SemanticdbPlugin.name}:include:${fileFilter.include} " +
       s"-P:${SemanticdbPlugin.name}:exclude:${fileFilter.exclude} "
-      s"-P:${SemanticdbPlugin.name}:messages:${messages.name} " +
-      s"-P:${SemanticdbPlugin.name}:synthetics:${synthetics.name} "
+  s"-P:${SemanticdbPlugin.name}:messages:${messages.name} " +
+    s"-P:${SemanticdbPlugin.name}:synthetics:${synthetics.name} "
 }
 object SemanticdbConfig {
   def default = SemanticdbConfig(
@@ -37,7 +37,8 @@ object SemanticdbConfig {
     ProfilingMode.Off,
     FileFilter.matchEverything,
     MessageMode.All,
-    SyntheticMode.All)
+    SyntheticMode.All
+  )
 }
 
 sealed abstract class SemanticdbMode {
@@ -109,7 +110,7 @@ object ProfilingMode {
 case class FileFilter(include: Regex, exclude: Regex) {
   def matches(path: String): Boolean =
     include.findFirstIn(path).isDefined &&
-    exclude.findFirstIn(path).isEmpty
+      exclude.findFirstIn(path).isEmpty
 }
 object FileFilter {
   def apply(include: String, exclude: String): FileFilter =

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/DocumentOps.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/DocumentOps.scala
@@ -166,19 +166,24 @@ trait DocumentOps { self: DatabaseOps =>
                 val symbol = gsym.toSemantic
                 if (symbol == m.Symbol.None) return
 
+                todo -= mtree
+
                 names(mtree.pos) = symbol
                 if (mtree.isDefinition) binders += mtree.pos
-                if (!gsym.isOverloaded &&
-                    gsym != g.definitions.RepeatedParamClass) {
-                  denotations(symbol) = gsym.toDenotation
-                }
-                if (gsym.isClass && !gsym.isTrait) {
-                  val gprim = gsym.primaryConstructor
-                  if (gprim != g.NoSymbol) {
-                    denotations(gprim.toSemantic) = gprim.toDenotation
+
+                def saveDenotation(): Unit = {
+                  if (!gsym.isOverloaded &&  gsym != g.definitions.RepeatedParamClass) {
+                    denotations(symbol) = gsym.toDenotation
+                  }
+                  if (gsym.isClass && !gsym.isTrait) {
+                    val gprim = gsym.primaryConstructor
+                    if (gprim != g.NoSymbol) {
+                      denotations(gprim.toSemantic) = gprim.toDenotation
+                    }
                   }
                 }
-                todo -= mtree
+                if (mtree.isDefinition && config.denotations.saveDefinitions) saveDenotation()
+                if (mtree.isReference && config.denotations.saveReferences) saveDenotation()
 
                 def tryWithin(map: mutable.Map[m.Tree, m.Name], gsym0: g.Symbol): Unit = {
                   if (map.contains(mtree)) {

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/DocumentOps.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/DocumentOps.scala
@@ -11,7 +11,6 @@ trait DocumentOps { self: DatabaseOps =>
 
   implicit class XtensionCompilationUnitDocument(unit: g.CompilationUnit) {
     def toDocument: m.Document = {
-      unit.cache.getOrElse("attributes", {
         if (!g.settings.Yrangepos.value) {
           sys.error("the compiler instance must have -Yrangepos enabled")
         }
@@ -470,7 +469,6 @@ trait DocumentOps { self: DatabaseOps =>
           symbols,
           synthetics.toList
         )
-      })
     }
   }
 

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/DocumentOps.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/DocumentOps.scala
@@ -463,7 +463,7 @@ trait DocumentOps { self: DatabaseOps =>
         input,
         language,
         names.map { case (pos, sym) => m.ResolvedName(pos, sym, binders(pos)) }.toList,
-        Nil, // added in a separate phase.
+        unit.reportedMessages(mstarts),
         symbols,
         synthetics.toList
       )

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/DocumentOps.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/DocumentOps.scala
@@ -325,6 +325,8 @@ trait DocumentOps { self: DatabaseOps =>
             }
 
             private def tryFindInferred(gtree: g.Tree): Unit = {
+              if (!config.synthetics.saveSynthetics) return
+
               import scala.meta.internal.semanticdb.{AttributedSynthetic => S}
               def success(pos: m.Position, f: Inferred => Inferred): Unit = {
                 inferred(pos) = f(inferred(pos))
@@ -464,7 +466,7 @@ trait DocumentOps { self: DatabaseOps =>
           input,
           language,
           names.map { case (pos, sym) => m.ResolvedName(pos, sym, binders(pos)) }.toList,
-          Nil, // added after jvm phase.
+          Nil, // added in a separate phase.
           symbols,
           synthetics.toList
         )

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/DocumentOps.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/DocumentOps.scala
@@ -11,464 +11,462 @@ trait DocumentOps { self: DatabaseOps =>
 
   implicit class XtensionCompilationUnitDocument(unit: g.CompilationUnit) {
     def toDocument: m.Document = {
-        if (!g.settings.Yrangepos.value) {
-          sys.error("the compiler instance must have -Yrangepos enabled")
-        }
-        if (g.useOffsetPositions) {
-          sys.error("The compiler instance must use range positions")
-        }
-        if (!g.settings.plugin.value.exists(_.contains("semanticdb"))) {
-          sys.error("the compiler instance must use the semanticdb plugin")
-        }
-        if (!g.analyzer.getClass.getName.contains("HijackAnalyzer")) {
-          println(g.analyzer.getClass.getName)
-          sys.error("the compiler instance must use a hijacked analyzer")
-        }
-        if (g.phase.id < g.currentRun.phaseNamed("typer").id) {
-          sys.error("the compiler phase must be not earlier than typer")
-        }
-        if (g.phase.id > g.currentRun.phaseNamed("patmat").id) {
-          sys.error("the compiler phase must be not later than patmat")
-        }
+      if (!g.settings.Yrangepos.value) {
+        sys.error("the compiler instance must have -Yrangepos enabled")
+      }
+      if (g.useOffsetPositions) {
+        sys.error("The compiler instance must use range positions")
+      }
+      if (!g.settings.plugin.value.exists(_.contains("semanticdb"))) {
+        sys.error("the compiler instance must use the semanticdb plugin")
+      }
+      if (!g.analyzer.getClass.getName.contains("HijackAnalyzer")) {
+        println(g.analyzer.getClass.getName)
+        sys.error("the compiler instance must use a hijacked analyzer")
+      }
+      if (g.phase.id < g.currentRun.phaseNamed("typer").id) {
+        sys.error("the compiler phase must be not earlier than typer")
+      }
+      if (g.phase.id > g.currentRun.phaseNamed("patmat").id) {
+        sys.error("the compiler phase must be not later than patmat")
+      }
 
-        val binders = mutable.Set[m.Position]()
-        val names = mutable.Map[m.Position, m.Symbol]()
-        val denotations = mutable.Map[m.Symbol, m.Denotation]()
-        val members = mutable.Map[m.Symbol, List[m.Signature]]()
-        val inferred = mutable.Map[m.Position, Inferred]().withDefaultValue(Inferred())
-        val isVisited = mutable.Set.empty[g.Tree] // macro expandees can have cycles, keep tracks of visited nodes.
-        val todo = mutable.Set[m.Name]() // names to map to global trees
-        val mstarts = mutable.Map[Int, m.Name]() // start offset -> tree
-        unit.body.appendMetadata("semanticdbMstarts" -> mstarts) // used in MessagesOps
-        val mends = mutable.Map[Int, m.Name]() // end offset -> tree
-        val margnames = mutable.Map[Int, List[m.Name]]() // start offset of enclosing apply -> its arg names
-        val mwithins = mutable.Map[m.Tree, m.Name]() // name of enclosing member -> name of private/protected within
-        val mwithinctors = mutable.Map[m.Tree, m.Name]() // name of enclosing class -> name of private/protected within for primary ctor
-        val mctordefs = mutable.Map[Int, m.Name]() // start offset of ctor -> ctor's anonymous name
-        val mctorrefs = mutable.Map[Int, m.Name]() // start offset of new/init -> new's anonymous name
+      val binders = mutable.Set[m.Position]()
+      val names = mutable.Map[m.Position, m.Symbol]()
+      val denotations = mutable.Map[m.Symbol, m.Denotation]()
+      val members = mutable.Map[m.Symbol, List[m.Signature]]()
+      val inferred = mutable.Map[m.Position, Inferred]().withDefaultValue(Inferred())
+      val isVisited = mutable.Set.empty[g.Tree] // macro expandees can have cycles, keep tracks of visited nodes.
+      val todo = mutable.Set[m.Name]() // names to map to global trees
+      val mstarts = mutable.Map[Int, m.Name]() // start offset -> tree
+      unit.body.appendMetadata("semanticdbMstarts" -> mstarts) // used in MessagesOps
+      val mends = mutable.Map[Int, m.Name]() // end offset -> tree
+      val margnames = mutable.Map[Int, List[m.Name]]() // start offset of enclosing apply -> its arg names
+      val mwithins = mutable.Map[m.Tree, m.Name]() // name of enclosing member -> name of private/protected within
+      val mwithinctors = mutable.Map[m.Tree, m.Name]() // name of enclosing class -> name of private/protected within for primary ctor
+      val mctordefs = mutable.Map[Int, m.Name]() // start offset of ctor -> ctor's anonymous name
+      val mctorrefs = mutable.Map[Int, m.Name]() // start offset of new/init -> new's anonymous name
 
-        locally {
-          object traverser extends m.Traverser {
-            private def indexName(mname: m.Name): Unit = {
-              todo += mname
-              // TODO: also drop trivia (no idea how to formulate this concisely)
-              val tok = mname.tokens.dropWhile(_.is[m.Token.LeftParen]).headOption
-              val mstart1 = tok.map(_.start).getOrElse(mname.pos.start)
-              val mend1 = tok.map(_.end).getOrElse(mname.pos.end)
-              if (mstarts.contains(mstart1)) {
-                val details = syntaxAndPos(mname) + " " + syntaxAndPos(mstarts(mstart1))
-                sys.error(s"ambiguous mstart $details")
-              }
-              if (mends.contains(mend1)) {
-                val details = syntaxAndPos(mname) + " " + syntaxAndPos(mends(mend1))
-                sys.error(s"ambiguous mend $details")
-              }
-              mstarts(mstart1) = mname
-              mends(mend1) = mname
+      locally {
+        object traverser extends m.Traverser {
+          private def indexName(mname: m.Name): Unit = {
+            todo += mname
+            // TODO: also drop trivia (no idea how to formulate this concisely)
+            val tok = mname.tokens.dropWhile(_.is[m.Token.LeftParen]).headOption
+            val mstart1 = tok.map(_.start).getOrElse(mname.pos.start)
+            val mend1 = tok.map(_.end).getOrElse(mname.pos.end)
+            if (mstarts.contains(mstart1)) {
+              val details = syntaxAndPos(mname) + " " + syntaxAndPos(mstarts(mstart1))
+              sys.error(s"ambiguous mstart $details")
             }
-            private def indexArgNames(mapp: m.Tree, mnames: List[m.Name]): Unit = {
-              if (mnames.isEmpty) return
-              todo ++= mnames
-              // TODO: also drop trivia (no idea how to formulate this concisely)
-              val mstart1 = mapp.tokens
-                .dropWhile(_.is[m.Token.LeftParen])
-                .headOption
-                .map(_.start)
-                .getOrElse(-1)
-              // only add names for the top-level term.apply of a curried function application.
-              if (!margnames.contains(mstart1))
-                margnames(mstart1) = mnames
+            if (mends.contains(mend1)) {
+              val details = syntaxAndPos(mname) + " " + syntaxAndPos(mends(mend1))
+              sys.error(s"ambiguous mend $details")
             }
-            private def indexWithin(mname: m.Name.Indeterminate): Unit = {
-              todo += mname
-              val mencl = mname.parent.flatMap(_.parent).get
-              mencl match {
-                case mencl: m.Ctor.Primary =>
-                  val menclDefn = mencl.parent.get.asInstanceOf[m.Member]
-                  val menclName = menclDefn.name
-                  if (mwithinctors.contains(menclName)) {
-                    val details = syntaxAndPos(mname) + " " + syntaxAndPos(mwithinctors(menclName))
-                    sys.error(s"ambiguous mwithinctors $details")
-                  }
-                  mwithinctors(menclName) = mname
-                case _ =>
-                  def findBinder(pat: m.Pat) =
-                    pat.collect { case m.Pat.Var(name) => name }.head
-                  val menclName = mencl match {
-                    case mtree: m.Member => mtree.name
-                    case m.Decl.Val(_, pat :: Nil, _) => findBinder(pat)
-                    case m.Decl.Var(_, pat :: Nil, _) => findBinder(pat)
-                    case m.Defn.Val(_, pat :: Nil, _, _) => findBinder(pat)
-                    case m.Defn.Var(_, pat :: Nil, _, _) => findBinder(pat)
-                  }
-                  if (mwithins.contains(menclName)) {
-                    val details = syntaxAndPos(mname) + " " + syntaxAndPos(mwithins(menclName))
-                    sys.error(s"ambiguous mwithins $details")
-                  }
-                  mwithins(menclName) = mname
-              }
-            }
-            override def apply(mtree: m.Tree): Unit = {
-              mtree match {
-                case mtree @ m.Term.Apply(_, margs) =>
-                  def loop(term: m.Term): List[m.Term.Name] = term match {
-                    case m.Term.Apply(mfn, margs) =>
-                      margs.toList.collect {
-                        case m.Term.Assign(mname: m.Term.Name, _) => mname
-                      } ++ loop(mfn)
-                    case _ => Nil
-                  }
-                  indexArgNames(mtree, loop(mtree))
-                case mtree @ m.Mod.Private(mname: m.Name.Indeterminate) =>
-                  indexWithin(mname)
-                case mtree @ m.Mod.Protected(mname: m.Name.Indeterminate) =>
-                  indexWithin(mname)
-                case mtree @ m.Importee.Rename(mname, mrename) =>
-                  indexName(mname)
-                  return // NOTE: ignore mrename for now, we may decide to make it a binder
-                case mtree @ m.Name.Anonymous() =>
-                // TODO: support non-ctor-related use cases for anonymous names
-                case mtree: m.Ctor =>
-                  mctordefs(mtree.pos.start) = mtree.name
-                case mtree: m.Term.New =>
-                  mctorrefs(mtree.pos.start) = mtree.init.name
-                case mtree: m.Init =>
-                  mctorrefs(mtree.pos.start) = mtree.name
-                case mtree: m.Name =>
-                  indexName(mtree)
-                case _ =>
-                // do nothing
-              }
-              super.apply(mtree)
+            mstarts(mstart1) = mname
+            mends(mend1) = mname
+          }
+          private def indexArgNames(mapp: m.Tree, mnames: List[m.Name]): Unit = {
+            if (mnames.isEmpty) return
+            todo ++= mnames
+            // TODO: also drop trivia (no idea how to formulate this concisely)
+            val mstart1 = mapp.tokens
+              .dropWhile(_.is[m.Token.LeftParen])
+              .headOption
+              .map(_.start)
+              .getOrElse(-1)
+            // only add names for the top-level term.apply of a curried function application.
+            if (!margnames.contains(mstart1))
+              margnames(mstart1) = mnames
+          }
+          private def indexWithin(mname: m.Name.Indeterminate): Unit = {
+            todo += mname
+            val mencl = mname.parent.flatMap(_.parent).get
+            mencl match {
+              case mencl: m.Ctor.Primary =>
+                val menclDefn = mencl.parent.get.asInstanceOf[m.Member]
+                val menclName = menclDefn.name
+                if (mwithinctors.contains(menclName)) {
+                  val details = syntaxAndPos(mname) + " " + syntaxAndPos(mwithinctors(menclName))
+                  sys.error(s"ambiguous mwithinctors $details")
+                }
+                mwithinctors(menclName) = mname
+              case _ =>
+                def findBinder(pat: m.Pat) =
+                  pat.collect { case m.Pat.Var(name) => name }.head
+                val menclName = mencl match {
+                  case mtree: m.Member => mtree.name
+                  case m.Decl.Val(_, pat :: Nil, _) => findBinder(pat)
+                  case m.Decl.Var(_, pat :: Nil, _) => findBinder(pat)
+                  case m.Defn.Val(_, pat :: Nil, _, _) => findBinder(pat)
+                  case m.Defn.Var(_, pat :: Nil, _, _) => findBinder(pat)
+                }
+                if (mwithins.contains(menclName)) {
+                  val details = syntaxAndPos(mname) + " " + syntaxAndPos(mwithins(menclName))
+                  sys.error(s"ambiguous mwithins $details")
+                }
+                mwithins(menclName) = mname
             }
           }
-          traverser(unit.toSource)
+          override def apply(mtree: m.Tree): Unit = {
+            mtree match {
+              case mtree @ m.Term.Apply(_, margs) =>
+                def loop(term: m.Term): List[m.Term.Name] = term match {
+                  case m.Term.Apply(mfn, margs) =>
+                    margs.toList.collect {
+                      case m.Term.Assign(mname: m.Term.Name, _) => mname
+                    } ++ loop(mfn)
+                  case _ => Nil
+                }
+                indexArgNames(mtree, loop(mtree))
+              case mtree @ m.Mod.Private(mname: m.Name.Indeterminate) =>
+                indexWithin(mname)
+              case mtree @ m.Mod.Protected(mname: m.Name.Indeterminate) =>
+                indexWithin(mname)
+              case mtree @ m.Importee.Rename(mname, mrename) =>
+                indexName(mname)
+                return // NOTE: ignore mrename for now, we may decide to make it a binder
+              case mtree @ m.Name.Anonymous() =>
+              // TODO: support non-ctor-related use cases for anonymous names
+              case mtree: m.Ctor =>
+                mctordefs(mtree.pos.start) = mtree.name
+              case mtree: m.Term.New =>
+                mctorrefs(mtree.pos.start) = mtree.init.name
+              case mtree: m.Init =>
+                mctorrefs(mtree.pos.start) = mtree.name
+              case mtree: m.Name =>
+                indexName(mtree)
+              case _ =>
+              // do nothing
+            }
+            super.apply(mtree)
+          }
         }
+        traverser(unit.toSource)
+      }
 
-        locally {
-          object traverser extends g.Traverser {
-            private def tryFindMtree(gtree: g.Tree): Unit = {
-              def success(mtree: m.Name, gsym0: g.Symbol): Unit = {
-                // We cannot be guaranteed that all symbols have a position, see
-                // https://github.com/scalameta/scalameta/issues/665
-                // Instead of crashing with "unsupported file", we ignore these cases.
-                if (gsym0 == null) return
-                if (gsym0.isAnonymousClass) return
-                if (mtree.pos == m.Position.None) return
-                if (names.contains(mtree.pos)) return // NOTE: in the future, we may decide to preempt preexisting db entries
+      locally {
+        object traverser extends g.Traverser {
+          private def tryFindMtree(gtree: g.Tree): Unit = {
+            def success(mtree: m.Name, gsym0: g.Symbol): Unit = {
+              // We cannot be guaranteed that all symbols have a position, see
+              // https://github.com/scalameta/scalameta/issues/665
+              // Instead of crashing with "unsupported file", we ignore these cases.
+              if (gsym0 == null) return
+              if (gsym0.isAnonymousClass) return
+              if (mtree.pos == m.Position.None) return
+              if (names.contains(mtree.pos)) return // NOTE: in the future, we may decide to preempt preexisting db entries
 
-                val gsym = {
-                  def isClassRefInCtorCall = gsym0.isConstructor && mtree.isNot[m.Name.Anonymous]
-                  if (gsym0 != null && isClassRefInCtorCall) gsym0.owner
-                  else gsym0 // TODO: fix this in callers of `success`
+              val gsym = {
+                def isClassRefInCtorCall = gsym0.isConstructor && mtree.isNot[m.Name.Anonymous]
+                if (gsym0 != null && isClassRefInCtorCall) gsym0.owner
+                else gsym0 // TODO: fix this in callers of `success`
+              }
+              val symbol = gsym.toSemantic
+              if (symbol == m.Symbol.None) return
+
+              todo -= mtree
+
+              names(mtree.pos) = symbol
+              if (mtree.isDefinition) binders += mtree.pos
+
+              def saveDenotation(): Unit = {
+                if (!gsym.isOverloaded && gsym != g.definitions.RepeatedParamClass) {
+                  denotations(symbol) = gsym.toDenotation
                 }
-                val symbol = gsym.toSemantic
-                if (symbol == m.Symbol.None) return
-
-                todo -= mtree
-
-                names(mtree.pos) = symbol
-                if (mtree.isDefinition) binders += mtree.pos
-
-                def saveDenotation(): Unit = {
-                  if (!gsym.isOverloaded &&  gsym != g.definitions.RepeatedParamClass) {
-                    denotations(symbol) = gsym.toDenotation
-                  }
-                  if (gsym.isClass && !gsym.isTrait) {
-                    val gprim = gsym.primaryConstructor
-                    if (gprim != g.NoSymbol) {
-                      denotations(gprim.toSemantic) = gprim.toDenotation
-                    }
-                  }
-                }
-                if (mtree.isDefinition && config.denotations.saveDefinitions) saveDenotation()
-                if (mtree.isReference && config.denotations.saveReferences) saveDenotation()
-
-                def tryWithin(map: mutable.Map[m.Tree, m.Name], gsym0: g.Symbol): Unit = {
-                  if (map.contains(mtree)) {
-                    val gsym = gsym0.getterIn(gsym0.owner).orElse(gsym0)
-                    if (!gsym.hasAccessBoundary) return
-                    val within1 = gsym.privateWithin
-                    val within2 = within1.owner.info.member({
-                      if (within1.name.isTermName) within1.name.toTypeName
-                      else within1.name.toTermName
-                    })
-                    success(
-                      map(mtree),
-                      wrapAlternatives("<within " + symbol + ">", within1, within2))
+                if (gsym.isClass && !gsym.isTrait) {
+                  val gprim = gsym.primaryConstructor
+                  if (gprim != g.NoSymbol) {
+                    denotations(gprim.toSemantic) = gprim.toDenotation
                   }
                 }
-                tryWithin(mwithins, gsym)
-                tryWithin(mwithinctors, gsym.primaryConstructor)
               }
-              def tryMstart(start: Int): Boolean = {
-                if (!mstarts.contains(start)) return false
-                success(mstarts(start), gtree.symbol)
-                return true
-              }
-              def tryMend(end: Int): Boolean = {
-                if (!mends.contains(end)) return false
-                success(mends(end), gtree.symbol)
-                return true
-              }
-              def tryMpos(start: Int, end: Int): Boolean = {
-                if (!mstarts.contains(start)) return false
-                val mtree = mstarts(start)
-                if (mtree.pos.end != end) return false
-                success(mtree, gtree.symbol)
-                return true
-              }
+              if (mtree.isDefinition && config.denotations.saveDefinitions) saveDenotation()
+              if (mtree.isReference && config.denotations.saveReferences) saveDenotation()
 
-              if (gtree.pos == null || gtree.pos == NoPosition) return
-              val gstart = gtree.pos.start
-              val gpoint = gtree.pos.point
-              val gend = gtree.pos.end
-
-              if (margnames.contains(gstart) || margnames.contains(gpoint)) {
-                (margnames.get(gstart) ++ margnames.get(gpoint)).flatten.foreach(margname => {
-                  if (gtree.symbol != null && gtree.symbol.isMethod) {
-                    val gsym = gtree.symbol.paramss.flatten.find(_.name.decoded == margname.value)
-                    gsym.foreach(success(margname, _))
-                  }
-                })
-              }
-
-              if (mctordefs.contains(gstart)) {
-                val mname = mctordefs(gstart)
-                gtree match {
-                  case gtree: g.Template =>
-                    if (config.members.isAll) {
-                      gtree.parents.foreach { parent =>
-                        members(parent.symbol.toSemantic) = parent.tpe.lookupMembers
-                      }
-                    }
-                    val gctor =
-                      gtree.body.find(x => Option(x.symbol).exists(_.isPrimaryConstructor))
-                    success(mname, gctor.map(_.symbol).getOrElse(g.NoSymbol))
-                  case gtree: g.DefDef if gtree.symbol.isConstructor =>
-                    success(mname, gtree.symbol)
-                  case _ =>
+              def tryWithin(map: mutable.Map[m.Tree, m.Name], gsym0: g.Symbol): Unit = {
+                if (map.contains(mtree)) {
+                  val gsym = gsym0.getterIn(gsym0.owner).orElse(gsym0)
+                  if (!gsym.hasAccessBoundary) return
+                  val within1 = gsym.privateWithin
+                  val within2 = within1.owner.info.member({
+                    if (within1.name.isTermName) within1.name.toTypeName
+                    else within1.name.toTermName
+                  })
+                  success(map(mtree), wrapAlternatives("<within " + symbol + ">", within1, within2))
                 }
               }
+              tryWithin(mwithins, gsym)
+              tryWithin(mwithinctors, gsym.primaryConstructor)
+            }
+            def tryMstart(start: Int): Boolean = {
+              if (!mstarts.contains(start)) return false
+              success(mstarts(start), gtree.symbol)
+              return true
+            }
+            def tryMend(end: Int): Boolean = {
+              if (!mends.contains(end)) return false
+              success(mends(end), gtree.symbol)
+              return true
+            }
+            def tryMpos(start: Int, end: Int): Boolean = {
+              if (!mstarts.contains(start)) return false
+              val mtree = mstarts(start)
+              if (mtree.pos.end != end) return false
+              success(mtree, gtree.symbol)
+              return true
+            }
 
-              if (mctorrefs.contains(gpoint)) {
-                val mname = mctorrefs(gpoint)
-                gtree match {
-                  case g.Select(_, g.nme.CONSTRUCTOR) => success(mname, gtree.symbol)
-                  case _ =>
+            if (gtree.pos == null || gtree.pos == NoPosition) return
+            val gstart = gtree.pos.start
+            val gpoint = gtree.pos.point
+            val gend = gtree.pos.end
+
+            if (margnames.contains(gstart) || margnames.contains(gpoint)) {
+              (margnames.get(gstart) ++ margnames.get(gpoint)).flatten.foreach(margname => {
+                if (gtree.symbol != null && gtree.symbol.isMethod) {
+                  val gsym = gtree.symbol.paramss.flatten.find(_.name.decoded == margname.value)
+                  gsym.foreach(success(margname, _))
                 }
-              }
+              })
+            }
 
-              // Ideally, we'd like a perfect match when gtree.pos == mtree.pos.
-              // Unfortunately, this is often not the case as demonstrated by a bunch of cases above and below.
-              if (tryMpos(gstart, gend)) return
-
+            if (mctordefs.contains(gstart)) {
+              val mname = mctordefs(gstart)
               gtree match {
-                case gtree: g.ValDef if gtree.symbol == gtree.symbol.owner.thisSym =>
-                  tryMstart(gstart)
-                case gtree: g.MemberDef if gtree.symbol.isSynthetic || gtree.symbol.isArtifact =>
-                // NOTE: never interested in synthetics except for the ones above
-                case gtree: g.PackageDef =>
+                case gtree: g.Template =>
                   if (config.members.isAll) {
-                    members(gtree.symbol.toSemantic) = gtree.pid.tpe.lookupMembers
-                  }
-                // NOTE: capture PackageDef.pid instead
-                case gtree: g.ModuleDef if gtree.name == g.nme.PACKAGE =>
-                  // TODO: if a package object comes first in the compilation unit
-                  // then its positions are completely mental, so we just hack around
-                  tryMstart(gpoint + 7)
-                  tryMstart(gpoint)
-                case gtree: g.ValDef =>
-                  tryMstart(gstart)
-                  tryMstart(gpoint)
-                case gtree: g.MemberDef =>
-                  tryMstart(gpoint)
-                case gtree: g.DefTree =>
-                  tryMstart(gpoint)
-                case gtree: g.This =>
-                  tryMstart(gpoint)
-                case gtree: g.Super =>
-                  // TODO: change the delta to account for whitespace and comments
-                  tryMend(gend - 1)
-                case gtree: g.Select if gtree.symbol == g.definitions.NilModule =>
-                  // NOTE: List() gets desugared into mkAttributedRef(NilModule)
-                  tryMstart(gstart)
-                case gtree: g.RefTree =>
-                  def prohibited(name: String) = {
-                    name.contains(g.nme.DEFAULT_GETTER_STRING)
-                  }
-                  if (prohibited(gtree.name.decoded)) return
-                  tryMstart(gpoint)
-                case gtree: g.Import =>
-                  val sels = gtree.selectors.flatMap { sel =>
-                    if (sel.name == g.nme.WILDCARD && config.members.isAll) {
-                      members(gtree.expr.symbol.toSemantic) = gtree.expr.tpe.lookupMembers
-                      Nil
-                    } else {
-                      mstarts.get(sel.namePos).map(mname => (sel.name, mname))
+                    gtree.parents.foreach { parent =>
+                      members(parent.symbol.toSemantic) = parent.tpe.lookupMembers
                     }
                   }
-                  sels.foreach {
-                    case (gname, mname) =>
-                      val import1 = gtree.expr.tpe.member(gname.toTermName)
-                      val import2 = gtree.expr.tpe.member(gname.toTypeName)
-                      success(
-                        mname,
-                        wrapAlternatives(
-                          "<import " + gtree.expr + "." + gname + ">",
-                          import1,
-                          import2))
-                  }
+                  val gctor =
+                    gtree.body.find(x => Option(x.symbol).exists(_.isPrimaryConstructor))
+                  success(mname, gctor.map(_.symbol).getOrElse(g.NoSymbol))
+                case gtree: g.DefDef if gtree.symbol.isConstructor =>
+                  success(mname, gtree.symbol)
                 case _ =>
               }
             }
 
-            private def tryFindInferred(gtree: g.Tree): Unit = {
-              if (!config.synthetics.saveSynthetics) return
-
-              import scala.meta.internal.semanticdb.{AttributedSynthetic => S}
-              def success(pos: m.Position, f: Inferred => Inferred): Unit = {
-                inferred(pos) = f(inferred(pos))
-              }
-
-              if (!gtree.pos.isRange) return
-
-              object ApplySelect {
-                def unapply(tree: g.Tree): Option[g.Select] = Option(tree).collect {
-                  case g.Apply(select: g.Select, _) => select
-                  case select: g.Select => select
-                }
-              }
-
-              object ForComprehensionImplicitArg {
-                private def isForComprehensionSyntheticName(select: g.Select): Boolean = {
-                  select.pos == select.qualifier.pos && (select.name == g.nme.map ||
-                  select.name == g.nme.withFilter ||
-                  select.name == g.nme.flatMap ||
-                  select.name == g.nme.foreach)
-                }
-
-                private def findSelect(t: g.Tree): Option[g.Tree] = t match {
-                  case g.Apply(fun, _) => findSelect(fun)
-                  case g.TypeApply(fun, _) => findSelect(fun)
-                  case s @ g.Select(qual, _) if isForComprehensionSyntheticName(s) => Some(qual)
-                  case _ => None
-                }
-
-                def unapply(gfun: g.Apply): Option[g.Tree] = findSelect(gfun)
-              }
-
+            if (mctorrefs.contains(gpoint)) {
+              val mname = mctorrefs(gpoint)
               gtree match {
-                case gview: g.ApplyImplicitView =>
-                  val pos = gtree.pos.toMeta
-                  val syntax = showSynthetic(gview.fun) + "(" + S.star + ")"
-                  success(pos, _.copy(conversion = Some(syntax)))
-                  isVisited += gview.fun
-                case gimpl: g.ApplyToImplicitArgs =>
-                  val args = S.mkString(gimpl.args.map(showSynthetic), ", ")
-                  gimpl.fun match {
-                    case gview: g.ApplyImplicitView =>
-                      isVisited += gview
-                      val pos = gtree.pos.toMeta
-                      val syntax = showSynthetic(gview.fun) + "(" + S.star + ")(" + args + ")"
-                      success(pos, _.copy(conversion = Some(syntax)))
-                    case ForComprehensionImplicitArg(qual) =>
-                      val morePrecisePos = qual.pos.withStart(qual.pos.end).toMeta
-                      val syntax = S("(") + S.star + ")" + "(" + args + ")"
-                      success(morePrecisePos, _.copy(args = Some(syntax)))
-                    case gfun =>
-                      val morePrecisePos = gimpl.pos.withStart(gimpl.pos.end).toMeta
-                      val syntax = S("(") + args + ")"
-                      success(morePrecisePos, _.copy(args = Some(syntax)))
-                  }
-                case g.TypeApply(fun, targs @ List(targ, _*)) =>
-                  if (targ.pos.isRange) return
-                  val morePrecisePos = fun.pos.withStart(fun.pos.end).toMeta
-                  val args = S.mkString(targs.map(showSynthetic), ", ")
-                  val syntax = S("[") + args + "]"
-                  success(morePrecisePos, _.copy(targs = Some(syntax)))
-                case ApplySelect(select @ g.Select(qual, nme)) if isSyntheticName(select) =>
-                  val pos = qual.pos.withStart(qual.pos.end).toMeta
-                  val symbol = select.symbol.toSemantic
-                  val name = nme.decoded
-                  val names = List(SyntheticRange(0, name.length, symbol))
-                  val syntax = S(".") + S(nme.decoded, names)
-                  success(pos, _.copy(select = Some(syntax)))
+                case g.Select(_, g.nme.CONSTRUCTOR) => success(mname, gtree.symbol)
                 case _ =>
-                // do nothing
               }
             }
 
-            override def traverse(gtree: g.Tree): Unit = {
-              if (isVisited(gtree)) return else isVisited += gtree
-              gtree.attachments.all.foreach {
-                case att: g.analyzer.MacroExpansionAttachment =>
-                  traverse(att.expandee)
-                case _ =>
-              }
-              gtree match {
-                case ConstfoldOf(original) =>
-                  traverse(original)
-                case ClassOf(original) =>
-                  traverse(original)
-                case NewArrayOf(original) =>
-                  traverse(original)
-                case SingletonTypeTreeOf(original) =>
-                  traverse(original)
-                case CompoundTypeTreeOf(original) =>
-                  traverse(original)
-                case ExistentialTypeTreeOf(original) =>
-                  traverse(original)
-                case AnnotatedOf(original) =>
-                  traverse(original)
-                case SelfTypeOf(original) =>
-                  traverse(original)
-                case SelectOf(original) =>
-                  traverse(original)
-                case g.Function(params, body) if params.exists(_.name.decoded.startsWith("x$")) =>
-                  traverse(body)
-                case gtree: g.TypeTree if gtree.original != null =>
-                  traverse(gtree.original)
-                case gtree: g.TypeTreeWithDeferredRefCheck =>
-                  traverse(gtree.check())
-                case gtree: g.MemberDef =>
-                  gtree.symbol.annotations.map(ann => traverse(ann.original))
-                  tryFindMtree(gtree)
-                case _: g.Apply | _: g.TypeApply =>
-                  tryFindInferred(gtree)
-                case select: g.Select if isSyntheticName(select) =>
-                  tryFindMtree(select.qualifier)
-                  tryFindInferred(select)
-                case _ =>
-                  tryFindMtree(gtree)
-              }
-              super.traverse(gtree)
+            // Ideally, we'd like a perfect match when gtree.pos == mtree.pos.
+            // Unfortunately, this is often not the case as demonstrated by a bunch of cases above and below.
+            if (tryMpos(gstart, gend)) return
+
+            gtree match {
+              case gtree: g.ValDef if gtree.symbol == gtree.symbol.owner.thisSym =>
+                tryMstart(gstart)
+              case gtree: g.MemberDef if gtree.symbol.isSynthetic || gtree.symbol.isArtifact =>
+              // NOTE: never interested in synthetics except for the ones above
+              case gtree: g.PackageDef =>
+                if (config.members.isAll) {
+                  members(gtree.symbol.toSemantic) = gtree.pid.tpe.lookupMembers
+                }
+              // NOTE: capture PackageDef.pid instead
+              case gtree: g.ModuleDef if gtree.name == g.nme.PACKAGE =>
+                // TODO: if a package object comes first in the compilation unit
+                // then its positions are completely mental, so we just hack around
+                tryMstart(gpoint + 7)
+                tryMstart(gpoint)
+              case gtree: g.ValDef =>
+                tryMstart(gstart)
+                tryMstart(gpoint)
+              case gtree: g.MemberDef =>
+                tryMstart(gpoint)
+              case gtree: g.DefTree =>
+                tryMstart(gpoint)
+              case gtree: g.This =>
+                tryMstart(gpoint)
+              case gtree: g.Super =>
+                // TODO: change the delta to account for whitespace and comments
+                tryMend(gend - 1)
+              case gtree: g.Select if gtree.symbol == g.definitions.NilModule =>
+                // NOTE: List() gets desugared into mkAttributedRef(NilModule)
+                tryMstart(gstart)
+              case gtree: g.RefTree =>
+                def prohibited(name: String) = {
+                  name.contains(g.nme.DEFAULT_GETTER_STRING)
+                }
+                if (prohibited(gtree.name.decoded)) return
+                tryMstart(gpoint)
+              case gtree: g.Import =>
+                val sels = gtree.selectors.flatMap { sel =>
+                  if (sel.name == g.nme.WILDCARD && config.members.isAll) {
+                    members(gtree.expr.symbol.toSemantic) = gtree.expr.tpe.lookupMembers
+                    Nil
+                  } else {
+                    mstarts.get(sel.namePos).map(mname => (sel.name, mname))
+                  }
+                }
+                sels.foreach {
+                  case (gname, mname) =>
+                    val import1 = gtree.expr.tpe.member(gname.toTermName)
+                    val import2 = gtree.expr.tpe.member(gname.toTypeName)
+                    success(
+                      mname,
+                      wrapAlternatives(
+                        "<import " + gtree.expr + "." + gname + ">",
+                        import1,
+                        import2))
+                }
+              case _ =>
             }
           }
-          traverser.traverse(unit.body)
-        }
 
-        val input = unit.source.toInput
+          private def tryFindInferred(gtree: g.Tree): Unit = {
+            if (!config.synthetics.saveSynthetics) return
 
-        val synthetics = inferred.toIterator.map {
-          case (pos, inferred) => inferred.toSynthetic(input, pos)
-        }
-        val symbols = denotations.map {
-          case (sym, denot) =>
-            val denotationWithMembers = members.get(sym).fold(denot) { members =>
-              new m.Denotation(denot.flags, denot.name, denot.signature, denot.names, members)
+            import scala.meta.internal.semanticdb.{AttributedSynthetic => S}
+            def success(pos: m.Position, f: Inferred => Inferred): Unit = {
+              inferred(pos) = f(inferred(pos))
             }
-            m.ResolvedSymbol(sym, denotationWithMembers)
-        }.toList
 
-        m.Document(
-          input,
-          language,
-          names.map { case (pos, sym) => m.ResolvedName(pos, sym, binders(pos)) }.toList,
-          Nil, // added in a separate phase.
-          symbols,
-          synthetics.toList
-        )
+            if (!gtree.pos.isRange) return
+
+            object ApplySelect {
+              def unapply(tree: g.Tree): Option[g.Select] = Option(tree).collect {
+                case g.Apply(select: g.Select, _) => select
+                case select: g.Select => select
+              }
+            }
+
+            object ForComprehensionImplicitArg {
+              private def isForComprehensionSyntheticName(select: g.Select): Boolean = {
+                select.pos == select.qualifier.pos && (select.name == g.nme.map ||
+                select.name == g.nme.withFilter ||
+                select.name == g.nme.flatMap ||
+                select.name == g.nme.foreach)
+              }
+
+              private def findSelect(t: g.Tree): Option[g.Tree] = t match {
+                case g.Apply(fun, _) => findSelect(fun)
+                case g.TypeApply(fun, _) => findSelect(fun)
+                case s @ g.Select(qual, _) if isForComprehensionSyntheticName(s) => Some(qual)
+                case _ => None
+              }
+
+              def unapply(gfun: g.Apply): Option[g.Tree] = findSelect(gfun)
+            }
+
+            gtree match {
+              case gview: g.ApplyImplicitView =>
+                val pos = gtree.pos.toMeta
+                val syntax = showSynthetic(gview.fun) + "(" + S.star + ")"
+                success(pos, _.copy(conversion = Some(syntax)))
+                isVisited += gview.fun
+              case gimpl: g.ApplyToImplicitArgs =>
+                val args = S.mkString(gimpl.args.map(showSynthetic), ", ")
+                gimpl.fun match {
+                  case gview: g.ApplyImplicitView =>
+                    isVisited += gview
+                    val pos = gtree.pos.toMeta
+                    val syntax = showSynthetic(gview.fun) + "(" + S.star + ")(" + args + ")"
+                    success(pos, _.copy(conversion = Some(syntax)))
+                  case ForComprehensionImplicitArg(qual) =>
+                    val morePrecisePos = qual.pos.withStart(qual.pos.end).toMeta
+                    val syntax = S("(") + S.star + ")" + "(" + args + ")"
+                    success(morePrecisePos, _.copy(args = Some(syntax)))
+                  case gfun =>
+                    val morePrecisePos = gimpl.pos.withStart(gimpl.pos.end).toMeta
+                    val syntax = S("(") + args + ")"
+                    success(morePrecisePos, _.copy(args = Some(syntax)))
+                }
+              case g.TypeApply(fun, targs @ List(targ, _*)) =>
+                if (targ.pos.isRange) return
+                val morePrecisePos = fun.pos.withStart(fun.pos.end).toMeta
+                val args = S.mkString(targs.map(showSynthetic), ", ")
+                val syntax = S("[") + args + "]"
+                success(morePrecisePos, _.copy(targs = Some(syntax)))
+              case ApplySelect(select @ g.Select(qual, nme)) if isSyntheticName(select) =>
+                val pos = qual.pos.withStart(qual.pos.end).toMeta
+                val symbol = select.symbol.toSemantic
+                val name = nme.decoded
+                val names = List(SyntheticRange(0, name.length, symbol))
+                val syntax = S(".") + S(nme.decoded, names)
+                success(pos, _.copy(select = Some(syntax)))
+              case _ =>
+              // do nothing
+            }
+          }
+
+          override def traverse(gtree: g.Tree): Unit = {
+            if (isVisited(gtree)) return else isVisited += gtree
+            gtree.attachments.all.foreach {
+              case att: g.analyzer.MacroExpansionAttachment =>
+                traverse(att.expandee)
+              case _ =>
+            }
+            gtree match {
+              case ConstfoldOf(original) =>
+                traverse(original)
+              case ClassOf(original) =>
+                traverse(original)
+              case NewArrayOf(original) =>
+                traverse(original)
+              case SingletonTypeTreeOf(original) =>
+                traverse(original)
+              case CompoundTypeTreeOf(original) =>
+                traverse(original)
+              case ExistentialTypeTreeOf(original) =>
+                traverse(original)
+              case AnnotatedOf(original) =>
+                traverse(original)
+              case SelfTypeOf(original) =>
+                traverse(original)
+              case SelectOf(original) =>
+                traverse(original)
+              case g.Function(params, body) if params.exists(_.name.decoded.startsWith("x$")) =>
+                traverse(body)
+              case gtree: g.TypeTree if gtree.original != null =>
+                traverse(gtree.original)
+              case gtree: g.TypeTreeWithDeferredRefCheck =>
+                traverse(gtree.check())
+              case gtree: g.MemberDef =>
+                gtree.symbol.annotations.map(ann => traverse(ann.original))
+                tryFindMtree(gtree)
+              case _: g.Apply | _: g.TypeApply =>
+                tryFindInferred(gtree)
+              case select: g.Select if isSyntheticName(select) =>
+                tryFindMtree(select.qualifier)
+                tryFindInferred(select)
+              case _ =>
+                tryFindMtree(gtree)
+            }
+            super.traverse(gtree)
+          }
+        }
+        traverser.traverse(unit.body)
+      }
+
+      val input = unit.source.toInput
+
+      val synthetics = inferred.toIterator.map {
+        case (pos, inferred) => inferred.toSynthetic(input, pos)
+      }
+      val symbols = denotations.map {
+        case (sym, denot) =>
+          val denotationWithMembers = members.get(sym).fold(denot) { members =>
+            new m.Denotation(denot.flags, denot.name, denot.signature, denot.names, members)
+          }
+          m.ResolvedSymbol(sym, denotationWithMembers)
+      }.toList
+
+      m.Document(
+        input,
+        language,
+        names.map { case (pos, sym) => m.ResolvedName(pos, sym, binders(pos)) }.toList,
+        Nil, // added in a separate phase.
+        symbols,
+        synthetics.toList
+      )
     }
   }
 

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/MessageOps.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/MessageOps.scala
@@ -1,21 +1,14 @@
 package scala.meta.internal.semanticdb
 
-import scala.collection.mutable
 import org.scalameta.unreachable
 import scala.{meta => m}
 
 trait MessageOps { self: DatabaseOps =>
   implicit class XtensionCompilationUnitMessages(unit: g.CompilationUnit) {
-    def reportedMessages: List[m.Message] = {
-      val mstarts = {
-        val x =
-          unit.body.metadata.get("semanticdbMstarts").map(_.asInstanceOf[mutable.Map[Int, m.Name]])
-        if (x.nonEmpty) unit.body.removeMetadata("semanticdbMstarts")
-        x.getOrElse(mutable.Map.empty)
-      }
+    def reportedMessages(mstarts: collection.Map[Int, m.Name]): List[m.Message] = {
       val messages = unit.hijackedMessages.map {
         case (gpos, gseverity, text) =>
-          val mpos = {
+          val mpos: m.Position = {
             // NOTE: The caret in unused import warnings points to Importee.pos, but
             // the message position start/end point to the enclosing Import.pos.
             // See https://github.com/scalameta/scalameta/issues/839
@@ -37,7 +30,6 @@ trait MessageOps { self: DatabaseOps =>
           }
           m.Message(mpos, mseverity, text)
       }
-      mstarts.clear()
       messages
     }
   }

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/ParseOps.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/ParseOps.scala
@@ -9,7 +9,9 @@ trait ParseOps { self: DatabaseOps =>
     def toSource: m.Source = {
       val dialect =
         m.Dialect.standards.getOrElse(language, sys.error(s"unsupported dialect $language"))
-      unit.cache.getOrElse("source", dialect(unit.source.toInput).parse[m.Source].get)
+      // TODO(olafur) remove
+      // TODO(olafur) upgrade to 2.11.12
+      dialect(unit.source.toInput).parse[m.Source].get
     }
   }
 }

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/ParseOps.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/ParseOps.scala
@@ -9,8 +9,6 @@ trait ParseOps { self: DatabaseOps =>
     def toSource: m.Source = {
       val dialect =
         m.Dialect.standards.getOrElse(language, sys.error(s"unsupported dialect $language"))
-      // TODO(olafur) remove
-      // TODO(olafur) upgrade to 2.11.12
       dialect(unit.source.toInput).parse[m.Source].get
     }
   }

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/ReporterOps.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/ReporterOps.scala
@@ -8,7 +8,7 @@ import scala.reflect.internal.util.{Position => gPosition}
 trait ReporterOps { self: DatabaseOps =>
   // Hack, keep track of how many messages we have returns for each path to avoid
   // duplicate messages. The key is System.identityHashCode to keep memory usage low.
-  private val returnedMessagesByPath = mutable.LongMap.empty[Int]
+  private val returnedMessagesByPath = mutable.Map.empty[g.CompilationUnit, Int]
   implicit class XtensionCompilationUnitReporter(unit: g.CompilationUnit) {
     def hijackedMessages: List[(gPosition, Int, String)] = {
       g.reporter match {
@@ -21,9 +21,8 @@ trait ReporterOps { self: DatabaseOps =>
             }
           }
           val infos = r.infos
-          val key = System.identityHashCode(unit).toLong
-          val toDrop = returnedMessagesByPath.getOrElse(key, 0)
-          returnedMessagesByPath.put(key, infos.size)
+          val toDrop = returnedMessagesByPath.getOrElse(unit, 0)
+          returnedMessagesByPath.put(unit, infos.size)
           infos.iterator
             .drop(toDrop) // drop messages that have been reported before.
             .collect {

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/ReporterOps.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/ReporterOps.scala
@@ -1,11 +1,14 @@
 package scala.meta.internal
 package semanticdb
 
+import scala.collection.mutable
 import scala.tools.nsc.reporters.StoreReporter
 import scala.reflect.internal.util.{Position => gPosition}
 
 trait ReporterOps { self: DatabaseOps =>
-
+  // Hack, keep track of how many messages we have returns for each path to avoid
+  // duplicate messages. The key is System.identityHashCode to keep memory usage low.
+  private val returnedMessagesByPath = mutable.LongMap.empty[Int]
   implicit class XtensionCompilationUnitReporter(unit: g.CompilationUnit) {
     def hijackedMessages: List[(gPosition, Int, String)] = {
       g.reporter match {
@@ -17,10 +20,15 @@ trait ReporterOps { self: DatabaseOps =>
               Some((info.pos, info.severity.id, info.msg))
             }
           }
-          r.infos
+          val infos = r.infos
+          val key = System.identityHashCode(unit).toLong
+          val toDrop = returnedMessagesByPath.getOrElse(key, 0)
+          returnedMessagesByPath.put(key, infos.size)
+          infos.iterator
+            .drop(toDrop) // drop messages that have been reported before.
             .collect {
               case RelevantMessage(pos, severity, msg) =>
-                ((pos, severity, msg))
+                (pos, severity, msg)
             }
             .to[List]
         case _ =>

--- a/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/DatabaseSuite.scala
+++ b/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/DatabaseSuite.scala
@@ -82,8 +82,8 @@ abstract class DatabaseSuite(mode: SemanticdbMode, members: MemberMode = MemberM
     g.phase = run.phaseNamed("patmat")
     g.globalPhase = run.phaseNamed("patmat")
 
-    val mattrs = unit.toDocument.copy(messages = unit.reportedMessages)
-    m.Database(List(mattrs))
+    val mdoc = unit.toDocument
+    m.Database(List(mdoc))
   }
 
   private def computeDatabaseSectionFromSnippet(code: String, sectionName: String): String = {


### PR DESCRIPTION
This PR supersedes  #1129. The biggest change is that semanticdbs are persisted immediately after typer, significantly reducing memory pressure for large projects. This change introduces a lot of complexity because some messages like deprecations are reported after typer. The solution in this PR is to append the messages reported after typer into the same .semanticdb file but as a separate m.Database and merge the two databases on m.Database.load. This is not an optimal solution, but it's the best we can do without compromising memory usage.

Fixes #1067