### PR TITLE
Setup publish -SNAPSHOT on merge to master.

### DIFF
--- a/bin/ci-publish.sh
+++ b/bin/ci-publish.sh
@@ -3,10 +3,14 @@ set -eu
 PUBLISH=${CI_PUBLISH:-false}
 SECURE_VAR=${TRAVIS_SECURE_ENV_VARS:-false}
 
-if [[ "$TRAVIS_SECURE_ENV_VARS" == true && -n "$TRAVIS_TAG" && "$CI_PUBLISH" == true ]]; then
+if [[ "$TRAVIS_SECURE_ENV_VARS" == true && "$CI_PUBLISH" == true ]]; then
   git log | head -n 20
   echo "$PGP_SECRET" | base64 --decode | gpg --import
-  sbt ci-publish
+  if [ -n "$TRAVIS_TAG" ]; then
+    sbt ci-publish
+  else
+    sbt -Dscalameta.snapshot=true ci-publish
+  fi
 else
   echo "Skipping publish, branch=$TRAVIS_BRANCH publish=$PUBLISH test=$CI_TEST"
 fi

--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,12 @@ lazy val LanguageVersion = LanguageVersions.head
 // ==========================================
 
 sharedSettings
+version.in(ThisBuild) ~= { old =>
+  val suffix =
+    if (sys.props.contains("scalameta.snapshot")) "-SNAPSHOT"
+    else ""
+  customVersion.getOrElse(old.replace('+', '-') + suffix)
+}
 name := {
   println(s"[info] Welcome to scalameta ${version.value}")
   "scalametaRoot"
@@ -40,8 +46,7 @@ commands += Command.command("ci-fast") { s =>
   }
 }
 commands += CiCommand("ci-publish")(
-  if (isTagPush) "publishSigned" :: Nil
-  else Nil
+  "publishSigned" :: Nil
 )
 commands += Command.command("mima") { s =>
   s"very mimaReportBinaryIssues" ::
@@ -400,7 +405,6 @@ lazy val sharedSettings = Def.settings(
       case _ => CrossVersion.binary
     }
   },
-  version := customVersion.getOrElse(version.value.replace('+', '-')),
   organization := "org.scalameta",
   addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
   libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.1" % "test",


### PR DESCRIPTION
To make it easier to consume latest fixes without triggering a stable
release. We should still be unafraid to cut stable releases, but this
is a nice way to give a pre-release a try before pushing the tag.