### PR TITLE
Exclude semanticdb-scalac-core from semanticdb-scalac.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -273,7 +273,7 @@ lazy val semanticdbScalacPlugin = project
             node.label == "artifactId" && fn(node.text)
           node.label == "dependency" && node.child.exists(child =>
             isArtifactId(child, _.startsWith("langmeta-")) ||
-            isArtifactId(child, _.startsWith("scalameta_")))
+            isArtifactId(child, _.startsWith("semanticdb")))
         }
         override def transform(node: XmlNode): XmlNodeSeq = node match {
           case e: Elem if isAbsorbedDependency(node) =>


### PR DESCRIPTION
Hotfix, 2.1.0 is broken since `addCompilerPlugin(semanticdb-scalac)` causes "Ignoring duplicate plugin semanticdb (scala.meta.internal.SemanticdbPlugin)" warnings at best and InvocationTargetExceptions at work. The pomPostProcess no longer worked after #1159. This change was manually tested locally and the .pom now correctly excludes the semanticdb dependency.