### PR TITLE
Make release infrastructure more robust

### DIFF
--- a/bin/ci-publish.sh
+++ b/bin/ci-publish.sh
@@ -6,7 +6,7 @@ SECURE_VAR=${TRAVIS_SECURE_ENV_VARS:-false}
 if [[ "$TRAVIS_SECURE_ENV_VARS" == true && -n "$TRAVIS_TAG" && "$CI_PUBLISH" == true ]]; then
   git log | head -n 20
   echo "$PGP_SECRET" | base64 --decode | gpg --import
-  sbt ci-publish sonatypeReleaseAll
+  sbt ci-publish
 else
   echo "Skipping publish, branch=$TRAVIS_BRANCH publish=$PUBLISH test=$CI_TEST"
 fi

--- a/bin/test-release.sh
+++ b/bin/test-release.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eux
+VERSION=${1}
+coursier fetch org.scalameta:scalameta_2.12:$VERSION -r sonatype:releases
+coursier fetch org.scalameta:scalameta_2.11:$VERSION -r sonatype:releases
+coursier fetch org.scalameta:langmeta_2.10:$VERSION -r sonatype:releases
+coursier fetch org.scalameta:semanticdb-scalac_2.12.4:$VERSION -r sonatype:releases
+coursier fetch org.scalameta:semanticdb-scalac_2.11.12:$VERSION -r sonatype:releases


### PR DESCRIPTION
v2.1.1 is broken, see https://github.com/scalameta/scalameta/pull/1160#issuecomment-343679764. This PR addresses it by

1. not running sonatypeRelease from travis, this will need to be done manually from either sbt or from the sonatype ui
2. adding test scripts to ensure a release is complete