### PR TITLE
Crosscompile semanticdb/ to Scala Native

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ env:
     - CI_TEST: ci-fast
       CI_SCALA_VERSION: 2.11.12
       CI_SCALA_JS: true
+    - CI_TEST: ci-native
+      CI_SCALA_VERSION: 2.11.12
+      CI_SCALA_NATIVE: true
     - CI_TEST: ci-fast
       CI_SCALA_VERSION: 2.12.4
       CI_PUBLISH: true
@@ -38,6 +41,9 @@ cache:
   - $HOME/.ivy2/cache
   - $HOME/.coursier
   - target/repos
+
+before_install:
+  - bin/travis_before_install
 
 before_cache:
   - du -h -d 1 $HOME/.ivy2/cache

--- a/bin/travis_before_install
+++ b/bin/travis_before_install
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+sudo find /usr -name "*libunwind*" -delete
+sudo apt-get install -y -qq clang++-3.9 libunwind8-dev make
+export CXX=clang++-3.9
+git clone https://code.googlesource.com/re2
+pushd re2
+git checkout 2017-03-01
+make -j4 test
+sudo make install prefix=/usr
+make testinstall prefix=/usr
+popd

--- a/build.sbt
+++ b/build.sbt
@@ -472,6 +472,7 @@ lazy val sharedSettings = Def.settings(
   crossVersion := {
     crossVersion.value match {
       case old @ ScalaJSCrossVersion.binary => old
+      case old @ ScalaNativeCrossVersion.binary => old
       case _ => CrossVersion.binary
     }
   },

--- a/build.sbt
+++ b/build.sbt
@@ -648,6 +648,7 @@ lazy val hasLargeIntegrationTests = Seq(
 lazy val nativeSettings = Seq(
   scalaVersion := LatestScala211,
   crossScalaVersions := List(LatestScala211),
+  scalacOptions -= "-Xfatal-warnings",
   nativeGC := "immix",
   nativeMode := "release",
   nativeLinkStubs := false,

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,7 @@ import scala.util.Try
 import scala.xml.{Node => XmlNode, NodeSeq => XmlNodeSeq, _}
 import scala.xml.transform.{RewriteRule, RuleTransformer}
 import org.scalajs.sbtplugin.ScalaJSCrossVersion
+import sbtcrossproject.{crossProject, CrossType}
 import org.scalameta.build._
 import org.scalameta.build.Versions._
 import org.scalameta.os
@@ -73,7 +74,7 @@ console := console.in(scalametaJVM, Compile).value
 
 /** ======================== SEMANTICDB ======================== **/
 
-lazy val semanticdb3 = crossProject
+lazy val semanticdb3 = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Pure)
   .in(file("semanticdb/semanticdb3"))
   .settings(
@@ -143,7 +144,7 @@ lazy val metac = project
   .disablePlugins(BackgroundRunPlugin)
   .dependsOn(semanticdbScalacPlugin)
 
-lazy val metap = crossProject
+lazy val metap = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Pure)
   .in(file("semanticdb/metap"))
   .settings(
@@ -160,7 +161,7 @@ lazy val metapJS = metap.js
 
 /** ======================== LANGMETA ======================== **/
 
-lazy val langmeta = crossProject
+lazy val langmeta = crossProject(JSPlatform, JVMPlatform)
   .in(file("langmeta/langmeta"))
   .settings(
     publishableSettings,
@@ -178,7 +179,7 @@ lazy val langmetaJS = langmeta.js
 
 /** ======================== SCALAMETA ======================== **/
 
-lazy val common = crossProject
+lazy val common = crossProject(JSPlatform, JVMPlatform)
   .in(file("scalameta/common"))
   .settings(
     publishableSettings,
@@ -189,7 +190,7 @@ lazy val common = crossProject
 lazy val commonJVM = common.jvm
 lazy val commonJS = common.js
 
-lazy val io = crossProject
+lazy val io = crossProject(JSPlatform, JVMPlatform)
   .in(file("scalameta/io"))
   .settings(
     publishableSettings,
@@ -200,7 +201,7 @@ lazy val io = crossProject
 lazy val ioJVM = io.jvm
 lazy val ioJS = io.js
 
-lazy val dialects = crossProject
+lazy val dialects = crossProject(JSPlatform, JVMPlatform)
   .in(file("scalameta/dialects"))
   .settings(
     publishableSettings,
@@ -211,7 +212,7 @@ lazy val dialects = crossProject
 lazy val dialectsJVM = dialects.jvm
 lazy val dialectsJS = dialects.js
 
-lazy val inputs = crossProject
+lazy val inputs = crossProject(JSPlatform, JVMPlatform)
   .in(file("scalameta/inputs"))
   .settings(
     publishableSettings,
@@ -232,7 +233,7 @@ lazy val interactive = project
   )
   .dependsOn(semanticdbScalacCore)
 
-lazy val parsers = crossProject
+lazy val parsers = crossProject(JSPlatform, JVMPlatform)
   .in(file("scalameta/parsers"))
   .settings(
     publishableSettings,
@@ -243,7 +244,7 @@ lazy val parsers = crossProject
 lazy val parsersJVM = parsers.jvm
 lazy val parsersJS = parsers.js
 
-lazy val quasiquotes = crossProject
+lazy val quasiquotes = crossProject(JSPlatform, JVMPlatform)
   .in(file("scalameta/quasiquotes"))
   .settings(
     publishableSettings,
@@ -254,7 +255,7 @@ lazy val quasiquotes = crossProject
 lazy val quasiquotesJVM = quasiquotes.jvm
 lazy val quasiquotesJS = quasiquotes.js
 
-lazy val tokenizers = crossProject
+lazy val tokenizers = crossProject(JSPlatform, JVMPlatform)
   .in(file("scalameta/tokenizers"))
   .settings(
     publishableSettings,
@@ -266,7 +267,7 @@ lazy val tokenizers = crossProject
 lazy val tokenizersJVM = tokenizers.jvm
 lazy val tokenizersJS = tokenizers.js
 
-lazy val tokens = crossProject
+lazy val tokens = crossProject(JSPlatform, JVMPlatform)
   .in(file("scalameta/tokens"))
   .settings(
     publishableSettings,
@@ -277,7 +278,7 @@ lazy val tokens = crossProject
 lazy val tokensJVM = tokens.jvm
 lazy val tokensJS = tokens.js
 
-lazy val transversers = crossProject
+lazy val transversers = crossProject(JSPlatform, JVMPlatform)
   .in(file("scalameta/transversers"))
   .settings(
     publishableSettings,
@@ -288,7 +289,7 @@ lazy val transversers = crossProject
 lazy val traversersJVM = transversers.jvm
 lazy val traversersJS = transversers.js
 
-lazy val trees = crossProject
+lazy val trees = crossProject(JSPlatform, JVMPlatform)
   .in(file("scalameta/trees"))
   .settings(
     publishableSettings,
@@ -301,7 +302,7 @@ lazy val trees = crossProject
 lazy val treesJVM = trees.jvm
 lazy val treesJS = trees.js
 
-lazy val semanticdb = crossProject
+lazy val semanticdb = crossProject(JSPlatform, JVMPlatform)
   .in(file("scalameta/semanticdb"))
   .settings(
     publishableSettings,
@@ -311,7 +312,7 @@ lazy val semanticdb = crossProject
 lazy val semanticdbJVM = semanticdb.jvm
 lazy val semanticdbJS = semanticdb.js
 
-lazy val scalameta = crossProject
+lazy val scalameta = crossProject(JSPlatform, JVMPlatform)
   .in(file("scalameta/scalameta"))
   .settings(
     publishableSettings,
@@ -332,7 +333,7 @@ lazy val scalameta = crossProject
 lazy val scalametaJVM = scalameta.jvm
 lazy val scalametaJS = scalameta.js
 
-lazy val contrib = crossProject
+lazy val contrib = crossProject(JSPlatform, JVMPlatform)
   .in(file("scalameta/contrib"))
   .settings(
     publishableSettings,
@@ -386,7 +387,7 @@ lazy val testkit = project
   )
   .dependsOn(contribJVM)
 
-lazy val tests = crossProject
+lazy val tests = crossProject(JSPlatform, JVMPlatform)
   .in(file("tests"))
   .settings(
     sharedSettings,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -31,3 +31,7 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "2.0.0")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.18")
+
+// These builds are published from my private fork of Scala Native
+// https://github.com/xeno-by/scala-native/commits/topic/scalameta
+addSbtPlugin("com.github.xenoby" %% "sbt-scala-native" % "0.3.6-20-g0afae98f36" exclude("org.scala-native", "sbt-crossproject"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,9 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.21")
 
+addSbtPlugin("org.portable-scala" % "sbt-crossproject" % "0.3.1")
+
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.3.1")
+
 // exclude is a workaround for https://github.com/sbt/sbt-assembly/issues/236#issuecomment-294452474
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6" exclude("org.apache.maven", "maven-plugin-api"))
 


### PR DESCRIPTION
This is a follow-up from https://github.com/scalameta/scalameta/pull/1243 that is limited to just the crosscompilable projects in `semanticdb/`.