### PR TITLE
Update travis script to only run native install on native entry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,35 +3,44 @@ git:
   depth: 9999
 install:
   - git fetch --tags
-  - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
+  - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install 8
 script:
   - ./bin/runci.sh $CI_TEST
 jdk:
   - oraclejdk8
-env:
-  global:
-  - TRAVIS_NODE_VERSION="8"
-  matrix:
-    - CI_TEST: check
-    - CI_TEST: ci-fast
-      CI_SCALA_VERSION: 2.11.12
-      CI_PUBLISH: true
-    - CI_TEST: ci-fast
-      CI_SCALA_VERSION: 2.11.12
-      CI_SCALA_JS: true
-    - CI_TEST: ci-native
-      CI_SCALA_VERSION: 2.11.12
-      CI_SCALA_NATIVE: true
-    - CI_TEST: ci-fast
-      CI_SCALA_VERSION: 2.12.4
-      CI_PUBLISH: true
-    - CI_TEST: ci-fast
-      CI_SCALA_VERSION: 2.12.4
-      CI_SCALA_JS: true
-    - CI_TEST: ci-fast
-      CI_SCALA_VERSION: 2.10.6
-      CI_PUBLISH: true
-    - CI_TEST: mima
+
+matrix:
+  include:
+    - env:
+      - CI_TEST: check
+    - env:
+      - CI_TEST: ci-fast
+      - CI_SCALA_VERSION: 2.11.12
+      - CI_PUBLISH: true
+    - env:
+      - CI_TEST: ci-fast
+      - CI_SCALA_VERSION: 2.11.12
+      - CI_SCALA_JS: true
+    - env:
+        - CI_TEST: ci-native
+        - CI_SCALA_VERSION: 2.11.12
+        - CI_SCALA_NATIVE: true
+      before_install:
+        - bin/travis_before_install
+    - env:
+      - CI_TEST: ci-fast
+      - CI_SCALA_VERSION: 2.12.4
+      - CI_PUBLISH: true
+    - env:
+      - CI_TEST: ci-fast
+      - CI_SCALA_VERSION: 2.12.4
+      - CI_SCALA_JS: true
+    - env:
+      - CI_TEST: ci-fast
+      - CI_SCALA_VERSION: 2.10.6
+      - CI_PUBLISH: true
+    - env:
+      - CI_TEST: mima
 
 cache:
   directories:
@@ -42,8 +51,6 @@ cache:
   - $HOME/.coursier
   - target/repos
 
-before_install:
-  - bin/travis_before_install
 
 before_cache:
   - du -h -d 1 $HOME/.ivy2/cache


### PR DESCRIPTION
To speed up non-native entries, native installation is kind of slow.