### PR TITLE
Replace assert with guard.

### DIFF
--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DocumentOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DocumentOps.scala
@@ -206,8 +206,9 @@ trait DocumentOps { self: DatabaseOps =>
                   (todoTpe1 ++ todoTpe2).foreach { tgs =>
                     if (tgs.isSemanticdbLocal) {
                       val tms = tgs.toSemantic
-                      assert(tms != m.Symbol.None)
-                      if (!denotations.contains(tms)) add(tms, tgs)
+                      if (tms != m.Symbol.None && !denotations.contains(tms)) {
+                        add(tms, tgs)
+                      }
                     }
                   }
                 }


### PR DESCRIPTION
This assert triggered several dozen times while compiling ammonite with
latest semanticdb-scalac. Fixes #1272.