### PR TITLE
Relational schema for SemanticDB and a converter to SQLite

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -110,6 +110,17 @@ lazy val langmeta = crossProject
 lazy val langmetaJVM = langmeta.jvm
 lazy val langmetaJS = langmeta.js
 
+lazy val langmetaSqlite = project
+  .in(file("langmeta-sqlite"))
+  .settings(
+    moduleName := "langmeta-sqlite",
+    description := "App to generate sqlite databases from semanticdb files",
+    publishableSettings,
+    mimaPreviousArtifacts := Set.empty,
+    libraryDependencies += "org.xerial" % "sqlite-jdbc" % "3.21.0"
+  )
+  .dependsOn(langmetaJVM)
+
 /** ======================== SCALAMETA ======================== **/
 
 lazy val common = crossProject

--- a/langmeta-sqlite/src/main/resources/semanticdb.ddl
+++ b/langmeta-sqlite/src/main/resources/semanticdb.ddl
@@ -1,7 +1,49 @@
-create table names(
+create table document(
   id int,
-  filename string,
+  filename text,
+  contents text,
+  language text,
+  primary key (id)
+);
+
+create table name(
+  id int,
+  document int,
   start int,
   end int,
-  symbol string,
-  is_definition boolean)
+  symbol int,
+  is_definition boolean,
+  primary key (id),
+  foreign key (document) references document (id),
+  foreign key (symbol) references symbol (id)
+);
+
+create table message(
+  id int,
+  document int,
+  start int,
+  end int,
+  severity int,
+  text text,
+  primary key (id),
+  foreign key (document) references document(id)
+);
+
+create table symbol(
+  id int,
+  symbol text,
+  flags int,
+  name text,
+  signature int,
+  primary key (id),
+  foreign key (signature) references document (id)
+);
+
+create table synthetic(
+  id int,
+  start int,
+  end int,
+  text int,
+  primary key (id),
+  foreign key (text) references document (id)
+);

--- a/langmeta-sqlite/src/main/resources/semanticdb.ddl
+++ b/langmeta-sqlite/src/main/resources/semanticdb.ddl
@@ -1,0 +1,7 @@
+create table names(
+  id int,
+  filename string,
+  start int,
+  end int,
+  symbol string,
+  is_definition boolean)

--- a/langmeta-sqlite/src/main/scala/org/langmeta/sqlite/Main.scala
+++ b/langmeta-sqlite/src/main/scala/org/langmeta/sqlite/Main.scala
@@ -1,5 +1,6 @@
 package org.langmeta.sqlite
 
+import java.io._
 import java.nio.file._
 import java.sql._
 import scala.Array
@@ -190,9 +191,11 @@ object Main {
         } finally {
           conn.commit()
           conn.close()
-          val appElapsed = (System.nanoTime() - appStart) * 1.0 / 1000000000
-          val appPerformance = genuineDocuments / appElapsed
-          println(s"Elapsed: ${"%.3f".format(appElapsed)}s")
+          val appCPU = (System.nanoTime() - appStart) * 1.0 / 1000000000
+          val appDisk = new File(sqliteFilename).length * 1.0 / 1024 / 1024
+          val appPerformance = genuineDocuments / appCPU
+          println(s"CPU time: ${"%.3f".format(appCPU)}s")
+          println(s"Disk size: ${"%.1f".format(appDisk)} MB")
           println(s"Performance: ${"%.3f".format(appPerformance)} documents/s")
         }
       case _ =>

--- a/langmeta-sqlite/src/main/scala/org/langmeta/sqlite/Main.scala
+++ b/langmeta-sqlite/src/main/scala/org/langmeta/sqlite/Main.scala
@@ -13,8 +13,8 @@ object Main {
     args match {
       case Array(sqliteFilename, semanticdbFilenames @ _*) =>
         val appStart = System.nanoTime()
+        var genuineDocuments = 0
         class Counter { var value = 0; def next() = { value += 1; value }; }
-        var documentId = new Counter()
         val sqlitePath = Paths.get(sqliteFilename)
         if (Files.exists(sqlitePath)) sys.error(s"$sqlitePath already exists")
         val conn = DriverManager.getConnection(s"jdbc:sqlite:$sqliteFilename")
@@ -39,15 +39,19 @@ object Main {
           }
           val documentStmt = tableInsertStmt("document")
           val nameStmt = tableInsertStmt("name")
+          val messageStmt = tableInsertStmt("message")
           val symbolStmt = tableInsertStmt("symbol")
+          val syntheticStmt = tableInsertStmt("synthetic")
 
           val semanticdbStart = System.nanoTime()
           val documentsToPaths = mutable.Map[String, Path]()
+          var documentId = new Counter()
           var nameId = new Counter()
           var messageId = new Counter()
           var _symbolId = new Counter()
           var symbolIds = mutable.Map[String, Int]()
           var symbolTodo = mutable.Map[Int, String]()
+          var symbolDone = mutable.Set[Int]()
           def symbolId(symbol: String): Int = {
             if (symbolIds.contains(symbol)) {
               symbolIds(symbol)
@@ -71,8 +75,11 @@ object Main {
                   val details = "both $existingPath and $path"
                   println(s"Duplicate document filename $what in $details")
                 case None =>
+                  genuineDocuments += 1
                   documentsToPaths(document.filename) = path
-                  documentStmt.setInt(1, documentId.next)
+
+                  val documentRef = documentId.next
+                  documentStmt.setInt(1, documentRef)
                   documentStmt.setString(2, document.filename)
                   documentStmt.setString(3, document.contents)
                   documentStmt.setString(4, document.language)
@@ -80,7 +87,7 @@ object Main {
 
                   document.names.foreach { name =>
                     nameStmt.setInt(1, nameId.next)
-                    nameStmt.setInt(2, documentId.value)
+                    nameStmt.setInt(2, documentRef)
                     nameStmt.setInt(3, name.position.get.start)
                     nameStmt.setInt(4, name.position.get.end)
                     nameStmt.setInt(5, symbolId(name.symbol))
@@ -88,10 +95,76 @@ object Main {
                     nameStmt.executeUpdate()
                   }
 
-                  if ((documentId.value % 1000) == 0) {
+                  document.messages.foreach { message =>
+                    messageStmt.setInt(1, messageId.next)
+                    messageStmt.setInt(2, documentRef)
+                    messageStmt.setInt(3, message.position.get.start)
+                    messageStmt.setInt(4, message.position.get.end)
+                    messageStmt.setInt(5, message.severity.value)
+                    messageStmt.setString(6, message.text)
+                    messageStmt.executeUpdate()
+                  }
+
+                  document.symbols.foreach { symbol =>
+                    val symbolRef = symbolId(symbol.symbol)
+                    if (!symbolDone.contains(symbolRef)) {
+                      symbolStmt.setInt(1, symbolRef)
+                      symbolStmt.setString(2, symbol.symbol)
+                      symbolStmt.setLong(3, symbol.denotation.get.flags)
+                      symbolStmt.setString(4, symbol.denotation.get.name)
+                      val signatureDocumentRef = {
+                        documentStmt.setInt(1, documentId.next)
+                        documentStmt.setString(2, null)
+                        documentStmt.setString(3, symbol.denotation.get.signature)
+                        documentStmt.setString(4, null)
+                        documentStmt.executeUpdate()
+                        documentId.value
+                      }
+                      symbolStmt.setInt(5, signatureDocumentRef)
+                      symbol.denotation.get.names.foreach { name =>
+                        nameStmt.setInt(1, nameId.next)
+                        nameStmt.setInt(2, signatureDocumentRef)
+                        nameStmt.setInt(3, name.position.get.start)
+                        nameStmt.setInt(4, name.position.get.end)
+                        nameStmt.setInt(5, symbolId(name.symbol))
+                        nameStmt.setBoolean(6, name.isDefinition)
+                        nameStmt.executeUpdate()
+                      }
+                      symbolStmt.executeUpdate()
+                      symbolTodo.remove(symbolRef)
+                      symbolDone.add(symbolRef)
+                    }
+                  }
+
+                  document.synthetics.foreach { synthetic =>
+                    syntheticStmt.setInt(1, syntheticId.next)
+                    syntheticStmt.setInt(2, synthetic.pos.get.start)
+                    syntheticStmt.setInt(3, synthetic.pos.get.end)
+                    val syntheticDocumentRef = {
+                      documentStmt.setInt(1, documentId.next)
+                      documentStmt.setString(2, null)
+                      documentStmt.setString(3, synthetic.text)
+                      documentStmt.setString(4, null)
+                      documentStmt.executeUpdate()
+                      documentId.value
+                    }
+                    syntheticStmt.setInt(4, syntheticDocumentRef)
+                    synthetic.names.foreach { name =>
+                      nameStmt.setInt(1, nameId.next)
+                      nameStmt.setInt(2, syntheticDocumentRef)
+                      nameStmt.setInt(3, name.position.get.start)
+                      nameStmt.setInt(4, name.position.get.end)
+                      nameStmt.setInt(5, symbolId(name.symbol))
+                      nameStmt.setBoolean(6, name.isDefinition)
+                      nameStmt.executeUpdate()
+                    }
+                    syntheticStmt.executeUpdate()
+                  }
+
+                  if ((genuineDocuments % 1000) == 0) {
                     val semanticdbElapsed = System.nanoTime() - semanticdbStart
                     val buf = new StringBuilder
-                    buf.append(s"${documentId.value} documents: ")
+                    buf.append(s"$genuineDocuments documents: ")
                     buf.append(s"${nameId.value} names, ")
                     buf.append(s"${messageId.value} messages, ")
                     buf.append(s"${_symbolId.value} symbols, ")
@@ -118,9 +191,9 @@ object Main {
           conn.commit()
           conn.close()
           val appElapsed = (System.nanoTime() - appStart) * 1.0 / 1000000000
-          val appPerformance = documentId.value / appElapsed
+          val appPerformance = genuineDocuments / appElapsed
           println(s"Elapsed: ${"%.3f".format(appElapsed)}s")
-          println(s"Performance: ${"%.3f".format(appPerformance)} docs/s")
+          println(s"Performance: ${"%.3f".format(appPerformance)} documents/s")
         }
       case _ =>
         val objectName = classTag[Main.type].toString.stripSuffix("$")

--- a/langmeta-sqlite/src/main/scala/org/langmeta/sqlite/Main.scala
+++ b/langmeta-sqlite/src/main/scala/org/langmeta/sqlite/Main.scala
@@ -7,6 +7,7 @@ import scala.Array
 import scala.collection.mutable
 import scala.io.Codec
 import scala.reflect.classTag
+import scala.util.control.NonFatal
 import org.langmeta.internal.semanticdb.schema._
 
 object Main {
@@ -67,113 +68,119 @@ object Main {
 
           semanticdbFilenames.foreach { semanticdbFilename =>
             val path = Paths.get(semanticdbFilename)
-            val bytes = Files.readAllBytes(path)
-            val db = Database.parseFrom(bytes)
-            db.documents.foreach { document =>
-              documentsToPaths.get(document.filename) match {
-                case Some(existingPath) =>
-                  val what = document.filename
-                  val details = "both $existingPath and $path"
-                  println(s"Duplicate document filename $what in $details")
-                case None =>
-                  genuineDocuments += 1
-                  documentsToPaths(document.filename) = path
+            try {
+              val bytes = Files.readAllBytes(path)
+              val db = Database.parseFrom(bytes)
+              db.documents.foreach { document =>
+                documentsToPaths.get(document.filename) match {
+                  case Some(existingPath) =>
+                    val what = document.filename
+                    val details = "both $existingPath and $path"
+                    println(s"Duplicate document filename $what in $details")
+                  case None =>
+                    genuineDocuments += 1
+                    documentsToPaths(document.filename) = path
 
-                  val documentRef = documentId.next
-                  documentStmt.setInt(1, documentRef)
-                  documentStmt.setString(2, document.filename)
-                  documentStmt.setString(3, document.contents)
-                  documentStmt.setString(4, document.language)
-                  documentStmt.executeUpdate()
+                    val documentRef = documentId.next
+                    documentStmt.setInt(1, documentRef)
+                    documentStmt.setString(2, document.filename)
+                    documentStmt.setString(3, document.contents)
+                    documentStmt.setString(4, document.language)
+                    documentStmt.executeUpdate()
 
-                  document.names.foreach { name =>
-                    nameStmt.setInt(1, nameId.next)
-                    nameStmt.setInt(2, documentRef)
-                    nameStmt.setInt(3, name.position.get.start)
-                    nameStmt.setInt(4, name.position.get.end)
-                    nameStmt.setInt(5, symbolId(name.symbol))
-                    nameStmt.setBoolean(6, name.isDefinition)
-                    nameStmt.executeUpdate()
-                  }
-
-                  document.messages.foreach { message =>
-                    messageStmt.setInt(1, messageId.next)
-                    messageStmt.setInt(2, documentRef)
-                    messageStmt.setInt(3, message.position.get.start)
-                    messageStmt.setInt(4, message.position.get.end)
-                    messageStmt.setInt(5, message.severity.value)
-                    messageStmt.setString(6, message.text)
-                    messageStmt.executeUpdate()
-                  }
-
-                  document.symbols.foreach { symbol =>
-                    val symbolRef = symbolId(symbol.symbol)
-                    if (!symbolDone.contains(symbolRef)) {
-                      symbolStmt.setInt(1, symbolRef)
-                      symbolStmt.setString(2, symbol.symbol)
-                      symbolStmt.setLong(3, symbol.denotation.get.flags)
-                      symbolStmt.setString(4, symbol.denotation.get.name)
-                      val signatureDocumentRef = {
-                        documentStmt.setInt(1, documentId.next)
-                        documentStmt.setString(2, null)
-                        documentStmt.setString(3, symbol.denotation.get.signature)
-                        documentStmt.setString(4, null)
-                        documentStmt.executeUpdate()
-                        documentId.value
-                      }
-                      symbolStmt.setInt(5, signatureDocumentRef)
-                      symbol.denotation.get.names.foreach { name =>
-                        nameStmt.setInt(1, nameId.next)
-                        nameStmt.setInt(2, signatureDocumentRef)
-                        nameStmt.setInt(3, name.position.get.start)
-                        nameStmt.setInt(4, name.position.get.end)
-                        nameStmt.setInt(5, symbolId(name.symbol))
-                        nameStmt.setBoolean(6, name.isDefinition)
-                        nameStmt.executeUpdate()
-                      }
-                      symbolStmt.executeUpdate()
-                      symbolTodo.remove(symbolRef)
-                      symbolDone.add(symbolRef)
-                    }
-                  }
-
-                  document.synthetics.foreach { synthetic =>
-                    syntheticStmt.setInt(1, syntheticId.next)
-                    syntheticStmt.setInt(2, synthetic.pos.get.start)
-                    syntheticStmt.setInt(3, synthetic.pos.get.end)
-                    val syntheticDocumentRef = {
-                      documentStmt.setInt(1, documentId.next)
-                      documentStmt.setString(2, null)
-                      documentStmt.setString(3, synthetic.text)
-                      documentStmt.setString(4, null)
-                      documentStmt.executeUpdate()
-                      documentId.value
-                    }
-                    syntheticStmt.setInt(4, syntheticDocumentRef)
-                    synthetic.names.foreach { name =>
+                    document.names.foreach { name =>
                       nameStmt.setInt(1, nameId.next)
-                      nameStmt.setInt(2, syntheticDocumentRef)
+                      nameStmt.setInt(2, documentRef)
                       nameStmt.setInt(3, name.position.get.start)
                       nameStmt.setInt(4, name.position.get.end)
                       nameStmt.setInt(5, symbolId(name.symbol))
                       nameStmt.setBoolean(6, name.isDefinition)
                       nameStmt.executeUpdate()
                     }
-                    syntheticStmt.executeUpdate()
-                  }
 
-                  if ((genuineDocuments % 1000) == 0) {
-                    val semanticdbElapsed = System.nanoTime() - semanticdbStart
-                    val buf = new StringBuilder
-                    buf.append(s"$genuineDocuments documents: ")
-                    buf.append(s"${nameId.value} names, ")
-                    buf.append(s"${messageId.value} messages, ")
-                    buf.append(s"${_symbolId.value} symbols, ")
-                    buf.append(s"${syntheticId.value} synthetics")
-                    buf.append(s" (~${semanticdbElapsed / 1000000000}s) ")
-                    println(buf.toString)
-                  }
+                    document.messages.foreach { message =>
+                      messageStmt.setInt(1, messageId.next)
+                      messageStmt.setInt(2, documentRef)
+                      messageStmt.setInt(3, message.position.get.start)
+                      messageStmt.setInt(4, message.position.get.end)
+                      messageStmt.setInt(5, message.severity.value)
+                      messageStmt.setString(6, message.text)
+                      messageStmt.executeUpdate()
+                    }
+
+                    document.symbols.foreach { symbol =>
+                      val symbolRef = symbolId(symbol.symbol)
+                      if (!symbolDone.contains(symbolRef)) {
+                        symbolStmt.setInt(1, symbolRef)
+                        symbolStmt.setString(2, symbol.symbol)
+                        symbolStmt.setLong(3, symbol.denotation.get.flags)
+                        symbolStmt.setString(4, symbol.denotation.get.name)
+                        val signatureDocumentRef = {
+                          documentStmt.setInt(1, documentId.next)
+                          documentStmt.setString(2, null)
+                          documentStmt.setString(3, symbol.denotation.get.signature)
+                          documentStmt.setString(4, null)
+                          documentStmt.executeUpdate()
+                          documentId.value
+                        }
+                        symbolStmt.setInt(5, signatureDocumentRef)
+                        symbol.denotation.get.names.foreach { name =>
+                          nameStmt.setInt(1, nameId.next)
+                          nameStmt.setInt(2, signatureDocumentRef)
+                          nameStmt.setInt(3, name.position.get.start)
+                          nameStmt.setInt(4, name.position.get.end)
+                          nameStmt.setInt(5, symbolId(name.symbol))
+                          nameStmt.setBoolean(6, name.isDefinition)
+                          nameStmt.executeUpdate()
+                        }
+                        symbolStmt.executeUpdate()
+                        symbolTodo.remove(symbolRef)
+                        symbolDone.add(symbolRef)
+                      }
+                    }
+
+                    document.synthetics.foreach { synthetic =>
+                      syntheticStmt.setInt(1, syntheticId.next)
+                      syntheticStmt.setInt(2, synthetic.pos.get.start)
+                      syntheticStmt.setInt(3, synthetic.pos.get.end)
+                      val syntheticDocumentRef = {
+                        documentStmt.setInt(1, documentId.next)
+                        documentStmt.setString(2, null)
+                        documentStmt.setString(3, synthetic.text)
+                        documentStmt.setString(4, null)
+                        documentStmt.executeUpdate()
+                        documentId.value
+                      }
+                      syntheticStmt.setInt(4, syntheticDocumentRef)
+                      synthetic.names.foreach { name =>
+                        nameStmt.setInt(1, nameId.next)
+                        nameStmt.setInt(2, syntheticDocumentRef)
+                        nameStmt.setInt(3, name.position.get.start)
+                        nameStmt.setInt(4, name.position.get.end)
+                        nameStmt.setInt(5, symbolId(name.symbol))
+                        nameStmt.setBoolean(6, name.isDefinition)
+                        nameStmt.executeUpdate()
+                      }
+                      syntheticStmt.executeUpdate()
+                    }
+
+                    if ((genuineDocuments % 1000) == 0) {
+                      val semanticdbElapsed = System.nanoTime() - semanticdbStart
+                      val buf = new StringBuilder
+                      buf.append(s"$genuineDocuments documents: ")
+                      buf.append(s"${nameId.value} names, ")
+                      buf.append(s"${messageId.value} messages, ")
+                      buf.append(s"${_symbolId.value} symbols, ")
+                      buf.append(s"${syntheticId.value} synthetics")
+                      buf.append(s" (~${semanticdbElapsed / 1000000000}s) ")
+                      println(buf.toString)
+                    }
+                }
               }
+            } catch {
+              case NonFatal(ex) =>
+                println(s"Error processing $path")
+                ex.printStackTrace
             }
           }
 

--- a/langmeta-sqlite/src/main/scala/org/langmeta/sqlite/Main.scala
+++ b/langmeta-sqlite/src/main/scala/org/langmeta/sqlite/Main.scala
@@ -1,0 +1,95 @@
+package org.langmeta.sqlite
+
+import java.nio.file._
+import java.sql._
+import scala.Array
+import scala.collection.mutable
+import scala.io.Codec
+import scala.reflect.classTag
+import org.langmeta.internal.semanticdb.schema._
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    args match {
+      case Array(sqliteFilename, semanticdbFilenames @ _*) =>
+        val appStart = System.nanoTime()
+        val docsToPaths = mutable.Map[String, Path]()
+        val sqlitePath = Paths.get(sqliteFilename)
+        if (Files.exists(sqlitePath)) sys.error(s"$sqlitePath already exists")
+        val conn = DriverManager.getConnection(s"jdbc:sqlite:$sqliteFilename")
+        conn.setAutoCommit(false)
+        try {
+          val ddlUrl = getClass.getClassLoader.getResource("semanticdb.ddl")
+          val ddlStream = ddlUrl.openStream
+          val ddl = scala.io.Source.fromInputStream(ddlStream)(Codec.UTF8)
+          val ddlStmt = conn.createStatement()
+          ddlStmt.executeUpdate(ddl.mkString)
+
+          def tableInsertStmt(table: String): PreparedStatement = {
+            val rs = ddlStmt.executeQuery("select * from " + table)
+            val rsmd = rs.getMetaData()
+            val columnCount = rsmd.getColumnCount()
+            val columnNames = 1.to(columnCount).map(rsmd.getColumnName)
+            val s_columns = "(" + columnNames.mkString(", ") + ")"
+            val columnValues = "?" * columnCount
+            val s_values = "(" + columnValues.mkString(", ") + ")"
+            val sql = s"insert into $table $s_columns values $s_values"
+            conn.prepareStatement(sql)
+          }
+          val namesStmt = tableInsertStmt("names")
+
+          val semanticdbStart = System.nanoTime()
+          var nameCount = 0
+          var messageCount = 0
+          var symbolCount = 0
+          val syntheticCount = 0
+          semanticdbFilenames.foreach { semanticdbFilename =>
+            val path = Paths.get(semanticdbFilename)
+            val bytes = Files.readAllBytes(path)
+            val db = Database.parseFrom(bytes)
+            db.documents.foreach { doc =>
+              docsToPaths.get(doc.filename) match {
+                case Some(existingPath) =>
+                  val what = doc.filename
+                  val details = "both $existingPath and $path"
+                  println(s"Duplicate document filename $what in $details")
+                case None =>
+                  docsToPaths(doc.filename) = path
+                  doc.names.foreach { name =>
+                    nameCount += 1
+                    namesStmt.setString(1, doc.filename)
+                    namesStmt.setInt(2, name.position.get.start)
+                    namesStmt.setInt(3, name.position.get.end)
+                    namesStmt.setString(4, name.symbol)
+                    namesStmt.setBoolean(5, name.isDefinition)
+                    namesStmt.executeUpdate()
+                  }
+                  if ((docsToPaths.size % 1000) == 0) {
+                    val semanticdbElapsed = System.nanoTime() - semanticdbStart
+                    val buf = new StringBuilder
+                    buf.append(s"${docsToPaths.size} docs: ")
+                    buf.append(s"$nameCount names, ")
+                    buf.append(s"$messageCount messages, ")
+                    buf.append(s"$symbolCount symbols, ")
+                    buf.append(s"$syntheticCount synthetics")
+                    buf.append(s" (~${semanticdbElapsed / 1000000000}s) ")
+                    println(buf.toString)
+                  }
+              }
+            }
+          }
+        } finally {
+          conn.commit()
+          conn.close()
+          val appElapsed = (System.nanoTime() - appStart) * 1.0 / 1000000000
+          val appPerformance = docsToPaths.size / appElapsed
+          println(s"Elapsed: ${"%.3f".format(appElapsed)}s")
+          println(s"Performance: ${"%.3f".format(appPerformance)} docs/s")
+        }
+      case _ =>
+        val objectName = classTag[Main.type].toString.stripSuffix("$")
+        println(s"usage: $objectName </path/to/sqlite.db> [<glob> <glob> ...]")
+        sys.exit(1)
+    }
+  }
+}


### PR DESCRIPTION
Converting SemanticDB classpaths to SQLite databases takes reasonable time and requires reasonable disk space even for huge codebases. Even linear searches (like find all references) within these databases take acceptable time. When paired with appropriate indices, these searches become instantaneous. /cc @laughedelic @gabro @olafurpg @ShaneDelmore 

Here are the numbers from experimenting on the @olafurpg's legendary corpus of Scala projects (for full details see https://github.com/scalameta/scalameta/pull/1174#pullrequestreview-80697994):
```
14000 documents: 9575440 names, 1321 messages, 1037584 symbols, 650003 synthetics (~54s)
CPU time: 59.088s
Disk size: 764.2 MB (260MB compressed)
Performance: 250.254 documents/s
```