### PR TITLE
Fix #1194, gracefully handle errors for broken code in interactive mode

### DIFF
--- a/scalameta/semanticdb-scalac-core/src/main/scala/scala/meta/internal/semanticdb/SymbolOps.scala
+++ b/scalameta/semanticdb-scalac-core/src/main/scala/scala/meta/internal/semanticdb/SymbolOps.scala
@@ -4,6 +4,7 @@ package semanticdb
 import java.util.HashMap
 import scala.{meta => m}
 import scala.meta.internal.inputs._
+import scala.util.control.NonFatal
 
 trait SymbolOps { self: DatabaseOps =>
 
@@ -87,7 +88,14 @@ trait SymbolOps { self: DatabaseOps =>
       if (msym != null) {
         msym
       } else {
-        val msym = uncached(sym)
+        val msym = try {
+          uncached(sym)
+        } catch {
+          case NonFatal(e) if isInteractiveCompiler =>
+            // happens regularly for broken code with the pc, see
+            // https://github.com/scalameta/scalameta/issues/1194
+            m.Symbol.None
+        }
         symbolCache.put(sym, msym)
         msym
       }

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/InteractiveSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/InteractiveSuite.scala
@@ -1,7 +1,6 @@
 package scala.meta.tests
 package semanticdb
 
-import scala.meta.internal.semanticdb.DatabaseOps
 import org.scalameta.logger
 import org.scalatest.FunSuite
 import scala.meta.interactive.InteractiveSemanticdb._
@@ -74,4 +73,28 @@ class InteractiveSuite extends FunSuite with DiffAssertions {
     """.stripMargin
   )
 
+  // This tests a case where SymbolOps.toSemantic crashes
+  check(
+    """
+      |object b {
+      |  def add(a: In) = 1
+      |}""".stripMargin,
+    """
+      |Language:
+      |Interactive
+      |
+      |Names:
+      |[8..9): b <= _empty_.b.
+      |[22..23): a <= (a)
+      |[25..27): In => (a)`<error: <none>>`#
+      |
+      |Messages:
+      |[25..27): [error] not found: type In
+      |
+      |Symbols:
+      |(a) => param a: <error>
+      |(a)`<error: <none>>`# => class `<error: <none>>`
+      |_empty_.b. => final object b
+    """.stripMargin
+  )
 }


### PR DESCRIPTION
Previously, semanticdb-scalac would crash when the presentation compiler
emitted erroneous symbols. Now, the plugin returns Symbol.None while
running in interactive mode. The plugin keeps the fail-fast mode for
batch compilation.