### PR TITLE
Fix bug in Tokens.slice causing incorrect length

### DIFF
--- a/scalameta/tokens/shared/src/main/scala/scala/meta/tokens/Tokens.scala
+++ b/scalameta/tokens/shared/src/main/scala/scala/meta/tokens/Tokens.scala
@@ -29,7 +29,11 @@ import scala.meta.internal.prettyprinters._
 extends immutable.IndexedSeq[Token] with collection.IndexedSeqOptimized[Token, immutable.IndexedSeq[Token]] {
   def apply(idx: Int): Token = tokens(start + idx)
   def length: Int = end - start
-  override def slice(from: Int, until: Int): Tokens = Tokens(tokens, start + math.max(from, 0), start + math.min(math.max(until, 0), length))
+  override def slice(from: Int, until: Int): Tokens = {
+    val lo = start + from.max(0).min(length)
+    val hi = lo.max(start + until.min(length))
+    Tokens(tokens, lo, hi)
+  }
   override def toString = scala.meta.internal.prettyprinters.TokensToString(this)
 
   override def segmentLength(p: Token => Boolean, from: Int = 0): Int = super.segmentLength(p, from)

--- a/tests/shared/src/test/scala/scala/meta/tests/tokens/TokensSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokens/TokensSuite.scala
@@ -51,13 +51,12 @@ class TokensApiSuite extends FunSuite {
 
   test("Maintains Tokens type when implementing collections API methods") {
     //Drop BOF and EOF to make tests more readable
-    var tokens = tokenize("((1 + 1) == 2)").drop(1).dropRight(1)
+    val tokens = tokenize("((1 + 1) == 2)").drop(1).dropRight(1)
 
     assert(tokens.length == 13)
     assert(tokens.segmentLength(_.is[LeftParen]) === 2)
     assert(tokens.segmentLengthRight(_.is[RightParen]) === 1)
     assert(tokens.take(2).syntax === "((")
-    assert(tokens.slice(11, 13).syntax === "2)")
     assert(tokens.slice(11, 13).syntax === "2)")
     assert(tokens.takeRight(2).syntax === "2)")
     assert(tokens.drop(11).syntax === "2)")
@@ -80,5 +79,56 @@ class TokensApiSuite extends FunSuite {
       val (front, back) = tokens.spanRight(_.isNot[LeftParen])
       front.syntax === "((" && back.syntax === "1 + 1) == 2)"
     }
+  }
+
+  test("Tokens.slice - 'from' < 'until'") {
+    val tokens = tokenize("val foo = List(1, 2, 3)")
+
+    val slice = tokens.slice(0, 5)
+    assert(slice.length === 5)
+    for (i <- 0 until 5) assert(slice(i) === tokens(i))
+  }
+
+  test("Tokens.slice - 'from' == 'until'") {
+    val tokens = tokenize("val foo = 1")
+
+    assert(tokens.slice(1, 1).length === 0)
+  }
+
+  test("Tokens.slice - 'from' > 'until'") {
+    val tokens = tokenize("val foo = 1")
+
+    assert(tokens.slice(5, 1).length === 0)
+  }
+
+  test("Tokens.slice - 'from' < 0") {
+    val tokens = tokenize("1 + 2")
+
+    val slice = tokens.slice(-100, 1)
+
+    assert(slice.length === 1)
+    assert(slice.head === tokens.head)
+  }
+
+  test("Tokens.slice - 'from' > 'length'") {
+    val tokens = tokenize("1 + 2")
+
+    assert(tokens.slice(100, 101).length === 0)
+  }
+
+  test("Tokens.slice - 'until' > 'length'") {
+    val tokens = tokenize("val foo = 0")
+
+    assert(tokens.slice(0, 100) === tokens)
+  }
+
+  test("Tokens.slice - multiple calls") {
+    val tokens = tokenize("def foo(bar: String): Unit = ???")
+
+    val slice = tokens.slice(0, 18).slice(5, 15).slice(6, 8)
+
+    assert(slice.length === 2)
+    assert(slice(0) === tokens(11))
+    assert(slice(1) === tokens(12))
   }
 }


### PR DESCRIPTION
```scala
val tokens = "foo".tokenize.get

tokens.slice(1, 0).length
res0: Int = -1

tokens.slice(1, 0).isEmpty
res1: Boolean = false

tokens.slice(100, 200).length
res5: Int = -97
```

/cc @olafurpg 
  