### PR TITLE
Print type ref prefix with type arguments.

### DIFF
--- a/scalameta/semanticdb-scalac-core/src/main/scala/scala/meta/internal/semanticdb/PrinterOps.scala
+++ b/scalameta/semanticdb-scalac-core/src/main/scala/scala/meta/internal/semanticdb/PrinterOps.scala
@@ -423,6 +423,9 @@ trait PrinterOps { self: DatabaseOps =>
                   !sym.isConstructor =>
               this.print(ResolvedName(sym))
               this.print(".this.")
+            case TypeRef(_, _, _ :: _) =>
+              this.printType(pre)
+              this.print("#")
             case _ =>
           }
           this.print(ResolvedName(sym))


### PR DESCRIPTION
Fixes #1222, unblocking a bug in scalafix ExplicitResultTypes.