### PR TITLE
Add SymbolInformation.Property.{VALPARAM/VARPARAM}

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,7 @@ lazy val semanticdb3 = crossProject
     ignoreMimaSettings,
     protobufSettings,
     PB.protoSources.in(Compile) := Seq(file("semanticdb/semanticdb3")),
-    version := "3.0.0"
+    version := "3.1.0"
   )
   .jvmSettings(
     crossScalaVersions := List(LatestScala210, LatestScala211, LatestScala212)

--- a/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/package.scala
+++ b/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/package.scala
@@ -136,6 +136,8 @@ package object semanticdb {
               if (stest(p.CASE.value)) dflip(d.CASE)
               if (stest(p.COVARIANT.value)) dflip(d.COVARIANT)
               if (stest(p.CONTRAVARIANT.value)) dflip(d.CONTRAVARIANT)
+              if (stest(p.VALPARAM.value)) dflip(d.VAL)
+              if (stest(p.VARPARAM.value)) dflip(d.VAR)
               dflags
             }
             val dname = sname
@@ -256,8 +258,8 @@ package object semanticdb {
               val slanguage = dlanguage
               def dtest(bit: Long) = (ddenot.flags & bit) == bit
               val skind = {
-                if (dtest(d.VAL)) k.VAL
-                else if (dtest(d.VAR)) k.VAR
+                if (dtest(d.VAL) && !dtest(d.PARAM)) k.VAL
+                else if (dtest(d.VAR) && !dtest(d.PARAM)) k.VAR
                 else if (dtest(d.DEF)) k.DEF
                 else if (dtest(d.PRIMARYCTOR)) k.PRIMARY_CONSTRUCTOR
                 else if (dtest(d.SECONDARYCTOR)) k.SECONDARY_CONSTRUCTOR
@@ -285,6 +287,8 @@ package object semanticdb {
                 if (dtest(d.CASE)) sflip(p.CASE.value)
                 if (dtest(d.COVARIANT)) sflip(p.COVARIANT.value)
                 if (dtest(d.CONTRAVARIANT)) sflip(p.CONTRAVARIANT.value)
+                if (dtest(d.VAL) && dtest(d.PARAM)) sflip(p.VALPARAM.value)
+                if (dtest(d.VAR) && dtest(d.PARAM)) sflip(p.VARPARAM.value)
                 sproperties
               }
               val sname = ddenot.name

--- a/semanticdb/integration/src/main/scala/example/Flags.scala
+++ b/semanticdb/integration/src/main/scala/example/Flags.scala
@@ -14,4 +14,5 @@ package object p {
   case object X
   final class Y
   sealed trait Z
+  class AA(x: Int, val y: Int, var z: Int)
 }

--- a/semanticdb/semanticdb3/semanticdb3.md
+++ b/semanticdb/semanticdb3/semanticdb3.md
@@ -1,4 +1,4 @@
-# SemanticDB Specification, Version 3.0.0
+# SemanticDB Specification, Version 3.1.0
 
   * [Motivation](#motivation)
   * [Data Model](#data-model)
@@ -13,6 +13,7 @@
     * [Protobuf](#protobuf)
   * [Changelog](#changelog)
     * [3.0.0](#300)
+    * [3.1.0](#310)
 
 ## Motivation
 
@@ -343,6 +344,16 @@ or features from other languages.
     <td><code>CONTRAVARIANT</code></td>
     <td>Has a contravariant (<code>-</code>) modifier?</td>
   </tr>
+  <tr>
+    <td><code>0x400</code></td>
+    <td><code>VALPARAM</code></td>
+    <td>Is a `val` parameter of a primary constructor?</td>
+  </tr>
+  <tr>
+    <td><code>0x800</code></td>
+    <td><code>VARPARAM</code></td>
+    <td>Is a `var` parameter of a primary constructor?</td>
+  </tr>
 </table>
 
 `name`. String that represents the name of the symbol.
@@ -488,6 +499,9 @@ in the future, but this is highly unlikely.
 [semanticdb3.proto][semanticdb3.proto]
 
 ## Changelog
+
+### 3.1.0
+  * Added SymbolInformation.Property.{VALPARAM/VARPARAM}.
 
 ### 3.0.0
   * Codified the first specification of SemanticDB.

--- a/semanticdb/semanticdb3/semanticdb3.md
+++ b/semanticdb/semanticdb3/semanticdb3.md
@@ -1,4 +1,4 @@
-# SemanticDB Specification, Version 3
+# SemanticDB Specification, Version 3.0.0
 
   * [Motivation](#motivation)
   * [Data Model](#data-model)
@@ -11,6 +11,8 @@
     * [Synthetic](#synthetic)
   * [Data Schemas](#data-schemas)
     * [Protobuf](#protobuf)
+  * [Changelog](#changelog)
+    * [3.0.0](#300)
 
 ## Motivation
 
@@ -484,6 +486,18 @@ in the future, but this is highly unlikely.
 ### Protobuf
 
 [semanticdb3.proto][semanticdb3.proto]
+
+## Changelog
+
+### 3.0.0
+  * Codified the first specification of SemanticDB.
+    Previously (in Scalameta 1.x and 2.x), SemanticDB was loosely specified by
+    [an internal protobuf schema][semanticdb2.proto] and the reference
+    implementation in `semanticdb-scalac`.
+  * Changed the package of the protobuf schema to `scala.meta.internal.semanticdb3`.
+  * Significantly changed the schema to perform long-awaited cleanups and ensure
+    consistency with LSP [\[2\]][2]. Some changes were
+    inspired by the design of Index-While-Building in Clang [[23][23], [24][24]].
 
 [semanticdb2.proto]: https://github.com/scalameta/scalameta/blob/master/semanticdb/semanticdb2/semanticdb2.proto
 [semanticdb3.proto]: https://github.com/scalameta/scalameta/blob/master/semanticdb/semanticdb3/semanticdb3.proto

--- a/semanticdb/semanticdb3/semanticdb3.proto
+++ b/semanticdb/semanticdb3/semanticdb3.proto
@@ -59,6 +59,8 @@ message SymbolInformation {
     CASE = 0x80;
     COVARIANT = 0x100;
     CONTRAVARIANT = 0x200;
+    VALPARAM = 0x400;
+    VARPARAM = 0x800;
   }
   string symbol = 1;
   string language = 2;

--- a/tests/jvm/src/test/resources/semanticdb.expect
+++ b/tests/jvm/src/test/resources/semanticdb.expect
@@ -126,10 +126,31 @@ Names:
 [290..291): Y <= _root_.flags.p.package.Y#
 [291..291): ε <= _root_.flags.p.package.Y#`<init>`()V.
 [307..308): Z <= _root_.flags.p.package.Z#
+[317..319): AA <= _root_.flags.p.package.AA#
+[319..319): ε <= _root_.flags.p.package.AA#`<init>`(III)V.
+[320..321): x <= _root_.flags.p.package.AA#(x)
+[323..326): Int => _root_.scala.Int#
+[332..333): y <= _root_.flags.p.package.AA#(y)
+[335..338): Int => _root_.scala.Int#
+[344..345): z <= _root_.flags.p.package.AA#(z)
+[347..350): Int => _root_.scala.Int#
 
 Symbols:
 _root_.flags. => package flags.{+1 members}
 _root_.flags.p.package. => packageobject package
+_root_.flags.p.package.AA# => class AA
+_root_.flags.p.package.AA#(x) => param x: Int
+  [0..3): Int => _root_.scala.Int#
+_root_.flags.p.package.AA#(y) => val param y: Int
+  [0..3): Int => _root_.scala.Int#
+_root_.flags.p.package.AA#(z) => var param z_=: (x$1: Int): Unit
+  [6..9): Int => _root_.scala.Int#
+  [12..16): Unit => _root_.scala.Unit#
+_root_.flags.p.package.AA#`<init>`(III)V. => primaryctor <init>: (x: Int, y: Int, z: Int): AA
+  [4..7): Int => _root_.scala.Int#
+  [12..15): Int => _root_.scala.Int#
+  [20..23): Int => _root_.scala.Int#
+  [26..28): AA => _root_.flags.p.package.AA#
 _root_.flags.p.package.C# => abstract class C
 _root_.flags.p.package.C#(x) => param x: T
   [0..1): T => _root_.flags.p.package.C#[T]


### PR DESCRIPTION
This is something that we lost when migrating from SemanticDB v2 to SemanticDB v3.