### PR TITLE
Disable semanticdb-scalac in presentation compiler

### DIFF
--- a/scalameta/semanticdb-scalac-core/src/main/scala/scala/meta/internal/ReflectionToolkit.scala
+++ b/scalameta/semanticdb-scalac-core/src/main/scala/scala/meta/internal/ReflectionToolkit.scala
@@ -16,7 +16,10 @@ trait ReflectionToolkit {
   lazy val isDocCompiler = global.isInstanceOf[ScaladocGlobal]
   lazy val isReplCompiler = global.isInstanceOf[ReplGlobal]
   lazy val isInteractiveCompiler = global.isInstanceOf[InteractiveGlobal]
-  lazy val isSupportedCompiler = !isDocCompiler && !isReplCompiler
+  // NOTE: InteractiveGlobal does not work with semanticdb-scalac, in scalameta/language-server
+  // we tried to enable semanticdb-scalac with the presentation compiler and it resulted
+  // in cryptic infinite while loops while completing scope members.
+  lazy val isSupportedCompiler = !isDocCompiler && !isReplCompiler && !isInteractiveCompiler
 
   // NOTE: this boilerplate is unfortunately necessary, because we don't expose Attachable in the public API
   trait Attachable[-T] {


### PR DESCRIPTION
It has taken me close to a full day to track down an infinite loop
in the pc to this change. Lesson learned, the presentation compiler
is a fragile beast.

I've manually verified that this patch fixes the infinite loop in language-server

<img width="356" alt="screen shot 2017-12-10 at 19 49 04" src="https://user-images.githubusercontent.com/1408093/33808265-b6cf1bf4-dde3-11e7-89b1-662dbaf8da2a.png">