### PR TITLE
Short circuit equality

### DIFF
--- a/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/implicits/Equality.scala
+++ b/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/implicits/Equality.scala
@@ -21,7 +21,7 @@ trait Equality {
     @inline
     def isEqual[F[x <: Tree] <: TreeEquality[x]](
         b: A)(implicit conv: Tree => F[Tree], eqEv: Equal[F[Tree]]): Boolean =
-      eqEv.isEqual(a, b)
+      (a eq b) || eqEv.isEqual(a, b)
   }
 }
 


### PR DESCRIPTION
This will prevent repeated structural equality checks in scalagen