### PR TITLE
Improve Position.Range.toString

### DIFF
--- a/langmeta/shared/src/main/scala/org/langmeta/inputs/Position.scala
+++ b/langmeta/shared/src/main/scala/org/langmeta/inputs/Position.scala
@@ -42,16 +42,62 @@ object Position {
     def endLine: Int = input.offsetToLine(end)
     def endColumn: Int = end - input.lineToOffset(endLine)
     override def text = new String(input.chars, start, end - start)
+
+    private def highlightLine(text: String, start: Int, end: Int): String = {
+      if(startLine == endLine) {
+        val startLineColumn = input.lineToOffset(startLine)
+        val endLineColumn = input.lineToOffset(endLine)
+        val highlight = UNDERLINED + B_BLACK + WHITE + text.slice(start, end) + RESET
+        text.slice(startLineColumn, start) + highlight + text.slice(end, endLineColumn)
+      } else {
+        ""
+      }
+    }
+
+    private def inputSyntax(input: Input): String = {
+      val path =
+        input match {
+          case Input.VirtualFile(path, _) => path
+          case Input.File(path, _) => path
+
+
+
+
+          // private def inputSyntax(input: Input)
+          // 
+          case Input.Synthetic(value, input, start2, end2) => 
+            Position.Range(input, start2, end2))
+
+
+          case Input.Slice(input, start2, end2) => 
+            Position.Range(input, start2, end2))
+
+          case Input.Denotation(_, symbol) => symbol.syntax
+          case _: Input.String => "<string>"
+          case _: Input.Stream => "<stream>"
+          case _: Input.None => "<none>"
+        }
+
+      s"${path}:${startLine}:${startColumn}"
+    }
+
     override def toString = {
-      val maxContextLenght = 100 //chars
-      val text = input.text
-      // nb slice will clips to [0 or text.lenght)
-      val contextBefore = text.slice(start - maxContextLenght, start) 
-      val highlight = UNDERLINED + WHITE + text.slice(start, end) + RESET
-      val contextAfter = text.slice(end, end + maxContextLenght)
-      val context = contextBefore + highlight + contextAfter
-      s"""|[$start..$end)
-          |$context""".stripMargin
+      input match {
+        case Input.VirtualFile(path, _) =>
+        case Input.File(path, _) =>
+        case Input.Synthetic(_, input, _, _) =>
+        case Input.Slice(input, _, _) =>
+        case _: Input.String => ""
+        case _: Input.Denotation => ""
+        case _: Input.Stream => default
+        case _: Input.None => ""
+      }
+
+      // def default = highlightLine(text, start, end)
+
+      s"${highlight}"
     }
   }
 }
+
+// <denotation> _root_.toString

--- a/langmeta/shared/src/main/scala/org/langmeta/inputs/Position.scala
+++ b/langmeta/shared/src/main/scala/org/langmeta/inputs/Position.scala
@@ -1,6 +1,8 @@
 package org.langmeta
 package inputs
 
+import scala.io.AnsiColor._
+
 // NOTE: `start` and `end` are String.substring-style,
 // i.e. `start` is inclusive and `end` is not.
 // Therefore Position.end can point to the last character plus one.
@@ -40,6 +42,16 @@ object Position {
     def endLine: Int = input.offsetToLine(end)
     def endColumn: Int = end - input.lineToOffset(endLine)
     override def text = new String(input.chars, start, end - start)
-    override def toString = s"[$start..$end) in $input"
+    override def toString = {
+      val maxContextLenght = 100 //chars
+      val text = input.text
+      // nb slice will clips to [0 or text.lenght)
+      val contextBefore = text.slice(start - maxContextLenght, start) 
+      val highlight = UNDERLINED + WHITE + text.slice(start, end) + RESET
+      val contextAfter = text.slice(end, end + maxContextLenght)
+      val context = contextBefore + highlight + contextAfter
+      s"""|[$start..$end)
+          |$context""".stripMargin
+    }
   }
 }


### PR DESCRIPTION
I don't like the current Position.Range toString, it outputs the whole string of a file. I'm open to other ideas but the first one that came to my mind is to use ANSI colors to highlight the range and wrap it with some context (100 chars before and after). This is what it looks like:

![a](https://user-images.githubusercontent.com/921490/33767271-3fe30f00-dc21-11e7-9e86-3cd35628cfc8.png)

To consider:

How to display Points such as `Position.Range(x, y) x = y` ?
What to do when `Position.Range(x, y)` y >>> x? Do we cut the text in the middle?
What to do when the range is the whole file?
