### PR TITLE
Add SymbolInformation.annotations

### DIFF
--- a/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/Flags.scala
+++ b/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/Flags.scala
@@ -28,6 +28,7 @@ private[semanticdb] trait Flags {
   final val CONTRAVARIANT: Long = 1 << 23
   final val INLINE: Long = 1 << 24
   final val JAVADEFINED: Long = 1 << 25
+  final val SPECIALIZED: Long = 1 << 26
 }
 
 private[semanticdb] trait HasFlags {
@@ -60,6 +61,7 @@ private[semanticdb] trait HasFlags {
   def isContravariant: Boolean = hasFlag(CONTRAVARIANT)
   def isInline: Boolean = hasFlag(INLINE)
   def isJavaDefined: Boolean = hasFlag(JAVADEFINED)
+  def isSpecialized: Boolean = hasFlag(SPECIALIZED)
 
   protected def flagSyntax: String = {
     val buf = new StringBuilder
@@ -80,6 +82,7 @@ private[semanticdb] trait HasFlags {
     if (hasFlag(CONTRAVARIANT)) append("CONTRAVARIANT")
     if (hasFlag(INLINE)) append("INLINE")
     if (hasFlag(JAVADEFINED)) append("JAVADEFINED")
+    if (hasFlag(SPECIALIZED)) append("SPECIALIZED")
     if (hasFlag(VAL)) append("VAL")
     if (hasFlag(VAR)) append("VAR")
     if (hasFlag(DEF)) append("DEF")

--- a/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/package.scala
+++ b/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/package.scala
@@ -140,6 +140,7 @@ package object semanticdb {
               if (stest(p.CONTRAVARIANT.value)) dflip(d.CONTRAVARIANT)
               if (stest(p.VALPARAM.value)) dflip(d.VAL)
               if (stest(p.VARPARAM.value)) dflip(d.VAR)
+              if (stest(p.SPECIALIZED.value)) dflip(d.SPECIALIZED)
               dflags
             }
             val dname = sname

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DenotationOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DenotationOps.scala
@@ -76,6 +76,8 @@ trait DenotationOps { self: DatabaseOps =>
       if (gsym.hasFlag(gf.CASE)) flags |= mf.CASE
       if (gsym.isType && gsym.hasFlag(gf.CONTRAVARIANT)) flags |= mf.CONTRAVARIANT
       if (gsym.isType && gsym.hasFlag(gf.COVARIANT)) flags |= mf.COVARIANT
+      if (gsym.isType && gsym.hasAnnotation(g.definitions.SpecializedClass)) flags |= mf.SPECIALIZED
+
       // TODO: mf.INLINE
       flags
     }

--- a/semanticdb/semanticdb3/semanticdb3.md
+++ b/semanticdb/semanticdb3/semanticdb3.md
@@ -655,6 +655,11 @@ or features from other languages.
     <td><code>VARPARAM</code></td>
     <td>Is a `var` parameter of a primary constructor?</td>
   </tr>
+  <tr>
+    <td><code>0x1000</code></td>
+    <td><code>SPECIALIZED</code></td>
+    <td>Is the type parameter specialized? (ex: class Foo[@specialized(Int) T](v: T))</td>
+  </tr>
 </table>
 
 `name`. String that represents the name of the symbol.

--- a/semanticdb/semanticdb3/semanticdb3.proto
+++ b/semanticdb/semanticdb3/semanticdb3.proto
@@ -158,6 +158,7 @@ message TypeType {
   Type upper_bound = 3;
 }
 
+// see https://github.com/scala/scala/blob/2.12.x/src/reflect/scala/reflect/internal/Flags.scala
 message SymbolInformation {
   enum Kind {
     UNKNOWN_KIND = 0;
@@ -178,18 +179,20 @@ message SymbolInformation {
   }
   enum Property {
     UNKNOWN_PROPERTY = 0;
-    PRIVATE = 0x1;
-    PROTECTED = 0x2;
-    ABSTRACT = 0x4;
-    FINAL = 0x8;
-    SEALED = 0x10;
-    IMPLICIT = 0x20;
-    LAZY = 0x40;
-    CASE = 0x80;
-    COVARIANT = 0x100;
-    CONTRAVARIANT = 0x200;
-    VALPARAM = 0x400;
-    VARPARAM = 0x800;
+    PRIVATE = 0x1;          // 1 <<  1
+    PROTECTED = 0x2;        // 1 <<  2
+    ABSTRACT = 0x4;         // 1 <<  3
+    FINAL = 0x8;            // 1 <<  4
+    SEALED = 0x10;          // 1 <<  5
+    IMPLICIT = 0x20;        // 1 <<  6 
+    LAZY = 0x40;            // 1 <<  7 
+    CASE = 0x80;            // 1 <<  8 
+    COVARIANT = 0x100;      // 1 <<  9 
+    CONTRAVARIANT = 0x200;  // 1 << 10 
+    VALPARAM = 0x400;       // 1 << 11 
+    VARPARAM = 0x800;       // 1 << 12 
+    SPECIALIZED = 0x1000;   // 1 << 13
+    // (1 << 15).toHexString
   }
   reserved 6;
   string symbol = 1;

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/TargetedSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/TargetedSuite.scala
@@ -1145,21 +1145,15 @@ class TargetedSuite extends DatabaseSuite(SemanticdbMode.Slim) {
     }
   )
 
-  symbols(
-    "class Foo[@specialized(Int) T](v: T)".stripMargin,
-    """|_empty_.Foo# => class Foo
-       |_empty_.Foo#(v) => param v: T
-       |  [0..1): T => _empty_.Foo#[T]
-       |_empty_.Foo#[T] => specialized typeparam T
-       |_empty_.Foo#`<init>`(Ljava/lang/Object;)V. => primaryctor <init>: (v: T): Foo[T]
-       |  [4..5): T => _empty_.Foo#[T]
-       |  [8..11): Foo => _empty_.Foo#
-       |  [12..13): T => _empty_.Foo#[T]
-       |_root_.scala.Int. => final object Int
-       |_root_.scala.specialized# => class specialized
-       |_root_.scala.specialized#`<init>`(Lscala/collection/Seq;)V. => secondaryctor <init>: (types: Specializable*): specialized
-       |  [8..21): Specializable => _root_.scala.Specializable#
-       |  [25..36): specialized => _root_.scala.specialized#
-       |""".stripMargin.trim
+  targeted(
+    "class Foo[@specialized(Int) <<T>>](v: T)",
+    { (db, foo) =>
+      //      assertNoDiff(foo.syntax, "")
+      val symbol = db.symbols.find(_.symbol == foo).get
+      val denotation = symbol.denotation
+      assert(foo == Symbol("_empty_.Foo#[T]"))
+      assertNoDiff(denotation.toString, "specialized typeparam T")
+
+    }
   )
 }

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/TargetedSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/TargetedSuite.scala
@@ -1144,4 +1144,22 @@ class TargetedSuite extends DatabaseSuite(SemanticdbMode.Slim) {
       )
     }
   )
+
+  symbols(
+    "class Foo[@specialized(Int) T](v: T)".stripMargin,
+    """|_empty_.Foo# => class Foo
+       |_empty_.Foo#(v) => param v: T
+       |  [0..1): T => _empty_.Foo#[T]
+       |_empty_.Foo#[T] => specialized typeparam T
+       |_empty_.Foo#`<init>`(Ljava/lang/Object;)V. => primaryctor <init>: (v: T): Foo[T]
+       |  [4..5): T => _empty_.Foo#[T]
+       |  [8..11): Foo => _empty_.Foo#
+       |  [12..13): T => _empty_.Foo#[T]
+       |_root_.scala.Int. => final object Int
+       |_root_.scala.specialized# => class specialized
+       |_root_.scala.specialized#`<init>`(Lscala/collection/Seq;)V. => secondaryctor <init>: (types: Specializable*): specialized
+       |  [8..21): Specializable => _root_.scala.Specializable#
+       |  [25..36): specialized => _root_.scala.specialized#
+       |""".stripMargin.trim
+  )
 }


### PR DESCRIPTION
SemanticDB currently doesn't include annotation to symbols such as `@specialized`. This information is necessary to implement Scalafix rules such as SAM conversion to guard against cases where a type parameter is specialized.

This PR adds a new `annotations: List[Symbol]` field to `SymbolInformation`. 