### PR TITLE
Implement leaf first traversal

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -186,7 +186,11 @@ lazy val transversers = crossProject
     description := "Scalameta traversal and transformation infrastructure for abstract syntax trees",
     enableMacros
   )
-  .dependsOn(common, trees)
+  .dependsOn(
+    common, trees,
+    parsers % "compile->test",
+    quasiquotes % "compile->test")
+
 lazy val traversersJVM = transversers.jvm
 lazy val traversersJS = transversers.js
 

--- a/scalameta/transversers/shared/src/main/scala/scala/meta/transversers/Api.scala
+++ b/scalameta/transversers/shared/src/main/scala/scala/meta/transversers/Api.scala
@@ -2,33 +2,58 @@ package scala.meta
 package transversers
 
 private[meta] trait Api {
+
+  sealed trait TraversalOrder
+  case object LeafFirst extends TraversalOrder
+  case object RootFirst extends TraversalOrder
+
+  implicit val order: TraversalOrder = RootFirst
+
   implicit class XtensionCollectionLikeUI(tree: Tree) {
-    def transform(fn: PartialFunction[Tree, Tree]): Tree = {
+    def transform(fn: PartialFunction[Tree, Tree])(implicit order: TraversalOrder): Tree = {
       object transformer extends Transformer {
         override def apply(tree: Tree): Tree = {
-          if (fn.isDefinedAt(tree)) super.apply(fn(tree))
-          else super.apply(tree)
+          order match {
+            case RootFirst =>
+              if (fn.isDefinedAt(tree)) super.apply(fn(tree))
+              else super.apply(tree)
+            case LeafFirst  =>
+              if (fn.isDefinedAt(tree)) fn(super.apply(tree))
+              else super.apply(tree)
+          }
         }
       }
       transformer(tree)
     }
 
-    def traverse(fn: PartialFunction[Tree, Unit]): Unit = {
+    def traverse(fn: PartialFunction[Tree, Unit])(implicit order: TraversalOrder): Unit = {
       object traverser extends Traverser {
         override def apply(tree: Tree): Unit = {
-          if (fn.isDefinedAt(tree)) fn(tree)
-          super.apply(tree)
+          order match {
+            case RootFirst =>
+              if (fn.isDefinedAt(tree)) fn(tree)
+              super.apply(tree)
+            case LeafFirst =>
+              super.apply(tree)
+              if (fn.isDefinedAt(tree)) fn(tree)
+          }
         }
       }
       traverser(tree)
     }
 
-    def collect[T](fn: PartialFunction[Tree, T]): List[T] = {
+    def collect[T](fn: PartialFunction[Tree, T])(implicit order: TraversalOrder): List[T] = {
       val buf = scala.collection.mutable.ListBuffer[T]()
       object traverser extends Traverser {
         override def apply(tree: Tree): Unit = {
-          if (fn.isDefinedAt(tree)) buf += fn(tree)
-          super.apply(tree)
+          order match {
+            case RootFirst =>
+              if (fn.isDefinedAt(tree)) buf += fn(tree)
+              super.apply(tree)
+            case LeafFirst =>
+              super.apply(tree)
+              if (fn.isDefinedAt(tree)) buf += fn(tree)
+          }
         }
       }
       traverser(tree)

--- a/scalameta/transversers/shared/src/test/scala/meta/transversers/OrderTests.scala
+++ b/scalameta/transversers/shared/src/test/scala/meta/transversers/OrderTests.scala
@@ -1,0 +1,109 @@
+package scala.meta.transversers
+
+import scala.meta._
+import org.scalatest._
+import scala.meta.quasiquotes._
+import scala.collection.mutable
+
+/**
+ * Note: Traversal is not exactly pre/post/in order.
+ * The children aare sorted. For most cases we only
+ * care about leaf first or parent first
+ */
+class OrderTests extends FunSuite {
+
+  val rootFirst = mutable.ArrayBuffer(
+    "scala.meta.Defn$Class$DefnClassImpl",
+    "scala.meta.Type$Name$TypeNameImpl",
+    "scala.meta.Ctor$Primary$CtorPrimaryImpl",
+    "scala.meta.Name$Anonymous$NameAnonymousImpl",
+    "scala.meta.Template$TemplateImpl",
+    "scala.meta.Self$SelfImpl",
+    "scala.meta.Name$Anonymous$NameAnonymousImpl",
+    "scala.meta.Defn$Def$DefnDefImpl",
+    "scala.meta.Term$Name$TermNameImpl",
+    "scala.meta.Lit$Int$LitIntImpl")
+
+    val leafFirst = mutable.ArrayBuffer(
+      "scala.meta.Type$Name$TypeNameImpl",
+      "scala.meta.Name$Anonymous$NameAnonymousImpl",
+      "scala.meta.Ctor$Primary$CtorPrimaryImpl",
+      "scala.meta.Name$Anonymous$NameAnonymousImpl",
+      "scala.meta.Self$SelfImpl",
+      "scala.meta.Term$Name$TermNameImpl",
+      "scala.meta.Lit$Int$LitIntImpl",
+      "scala.meta.Defn$Def$DefnDefImpl",
+      "scala.meta.Template$TemplateImpl",
+      "scala.meta.Defn$Class$DefnClassImpl")
+
+  val input = q"class Foo { def bar = 1 }"
+
+  test("Traverse visits roots first") {
+    val visited: mutable.ArrayBuffer[String] = mutable.ArrayBuffer()
+
+    input.traverse {
+      case a => visited.append(a.getClass.getName)
+    }
+
+    assert(visited === rootFirst)
+  }
+
+  test("Transform visits roots first") {
+    val visited: mutable.ArrayBuffer[String] = mutable.ArrayBuffer()
+
+    input.transform {
+      case a =>
+        visited.append(a.getClass.getName)
+        a
+    }
+
+    assert(visited === rootFirst)
+  }
+
+  test("Collect visits roots first") {
+    val visited: mutable.ArrayBuffer[String] = mutable.ArrayBuffer()
+
+    input.collect {
+      case a =>
+        visited.append(a.getClass.getName)
+        a
+    }
+
+    assert(visited === rootFirst)
+  }
+
+  test("Leaf first transform visits leafs first") {
+    val visited: mutable.ArrayBuffer[String] = mutable.ArrayBuffer()
+
+    input.transform({
+      case a =>
+        visited.append(a.getClass.getName)
+        a
+    })(LeafFirst)
+
+    assert(visited === leafFirst)
+  }
+
+  test("Leaf first traverse visits leafs first") {
+    val visited: mutable.ArrayBuffer[String] = mutable.ArrayBuffer()
+
+    input.traverse({
+      case a =>
+        visited.append(a.getClass.getName)
+    })(LeafFirst)
+
+    assert(visited === leafFirst)
+  }
+
+  test("Leaf first collect visits leafs first") {
+    val visited: mutable.ArrayBuffer[String] = mutable.ArrayBuffer()
+
+    input.collect({
+      case a =>
+        visited.append(a.getClass.getName)
+        a
+    })(LeafFirst)
+
+    assert(visited === leafFirst)
+  }
+}

--- a/tests/jvm/src/test/scala/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/api/SurfaceSuite.scala
@@ -113,6 +113,9 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.tokens.Token.Xml *
       |scala.meta.tokens.Tokens
       |scala.meta.transversers
+      |scala.meta.transversers.Api.LeafFirst
+      |scala.meta.transversers.Api.RootFirst
+      |scala.meta.transversers.Api.TraversalOrder
       |scala.meta.transversers.Transformer
       |scala.meta.transversers.Traverser
       |scala.meta.trees
@@ -155,9 +158,9 @@ class SurfaceSuite extends FunSuite {
       |* scala.meta.Dialect.apply(scala.meta.Tree): (scala.meta.Dialect, scala.meta.Tree)
       |* scala.meta.Dialect.apply(scala.meta.tokens.Token): (scala.meta.Dialect, scala.meta.tokens.Token)
       |* scala.meta.Dialect.apply(scala.meta.tokens.Tokens): (scala.meta.Dialect, scala.meta.tokens.Tokens)
-      |* scala.meta.Tree.collect(PartialFunction[scala.meta.Tree,T]): List[T]
-      |* scala.meta.Tree.transform(PartialFunction[scala.meta.Tree,scala.meta.Tree]): scala.meta.Tree
-      |* scala.meta.Tree.traverse(PartialFunction[scala.meta.Tree,Unit]): Unit
+      |* scala.meta.Tree.collect(PartialFunction[scala.meta.Tree,T])(implicit Api.this.TraversalOrder): List[T]
+      |* scala.meta.Tree.transform(PartialFunction[scala.meta.Tree,scala.meta.Tree])(implicit Api.this.TraversalOrder): scala.meta.Tree
+      |* scala.meta.Tree.traverse(PartialFunction[scala.meta.Tree,Unit])(implicit Api.this.TraversalOrder): Unit
     """.trim.stripMargin.split('\n').mkString(EOL))
   }
 


### PR DESCRIPTION
Needed for scalagen

Will not affect existing code.

Note: Implicit param has been added to the traverse method, so this is a bin-compat issue.