### PR TITLE
Add InteractiveSemanticdb utility.

### DIFF
--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/interactive/InteractiveSemanticdb.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/interactive/InteractiveSemanticdb.scala
@@ -1,0 +1,116 @@
+package scala.meta.interactive
+
+import java.io.File
+import java.net.URLClassLoader
+import scala.meta.internal.SemanticdbPlugin
+import scala.meta.internal.semanticdb.DatabaseOps
+import scala.reflect.io.VirtualDirectory
+import scala.tools.nsc.Settings
+import scala.tools.nsc.interactive.Global
+import scala.tools.nsc.interactive.Response
+import scala.tools.nsc.reporters.StoreReporter
+import org.langmeta.semanticdb.Document
+
+object InteractiveSemanticdb {
+
+  def newCompiler(): Global =
+    newCompiler(thisClasspath, Nil)
+  def newCompiler(scalacOptions: List[String]): Global =
+    newCompiler(thisClasspath, scalacOptions)
+
+  /** Construct new presentation compiler with given classpath and scalac flags. */
+  def newCompiler(classpath: String, scalacOptions: List[String]): Global = {
+    val vd = new VirtualDirectory("(memory)", None)
+    val settings = new Settings
+    settings.outputDirs.setSingleOutput(vd)
+    settings.classpath.value = classpath
+    if (classpath.isEmpty) {
+      settings.usejavacp.value = true
+    }
+    settings.processArgumentString(
+      ("-Ypresentation-any-thread" :: scalacOptions).mkString(" ")
+    )
+    val compiler = new Global(settings, new StoreReporter)
+    new SemanticdbPlugin(compiler) // hijack reporter/analyzer
+    compiler
+  }
+
+  def toDocument(compiler: Global, code: String): Document =
+    toDocument(compiler, code, "interactive.scala", 10000)
+
+  /**
+    * Build semanticdb document from this snippet of code.
+    *
+    * @param compiler an instance of scalac interactive global.
+    * @param code the code to be compiled.
+    * @param filename the name of the source file.
+    * @param timeout max number of milliseconds to allow the presentation compiler
+    *                to typecheck this file.
+    *  @throws Exception note that this method can fail in many different ways
+    *                    with exceptions, including but not limited to tokenize/parse/type
+    *                    errors.
+    */
+  def toDocument(compiler: Global, code: String, filename: String, timeout: Long): Document = {
+    val unit = addCompilationUnit(compiler, code, filename)
+    // reload seems to be necessary before askLoadedType.
+    ask[Unit](r => compiler.askReload(unit.source :: Nil, r)).get
+    val compiledTree =
+      ask[compiler.Tree](r => compiler.askLoadedTyped(unit.source, r))
+        .get(timeout)
+    val tree = compiledTree match {
+      case Some(Left(t)) => t
+      case Some(Right(ex)) => throw ex
+      case None => throw new IllegalArgumentException("Presentation compiler timed out")
+    }
+    lazy val databaseOps: DatabaseOps {
+      val global: compiler.type
+    } = new DatabaseOps {
+      val global: compiler.type = compiler
+    }
+    import databaseOps._
+    unit.body = tree
+    val document = unit.asInstanceOf[databaseOps.global.CompilationUnit].toDocument
+    document
+  }
+
+  /**
+    * Inserts "_CURSOR_" at given offset.
+    *
+    * _CURSOR_ hints to the presentation compiler that this file is being edited
+    * with the cursor at that offset. This hint helps completions amongst
+    * other things.
+    */
+  def addCursor(code: String, offset: Int): String = {
+    new StringBuilder(code.length + "_CURSOR_".length)
+      .append(code.substring(0, offset))
+      .append("_CURSOR_")
+      .append(code.substring(offset))
+      .toString()
+  }
+
+  /** Create new compilation unit from given code. */
+  def addCompilationUnit(
+      global: Global,
+      code: String,
+      filename: String
+  ): global.RichCompilationUnit = {
+    val unit = global.newCompilationUnit(code, filename)
+    val richUnit = new global.RichCompilationUnit(unit.source)
+    global.unitOfFile(richUnit.source.file) = richUnit
+    richUnit
+  }
+
+  private def thisClasspath: String = this.getClass.getClassLoader match {
+    case url: URLClassLoader =>
+      url.getURLs.map(_.toURI.getPath).mkString(File.pathSeparator)
+    case els =>
+      throw new IllegalStateException(s"Expected URLClassloader, got $els")
+  }
+
+  private def ask[A](f: Response[A] => Unit): Response[A] = {
+    val r = new Response[A]
+    f(r)
+    r
+  }
+
+}

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/HijackAnalyzer.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/HijackAnalyzer.scala
@@ -8,7 +8,7 @@ import scala.tools.nsc.typechecker.SemanticdbAnalyzer
 trait HijackAnalyzer extends SemanticdbAnalyzer { self: SemanticdbPlugin =>
 
   def hijackAnalyzer(): Unit = {
-    if (!isBatchCompiler) return
+    if (!isSupportedCompiler) return
 
     val oldMacroPlugins = {
       val macroPluginsGetter =

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/HijackReporter.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/HijackReporter.scala
@@ -3,7 +3,7 @@ package scala.meta.internal
 trait HijackReporter { self: SemanticdbPlugin =>
 
   def hijackReporter(): Unit = {
-    if (!isBatchCompiler) return
+    if (!isSupportedCompiler) return
 
     g.reporter match {
       case _: SemanticdbReporter => // do nothing, already hijacked

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/ReflectionToolkit.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/ReflectionToolkit.scala
@@ -16,7 +16,7 @@ trait ReflectionToolkit {
   lazy val isDocCompiler = global.isInstanceOf[ScaladocGlobal]
   lazy val isReplCompiler = global.isInstanceOf[ReplGlobal]
   lazy val isInteractiveCompiler = global.isInstanceOf[InteractiveGlobal]
-  lazy val isBatchCompiler = !isDocCompiler && !isReplCompiler && !isInteractiveCompiler
+  lazy val isSupportedCompiler = !isDocCompiler && !isReplCompiler
 
   // NOTE: this boilerplate is unfortunately necessary, because we don't expose Attachable in the public API
   trait Attachable[-T] {

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/SemanticdbPipeline.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/SemanticdbPipeline.scala
@@ -55,6 +55,7 @@ trait SemanticdbPipeline extends DatabaseOps { self: SemanticdbPlugin =>
       override def apply(unit: g.CompilationUnit): Unit = {
         try {
           if (unit.isIgnored) return
+          validateCompilerState()
           val mdoc = unit.toDocument
           val mdb = m.Database(List(mdoc))
           mdb.save(scalametaTargetroot, config.sourceroot)

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/SemanticdbPlugin.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/SemanticdbPlugin.scala
@@ -16,7 +16,7 @@ class SemanticdbPlugin(val global: Global)
   hijackAnalyzer()
   hijackReporter()
   val components = {
-    if (isBatchCompiler) List(SemanticdbTyperComponent, SemanticdbJvmComponent)
+    if (isSupportedCompiler) List(SemanticdbTyperComponent, SemanticdbJvmComponent)
     else Nil
   }
 

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/DocumentOps.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/DocumentOps.scala
@@ -39,7 +39,6 @@ trait DocumentOps { self: DatabaseOps =>
       val isVisited = mutable.Set.empty[g.Tree] // macro expandees can have cycles, keep tracks of visited nodes.
       val todo = mutable.Set[m.Name]() // names to map to global trees
       val mstarts = mutable.Map[Int, m.Name]() // start offset -> tree
-      unit.body.appendMetadata("semanticdbMstarts" -> mstarts) // used in MessagesOps
       val mends = mutable.Map[Int, m.Name]() // end offset -> tree
       val margnames = mutable.Map[Int, List[m.Name]]() // start offset of enclosing apply -> its arg names
       val mwithins = mutable.Map[m.Tree, m.Name]() // name of enclosing member -> name of private/protected within

--- a/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/InputOps.scala
+++ b/scalameta/semanticdb-scalac/src/main/scala/scala/meta/internal/semanticdb/InputOps.scala
@@ -6,6 +6,7 @@ import scala.collection.mutable
 import scala.{meta => m}
 import scala.meta.internal.io._
 import scala.reflect.internal.util.{Position => GPosition, SourceFile => GSourceFile}
+import scala.reflect.io.VirtualFile
 import scala.reflect.io.{PlainFile => GPlainFile}
 
 trait InputOps { self: DatabaseOps =>
@@ -31,6 +32,8 @@ trait InputOps { self: DatabaseOps =>
               case Disabled =>
                 m.Input.None
             }
+          case gfile: VirtualFile =>
+            m.Input.VirtualFile(gfile.path, gsource.content.mkString)
           case other =>
             m.Input.None
         }

--- a/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/InteractiveSemanticdbSuite.scala
+++ b/scalameta/semanticdb-scalac/src/test/scala/scala/meta/tests/InteractiveSemanticdbSuite.scala
@@ -1,0 +1,76 @@
+package scala.meta.tests
+
+import scala.meta.internal.semanticdb.DatabaseOps
+import org.scalameta.logger
+import org.scalatest.FunSuite
+import scala.meta.interactive.InteractiveSemanticdb._
+import scala.meta.testkit.DiffAssertions
+import scala.tools.nsc.interactive.Global
+
+class InteractiveSemanticdbSuite extends FunSuite with DiffAssertions {
+  val compiler: Global = newCompiler(scalacOptions = "-Ywarn-unused-import" :: Nil)
+  def check(
+      original: String,
+      expected: String
+  ): Unit = {
+    test(logger.revealWhitespace(original)) {
+      val document = toDocument(compiler, original).copy(language = "Interactive")
+      assertNoDiff(document.syntax, expected)
+    }
+  }
+
+  check(
+    """package b
+      |import scala.concurrent.Future
+      |object a {
+      |  val x = _root_.scala.List()
+      |  x + "string"
+      |}
+    """.stripMargin,
+    // Note that _root_.scala don't resolve to a symbol, this is a sign that the
+    // typer hijacking is not working as expected with interactive.Global.
+    """
+      |Language:
+      |Interactive
+      |
+      |Names:
+      |[8..9): b <= _root_.b.
+      |[17..22): scala => _root_.scala.
+      |[23..33): concurrent => _root_.scala.concurrent.
+      |[34..40): Future => _root_.scala.concurrent.Future.;_root_.scala.concurrent.Future#
+      |[48..49): a <= _root_.b.a.
+      |[58..59): x <= _root_.b.a.x.
+      |[75..79): List => _root_.scala.collection.immutable.List.
+      |[84..85): x => _root_.b.a.x.
+      |[86..87): + => _root_.scala.Predef.any2stringadd#`+`(Ljava/lang/String;)Ljava/lang/String;.
+      |
+      |Messages:
+      |[34..40): [warning] Unused import
+      |
+      |Symbols:
+      |_root_.b. => package b
+      |_root_.b.a. => final object a
+      |_root_.b.a.x. => val x: List[Nothing]
+      |  [0..4): List => _root_.scala.collection.immutable.List#
+      |  [5..12): Nothing => _root_.scala.Nothing#
+      |_root_.scala. => package scala
+      |_root_.scala.Predef.any2stringadd#`+`(Ljava/lang/String;)Ljava/lang/String;. => def +: (other: String): String
+      |  [8..14): String => _root_.scala.Predef.String#
+      |  [17..23): String => _root_.scala.Predef.String#
+      |_root_.scala.collection.immutable.List. => final object List
+      |_root_.scala.concurrent. => package concurrent
+      |
+      |Synthetics:
+      |[79..79): *.apply[Nothing]
+      |  [0..1): * => _star_.
+      |  [2..7): apply => _root_.scala.collection.immutable.List.apply(Lscala/collection/Seq;)Lscala/collection/immutable/List;.
+      |  [8..15): Nothing => _root_.scala.Nothing#
+      |[84..85): scala.Predef.any2stringadd[List[Nothing]](*)
+      |  [27..31): List => _root_.scala.collection.immutable.List#
+      |  [32..39): Nothing => _root_.scala.Nothing#
+      |  [13..26): any2stringadd => _root_.scala.Predef.any2stringadd(Ljava/lang/Object;)Ljava/lang/Object;.
+      |  [42..43): * => _star_.
+    """.stripMargin
+  )
+
+}


### PR DESCRIPTION
This commit adds a utility to build semanticdb files from a string.
This can be useful both for testing as well as for language-server.