### PR TITLE
Supersede SymbolInformation.signature

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -115,7 +115,7 @@ Scalameta contains parts which are derived from
 We include the text of the original license below:
 
 ```
-Copyright (c) 2017 Twitter, Inc.
+Copyright (c) 2017-2018 Twitter, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -139,8 +139,8 @@ We include the text of the original license below:
 ```
 This software includes projects with other licenses -- see `doc/LICENSE.md`.
 
-Copyright (c) 2002-2017 EPFL
-Copyright (c) 2011-2017 Lightbend, Inc.
+Copyright (c) 2002-2018 EPFL
+Copyright (c) 2011-2018 Lightbend, Inc.
 
 All rights reserved.
 

--- a/build.sbt
+++ b/build.sbt
@@ -78,6 +78,7 @@ lazy val semanticdb3 = crossProject
   .in(file("semanticdb/semanticdb3"))
   .settings(
     publishableSettings,
+    ignoreMimaSettings,
     protobufSettings,
     PB.protoSources.in(Compile) := Seq(file("semanticdb/semanticdb3")),
     version := "3.1.0"

--- a/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/package.scala
+++ b/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/package.scala
@@ -104,7 +104,7 @@ package object semanticdb {
       }
       object sSymbolInformation {
         def unapply(ssymbolInformation: s.SymbolInformation): Option[d.ResolvedSymbol] = ssymbolInformation match {
-          case s.SymbolInformation(d.Symbol(dsym), _, skind, sproperties, sname, _, ssignature, _, smembers, soverrides) =>
+          case s.SymbolInformation(d.Symbol(dsym), _, skind, sproperties, sname, _, ssignature, stpe, smembers, soverrides) =>
             val dflags = {
               var dflags = 0L
               def dflip(dbit: Long) = dflags ^= dbit
@@ -162,7 +162,8 @@ package object semanticdb {
               else sys.error(s"Unexpected signature $smember")
             }.toList
             val doverrides = soverrides.flatMap(d.Symbol.unapply).toList
-            Some(d.ResolvedSymbol(dsym, d.Denotation(dflags, dname, dsignature, dnames, dmembers, doverrides)))
+            val dtpe = stpe
+            Some(d.ResolvedSymbol(dsym, d.Denotation(dflags, dname, dsignature, dnames, dmembers, doverrides, dtpe)))
           case other => sys.error(s"bad protobuf: unsupported symbol information $other")
         }
       }
@@ -304,9 +305,10 @@ package object semanticdb {
                 }
                 Some(s.TextDocument(text = stext, occurrences = soccurrences))
               }
+              val stpe = ddenot.tpe
               val smembers = ddenot.members.map(_.syntax)
               val soverrides = ddenot.overrides.map(_.syntax)
-              Some(s.SymbolInformation(ssymbol, slanguage, skind, sproperties, sname, srange, ssignature, None, smembers, soverrides))
+              Some(s.SymbolInformation(ssymbol, slanguage, skind, sproperties, sname, srange, ssignature, stpe, smembers, soverrides))
             }
           }
           object dSynthetic {

--- a/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/package.scala
+++ b/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/package.scala
@@ -104,7 +104,7 @@ package object semanticdb {
       }
       object sSymbolInformation {
         def unapply(ssymbolInformation: s.SymbolInformation): Option[d.ResolvedSymbol] = ssymbolInformation match {
-          case s.SymbolInformation(d.Symbol(dsym), _, skind, sproperties, sname, _, ssignature, smembers, soverrides) =>
+          case s.SymbolInformation(d.Symbol(dsym), _, skind, sproperties, sname, _, ssignature, _, smembers, soverrides) =>
             val dflags = {
               var dflags = 0L
               def dflip(dbit: Long) = dflags ^= dbit
@@ -306,7 +306,7 @@ package object semanticdb {
               }
               val smembers = ddenot.members.map(_.syntax)
               val soverrides = ddenot.overrides.map(_.syntax)
-              Some(s.SymbolInformation(ssymbol, slanguage, skind, sproperties, sname, srange, ssignature, smembers, soverrides))
+              Some(s.SymbolInformation(ssymbol, slanguage, skind, sproperties, sname, srange, ssignature, None, smembers, soverrides))
             }
           }
           object dSynthetic {

--- a/semanticdb/metap/src/main/scala/scala/meta/cli/Metap.scala
+++ b/semanticdb/metap/src/main/scala/scala/meta/cli/Metap.scala
@@ -1,15 +1,17 @@
 package scala.meta.cli
 
 import java.nio.file._
-import java.util._
-import scala.collection.mutable
+import java.util.WeakHashMap
+import scala.collection.{immutable, mutable}
 import scala.compat.Platform.EOL
 import scala.math.Ordering
 import scala.util.control.NonFatal
 import scala.meta.internal.semanticdb3._
+import Diagnostic._, Severity._
+import LiteralType.Tag._
 import SymbolInformation._, Kind._, Property._
 import SymbolOccurrence._, Role._
-import Diagnostic._, Severity._
+import Type.Tag._
 
 object Metap {
   def main(args: Array[String]): Unit = {
@@ -77,9 +79,9 @@ object Metap {
     }
   }
 
-  private val cache = new WeakHashMap[TextDocument, Array[Int]]
+  private val offsetCache = new WeakHashMap[TextDocument, Array[Int]]
   private def offset(doc: TextDocument, line: Int): Int = {
-    var lineIndices = cache.get(doc)
+    var lineIndices = offsetCache.get(doc)
     if (lineIndices == null) {
       val chars = doc.text.toArray
       val buf = new mutable.ArrayBuffer[Int]
@@ -91,7 +93,7 @@ object Metap {
       }
       if (buf.last != chars.length) buf += chars.length // sentinel value used for binary search
       lineIndices = buf.toArray
-      cache.put(doc, lineIndices)
+      offsetCache.put(doc, lineIndices)
     }
     lineIndices(line)
   }
@@ -118,6 +120,206 @@ object Metap {
           print(s": $text")
       }
     }
+  }
+
+  private val symCache = new WeakHashMap[TextDocument, immutable.Map[String, SymbolInformation]]
+  private def pprint(sym: String, role: Role, doc: TextDocument): Unit = {
+    var infos = symCache.get(doc)
+    if (infos == null) {
+      infos = doc.symbols.map(info => (info.symbol, info)).toMap
+      symCache.put(doc, infos)
+    }
+    infos.get(sym) match {
+      case Some(info) =>
+        role match {
+          case REFERENCE =>
+            print(info.name)
+          case DEFINITION =>
+            def has(prop: Property) = (info.properties & prop.value) != 0
+            if (has(PRIVATE)) print("private ")
+            if (has(PROTECTED)) print("protected ")
+            if (has(ABSTRACT)) print("abstract ")
+            if (has(FINAL)) print("final ")
+            if (has(SEALED)) print("sealed ")
+            if (has(IMPLICIT)) print("implicit ")
+            if (has(LAZY)) print("lazy ")
+            if (has(CASE)) print("case ")
+            if (has(COVARIANT)) print("+")
+            if (has(CONTRAVARIANT)) print("-")
+            info.kind match {
+              case VAL =>
+                print("val ")
+                print(info.name)
+                print(": ")
+              case VAR =>
+                print("var ")
+                print(info.name)
+                print(": ")
+              case TYPE =>
+                print("type ")
+                print(info.name)
+              case PARAMETER =>
+                print("")
+                print(info.name)
+                print(": ")
+              case TYPE_PARAMETER =>
+                print("")
+                print(info.name)
+              case _ =>
+                print("<?>")
+                return
+            }
+            info.tpe match {
+              case Some(tpe) => pprint(tpe, doc)
+              case None => print("<?>")
+            }
+          case _ =>
+            ()
+        }
+      case None =>
+        role match {
+          case REFERENCE =>
+            // TODO: It would be nice to have a symbol parser in semanticdb3.
+            sym.split("\\.").toList match {
+              case _ :+ last =>
+                val approxName = {
+                  val last1 = last.stripPrefix("(").stripPrefix("[")
+                  val last2 = last1.stripSuffix(")").stripSuffix("]").stripSuffix("#")
+                  last2.stripPrefix("`").stripSuffix("`")
+                }
+                print(approxName)
+              case _ =>
+                print("<?>")
+            }
+          case DEFINITION =>
+            print("<?>")
+          case _ =>
+            ()
+        }
+    }
+  }
+
+  private def pprint(tpe: Type, doc: TextDocument): List[String] = {
+    val buf = List.newBuilder[String]
+    def ref(sym: String): Unit = {
+      buf += sym
+      pprint(sym, REFERENCE, doc)
+    }
+    def defn(sym: String): Unit = {
+      buf += sym
+      pprint(sym, DEFINITION, doc)
+    }
+    def loop(tpe: Type): Unit = {
+      tpe.tag match {
+        case TYPE_REF =>
+          val Some(TypeRef(pre, sym, args)) = tpe.typeRef
+          pre match {
+            case Some(pre) if pre.tag.isSingleType || pre.tag.isThisType || pre.tag.isSuperType =>
+              loop(pre)
+              print(".")
+            case Some(pre) =>
+              loop(pre)
+              print("#")
+            case _ =>
+              ()
+          }
+          ref(sym)
+          rep("[", args, ", ", "]")(loop)
+        case SINGLE_TYPE =>
+          val Some(SingleType(pre, sym)) = tpe.singleType
+          opt(pre, ".")(loop)
+          ref(sym)
+          print(".type")
+        case THIS_TYPE =>
+          val Some(ThisType(sym)) = tpe.thisType
+          if (sym.nonEmpty) {
+            ref(sym)
+            print(".")
+          }
+          print("this.type")
+        case SUPER_TYPE =>
+          val Some(SuperType(pre, mix)) = tpe.superType
+          opt(pre, ".")(loop)
+          print("super")
+          opt("[", mix, "]")(loop)
+        case LITERAL_TYPE =>
+          tpe.literalType match {
+            case Some(LiteralType(UNIT, _, _)) =>
+              println("()")
+            case Some(LiteralType(BOOLEAN, 0, _)) =>
+              println("false")
+            case Some(LiteralType(BOOLEAN, 1, _)) =>
+              println("true")
+            case Some(LiteralType(BYTE | SHORT, x, _)) =>
+              println(x)
+            case Some(LiteralType(CHAR, x, _)) =>
+              println("'" + x.toChar + "'")
+            case Some(LiteralType(INT, x, _)) =>
+              println(x)
+            case Some(LiteralType(LONG, x, _)) =>
+              println(x + "L")
+            case Some(LiteralType(FLOAT, x, _)) =>
+              println(java.lang.Float.intBitsToFloat(x.toInt) + "f")
+            case Some(LiteralType(DOUBLE, x, _)) =>
+              println(java.lang.Double.longBitsToDouble(x))
+            case Some(LiteralType(STRING, _, s)) =>
+              println("\"" + s + "\"")
+            case Some(LiteralType(NULL, _, _)) =>
+              println("null")
+            case _ =>
+              println("<?>")
+          }
+        case COMPOUND_TYPE =>
+          val Some(CompoundType(parents, decls)) = tpe.compoundType
+          rep(parents, " with ")(loop)
+          if (decls.nonEmpty || parents.length == 1) {
+            print("{ ")
+            rep(decls, "; ")(defn)
+            print(" }")
+          }
+        case ANNOTATED_TYPE =>
+          val Some(AnnotatedType(utpe, anns)) = tpe.annotatedType
+          utpe.foreach(loop)
+          print(" ")
+          rep("@", anns, " ", "")(loop)
+        case EXISTENTIAL_TYPE =>
+          val Some(ExistentialType(utpe, decls)) = tpe.existentialType
+          utpe.foreach(loop)
+          rep(" forSome { ", decls, "; ", " }")(defn)
+        case TYPE_LAMBDA =>
+          val Some(TypeLambda(tparams, utpe)) = tpe.typeLambda
+          rep("[", tparams, ", ", "] => ")(defn)
+          utpe.foreach(loop)
+        case CLASS_INFO_TYPE =>
+          val Some(ClassInfoType(tparams, parents, decls)) = tpe.classInfoType
+          rep("[", tparams, ", ", "] => ")(defn)
+          rep(parents, " with ")(loop)
+          rep(" { ", decls, "; ", " }")(defn)
+        case METHOD_TYPE =>
+          val Some(MethodType(tparams, paramss, res)) = tpe.methodType
+          rep("[", tparams, ", ", "] => ")(defn)
+          rep("(", paramss, ")(", ")")(params => rep(params.symbols, ", ")(defn))
+          print(": ")
+          res.foreach(loop)
+        case BY_NAME_TYPE =>
+          val Some(ByNameType(utpe)) = tpe.byNameType
+          print("=> ")
+          utpe.foreach(loop)
+        case REPEATED_TYPE =>
+          val Some(RepeatedType(utpe)) = tpe.repeatedType
+          utpe.foreach(loop)
+          print("*")
+        case TYPE_TYPE =>
+          val Some(TypeType(tparams, lo, hi)) = tpe.typeType
+          rep("[", tparams, ", ", "] => ")(defn)
+          opt(">: ", lo, "")(loop)
+          opt("<: ", hi, "")(loop)
+        case _ =>
+          print("<?>")
+      }
+    }
+    loop(tpe)
+    buf.result
   }
 
   private def pprint(info: SymbolInformation, doc: TextDocument): Unit = {
@@ -152,22 +354,49 @@ object Metap {
     info.kind match {
       case VAL | VAR | DEF | PRIMARY_CONSTRUCTOR |
            SECONDARY_CONSTRUCTOR | MACRO | TYPE | PARAMETER | TYPE_PARAMETER =>
-        info.signature match {
-          case Some(sig) =>
-            print(s": ${sig.text}")
+        info.tpe match {
+          case Some(tpe) =>
+            print(": ")
+            val syms = pprint(tpe, doc)
             println("")
-            val occs = sig.occurrences.sorted
-            occs.foreach { occ => print("  "); pprint(occ, sig) }
-          case _ =>
-            println("")
+            syms.foreach { sym =>
+              print("  ")
+              pprint(sym, REFERENCE, doc)
+              print(" => ")
+              println(sym)
+            }
+          case None =>
+            info.signature match {
+              case Some(sig) =>
+                print(s": ${sig.text}")
+                println("")
+                val occs = sig.occurrences.sorted
+                occs.foreach { occ => print("  "); pprint(occ, sig) }
+              case _ =>
+                println("")
+            }
         }
         info.overrides.foreach(sym => println(s"  overrides $sym"))
       case OBJECT | PACKAGE | PACKAGE_OBJECT | CLASS | TRAIT =>
-        info.members match {
-          case _ :: _ => println(s".{+${info.members.length}} members")
-          case Nil => println("")
+        info.tpe match {
+          case Some(tpe: Type) =>
+            tpe.classInfoType match {
+              case Some(ClassInfoType(_, parents, decls)) =>
+                if (decls.nonEmpty) println(s".{+${decls.length} decls}")
+                else println("")
+                parents.foreach{ tpe =>
+                  print("  extends ")
+                  pprint(tpe, doc)
+                  println("")
+                }
+              case _ =>
+                println("")
+            }
+          case None =>
+            if (info.members.nonEmpty) println(s".{+${info.members.length} members}")
+            else println("")
+            info.overrides.sorted.foreach(sym => println(s"  extends $sym"))
         }
-        info.overrides.sorted.foreach(sym => println(s"  extends $sym"))
       case _ =>
         ()
     }
@@ -178,7 +407,7 @@ object Metap {
     occ.role match {
       case REFERENCE => print(" => ")
       case DEFINITION => print(" <= ")
-      case _ => print(" ??? ")
+      case _ => print(" <?> ")
     }
     println(occ.symbol)
   }
@@ -190,7 +419,7 @@ object Metap {
       case WARNING => print("[warning] ")
       case INFORMATION => print("[info] ")
       case HINT => print("[hint] ")
-      case _ => print("[???] ")
+      case _ => print("[<?>] ")
     }
     println(diag.message)
   }
@@ -204,7 +433,7 @@ object Metap {
         val occs = text.occurrences.sorted
         occs.foreach { occ => print("  "); pprint(occ, text) }
       case _ =>
-        println("???")
+        println("<?>")
     }
   }
 
@@ -218,4 +447,40 @@ object Metap {
     Ordering.by(_.range)
   private implicit def synthOrder: Ordering[Synthetic] =
     Ordering.by(_.range)
+
+  private def rep[T](pre: String, xs: Seq[T], sep: String, suf: String)(f: T => Unit): Unit = {
+    if (xs.nonEmpty) {
+      print(pre)
+      rep(xs, sep)(f)
+      print(suf)
+    }
+  }
+
+  private def rep[T](xs: Seq[T], sep: String)(f: T => Unit): Unit = {
+    xs.zipWithIndex.foreach {
+      case (x, i) =>
+        if (i != 0) print(sep)
+        f(x)
+    }
+  }
+
+  private def opt[T](pre: String, xs: Option[T], suf: String)(f: T => Unit): Unit = {
+    xs.foreach { x =>
+      print(pre)
+      f(x)
+      print(suf)
+    }
+  }
+
+  private def opt[T](pre: String, xs: Option[T])(f: T => Unit): Unit = {
+    opt(pre, xs, "")(f)
+  }
+
+  private def opt[T](xs: Option[T], suf: String)(f: T => Unit): Unit = {
+    opt("", xs, suf)(f)
+  }
+
+  private def opt[T](xs: Option[T])(f: T => Unit): Unit = {
+    opt("", xs, "")(f)
+  }
 }

--- a/semanticdb/metap/src/main/scala/scala/meta/cli/Metap.scala
+++ b/semanticdb/metap/src/main/scala/scala/meta/cli/Metap.scala
@@ -177,24 +177,22 @@ object Metap {
             ()
         }
       case None =>
-        role match {
-          case REFERENCE =>
-            // TODO: It would be nice to have a symbol parser in semanticdb3.
-            sym.split("\\.").toList match {
-              case _ :+ last =>
-                val approxName = {
-                  val last1 = last.stripPrefix("(").stripPrefix("[")
-                  val last2 = last1.stripSuffix(")").stripSuffix("]").stripSuffix("#")
-                  last2.stripPrefix("`").stripSuffix("`")
-                }
-                print(approxName)
-              case _ =>
-                print("<?>")
+        // TODO: It would be nice to have a symbol parser in semanticdb3.
+        sym.split("\\.").toList match {
+          case _ :+ last =>
+            val approxName = {
+              val last1 = last.stripPrefix("(").stripPrefix("[")
+              val last2 = last1.stripSuffix(")").stripSuffix("]").stripSuffix("#")
+              last2.stripPrefix("`").stripSuffix("`")
             }
-          case DEFINITION =>
-            print("<?>")
+            print(approxName)
           case _ =>
-            ()
+            print("<?>")
+        }
+        role match {
+          case REFERENCE => ()
+          case DEFINITION => print(": <?>")
+          case _ => ()
         }
     }
   }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/ConfigOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/ConfigOps.scala
@@ -41,7 +41,7 @@ object SemanticdbConfig {
     SemanticdbMode.Fat,
     FailureMode.Warning,
     DenotationMode.All,
-    SignatureMode.Old,
+    SignatureMode.All,
     MemberMode.None,
     OverrideMode.None,
     ProfilingMode.Off,

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/ConfigOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/ConfigOps.scala
@@ -8,9 +8,10 @@ case class SemanticdbConfig(
     sourceroot: AbsolutePath,
     mode: SemanticdbMode,
     failures: FailureMode,
+    denotations: DenotationMode,
+    signatures: SignatureMode,
     members: MemberMode,
     overrides: OverrideMode,
-    denotations: DenotationMode,
     profiling: ProfilingMode,
     fileFilter: FileFilter,
     messages: MessageMode,
@@ -21,9 +22,10 @@ case class SemanticdbConfig(
       "sourceroot" -> sourceroot,
       "mode" -> mode.name,
       "failures" -> failures.name,
+      "signatures" -> signatures.name,
+      "denotations" -> denotations.name,
       "members" -> members.name,
       "overrides" -> overrides.name,
-      "denotations" -> denotations.name,
       "profiling" -> profiling.name,
       "include" -> fileFilter.include,
       "exclude" -> fileFilter.exclude,
@@ -38,9 +40,10 @@ object SemanticdbConfig {
     PathIO.workingDirectory,
     SemanticdbMode.Fat,
     FailureMode.Warning,
+    DenotationMode.All,
+    SignatureMode.Old,
     MemberMode.None,
     OverrideMode.None,
-    DenotationMode.All,
     ProfilingMode.Off,
     FileFilter.matchEverything,
     MessageMode.All,
@@ -88,6 +91,23 @@ object DenotationMode {
   case object All extends DenotationMode
   case object Definitions extends DenotationMode
   case object None extends DenotationMode
+}
+
+sealed abstract class SignatureMode {
+  def name: String = toString.toLowerCase
+  import SignatureMode._
+  def isAll: Boolean = this == All
+  def isNew: Boolean = this == New
+  def isOld: Boolean = this == Old
+  def isNone: Boolean = this == None
+}
+object SignatureMode {
+  def unapply(arg: String): Option[SignatureMode] = all.find(_.toString.equalsIgnoreCase(arg))
+  def all = List(All, New, Old, None)
+  case object All extends SignatureMode
+  case object New extends SignatureMode
+  case object Old extends SignatureMode
+  case object None extends SignatureMode
 }
 
 sealed abstract class MemberMode {
@@ -168,8 +188,9 @@ trait ConfigOps { self: DatabaseOps =>
   val SetSourceroot = "sourceroot:(.*)".r
   val SetMode = "mode:(.*)".r
   val SetFailures = "failures:(.*)".r
-  val SetMembers = "members:(.*)".r
   val SetDenotations = "denotations:(.*)".r
+  val SetSignatures = "signatures:(.*)".r
+  val SetMembers = "members:(.*)".r
   val SetOverrides = "overrides:(.*)".r
   val SetProfiling = "profiling:(.*)".r
   val SetInclude = "include:(.*)".r
@@ -185,12 +206,14 @@ trait ConfigOps { self: DatabaseOps =>
       config = config.copy(mode = mode)
     def setFailures(severity: FailureMode): Unit =
       config = config.copy(failures = severity)
+    def setDenotations(denotations: DenotationMode): Unit =
+      config = config.copy(denotations = denotations)
+    def setSignatures(signatures: SignatureMode): Unit =
+      config = config.copy(signatures = signatures)
     def setMembers(members: MemberMode): Unit =
       config = config.copy(members = members)
     def setOverrides(overrides: OverrideMode): Unit =
       config = config.copy(overrides = overrides)
-    def setDenotations(denotations: DenotationMode): Unit =
-      config = config.copy(denotations = denotations)
     def setProfiling(profiling: ProfilingMode): Unit =
       config = config.copy(profiling = profiling)
     def setInclude(include: String): Unit =

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DatabaseOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DatabaseOps.scala
@@ -8,6 +8,7 @@ trait DatabaseOps
     with DocumentOps
     with InputOps
     with LanguageOps
+    with MemberOps
     with MessageOps
     with ParseOps
     with PrinterOps

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DenotationOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DenotationOps.scala
@@ -105,7 +105,7 @@ trait DenotationOps { self: DatabaseOps =>
       }
     }
 
-    private def newInfo: (s.Type, List[g.Symbol]) = {
+    private def newInfo: (Option[s.Type], List[g.Symbol]) = {
       gsym.info.toSemantic
     }
 
@@ -132,12 +132,12 @@ trait DenotationOps { self: DatabaseOps =>
           DenotationResult(denot, todoOverrides, Nil)
         case SignatureMode.New =>
           val (tpe, todoTpe) = newInfo
-          val denot = m.Denotation(flags, name, "", Nil, Nil, over, Some(tpe))
+          val denot = m.Denotation(flags, name, "", Nil, Nil, over, tpe)
           DenotationResult(denot, todoOverrides, todoTpe)
         case SignatureMode.All =>
           val (signature, names) = oldInfo
           val (tpe, todoTpe) = newInfo
-          val denot = m.Denotation(flags, name, signature, names, Nil, over, Some(tpe))
+          val denot = m.Denotation(flags, name, signature, names, Nil, over, tpe)
           DenotationResult(denot, todoOverrides, todoTpe)
       }
     }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DenotationOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DenotationOps.scala
@@ -144,7 +144,7 @@ trait DenotationOps { self: DatabaseOps =>
   }
 
   case class DenotationResult(
-    denot: m.Denotation,
-    todoOverrides: List[g.Symbol],
-    todoTpe: List[g.Symbol])
+      denot: m.Denotation,
+      todoOverrides: List[g.Symbol],
+      todoTpe: List[g.Symbol])
 }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DenotationOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DenotationOps.scala
@@ -88,7 +88,7 @@ trait DenotationOps { self: DatabaseOps =>
       gsym.decodedName.toString
     }
 
-    private def info: (String, List[m.ResolvedName]) = {
+    private def oldInfo: (String, List[m.ResolvedName]) = {
       if (gsym.isClass || gsym.isModule) "" -> Nil
       else {
         val synthetic = showSynthetic(gsym.info)
@@ -105,33 +105,46 @@ trait DenotationOps { self: DatabaseOps =>
       }
     }
 
-    private def tpe: s.Type = {
-      ???
+    private def newInfo: (s.Type, List[g.Symbol]) = {
+      gsym.info.toSemantic
     }
 
     private def overrides: List[m.Symbol] =
       if (config.overrides.isAll) gsym.overrides.map(_.toSemantic)
       else Nil
 
-    def toDenotation(saveOverrides: Boolean): m.Denotation = {
-      val over = if (saveOverrides) overrides else Nil
+    def toDenotation(saveOverrides: Boolean): DenotationResult = {
+      val over = {
+        if (saveOverrides) overrides
+        else Nil
+      }
+      val todoOverrides = {
+        if (saveOverrides && config.denotations.saveReferences) gsym.overrides
+        else Nil
+      }
       config.signatures match {
         case SignatureMode.None =>
-          m.Denotation(flags, name, "", Nil, Nil, over, None)
+          val denot = m.Denotation(flags, name, "", Nil, Nil, over, None)
+          DenotationResult(denot, todoOverrides, Nil)
         case SignatureMode.Old =>
-          val (signature, names) = info
-          m.Denotation(flags, name, signature, names, Nil, over, None)
+          val (signature, names) = oldInfo
+          val denot = m.Denotation(flags, name, signature, names, Nil, over, None)
+          DenotationResult(denot, todoOverrides, Nil)
         case SignatureMode.New =>
-          m.Denotation(flags, name, "", Nil, Nil, over, Some(tpe))
+          val (tpe, todoTpe) = newInfo
+          val denot = m.Denotation(flags, name, "", Nil, Nil, over, Some(tpe))
+          DenotationResult(denot, todoOverrides, todoTpe)
         case SignatureMode.All =>
-          val (signature, names) = info
-          m.Denotation(flags, name, signature, names, Nil, over, Some(tpe))
+          val (signature, names) = oldInfo
+          val (tpe, todoTpe) = newInfo
+          val denot = m.Denotation(flags, name, signature, names, Nil, over, Some(tpe))
+          DenotationResult(denot, todoOverrides, todoTpe)
       }
     }
-
-    def overridesMembers: List[(m.Symbol, m.Denotation)] =
-      if (config.overrides.isAll && config.denotations.saveReferences)
-        gsym.overrides.map(ov => (ov.toSemantic, ov.toDenotation(saveOverrides = true)))
-      else Nil
   }
+
+  case class DenotationResult(
+    denot: m.Denotation,
+    todoOverrides: List[g.Symbol],
+    todoTpe: List[g.Symbol])
 }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DenotationOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DenotationOps.scala
@@ -5,6 +5,7 @@ import scala.{meta => mf}
 import scala.reflect.internal.{Flags => gf}
 import scala.util.Sorting
 import org.scalameta.logger
+import scala.meta.internal.{semanticdb3 => s}
 
 trait DenotationOps { self: DatabaseOps =>
   import g._
@@ -104,14 +105,28 @@ trait DenotationOps { self: DatabaseOps =>
       }
     }
 
+    private def tpe: s.Type = {
+      ???
+    }
+
     private def overrides: List[m.Symbol] =
       if (config.overrides.isAll) gsym.overrides.map(_.toSemantic)
       else Nil
 
     def toDenotation(saveOverrides: Boolean): m.Denotation = {
-      val (minfo, mnames) = info
       val over = if (saveOverrides) overrides else Nil
-      m.Denotation(flags, name, minfo, mnames, Nil, over)
+      config.signatures match {
+        case SignatureMode.None =>
+          m.Denotation(flags, name, "", Nil, Nil, over, None)
+        case SignatureMode.Old =>
+          val (signature, names) = info
+          m.Denotation(flags, name, signature, names, Nil, over, None)
+        case SignatureMode.New =>
+          m.Denotation(flags, name, "", Nil, Nil, over, Some(tpe))
+        case SignatureMode.All =>
+          val (signature, names) = info
+          m.Denotation(flags, name, signature, names, Nil, over, Some(tpe))
+      }
     }
 
     def overridesMembers: List[(m.Symbol, m.Denotation)] =

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DocumentOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DocumentOps.scala
@@ -202,8 +202,10 @@ trait DocumentOps { self: DatabaseOps =>
                     otodoTpe
                   }
                   (todoTpe1 ++ todoTpe2).foreach { tgs =>
-                    val tms = tgs.toSemantic
-                    if (!denotations.contains(tms)) add(tms, tgs)
+                    if (tgs.isSemanticdbLocal) {
+                      val tms = tgs.toSemantic
+                      if (!denotations.contains(tms)) add(tms, tgs)
+                    }
                   }
                 }
                 if (!gsym.isOverloaded && gsym != g.definitions.RepeatedParamClass) {

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DocumentOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DocumentOps.scala
@@ -194,10 +194,12 @@ trait DocumentOps { self: DatabaseOps =>
               def saveDenotation(): Unit = {
                 def add(ms: m.Symbol, gs: g.Symbol): Unit = {
                   val saveOverrides = config.overrides.isAll && mtree.isDefinition
-                  val DenotationResult(denot, todoOverrides, todoTpe1) = gs.toDenotation(saveOverrides)
+                  val DenotationResult(denot, todoOverrides, todoTpe1) =
+                    gs.toDenotation(saveOverrides)
                   denotations(ms) = denot
                   val todoTpe2 = todoOverrides.flatMap { ogs =>
-                    val DenotationResult(odenot, _, otodoTpe) = ogs.toDenotation(saveOverrides = true)
+                    val DenotationResult(odenot, _, otodoTpe) =
+                      ogs.toDenotation(saveOverrides = true)
                     denotations(ogs.toSemantic) = odenot
                     otodoTpe
                   }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DocumentOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DocumentOps.scala
@@ -211,7 +211,7 @@ trait DocumentOps { self: DatabaseOps =>
                 if (!gsym.isOverloaded && gsym != g.definitions.RepeatedParamClass) {
                   add(symbol, gsym)
                 }
-                if (gsym.isClass && !gsym.isTrait) {
+                if (gsym.isClass && !gsym.isTrait && mtree.isDefinition) {
                   val gprim = gsym.primaryConstructor
                   if (gprim != g.NoSymbol) {
                     add(gprim.toSemantic, gprim)

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DocumentOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DocumentOps.scala
@@ -204,6 +204,7 @@ trait DocumentOps { self: DatabaseOps =>
                   (todoTpe1 ++ todoTpe2).foreach { tgs =>
                     if (tgs.isSemanticdbLocal) {
                       val tms = tgs.toSemantic
+                      assert(tms != m.Symbol.None)
                       if (!denotations.contains(tms)) add(tms, tgs)
                     }
                   }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DocumentOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DocumentOps.scala
@@ -193,14 +193,19 @@ trait DocumentOps { self: DatabaseOps =>
 
               def saveDenotation(): Unit = {
                 def add(ms: m.Symbol, gs: g.Symbol): Unit = {
-                  denotations(ms) = gs.toDenotation(saveOverrides = mtree.isDefinition)
-                  if (config.overrides.isAll && mtree.isDefinition) {
-                    gs.overridesMembers.foreach {
-                      case (s, d) => denotations(s) = d
-                    }
+                  val saveOverrides = config.overrides.isAll && mtree.isDefinition
+                  val DenotationResult(denot, todoOverrides, todoTpe1) = gs.toDenotation(saveOverrides)
+                  denotations(ms) = denot
+                  val todoTpe2 = todoOverrides.flatMap { ogs =>
+                    val DenotationResult(odenot, _, otodoTpe) = ogs.toDenotation(saveOverrides = true)
+                    denotations(ogs.toSemantic) = odenot
+                    otodoTpe
+                  }
+                  (todoTpe1 ++ todoTpe2).foreach { tgs =>
+                    val tms = tgs.toSemantic
+                    if (!denotations.contains(tms)) add(tms, tgs)
                   }
                 }
-
                 if (!gsym.isOverloaded && gsym != g.definitions.RepeatedParamClass) {
                   add(symbol, gsym)
                 }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/MemberOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/MemberOps.scala
@@ -2,7 +2,7 @@ package scala.meta.internal.semanticdb.scalac
 
 import scala.{meta => m}
 
-trait TypeOps { self: DatabaseOps =>
+trait MemberOps { self: DatabaseOps =>
   private[this] lazy val ignoreName: Set[g.Name] = Set(
     g.nme.CONSTRUCTOR,
     g.nme.MIXIN_CONSTRUCTOR,

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/PrinterOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/PrinterOps.scala
@@ -335,18 +335,6 @@ trait PrinterOps { self: DatabaseOps =>
         case _ => None
       }
     }
-    object ByNameType {
-      def unapply(arg: g.Type): Option[Type] =
-        if (definitions.isByNameParamType(arg)) {
-          arg match { case TypeRef(_, _, arg :: Nil) => Some(arg) }
-        } else None
-    }
-    object RepeatedType {
-      def unapply(arg: g.Type): Option[Type] =
-        if (definitions.isRepeatedParamType(arg)) {
-          arg match { case TypeRef(_, _, arg :: Nil) => Some(arg) }
-        } else None
-    }
     def printType(tpe: Type): Unit = {
       def wrapped[T](
           ts: List[T],

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SymbolOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SymbolOps.scala
@@ -104,9 +104,8 @@ trait SymbolOps { self: DatabaseOps =>
       def definitelyLocal =
         sym == g.NoSymbol ||
           sym.name.decoded.startsWith(g.nme.LOCALDUMMY_PREFIX) ||
-          sym.owner.isMethod ||
-          sym.owner.isAliasType ||
-          sym.owner.isAbstractType
+          (sym.owner.isMethod && !sym.isParameter) ||
+          ((sym.owner.isAliasType || sym.owner.isAbstractType) && !sym.isParameter)
       !definitelyGlobal && (definitelyLocal || sym.owner.isSemanticdbLocal)
     }
     def isSemanticdbMulti: Boolean = sym.isOverloaded

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TypeOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TypeOps.scala
@@ -1,11 +1,174 @@
 package scala.meta.internal.semanticdb.scalac
 
 import scala.meta.internal.{semanticdb3 => s}
+import scala.meta.internal.semanticdb3.LiteralType.{Tag => l}
+import scala.meta.internal.semanticdb3.Type.{Tag => t}
 
 trait TypeOps { self: DatabaseOps =>
-  implicit class XtensionGTypeSType(tpe: g.Type) {
-    def toSemantic: (s.Type, List[g.Symbol]) = {
-      ???
+  implicit class XtensionGTypeSType(gtpe: g.Type) {
+    def toSemantic: (Option[s.Type], List[g.Symbol]) = {
+      val buf = List.newBuilder[g.Symbol]
+      def todo(gsym: g.Symbol): String = {
+        buf += gsym
+        gsym.toSemantic.syntax
+      }
+      def loop(gtpe: g.Type): Option[s.Type] = {
+        gtpe match {
+          case ByNameType(gtpe) =>
+            val stag = t.BY_NAME_TYPE
+            val stpe = loop(gtpe)
+            Some(s.Type(tag = stag, byNameType = Some(s.ByNameType(stpe))))
+          case RepeatedType(gtpe) =>
+            val stag = t.REPEATED_TYPE
+            val stpe = loop(gtpe)
+            Some(s.Type(tag = stag, repeatedType = Some(s.RepeatedType(stpe))))
+          case g.TypeRef(gpre, gsym, gargs) =>
+            val stag = t.TYPE_REF
+            val spre = if (gtpe.hasNontrivialPrefix) loop(gpre) else None
+            val ssym = todo(gsym)
+            val sargs = gargs.flatMap(loop)
+            Some(s.Type(tag = stag, typeRef = Some(s.TypeRef(spre, ssym, sargs))))
+          case g.SingleType(gpre, gsym) =>
+            val stag = t.SINGLE_TYPE
+            val spre = if (gtpe.hasNontrivialPrefix) loop(gpre) else None
+            val ssym = todo(gsym)
+            Some(s.Type(tag = stag, singleType = Some(s.SingleType(spre, ssym))))
+          case g.ThisType(gsym) =>
+            val stag = t.THIS_TYPE
+            val ssym = todo(gsym)
+            Some(s.Type(tag = stag, thisType = Some(s.ThisType(ssym))))
+          case g.SuperType(gpre, gmix) =>
+            val stag = t.SUPER_TYPE
+            val spre = loop(gpre)
+            val smix = loop(gmix)
+            Some(s.Type(tag = stag, superType = Some(s.SuperType(spre, smix))))
+          case g.ConstantType(gconst) =>
+            def floatBits(x: Float) = java.lang.Float.floatToRawIntBits(x).toLong
+            def doubleBits(x: Double) = java.lang.Double.doubleToRawLongBits(x)
+            val stag = t.LITERAL_TYPE
+            val sconst = gconst match {
+              case g.Constant(()) => s.LiteralType(l.UNIT, 0, "")
+              case g.Constant(false) => s.LiteralType(l.BOOLEAN, 0, "")
+              case g.Constant(true) => s.LiteralType(l.BOOLEAN, 1, "")
+              case g.Constant(x: Byte) => s.LiteralType(l.BYTE, x.toLong, "")
+              case g.Constant(x: Short) => s.LiteralType(l.SHORT, x.toLong, "")
+              case g.Constant(x: Char) => s.LiteralType(l.CHAR, x.toLong, "")
+              case g.Constant(x: Int) => s.LiteralType(l.INT, x.toLong, "")
+              case g.Constant(x: Long) => s.LiteralType(l.LONG, x, "")
+              case g.Constant(x: Float) => s.LiteralType(l.FLOAT, floatBits(x), "")
+              case g.Constant(x: Double) => s.LiteralType(l.DOUBLE, doubleBits(x), "")
+              case g.Constant(x: String) => s.LiteralType(l.STRING, 0, x)
+              case g.Constant(null) => s.LiteralType(l.NULL, 0, "")
+              case gother => sys.error(s"unsupported const ${gother}: ${g.showRaw(gother)}")
+            }
+            Some(s.Type(tag = stag, literalType = Some(sconst)))
+          case g.RefinedType(gparents, gdecls) =>
+            val stag = t.COMPOUND_TYPE
+            val sparents = gparents.flatMap(loop)
+            val sdecls = gdecls.sorted.map(todo)
+            Some(s.Type(tag = stag, compoundType = Some(s.CompoundType(sparents, sdecls))))
+          case g.AnnotatedType(ganns, gtpe) =>
+            val stag = t.ANNOTATED_TYPE
+            val stpe = loop(gtpe)
+            val sanns = ganns.flatMap(gann => loop(gann.atp))
+            Some(s.Type(tag = stag, annotatedType = Some(s.AnnotatedType(stpe, sanns))))
+          case g.ExistentialType(gquants, gtpe) =>
+            val stag = t.EXISTENTIAL_TYPE
+            val stpe = loop(gtpe)
+            val ssyms = gquants.map(todo)
+            Some(s.Type(tag = stag, existentialType = Some(s.ExistentialType(stpe, ssyms))))
+          case g.ClassInfoType(gparents, gdecls, _) =>
+            val stag = t.CLASS_INFO_TYPE
+            val sparents = gparents.flatMap(loop)
+            val sdecls = gdecls.sorted.map(todo)
+            Some(s.Type(tag = stag, classInfoType = Some(s.ClassInfoType(Nil, sparents, sdecls))))
+          case g.NullaryMethodType(gtpe) =>
+            val stag = t.METHOD_TYPE
+            val stpe = loop(gtpe)
+            Some(s.Type(tag = stag, methodType = Some(s.MethodType(Nil, Nil, stpe))))
+          case gtpe: g.MethodType =>
+            def flatten(gtpe: g.Type): (List[List[g.Symbol]], g.Type) = {
+              gtpe match {
+                case g.MethodType(ghead, gtpe) =>
+                  val (gtail, gret) = flatten(gtpe)
+                  (ghead :: gtail, gret)
+                case gother =>
+                  (Nil, gother)
+              }
+            }
+            val (gparamss, gret) = flatten(gtpe)
+            val stag = t.METHOD_TYPE
+            val sparamss = gparamss.map { gparams =>
+              val sparams = gparams.map(todo)
+              s.MethodType.ParameterList(sparams)
+            }
+            val sret = loop(gret)
+            Some(s.Type(tag = stag, methodType = Some(s.MethodType(Nil, sparamss, sret))))
+          case g.TypeBounds(glo, ghi) =>
+            val stag = t.TYPE_TYPE
+            val slo = loop(glo)
+            val shi = loop(ghi)
+            Some(s.Type(tag = stag, typeType = Some(s.TypeType(Nil, slo, shi))))
+          case g.PolyType(gtparams, gtpe) =>
+            val stparams = gtparams.map(todo)
+            val stpe = loop(gtpe)
+            stpe.map { stpe =>
+              if (stpe.tag == t.CLASS_INFO_TYPE) {
+                stpe.update(_.classInfoType.typeParameters := stparams)
+              } else if (stpe.tag == t.METHOD_TYPE) {
+                stpe.update(_.methodType.typeParameters := stparams)
+              } else if (stpe.tag == t.TYPE_TYPE) {
+                stpe.update(_.typeType.typeParameters := stparams)
+              } else {
+                val stag = t.TYPE_LAMBDA
+                s.Type(tag = stag, typeLambda = Some(s.TypeLambda(stparams, Some(stpe))))
+              }
+            }
+          case g.NoType =>
+            None
+          case g.NoPrefix =>
+            None
+          case g.ErrorType =>
+            None
+          case gother =>
+            sys.error(s"unsupported type ${gother}: ${g.showRaw(gother)}")
+        }
+      }
+      (loop(gtpe), buf.result)
     }
+  }
+
+  implicit class XtensionGType(gtpe: g.Type) {
+    def hasNontrivialPrefix: Boolean = {
+      val (gpre, gsym) = {
+        gtpe match {
+          case g.TypeRef(gpre, gsym, _) => (gpre, gsym)
+          case g.SingleType(gpre, gsym) => (gpre, gsym)
+          case _ => return true
+        }
+      }
+      gpre match {
+        case g.SingleType(_, gpresym) =>
+          gpresym.isTerm && !gpresym.isModule
+        case g.ThisType(gpresym) =>
+          !gpresym.hasPackageFlag && !gpresym.isModuleOrModuleClass && !gpresym.isConstructor
+        case _ =>
+          true
+      }
+    }
+  }
+
+  object ByNameType {
+    def unapply(gtpe: g.Type): Option[g.Type] =
+      if (g.definitions.isByNameParamType(gtpe)) {
+        gtpe match { case g.TypeRef(_, _, gtpe :: Nil) => Some(gtpe) }
+      } else None
+  }
+
+  object RepeatedType {
+    def unapply(gtpe: g.Type): Option[g.Type] =
+      if (g.definitions.isRepeatedParamType(gtpe)) {
+        gtpe match { case g.TypeRef(_, _, gtpe :: Nil) => Some(gtpe) }
+      } else None
   }
 }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TypeOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TypeOps.scala
@@ -1,0 +1,11 @@
+package scala.meta.internal.semanticdb.scalac
+
+import scala.meta.internal.{semanticdb3 => s}
+
+trait TypeOps { self: DatabaseOps =>
+  implicit class XtensionGTypeSType(tpe: g.Type) {
+    def toSemantic: (s.Type, List[g.Symbol]) = {
+      ???
+    }
+  }
+}

--- a/semanticdb/semanticdb3/semanticdb3.md
+++ b/semanticdb/semanticdb3/semanticdb3.md
@@ -186,12 +186,14 @@ message Type {
   ThisType thisType = 3;
   SuperType superType = 4;
   LiteralType literalType = 5;
-  RefinedType refinedType = 6;
+  CompoundType compoundType = 6;
   AnnotatedType annotatedType = 7;
   ExistentialType existentialType = 8;
   ClassInfoType classInfoType = 9;
   MethodType methodType = 10;
-  TypeType typeType = 11;
+  ByNameType byNameType = 11;
+  RepeatedType repeatedType = 12;
+  TypeType typeType = 13;
 }
 ```
 
@@ -348,6 +350,24 @@ secondary constructors and macros:
   * Signature of `def m(): Int` ~ `MethodType(List(), List(List()), <Int>)`.
   * Signature of `def m(x: Int): Int` ~ `MethodType(List(), List(List(<x>)), <Int>)`.
   * Signature of `def m[T](x: T): T` ~ `MethodType(List(<T>), List(List(<x>)), <T>)`.
+
+```protobuf
+message ByNameType {
+  Type tpe = 1;
+}
+```
+
+`ByNameType` represents signatures of by-name parameters [\[37\]][37]:
+  * Signature of `x` in `def m(x: => Int): Int` ~ `ByNameType(<Int>)`.
+
+```protobuf
+message RepeatedType {
+  Type tpe = 1;
+}
+```
+
+`RepeatedType` represents signatures of repeated parameters [\[38\]][38]:
+  * Signature of `xs` in `def m(xs: Int*): Int` ~ `RepeatedType(<Int>)`.
 
 ```protobuf
 message TypeType {
@@ -745,3 +765,5 @@ in the future, but this is highly unlikely.
 [34]: https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#compound-types
 [35]: https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#annotated-types
 [36]: https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#existential-types
+[37]: https://www.scala-lang.org/files/archive/spec/2.12/04-basic-declarations-and-definitions.html#by-name-parameters
+[38]: https://www.scala-lang.org/files/archive/spec/2.12/04-basic-declarations-and-definitions.html#repeated-parameters

--- a/semanticdb/semanticdb3/semanticdb3.proto
+++ b/semanticdb/semanticdb3/semanticdb3.proto
@@ -30,33 +30,44 @@ message Range {
 }
 
 message Type {
-  TypeRef typeRef = 1;
-  SingleType singleType = 2;
-  ThisType thisType = 3;
-  SuperType superType = 4;
-  LiteralType literalType = 5;
-  CompoundType compoundType = 6;
-  AnnotatedType annotatedType = 7;
-  ExistentialType existentialType = 8;
-  ClassInfoType classInfoType = 9;
-  MethodType methodType = 10;
-  ByNameType byNameType = 11;
-  RepeatedType repeatedType = 12;
-  TypeType typeType = 13;
+  enum Tag {
+    UNKNOWN_TAG = 0;
+    TYPE_REF = 1;
+    SINGLE_TYPE = 2;
+    THIS_TYPE = 3;
+    SUPER_TYPE = 4;
+    LITERAL_TYPE = 5;
+    COMPOUND_TYPE = 6;
+    ANNOTATED_TYPE = 7;
+    EXISTENTIAL_TYPE = 8;
+    TYPE_LAMBDA = 9;
+    CLASS_INFO_TYPE = 10;
+    METHOD_TYPE = 11;
+    BY_NAME_TYPE = 12;
+    REPEATED_TYPE = 13;
+    TYPE_TYPE = 14;
+  }
+  Tag tag = 1;
+  TypeRef typeRef = 2;
+  SingleType singleType = 3;
+  ThisType thisType = 4;
+  SuperType superType = 5;
+  LiteralType literalType = 6;
+  CompoundType compoundType = 7;
+  AnnotatedType annotatedType = 8;
+  ExistentialType existentialType = 9;
+  TypeLambda typeLambda = 10;
+  ClassInfoType classInfoType = 11;
+  MethodType methodType = 12;
+  ByNameType byNameType = 13;
+  RepeatedType repeatedType = 14;
+  TypeType typeType = 15;
 }
 
 message TypeRef {
   Type prefix = 1;
   string symbol = 2;
   repeated Type arguments = 3;
-}
-
-message ByNameType {
-  Type tpe = 1;
-}
-
-message RepeatedType {
-  Type tpe = 1;
 }
 
 message SingleType {
@@ -69,43 +80,54 @@ message ThisType {
 }
 
 message SuperType {
-  string symbol = 1;
+  Type prefix = 1;
   Type mix = 2;
 }
 
 message LiteralType {
-  bytes unit = 1;
-  bool boolean = 2;
-  int32 byte = 3;
-  int32 short = 4;
-  int32 char = 5;
-  int32 int = 6;
-  int64 long = 7;
-  float float = 8;
-  double double = 9;
-  string string = 10;
-  bytes null = 11;
+  enum Tag {
+    UNKNOWN_TAG = 0;
+    UNIT = 1;
+    BOOLEAN = 2;
+    BYTE = 3;
+    SHORT = 4;
+    CHAR = 5;
+    INT = 6;
+    LONG = 7;
+    FLOAT = 8;
+    DOUBLE = 9;
+    STRING = 10;
+    NULL = 11;
+  }
+  Tag tag = 1;
+  int64 primitive = 2;
+  string string = 3;
 }
 
 message CompoundType {
   repeated Type parents = 1;
-  repeated string members = 2;
+  repeated string declarations = 2;
 }
 
 message AnnotatedType {
   Type tpe = 1;
-  string symbol = 2;
+  repeated Type annotations = 2;
 }
 
 message ExistentialType {
   Type tpe = 1;
-  repeated string members = 2;
+  repeated string declarations = 2;
+}
+
+message TypeLambda {
+  repeated string type_parameters = 1;
+  Type tpe = 2;
 }
 
 message ClassInfoType {
   repeated string type_parameters = 1;
   repeated Type parents = 2;
-  repeated string members = 3;
+  repeated string declarations = 3;
 }
 
 message MethodType {
@@ -115,6 +137,14 @@ message MethodType {
   repeated string type_parameters = 1;
   repeated ParameterList parameters = 2;
   Type result = 3;
+}
+
+message ByNameType {
+  Type tpe = 1;
+}
+
+message RepeatedType {
+  Type tpe = 1;
 }
 
 message TypeType {

--- a/semanticdb/semanticdb3/semanticdb3.proto
+++ b/semanticdb/semanticdb3/semanticdb3.proto
@@ -40,13 +40,23 @@ message Type {
   ExistentialType existentialType = 8;
   ClassInfoType classInfoType = 9;
   MethodType methodType = 10;
-  TypeType typeType = 11;
+  ByNameType byNameType = 11;
+  RepeatedType repeatedType = 12;
+  TypeType typeType = 13;
 }
 
 message TypeRef {
   Type prefix = 1;
   string symbol = 2;
   repeated Type arguments = 3;
+}
+
+message ByNameType {
+  Type tpe = 1;
+}
+
+message RepeatedType {
+  Type tpe = 1;
 }
 
 message SingleType {

--- a/semanticdb/semanticdb3/semanticdb3.proto
+++ b/semanticdb/semanticdb3/semanticdb3.proto
@@ -29,6 +29,90 @@ message Range {
   int32 end_character = 4;
 }
 
+message Type {
+  TypeRef typeRef = 1;
+  SingleType singleType = 2;
+  ThisType thisType = 3;
+  SuperType superType = 4;
+  LiteralType literalType = 5;
+  CompoundType compoundType = 6;
+  AnnotatedType annotatedType = 7;
+  ExistentialType existentialType = 8;
+  ClassInfoType classInfoType = 9;
+  MethodType methodType = 10;
+  TypeType typeType = 11;
+}
+
+message TypeRef {
+  Type prefix = 1;
+  string symbol = 2;
+  repeated Type arguments = 3;
+}
+
+message SingleType {
+  Type prefix = 1;
+  string symbol = 2;
+}
+
+message ThisType {
+  string symbol = 1;
+}
+
+message SuperType {
+  string symbol = 1;
+  Type mix = 2;
+}
+
+message LiteralType {
+  bytes unit = 1;
+  bool boolean = 2;
+  int32 byte = 3;
+  int32 short = 4;
+  int32 char = 5;
+  int32 int = 6;
+  int64 long = 7;
+  float float = 8;
+  double double = 9;
+  string string = 10;
+  bytes null = 11;
+}
+
+message CompoundType {
+  repeated Type parents = 1;
+  repeated string members = 2;
+}
+
+message AnnotatedType {
+  Type tpe = 1;
+  string symbol = 2;
+}
+
+message ExistentialType {
+  Type tpe = 1;
+  repeated string members = 2;
+}
+
+message ClassInfoType {
+  repeated string type_parameters = 1;
+  repeated Type parents = 2;
+  repeated string members = 3;
+}
+
+message MethodType {
+  message ParameterList {
+    repeated string symbols = 1;
+  }
+  repeated string type_parameters = 1;
+  repeated ParameterList parameters = 2;
+  Type result = 3;
+}
+
+message TypeType {
+  repeated string type_parameters = 1;
+  Type lower_bound = 2;
+  Type upper_bound = 3;
+}
+
 message SymbolInformation {
   enum Kind {
     UNKNOWN_KIND = 0;
@@ -69,6 +153,7 @@ message SymbolInformation {
   string name = 5;
   Range range = 6;
   TextDocument signature = 7;
+  Type tpe = 10;
   repeated string members = 8;
   repeated string overrides = 9;
 }

--- a/tests/jvm/src/test/resources/semanticdb.expect
+++ b/tests/jvm/src/test/resources/semanticdb.expect
@@ -16,7 +16,7 @@ Names:
 [103..106): Int => _root_.scala.Int#
 [107..107): ε => _root_.scala.collection.mutable.Stack#`<init>`()V.
 [116..120): main <= _root_.example.Example.main([Ljava/lang/String;)V.
-[121..125): args <= local0
+[121..125): args <= _root_.example.Example.main([Ljava/lang/String;)V.(args)
 [127..132): Array => _root_.scala.Array#
 [133..139): String => _root_.scala.Predef.String#
 [143..147): Unit => _root_.scala.Unit#
@@ -38,45 +38,34 @@ _root_.example.Example.main([Ljava/lang/String;)V. => def main: (args: Array[Str
   [7..12): Array => _root_.scala.Array#
   [13..19): String => _root_.scala.Predef.String#
   [23..27): Unit => _root_.scala.Unit#
+_root_.example.Example.main([Ljava/lang/String;)V.(args) => param args: Array[String]
+  [0..5): Array => _root_.scala.Array#
+  [6..12): String => _root_.scala.Predef.String#
 _root_.example.Example.x. => val x: ClassTag[Int]
   [0..8): ClassTag => _root_.scala.reflect.ClassTag#
   [9..12): Int => _root_.scala.Int#
 _root_.scala. => package scala
 _root_.scala.Array# => final class Array
-_root_.scala.Array#`<init>`(I)V. => primaryctor <init>: (_length: Int): Array[T]
-  [10..13): Int => _root_.scala.Int#
-  [16..21): Array => _root_.scala.Array#
-  [22..23): T => _root_.scala.Array#[T]
 _root_.scala.Int# => abstract final class Int
-_root_.scala.Int#`<init>`()V. => primaryctor <init>: (): Int
-  [4..7): Int => _root_.scala.Int#
 _root_.scala.Predef.String# => type String: String
   [0..6): String => _root_.java.lang.String#
 _root_.scala.Predef.println(Ljava/lang/Object;)V. => def println: (x: Any): Unit
   [4..7): Any => _root_.scala.Any#
   [10..14): Unit => _root_.scala.Unit#
 _root_.scala.Unit# => abstract final class Unit
-_root_.scala.Unit#`<init>`()V. => primaryctor <init>: (): Unit
-  [4..8): Unit => _root_.scala.Unit#
 _root_.scala.collection. => package collection
 _root_.scala.collection.mutable. => package mutable
 _root_.scala.collection.mutable.Stack# => class Stack
 _root_.scala.collection.mutable.Stack#`<init>`()V. => secondaryctor <init>: (): Stack[A]
   [4..9): Stack => _root_.scala.collection.mutable.Stack#
   [10..11): A => _root_.scala.collection.mutable.Stack#[A]
-_root_.scala.collection.mutable.Stack#`<init>`(Lscala/collection/immutable/List;)V. => private primaryctor <init>: (elems: List[A]): Stack[A]
-  [8..12): List => _root_.scala.collection.immutable.List#
-  [13..14): A => _root_.scala.collection.mutable.Stack#[A]
-  [18..23): Stack => _root_.scala.collection.mutable.Stack#
-  [24..25): A => _root_.scala.collection.mutable.Stack#[A]
 _root_.scala.concurrent. => package concurrent
 _root_.scala.reflect. => package reflect
 _root_.scala.reflect.package.classTag(Lscala/reflect/ClassTag;)Lscala/reflect/ClassTag;. => def classTag: [T] => (implicit ctag: ClassTag[T]): ClassTag[T]
   [23..31): ClassTag => _root_.scala.reflect.ClassTag#
+  [32..33): T => _root_.scala.reflect.package.classTag(Lscala/reflect/ClassTag;)Lscala/reflect/ClassTag;.[T]
   [37..45): ClassTag => _root_.scala.reflect.ClassTag#
-local0 => param args: Array[String]
-  [0..5): Array => _root_.scala.Array#
-  [6..12): String => _root_.scala.Predef.String#
+  [46..47): T => _root_.scala.reflect.package.classTag(Lscala/reflect/ClassTag;)Lscala/reflect/ClassTag;.[T]
 
 Synthetics:
 [208..208): *(((ClassTag.Int): ClassTag[Int]))
@@ -193,8 +182,6 @@ _root_.flags.p.package.y. => protected var y_=: (x$1: Int): Unit
 _root_.flags.p.package.z()I. => def z: Int
   [0..3): Int => _root_.scala.Int#
 _root_.scala.Int# => abstract final class Int
-_root_.scala.Int#`<init>`()V. => primaryctor <init>: (): Int
-  [4..7): Int => _root_.scala.Int#
 _root_.scala.Predef.`???`()Lscala/Nothing;. => def ???: Nothing
   [0..7): Nothing => _root_.scala.Nothing#
 
@@ -230,8 +217,6 @@ _root_.example.B#foo()I. => def foo: Int
 _root_.java.lang.Object#`<init>`()V. => primaryctor <init>: (): Object
   [4..10): Object => _root_.java.lang.Object#
 _root_.scala.Int# => abstract final class Int
-_root_.scala.Int#`<init>`()V. => primaryctor <init>: (): Int
-  [4..7): Int => _root_.scala.Int#
 
 
 semanticdb/integration/src/main/scala/example/Synthetic.scala
@@ -260,22 +245,26 @@ _root_.example.Synthetic#`<init>`()V. => primaryctor <init>: (): Synthetic
 _root_.scala.Array. => final object Array
 _root_.scala.Array.empty(Lscala/reflect/ClassTag;)Ljava/lang/Object;. => def empty: [T] => (implicit evidence$1: ClassTag[T]): Array[T]
   [29..37): ClassTag => _root_.scala.reflect.ClassTag#
+  [38..39): T => _root_.scala.Array.empty(Lscala/reflect/ClassTag;)Ljava/lang/Object;.[T]
   [43..48): Array => _root_.scala.Array#
+  [49..50): T => _root_.scala.Array.empty(Lscala/reflect/ClassTag;)Ljava/lang/Object;.[T]
 _root_.scala.Int# => abstract final class Int
 _root_.scala.Int#`+`(I)I. => abstract def +: (x: Int): Int
   [4..7): Int => _root_.scala.Int#
   [10..13): Int => _root_.scala.Int#
-_root_.scala.Int#`<init>`()V. => primaryctor <init>: (): Int
-  [4..7): Int => _root_.scala.Int#
 _root_.scala.collection.TraversableLike#headOption()Lscala/Option;. => def headOption: Option[A]
   [0..6): Option => _root_.scala.Option#
   [7..8): A => _root_.scala.collection.TraversableLike#[A]
 _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;. => final def map: [B, That] => (f: Function1[A, B])(implicit bf: CanBuildFrom[List[A], B, That]): That
   [17..26): Function1 => _root_.scala.Function1#
   [27..28): A => _root_.scala.collection.immutable.List#[A]
+  [30..31): B => _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.[B]
   [47..59): CanBuildFrom => _root_.scala.collection.generic.CanBuildFrom#
   [60..64): List => _root_.scala.collection.immutable.List#
   [65..66): A => _root_.scala.collection.immutable.List#[A]
+  [69..70): B => _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.[B]
+  [72..76): That => _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.[That]
+  [80..84): That => _root_.scala.collection.immutable.List#map(Lscala/Function1;Lscala/collection/generic/CanBuildFrom;)Ljava/lang/Object;.[That]
 _root_.scala.collection.immutable.List. => final object List
 _root_.scala.collection.immutable.StringLike#stripPrefix(Ljava/lang/String;)Ljava/lang/String;. => def stripPrefix: (prefix: String): String
   [9..15): String => _root_.scala.Predef.String#

--- a/tests/jvm/src/test/scala-2.12/scala/meta/tests/semanticdb/OverridesSuite.scala
+++ b/tests/jvm/src/test/scala-2.12/scala/meta/tests/semanticdb/OverridesSuite.scala
@@ -45,9 +45,7 @@ class OverridesSuite extends DatabaseSuite(SemanticdbMode.Slim, overrides = Over
        |  [0..3): Int => _root_.scala.Int#
        |_root_.java.lang.Object#`<init>`()V. => primaryctor <init>: (): Object
        |  [4..10): Object => _root_.java.lang.Object#
-       |_root_.scala.Int# => abstract final class Int
-       |_root_.scala.Int#`<init>`()V. => primaryctor <init>: (): Int
-       |  [4..7): Int => _root_.scala.Int#""".stripMargin
+       |_root_.scala.Int# => abstract final class Int""".stripMargin
   )
   overrides(
      """

--- a/tests/jvm/src/test/scala/scala/meta/tests/cli/CliSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/cli/CliSuite.scala
@@ -64,7 +64,7 @@ class CliSuite extends FunSuite with DiffAssertions {
       |Uri => HelloWorld.scala
       |Text => non-empty
       |Language => $language
-      |Symbols => 9 entries
+      |Symbols => 7 entries
       |Occurrences => 7 entries
       |Diagnostics => 0 entries
       |Synthetics => 0 entries
@@ -72,30 +72,27 @@ class CliSuite extends FunSuite with DiffAssertions {
       |Symbols:
       |_empty_.HelloWorld. => final object HelloWorld
       |_empty_.HelloWorld.main([Ljava/lang/String;)V. => def main: (args: Array[String]): Unit
-      |  [0:7..0:12): Array => _root_.scala.Array#
-      |  [0:13..0:19): String => _root_.scala.Predef.String#
-      |  [0:23..0:27): Unit => _root_.scala.Unit#
-      |_root_.scala.Array# => final class Array
-      |_root_.scala.Array#`<init>`(I)V. => primaryctor <init>: (_length: Int): Array[T]
-      |  [0:10..0:13): Int => _root_.scala.Int#
-      |  [0:16..0:21): Array => _root_.scala.Array#
-      |  [0:22..0:23): T => _root_.scala.Array#[T]
+      |  args => _empty_.HelloWorld.main([Ljava/lang/String;)V.(args)
+      |  Unit => _root_.scala.Unit#
+      |_empty_.HelloWorld.main([Ljava/lang/String;)V.(args) => param args: Array[String]
+      |  Array => _root_.scala.Array#
+      |  String => _root_.scala.Predef.String#
+      |_root_.scala.Array# => final class Array.{+6 decls}
+      |  extends AnyRef
+      |  extends Serializable
+      |  extends Cloneable
       |_root_.scala.Predef.String# => type String: String
-      |  [0:0..0:6): String => _root_.java.lang.String#
-      |_root_.scala.Predef.println(Ljava/lang/Object;)V. => def println: (x: Any): Unit
-      |  [0:4..0:7): Any => _root_.scala.Any#
-      |  [0:10..0:14): Unit => _root_.scala.Unit#
-      |_root_.scala.Unit# => abstract final class Unit
-      |_root_.scala.Unit#`<init>`()V. => primaryctor <init>: (): Unit
-      |  [0:4..0:8): Unit => _root_.scala.Unit#
-      |local0 => param args: Array[String]
-      |  [0:0..0:5): Array => _root_.scala.Array#
-      |  [0:6..0:12): String => _root_.scala.Predef.String#
+      |  String => _root_.java.lang.String#
+      |_root_.scala.Predef.println(Ljava/lang/Object;)V. => def println: (x: <?>): Unit
+      |  x => _root_.scala.Predef.println(Ljava/lang/Object;)V.(x)
+      |  Unit => _root_.scala.Unit#
+      |_root_.scala.Unit# => abstract final class Unit.{+2 decls}
+      |  extends AnyVal
       |
       |Occurrences:
       |[1:11..1:21): HelloWorld <= _empty_.HelloWorld.
       |[2:10..2:14): main <= _empty_.HelloWorld.main([Ljava/lang/String;)V.
-      |[2:15..2:19): args <= local0
+      |[2:15..2:19): args <= _empty_.HelloWorld.main([Ljava/lang/String;)V.(args)
       |[2:21..2:26): Array => _root_.scala.Array#
       |[2:27..2:33): String => _root_.scala.Predef.String#
       |[2:37..2:41): Unit => _root_.scala.Unit#

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/InteractiveSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/InteractiveSuite.scala
@@ -85,16 +85,16 @@ class InteractiveSuite extends FunSuite with DiffAssertions {
       |
       |Names:
       |[8..9): b <= _empty_.b.
-      |[22..23): a <= local0
-      |[25..27): In => local1
+      |[22..23): a <= (a)
+      |[25..27): In => (a)`<error: <none>>`#
       |
       |Messages:
       |[25..27): [error] not found: type In
       |
       |Symbols:
+      |(a) => param a: <error>
+      |(a)`<error: <none>>`# => class `<error: <none>>`
       |_empty_.b. => final object b
-      |local0 => param a: <error>
-      |local1 => class `<error: <none>>`
     """.stripMargin
   )
 }

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/TargetedSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/TargetedSuite.scala
@@ -29,14 +29,14 @@ class TargetedSuite extends DatabaseSuite(SemanticdbMode.Slim) {
     """
     |[7..8): A <= _empty_.A.
     |[17..21): main <= _empty_.A.main([Ljava/lang/String;)V.
-    |[22..26): args <= local0
+    |[22..26): args <= _empty_.A.main([Ljava/lang/String;)V.(args)
     |[28..33): Array => _root_.scala.Array#
     |[34..40): String => _root_.scala.Predef.String#
     |[44..48): Unit => _root_.scala.Unit#
-    |[61..65): list <= local1
+    |[61..65): list <= local0
     |[68..72): List => _root_.scala.collection.immutable.List.
     |[86..93): println => _root_.scala.Predef.println(Ljava/lang/Object;)V.
-    |[94..98): list => local1
+    |[94..98): list => local0
   """.trim.stripMargin
   )
 
@@ -94,7 +94,7 @@ class TargetedSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |}
     """.trim.stripMargin, { (db, copy, age) =>
       assert(copy === Symbol("_root_.e.User#copy(Ljava/lang/String;I)Le/User;."))
-      assert(age === Symbol("local0"))
+      assert(age === Symbol("_root_.e.User#copy(Ljava/lang/String;I)Le/User;.(age)"))
     }
   )
 
@@ -179,6 +179,9 @@ class TargetedSuite extends DatabaseSuite(SemanticdbMode.Slim) {
        |_root_.f.C1#m1(I)I. => def m1: [T] => (x: Int): Int
        |  [11..14): Int => _root_.scala.Int#
        |  [17..20): Int => _root_.scala.Int#
+       |_root_.f.C1#m1(I)I.(x) => param x: Int
+       |  [0..3): Int => _root_.scala.Int#
+       |_root_.f.C1#m1(I)I.T# => typeparam T
        |_root_.f.C1#m2()Lscala/Nothing;. => macro m2: Nothing
        |  [0..7): Nothing => _root_.scala.Nothing#
        |_root_.f.C2# => abstract class C2
@@ -230,17 +233,12 @@ class TargetedSuite extends DatabaseSuite(SemanticdbMode.Slim) {
        |  [16..20): Unit => _root_.scala.Unit#
        |_root_.scala. => package scala
        |_root_.scala.Int# => abstract final class Int
-       |_root_.scala.Int#`<init>`()V. => primaryctor <init>: (): Int
-       |  [4..7): Int => _root_.scala.Int#
        |_root_.scala.Predef.`???`()Lscala/Nothing;. => def ???: Nothing
        |  [0..7): Nothing => _root_.scala.Nothing#
        |_root_.scala.language. => final object language
        |_root_.scala.language.experimental. => final object experimental
        |_root_.scala.language.experimental.macros. => implicit lazy val macros: macros
        |  [0..6): macros => _root_.scala.languageFeature.experimental.macros#
-       |local0 => typeparam T
-       |local2 => param x: Int
-       |  [0..3): Int => _root_.scala.Int#
   """.trim.stripMargin
   )
 
@@ -378,8 +376,10 @@ class TargetedSuite extends DatabaseSuite(SemanticdbMode.Slim) {
        |_root_.i.a. => final object a
        |_root_.i.a.foo(Li/B;)Ljava/lang/Object;. => def foo: (implicit b: B): b.X
        |  [13..14): B => _root_.i.B#
-       |  [17..18): b => local0
+       |  [17..18): b => _root_.i.a.foo(Li/B;)Ljava/lang/Object;.(b)
        |  [19..20): X => _root_.i.B#X#
+       |_root_.i.a.foo(Li/B;)Ljava/lang/Object;.(b) => implicit param b: B
+       |  [0..1): B => _root_.i.B#
        |_root_.i.a.x. => val x: ListBuffer[Int]
        |  [0..10): ListBuffer => _root_.scala.collection.mutable.ListBuffer#
        |  [11..14): Int => _root_.scala.Int#
@@ -390,30 +390,20 @@ class TargetedSuite extends DatabaseSuite(SemanticdbMode.Slim) {
        |  [4..10): Object => _root_.java.lang.Object#
        |_root_.scala. => package scala
        |_root_.scala.Int# => abstract final class Int
-       |_root_.scala.Int#`<init>`()V. => primaryctor <init>: (): Int
-       |  [4..7): Int => _root_.scala.Int#
        |_root_.scala.collection. => package collection
        |_root_.scala.collection.generic.GenericCompanion#empty()Lscala/collection/GenTraversable;. => def empty: [A] => CC[A]
        |  [7..9): CC => _root_.scala.collection.generic.GenericCompanion#[CC]
+       |  [10..11): A => _root_.scala.collection.generic.GenericCompanion#empty()Lscala/collection/GenTraversable;.[A]
        |_root_.scala.collection.mutable. => package mutable
        |_root_.scala.collection.mutable.HashSet# => class HashSet
-       |_root_.scala.collection.mutable.HashSet#`<init>`(Lscala/collection/mutable/FlatHashTable/Contents;)V. => private primaryctor <init>: (contents: Contents[A]): HashSet[A]
-       |  [11..19): Contents => _root_.scala.collection.mutable.FlatHashTable.Contents#
-       |  [20..21): A => _root_.scala.collection.mutable.HashSet#[A]
-       |  [25..32): HashSet => _root_.scala.collection.mutable.HashSet#
-       |  [33..34): A => _root_.scala.collection.mutable.HashSet#[A]
        |_root_.scala.collection.mutable.HashSet. => final object HashSet
        |_root_.scala.collection.mutable.HashSet.empty()Lscala/collection/mutable/HashSet;. => def empty: [A] => HashSet[A]
        |  [7..14): HashSet => _root_.scala.collection.mutable.HashSet#
+       |  [15..16): A => _root_.scala.collection.mutable.HashSet.empty()Lscala/collection/mutable/HashSet;.[A]
        |_root_.scala.collection.mutable.ListBuffer# => final class ListBuffer
-       |_root_.scala.collection.mutable.ListBuffer#`<init>`()V. => primaryctor <init>: (): ListBuffer[A]
-       |  [4..14): ListBuffer => _root_.scala.collection.mutable.ListBuffer#
-       |  [15..16): A => _root_.scala.collection.mutable.ListBuffer#[A]
        |_root_.scala.collection.mutable.ListBuffer. => final object ListBuffer
-       |local0 => implicit param b: B
-       |  [0..1): B => _root_.i.B#
-       |local1 => val result: b.X
-       |  [0..1): b => local0
+       |local0 => val result: b.X
+       |  [0..1): b => _root_.i.a.foo(Li/B;)Ljava/lang/Object;.(b)
        |  [2..3): X => _root_.i.B#X#
     """.stripMargin.trim
   )
@@ -529,14 +519,14 @@ class TargetedSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |}""".stripMargin,
     """|_empty_.o. => final object o
        |_root_.scala.Int# => abstract final class Int
-       |_root_.scala.Int#`<init>`()V. => primaryctor <init>: (): Int
-       |  [4..7): Int => _root_.scala.Int#
        |_root_.scala.collection.IterableLike#head()Ljava/lang/Object;. => def head: A
        |  [0..1): A => _root_.scala.collection.IterableLike#[A]
        |_root_.scala.collection.immutable.List. => final object List
        |_root_.scala.collection.immutable.List.newBuilder()Lscala/collection/mutable/Builder;. => def newBuilder: [A] => Builder[A, List[A]]
        |  [7..14): Builder => _root_.scala.collection.mutable.Builder#
+       |  [15..16): A => _root_.scala.collection.immutable.List.newBuilder()Lscala/collection/mutable/Builder;.[A]
        |  [18..22): List => _root_.scala.collection.immutable.List#
+       |  [23..24): A => _root_.scala.collection.immutable.List.newBuilder()Lscala/collection/mutable/Builder;.[A]
        |_root_.scala.collection.mutable.Builder#result()Ljava/lang/Object;. => abstract def result: (): To
        |  [4..6): To => _root_.scala.collection.mutable.Builder#[To]
     """.stripMargin.trim
@@ -799,6 +789,7 @@ class TargetedSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |  [0..3): Int => _root_.scala.Int#
       |_root_.scala.Predef.Class# => type Class: [T] => Class[T]
       |  [7..12): Class => _root_.java.lang.Class#
+      |  [13..14): T => _root_.scala.Predef.Class#[T]
       |_root_.scala.Predef.`???`()Lscala/Nothing;. => def ???: Nothing
       |  [0..7): Nothing => _root_.scala.Nothing#
     """.stripMargin
@@ -841,8 +832,11 @@ class TargetedSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |_empty_.ad.x.$anon#y. => val y: Int
       |  [0..3): Int => _root_.scala.Int#
       |_empty_.ad.x.$anon#z(Ljava/lang/Object;)Ljava/lang/Object;. => def z: [T] => (e: T): T
-      |  [11..12): T => local0
-      |  [15..16): T => local0
+      |  [11..12): T => _empty_.ad.x.$anon#z(Ljava/lang/Object;)Ljava/lang/Object;.[T]
+      |  [15..16): T => _empty_.ad.x.$anon#z(Ljava/lang/Object;)Ljava/lang/Object;.[T]
+      |_empty_.ad.x.$anon#z(Ljava/lang/Object;)Ljava/lang/Object;.(e) => param e: T
+      |  [0..1): T => _empty_.ad.x.$anon#z(Ljava/lang/Object;)Ljava/lang/Object;.T#
+      |_empty_.ad.x.$anon#z(Ljava/lang/Object;)Ljava/lang/Object;.T# => typeparam T
       |_empty_.ad.z. => val z: AnyRef with Foo{val y: Int}
       |  [0..6): AnyRef => _root_.scala.AnyRef#
       |  [12..15): Foo => _empty_.ad.Foo#
@@ -859,11 +853,6 @@ class TargetedSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       |  [0..6): AnyRef => _root_.scala.AnyRef#
       |  [12..25): Specializable => _root_.scala.Specializable#
       |_root_.scala.Int# => abstract final class Int
-      |_root_.scala.Int#`<init>`()V. => primaryctor <init>: (): Int
-      |  [4..7): Int => _root_.scala.Int#
-      |local1 => typeparam T
-      |local2 => param e: T
-      |  [0..1): T => local1
     """.stripMargin
   )
 
@@ -1149,7 +1138,7 @@ class TargetedSuite extends DatabaseSuite(SemanticdbMode.Slim) {
         """
           |_root_.am.A.foo()Ljava/lang/Object;. => def foo: [T] => A[T]#Self
           |  [7..8): A => _root_.am.A#
-          |  [9..10): T => local0
+          |  [9..10): T => _root_.am.A.foo()Ljava/lang/Object;.[T]
           |  [12..16): Self => _root_.am.A#Self#
         """.stripMargin
       )


### PR DESCRIPTION
This pull request defines and specifies `Type` - a new SemanticDB data structure to represent expression types and signatures of definitions. This data structure closely follows the ScalaSignature format to make sure that it can represent everything that the Scala compiler can throw at us.

Moreover, this pull request implements writing, reading and prettyprinting types via `semanticdb-scalac` and `metap`. Here's how the full cycle works for a simple Scala program from `CliSuite`:

```
$ cat Library.scala
object Test {
  def main(args: Array[String]): Unit = {
    val helloWorld = List("hello", "world")
    println(helloWorld.mkString)
  }
}

$ metac Library.scala

$ metap **/*.semanticdb
Library.scala
-------------

Summary:
Schema => SemanticDB v3
Uri => Library.scala
Text => non-empty
Language => Scala212
Symbols => 10 entries
Occurrences => 11 entries
Diagnostics => 0 entries
Synthetics => 1 entries

Symbols:
_empty_.Test. => final object Test
_empty_.Test.main([Ljava/lang/String;)V. => def main: (args: Array[String]): Unit
  args => _empty_.Test.main([Ljava/lang/String;)V.(args)
  Unit => _root_.scala.Unit#
_empty_.Test.main([Ljava/lang/String;)V.(args) => param args: Array[String]
  Array => _root_.scala.Array#
  String => _root_.scala.Predef.String#
_root_.scala.Array# => final class Array.{+6 decls}
  extends AnyRef
  extends Serializable
  extends Cloneable
_root_.scala.Predef.String# => type String: String
  String => _root_.java.lang.String#
_root_.scala.Predef.println(Ljava/lang/Object;)V. => def println: (x: <?>): Unit
  x => _root_.scala.Predef.println(Ljava/lang/Object;)V.(x)
  Unit => _root_.scala.Unit#
_root_.scala.Unit# => abstract final class Unit.{+2 decls}
  extends AnyVal
_root_.scala.collection.TraversableOnce#mkString()Ljava/lang/String;. => def mkString: : String
  String => _root_.scala.Predef.String#
_root_.scala.collection.immutable.List. => final object List
local0 => val helloWorld: List[String]
  List => _root_.scala.collection.immutable.List#
  String => _root_.java.lang.String#

Occurrences:
[0:7..0:11): Test <= _empty_.Test.
[1:6..1:10): main <= _empty_.Test.main([Ljava/lang/String;)V.
[1:11..1:15): args <= _empty_.Test.main([Ljava/lang/String;)V.(args)
[1:17..1:22): Array => _root_.scala.Array#
[1:23..1:29): String => _root_.scala.Predef.String#
[1:33..1:37): Unit => _root_.scala.Unit#
[2:8..2:18): helloWorld <= local0
[2:21..2:25): List => _root_.scala.collection.immutable.List.
[3:4..3:11): println => _root_.scala.Predef.println(Ljava/lang/Object;)V.
[3:12..3:22): helloWorld => local0
[3:23..3:31): mkString => _root_.scala.collection.TraversableOnce#mkString()Ljava/lang/String;.

Synthetics:
[2:25..2:25): ε => *.apply[String]
  [0:0..0:1): * => _star_.
  [0:2..0:7): apply => _root_.scala.collection.immutable.List.apply(Lscala/collection/Seq;)Lscala/collection/immutable/List;.
  [0:8..0:14): String => _root_.java.lang.String#
```

Check out the `Symbols` section that is powered by the newly introduced `SymbolInformation.tpe`. Note how thanks to `tpe`, we have been able to implement a portable and uniform alternative to two unspecified and adhoc `SymbolInformation` fields: `signature` and `members`.
