### PR TITLE
 Give local symbols reference equality.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,7 +79,10 @@ lazy val semanticdb3 = crossProject
   .settings(
     publishableSettings,
     protobufSettings,
-    PB.protoSources.in(Compile) := Seq(file("semanticdb/semanticdb3")),
+    PB.protoSources.in(Compile) := Seq(
+      file("semanticdb/semanticdb2"),
+      file("semanticdb/semanticdb3")
+    ),
     version := "3.1.0"
   )
   .jvmSettings(

--- a/langmeta/langmeta/shared/src/main/scala/org/langmeta/internal/semanticdb/schema/LegacySemanticdb.scala
+++ b/langmeta/langmeta/shared/src/main/scala/org/langmeta/internal/semanticdb/schema/LegacySemanticdb.scala
@@ -1,0 +1,137 @@
+package org.langmeta.internal.semanticdb.schema
+
+import org.langmeta.inputs
+
+import org.{langmeta => d}
+import scala.meta.internal.{semanticdb3 => s}
+import scala.meta.internal.semanticdb3.SymbolInformation.{Kind => k}
+import scala.meta.internal.semanticdb3.SymbolInformation.{Property => p}
+
+object LegacySemanticdb {
+
+  def toTextDocuments(database: Database): s.TextDocuments = {
+    val documents = database.documents.map(toTextDocument)
+    s.TextDocuments(documents)
+  }
+
+  def toTextDocument(document: Document): s.TextDocument = {
+
+    val input = inputs.Input.VirtualFile(document.filename, document.contents)
+
+    def toRange(pos: Position): s.Range = {
+      val r = inputs.Position.Range(input, pos.start, pos.end)
+      s.Range(r.startLine, r.startColumn, r.endLine, r.endColumn)
+    }
+
+    def toSymbol(symbol: String) = {
+      if (symbol.startsWith("_root_")) symbol
+      else if (symbol.startsWith("_empty_")) symbol
+      else if (symbol.startsWith("_star_")) symbol
+      // Convert old-style local symbol to new-style local symbol.
+      else "local" + symbol.replace('/', '_').replace('.', '_').replace('@', '_')
+    }
+
+    val occurences = document.names.map { name =>
+      s.SymbolOccurrence(
+        range = name.position.map(toRange),
+        symbol = toSymbol(name.symbol),
+        role =
+          if (name.isDefinition) s.SymbolOccurrence.Role.DEFINITION
+          else s.SymbolOccurrence.Role.REFERENCE
+      )
+    }
+
+    val symbols = document.symbols.map { symbol =>
+      val denot = symbol.denotation.get
+      val signature = toTextDocument(
+        Document(
+          contents = denot.signature,
+          names = denot.names
+        )
+      )
+      s.SymbolInformation(
+        toSymbol(symbol.symbol),
+        language = document.language,
+        kind = toKind(denot.flags),
+        properties = toProperty(denot.flags),
+        name = denot.name,
+        signature = Some(signature),
+        members = denot.members,
+        overrides = denot.overrides
+      )
+    }
+
+    val diagnostics = document.messages.map { message =>
+      s.Diagnostic(
+        range = message.position.map(toRange),
+        severity = message.severity match {
+          case Message.Severity.INFO => s.Diagnostic.Severity.INFORMATION
+          case Message.Severity.WARNING => s.Diagnostic.Severity.WARNING
+          case Message.Severity.ERROR => s.Diagnostic.Severity.ERROR
+          case _ => s.Diagnostic.Severity.UNKNOWN_SEVERITY
+        },
+        message = message.text
+      )
+    }
+
+    val synthetics = document.synthetics.map { synthetic =>
+      val text = toTextDocument(
+        Document(
+          contents = synthetic.text,
+          names = synthetic.names
+        ))
+      s.Synthetic(
+        range = synthetic.pos.map(toRange),
+        text = Some(text)
+      )
+    }
+
+    s.TextDocument(
+      schema = s.Schema.SEMANTICDB3,
+      uri = document.filename,
+      text = document.contents,
+      language = document.language,
+      symbols = symbols,
+      occurrences = occurences,
+      diagnostics = diagnostics,
+      synthetics = synthetics
+    )
+  }
+
+  def toKind(flags: Long): s.SymbolInformation.Kind = {
+    def dtest(bit: Long): Boolean = (flags & bit) == bit
+    if (dtest(d.VAL)) k.VAL
+    else if (dtest(d.VAR)) k.VAR
+    else if (dtest(d.DEF)) k.DEF
+    else if (dtest(d.PRIMARYCTOR)) k.PRIMARY_CONSTRUCTOR
+    else if (dtest(d.SECONDARYCTOR)) k.SECONDARY_CONSTRUCTOR
+    else if (dtest(d.MACRO)) k.MACRO
+    else if (dtest(d.TYPE)) k.TYPE
+    else if (dtest(d.PARAM)) k.PARAMETER
+    else if (dtest(d.TYPEPARAM)) k.TYPE_PARAMETER
+    else if (dtest(d.OBJECT)) k.OBJECT
+    else if (dtest(d.PACKAGE)) k.PACKAGE
+    else if (dtest(d.PACKAGEOBJECT)) k.PACKAGE_OBJECT
+    else if (dtest(d.CLASS)) k.CLASS
+    else if (dtest(d.TRAIT)) k.TRAIT
+    else k.UNKNOWN_KIND
+  }
+
+  def toProperty(flags: Long): Int = {
+    def dtest(bit: Long) = (flags & bit) == bit
+    var sproperties = 0
+    def sflip(sbit: Int): Unit = sproperties ^= sbit
+    if (dtest(d.PRIVATE)) sflip(p.PRIVATE.value)
+    if (dtest(d.PROTECTED)) sflip(p.PROTECTED.value)
+    if (dtest(d.ABSTRACT)) sflip(p.ABSTRACT.value)
+    if (dtest(d.FINAL)) sflip(p.FINAL.value)
+    if (dtest(d.SEALED)) sflip(p.SEALED.value)
+    if (dtest(d.IMPLICIT)) sflip(p.IMPLICIT.value)
+    if (dtest(d.LAZY)) sflip(p.LAZY.value)
+    if (dtest(d.CASE)) sflip(p.CASE.value)
+    if (dtest(d.COVARIANT)) sflip(p.COVARIANT.value)
+    if (dtest(d.CONTRAVARIANT)) sflip(p.CONTRAVARIANT.value)
+    sproperties
+  }
+
+}

--- a/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/Database.scala
+++ b/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/Database.scala
@@ -1,12 +1,11 @@
 package org.langmeta.semanticdb
 
 import scala.compat.Platform.EOL
-import org.langmeta.inputs._
 import org.langmeta.io._
 import org.langmeta.internal.io.PathIO
 import org.langmeta.internal.semanticdb._
 import org.langmeta.internal.semanticdb.{vfs => v}
-import scala.meta.internal.{semanticdb3 => s}
+import org.langmeta.internal.semanticdb.vfs.Entry
 
 final case class Database(documents: Seq[Document]) {
   lazy val names: Seq[ResolvedName] = documents.flatMap(_.names)
@@ -48,8 +47,8 @@ object Database {
   }
 
   def load(bytes: Array[Byte]): Database = {
-    val sdocs = s.TextDocuments.parseFrom(bytes)
-    val mdb = sdocs.mergeDiagnosticOnlyDocuments.toDb(None)
-    mdb
+    val ventry =
+      Entry.InMemory(Fragment(PathIO.workingDirectory, RelativePath("(in-memory)")), bytes)
+    v.Database(ventry :: Nil).toSchema.toDb(None)
   }
 }

--- a/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/Symbol.scala
+++ b/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/Symbol.scala
@@ -19,6 +19,10 @@ object Symbol {
     override def toString = syntax
     override def syntax = id
     override def structure = s"""Symbol.Local("$id")"""
+    // Local symbols have reference equality because two local symbols from
+    // different source files can have the same id (for example, local0).
+    override def equals(obj: scala.Any): Boolean = this.eq(obj.asInstanceOf[AnyRef])
+    override def hashCode(): Int = System.identityHashCode(this)
   }
 
   final case class Global(owner: Symbol, signature: Signature) extends Symbol {

--- a/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/package.scala
+++ b/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/package.scala
@@ -5,6 +5,7 @@ import java.nio.charset.Charset
 import java.nio.file.Files
 import java.nio.file.OpenOption
 import java.nio.file.StandardOpenOption
+import scala.collection.mutable
 import scala.util.control.NonFatal
 import org.langmeta.inputs.{Input => dInput}
 import org.langmeta.inputs.{Position => dPosition}
@@ -61,6 +62,10 @@ package object semanticdb {
 
     def toDb(sourcepath: Option[Sourcepath], sdoc: s.TextDocument): d.Document = {
       val s.TextDocument(sschema, suri, stext, slanguage, ssymbols, soccurrences, sdiagnostics, ssynthetics) = sdoc
+      val symbolCache = mutable.Map.empty[String, d.Symbol]
+      def dsymbol(symbol: String): d.Symbol =
+        if (!symbol.startsWith("local")) d.Symbol(symbol)
+        else symbolCache.getOrElseUpdate(symbol, d.Symbol(symbol))
       assert(sschema == s.Schema.SEMANTICDB3, "s.TextDocument.schema must be ${s.Schema.SEMANTICDB3}")
       val dinput = {
         val sfilename = {
@@ -105,7 +110,7 @@ package object semanticdb {
       object sSymbolInformation {
         def unapply(ssymbolInformation: s.SymbolInformation): Option[d.ResolvedSymbol] = ssymbolInformation match {
           case s.SymbolInformation(ssym, _, skind, sproperties, sname, _, ssignature, smembers, soverrides) =>
-            val dsym = d.Symbol(ssym)
+            val dsym = dsymbol(ssym)
             val dflags = {
               var dflags = 0L
               def dflip(dbit: Long) = dflags ^= dbit
@@ -148,7 +153,7 @@ package object semanticdb {
                 val dinput = dInput.Denotation(dsignature, dsym)
                 ssignature.occurrences.toIterator.map {
                   case s.SymbolOccurrence(Some(srange), ssym, sRole(disDefinition)) =>
-                    val dsym = d.Symbol(ssym)
+                    val dsym = dsymbol(ssym)
                     val dstartOffset = dinput.lineToOffset(srange.startLine) + srange.startCharacter
                     val dendOffset = dinput.lineToOffset(srange.endLine) + srange.endCharacter
                     val ddefnpos = dPosition.Range(dinput, dstartOffset, dendOffset)
@@ -163,7 +168,7 @@ package object semanticdb {
               else if (smember.endsWith(".")) d.Signature.Term(smember.stripSuffix("."))
               else sys.error(s"Unexpected signature $smember")
             }.toList
-            val doverrides = soverrides.iterator.map(d.Symbol.apply).toList
+            val doverrides = soverrides.iterator.map(dsymbol).toList
             Some(d.ResolvedSymbol(dsym, d.Denotation(dflags, dname, dsignature, dnames, dmembers, doverrides)))
           case other => sys.error(s"bad protobuf: unsupported symbol information $other")
         }
@@ -176,7 +181,7 @@ package object semanticdb {
               stext.map { stext =>
                 stext.occurrences.toIterator.map {
                   case s.SymbolOccurrence(Some(srange), ssym, sRole(disDefinition)) =>
-                    val dsym = d.Symbol(ssym)
+                    val dsym = dsymbol(ssym)
                     val dsyntheticinput = dInput.Synthetic(dtext, dpos.input, dpos.start, dpos.end)
                     val dstartOffset = dsyntheticinput.lineToOffset(srange.startLine) + srange.startCharacter
                     val dendOffset = dsyntheticinput.lineToOffset(srange.endLine) + srange.endCharacter
@@ -193,7 +198,7 @@ package object semanticdb {
       val dlanguage = slanguage
       val dnames = soccurrences.map {
         case s.SymbolOccurrence(Some(sRange(dpos)), ssym, sRole(disDefinition)) =>
-          val dsym = d.Symbol(ssym)
+          val dsym = dsymbol(ssym)
           d.ResolvedName(dpos, dsym, disDefinition)
         case other =>
           sys.error(s"bad protobuf: unsupported occurrence $other")

--- a/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/package.scala
+++ b/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/package.scala
@@ -104,7 +104,8 @@ package object semanticdb {
       }
       object sSymbolInformation {
         def unapply(ssymbolInformation: s.SymbolInformation): Option[d.ResolvedSymbol] = ssymbolInformation match {
-          case s.SymbolInformation(d.Symbol(dsym), _, skind, sproperties, sname, _, ssignature, smembers, soverrides) =>
+          case s.SymbolInformation(ssym, _, skind, sproperties, sname, _, ssignature, smembers, soverrides) =>
+            val dsym = d.Symbol(ssym)
             val dflags = {
               var dflags = 0L
               def dflip(dbit: Long) = dflags ^= dbit
@@ -146,7 +147,8 @@ package object semanticdb {
               ssignature.map { ssignature =>
                 val dinput = dInput.Denotation(dsignature, dsym)
                 ssignature.occurrences.toIterator.map {
-                  case s.SymbolOccurrence(Some(srange), d.Symbol(dsym), sRole(disDefinition)) =>
+                  case s.SymbolOccurrence(Some(srange), ssym, sRole(disDefinition)) =>
+                    val dsym = d.Symbol(ssym)
                     val dstartOffset = dinput.lineToOffset(srange.startLine) + srange.startCharacter
                     val dendOffset = dinput.lineToOffset(srange.endLine) + srange.endCharacter
                     val ddefnpos = dPosition.Range(dinput, dstartOffset, dendOffset)
@@ -161,7 +163,7 @@ package object semanticdb {
               else if (smember.endsWith(".")) d.Signature.Term(smember.stripSuffix("."))
               else sys.error(s"Unexpected signature $smember")
             }.toList
-            val doverrides = soverrides.flatMap(d.Symbol.unapply).toList
+            val doverrides = soverrides.iterator.map(d.Symbol.apply).toList
             Some(d.ResolvedSymbol(dsym, d.Denotation(dflags, dname, dsignature, dnames, dmembers, doverrides)))
           case other => sys.error(s"bad protobuf: unsupported symbol information $other")
         }
@@ -173,7 +175,8 @@ package object semanticdb {
             val dnames = {
               stext.map { stext =>
                 stext.occurrences.toIterator.map {
-                  case s.SymbolOccurrence(Some(srange), d.Symbol(dsym), sRole(disDefinition)) =>
+                  case s.SymbolOccurrence(Some(srange), ssym, sRole(disDefinition)) =>
+                    val dsym = d.Symbol(ssym)
                     val dsyntheticinput = dInput.Synthetic(dtext, dpos.input, dpos.start, dpos.end)
                     val dstartOffset = dsyntheticinput.lineToOffset(srange.startLine) + srange.startCharacter
                     val dendOffset = dsyntheticinput.lineToOffset(srange.endLine) + srange.endCharacter
@@ -189,8 +192,11 @@ package object semanticdb {
       }
       val dlanguage = slanguage
       val dnames = soccurrences.map {
-        case s.SymbolOccurrence(Some(sRange(dpos)), d.Symbol(dsym), sRole(disDefinition)) => d.ResolvedName(dpos, dsym, disDefinition)
-        case other => sys.error(s"bad protobuf: unsupported occurrence $other")
+        case s.SymbolOccurrence(Some(sRange(dpos)), ssym, sRole(disDefinition)) =>
+          val dsym = d.Symbol(ssym)
+          d.ResolvedName(dpos, dsym, disDefinition)
+        case other =>
+          sys.error(s"bad protobuf: unsupported occurrence $other")
       }.toList
       val dmessages = sdiagnostics.map {
         case s.Diagnostic(Some(sRange(dpos)), sSeverity(dseverity), dmsg: String) =>

--- a/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/vfs/Database.scala
+++ b/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/vfs/Database.scala
@@ -6,7 +6,9 @@ import java.io.File
 import java.io.FileOutputStream
 import org.langmeta.io._
 import org.langmeta.internal.semanticdb.{vfs => v}
+import org.langmeta.internal.semanticdb.{schema => legacy}
 import scala.meta.internal.{semanticdb3 => s}
+import com.google.protobuf.InvalidProtocolBufferException
 
 object Database {
   def load(classpath: Classpath): v.Database = {
@@ -17,13 +19,31 @@ object Database {
 }
 
 final case class Database(entries: List[Entry]) {
-  def toSchema: s.TextDocuments = {
+
+  def toSchema3: s.TextDocuments = {
     val sentries = entries.flatMap { ventry =>
       val sdocs = s.TextDocuments.parseFrom(ventry.bytes)
       sdocs.mergeDiagnosticOnlyDocuments.documents
     }
     s.TextDocuments(sentries)
   }
+
+  def toSchema: s.TextDocuments =
+    try toSchema3
+    catch {
+      case _: InvalidProtocolBufferException if isLegacyPayload =>
+        val sentries = entries.flatMap { ventry =>
+          val db = legacy.Database.parseFrom(ventry.bytes)
+          legacy.LegacySemanticdb.toTextDocuments(db).documents
+        }
+        s.TextDocuments(sentries)
+    }
+
+  private def isLegacyPayload: Boolean =
+    (for {
+      ventry <- entries.headOption
+      document <- legacy.LegacyTextDocuments.parseFrom(ventry.bytes).documents
+    } yield document.schema == legacy.LegacySchema.LEGACY).getOrElse(false)
 
   def save(append: Boolean): Unit = {
     entries.foreach(ventry => {

--- a/semanticdb/semanticdb2/semanticdb2.proto
+++ b/semanticdb/semanticdb2/semanticdb2.proto
@@ -60,3 +60,17 @@ message Synthetic {
   string text = 2;
   repeated ResolvedName names = 3;
 }
+
+message LegacyTextDocuments {
+  LegacyTextDocument documents = 1;
+}
+
+message LegacyTextDocument {
+  LegacySchema schema = 1;
+}
+
+enum LegacySchema {
+  LEGACY = 0;
+  SEMANTICDB3 = 3;
+}
+

--- a/tests/jvm/src/test/resources/User.semanticdb
+++ b/tests/jvm/src/test/resources/User.semanticdb
@@ -1,0 +1,65 @@
+
+Ô#
+!'_root_.scala.Predef.String#
+_root_.a.User#(name)7
+-_root_.a.User#`<init>`(Ljava/lang/String;I)V.
+;<_root_.a.a.
+EF_root_.a.a.x.5
+~â*src/main/scala/example/User.scala@122..145
+.1_root_.scala.Int#
+`a_root_.a.a.x.,
+¥∫"_root_.java.lang.String#length()I.
+		_root_.a.
+),_root_.a.User#(age)=
+ci5_root_.scala.collection.LinearSeqOptimized#length()I.4
+®≥*src/main/scala/example/User.scala@122..145
+pq_root_.a.a.z()I.
+_root_.a.User#
+TU_root_.a.a.y./
+X\'_root_.scala.collection.immutable.List."
+	_root_.a.ÄàÄa"L
+_root_.a.User#(name)4ÅnameString"!
+_root_.scala.Predef.String#"Q
+_root_.scala.Predef.String#2@StringString"
+_root_.java.lang.String#"7
+_root_.a.a.z()I.#zInt"
+_root_.scala.Int#">
+_root_.a.a.x.-xString"
+_root_.java.lang.String#"¥
+-_root_.a.User#`<init>`(Ljava/lang/String;I)V.Ç<init>(name: String, age: Int): User"#
+_root_.scala.Predef.String#"
+_root_.scala.Int#"
+_root_.a.User#"
+_root_.a.User#Ä†ÄUser"a
+5_root_.scala.collection.LinearSeqOptimized#length()I.(lengthInt"
+_root_.scala.Int#"W
+"_root_.java.lang.String#length()I.1ÑÄÄlength(): Int"
+_root_.scala.Int#"4
+_root_.a.a.y.#yInt"
+_root_.scala.Int#"5
+'_root_.scala.collection.immutable.List.
+ÄÑList"e
+*src/main/scala/example/User.scala@122..1457localSymbolString"
+_root_.java.lang.String#"
+_root_.a.a.ÄÑa"O
+_root_.scala.Int#`<init>`()V..<init>(): Int"
+_root_.scala.Int#"=
+_root_.a.User#(age)&ÅageInt"
+_root_.scala.Int#"
+_root_.scala.Int#	Ä†Int2Æ
+\\*.apply[Any]
+_star_.n
+f_root_.scala.collection.immutable.List.apply(Lscala/collection/Seq;)Lscala/collection/immutable/List;.
+_root_.scala.Any#:Scala212B¡package a
+
+case class User(name: String, age: Int)
+
+object a {
+  val x = "ba"
+  val y = List(1, x).length
+  def z = {
+    val localSymbol = "222" // can be renamed
+    localSymbol.length
+  }
+}
+J!src/main/scala/example/User.scala

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/DatabaseSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/DatabaseSuite.scala
@@ -18,6 +18,9 @@ abstract class DatabaseSuite(mode: SemanticdbMode,
                              overrides: OverrideMode = OverrideMode.None)
     extends FunSuite
     with DiffAssertions { self =>
+
+  var sourceroot: AbsolutePath = _
+
   private def test(code: String)(fn: => Unit): Unit = {
     var name = code.trim.replace(EOL, " ")
     if (name.length > 50) name = name.take(50) + "..."
@@ -56,7 +59,8 @@ abstract class DatabaseSuite(mode: SemanticdbMode,
     val writer = new PrintWriter(javaFile)
     try writer.write(code)
     finally writer.close()
-    databaseOps.config.setSourceroot(AbsolutePath(javaFile.getParentFile))
+    sourceroot = AbsolutePath(javaFile.getParentFile)
+    databaseOps.config.setSourceroot(sourceroot)
     val run = new g.Run
     val abstractFile = AbstractFile.getFile(javaFile)
     val sourceFile = g.getSourceFile(abstractFile)

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/LegacySemanticdbSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/LegacySemanticdbSuite.scala
@@ -1,0 +1,82 @@
+package scala.meta.tests.semanticdb
+
+import scala.meta.internal.semanticdb.scalac.MemberMode
+import scala.meta.internal.semanticdb.scalac.OverrideMode
+import scala.meta.internal.semanticdb.scalac.SemanticdbMode
+import scala.meta.testkit.DiffAssertions
+import org.langmeta.internal.io.InputStreamIO
+import org.langmeta.semanticdb.Database
+import org.scalatest.FunSuite
+
+class LegacySemanticdbSuite extends FunSuite with DiffAssertions {
+  test("Database.load(Legacy)") {
+    val bytes =
+      InputStreamIO.readBytes(this.getClass.getClassLoader.getResourceAsStream("User.semanticdb"))
+    val obtained = Database.load(bytes).syntax
+    assertNoDiff(
+      obtained,
+      """
+        |src/main/scala/example/User.scala
+        |---------------------------------
+        |Language:
+        |Scala212
+        |
+        |Names:
+        |[8..9): a <= _root_.a.
+        |[22..26): User <= _root_.a.User#
+        |[26..26): ε <= _root_.a.User#`<init>`(Ljava/lang/String;I)V.
+        |[27..31): name <= _root_.a.User#(name)
+        |[33..39): String => _root_.scala.Predef.String#
+        |[41..44): age <= _root_.a.User#(age)
+        |[46..49): Int => _root_.scala.Int#
+        |[59..60): a <= _root_.a.a.
+        |[69..70): x <= _root_.a.a.x.
+        |[84..85): y <= _root_.a.a.y.
+        |[88..92): List => _root_.scala.collection.immutable.List.
+        |[96..97): x => _root_.a.a.x.
+        |[99..105): length => _root_.scala.collection.LinearSeqOptimized#length()I.
+        |[112..113): z <= _root_.a.a.z()I.
+        |[126..137): localSymbol <= localsrc_main_scala_example_User_scala_122__145
+        |[168..179): localSymbol => localsrc_main_scala_example_User_scala_122__145
+        |[180..186): length => _root_.java.lang.String#length()I.
+        |
+        |Symbols:
+        |_root_.a. => package a
+        |_root_.a.User# => case class User
+        |_root_.a.User#(age) => val age: Int
+        |  [0..3): Int => _root_.scala.Int#
+        |_root_.a.User#(name) => val name: String
+        |  [0..6): String => _root_.scala.Predef.String#
+        |_root_.a.User#`<init>`(Ljava/lang/String;I)V. => primaryctor <init>: (name: String, age: Int): User
+        |  [7..13): String => _root_.scala.Predef.String#
+        |  [20..23): Int => _root_.scala.Int#
+        |  [26..30): User => _root_.a.User#
+        |_root_.a.a. => final object a
+        |_root_.a.a.x. => val x: String
+        |  [0..6): String => _root_.java.lang.String#
+        |_root_.a.a.y. => val y: Int
+        |  [0..3): Int => _root_.scala.Int#
+        |_root_.a.a.z()I. => def z: Int
+        |  [0..3): Int => _root_.scala.Int#
+        |_root_.java.lang.String#length()I. => def length: (): Int
+        |  [4..7): Int => _root_.scala.Int#
+        |_root_.scala.Int# => abstract final class Int
+        |_root_.scala.Int#`<init>`()V. => primaryctor <init>: (): Int
+        |  [4..7): Int => _root_.scala.Int#
+        |_root_.scala.Predef.String# => type String: String
+        |  [0..6): String => _root_.java.lang.String#
+        |_root_.scala.collection.LinearSeqOptimized#length()I. => def length: Int
+        |  [0..3): Int => _root_.scala.Int#
+        |_root_.scala.collection.immutable.List. => final object List
+        |localsrc_main_scala_example_User_scala_122__145 => val localSymbol: String
+        |  [0..6): String => _root_.java.lang.String#
+        |
+        |Synthetics:
+        |[92..92): *.apply[Any]
+        |  [0..1): * => _star_.
+        |  [2..7): apply => _root_.scala.collection.immutable.List.apply(Lscala/collection/Seq;)Lscala/collection/immutable/List;.
+        |  [8..11): Any => _root_.scala.Any#
+      """.stripMargin
+    )
+  }
+}


### PR DESCRIPTION
While upgrading to semanticdb v3.0 in scalafix we encountered that our
SemanticdbIndex was giving bogus results for local symbols. The bug was
not caught in our test suite, Guillaume discovered it while working on
SAM rewrite. This commit makes Symbol.Local use reference equality and
changes Database.load to use the same Symbol.Local instance for the same
id in the same document.

Applications that use alternative indexing techniques like SQL will need
to figure out another solution to distinguish between conflicting local
symbols between different files. One trick is to compute
definition/references on the fly from a Semanticdb for local symbols
because they cannot be referenced elsewhere.
1ad7790