### PR TITLE
Add real-world integration test for metac.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,10 @@ matrix:
       - CI_SCALA_VERSION: 2.10.6
       - CI_PUBLISH: true
     - env:
+      - CI_TEST: ci-metac
+      - CI_SCALA_VERSION: 2.12.4
+      - CI_SCALA_JS: true
+    - env:
       - CI_TEST: mima
 
 cache:

--- a/build.sbt
+++ b/build.sbt
@@ -57,6 +57,17 @@ commands += Command.command("mima") { s =>
   s"very mimaReportBinaryIssues" ::
   s
 }
+commands += Command.command("ci-metac") { s =>
+  val out = file("target/scala-library")
+  if (!out.exists()) {
+    IO.unzipURL(
+      new URL(s"https://github.com/scala/scala/archive/v$LatestScala212.zip"),
+      toDirectory = out,
+      filter = s"scala-$LatestScala212/src/library/*"
+    )
+  }
+  "testsJVM/test:runMain scala.meta.tests.semanticdb.MetacScalaLibrary" :: s
+}
 // NOTE: These tasks are aliased here in order to support running "tests/test"
 // from a command. Running "test" inside a command will trigger the `test` task
 // to run in all defined modules, including ones like inputs/io/dialects which

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/MetacScalaLibrary.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/MetacScalaLibrary.scala
@@ -1,0 +1,47 @@
+package scala.meta.tests.semanticdb
+
+import java.io.File
+import java.net.URLClassLoader
+import java.nio.file.Files
+import java.nio.file.Paths
+import scala.meta.cli.metac
+import scala.meta.tests.BuildInfo
+import org.langmeta.internal.io.FileIO
+import org.langmeta.io.AbsolutePath
+
+// Compile all of scala-library with metac and report any semanticdb errors.
+object MetacScalaLibrary {
+  def main(args: Array[String]): Unit = {
+    val library = Paths
+      .get("target")
+      .resolve("scala-library")
+      .resolve(s"scala-${BuildInfo.scalaVersion}")
+      .resolve("src")
+      .resolve("library")
+      .toAbsolutePath
+    assert(Files.isDirectory(library), s"$library is not a directory! Run `sbt ci-metac`")
+    val classpath = this.getClass.getClassLoader
+      .asInstanceOf[URLClassLoader]
+      .getURLs
+      .map(_.getPath)
+      .filter(_.contains("scala-library"))
+      .mkString(File.pathSeparator)
+    val files = FileIO
+      .listAllFilesRecursively(AbsolutePath(library))
+      .map(_.toString)
+      .filter(_.endsWith("scala"))
+    val out = Files.createTempDirectory("metac")
+    println(s"Compiling ${files.length} sources from scala-library...")
+    val code = metac.Main.process(
+      Array(
+        "-d",
+        out.toString,
+        "-classpath",
+        classpath,
+        "-P:semanticdb:failures:error"
+      ) ++ files
+    )
+    println(out)
+    sys.exit(code)
+  }
+}


### PR DESCRIPTION
Fixes #1279. This commit adds a new entry to our matrix build that runs
metac with -P:semanticdb:failures:error on all of scala-library.
The test currently fails due to several bugs in semanticdb-scalac.