### PR TITLE
Add Denotation.annotations

### DIFF
--- a/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/Denotation.scala
+++ b/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/Denotation.scala
@@ -13,21 +13,32 @@ final class Denotation(
     val names: List[ResolvedName],
     val members: List[Signature],
     val overrides: List[Symbol],
-    val tpe: Option[s.Type]
+    val tpe: Option[s.Type],
+    val annotations: List[Symbol]
 ) extends HasFlags
     with Product
     with Serializable {
   def this(flags: Long, name: String, signature: String, names: List[ResolvedName]) =
-      this(flags, name, signature, names, Nil, Nil, None)
+      this(flags, name, signature, names, Nil, Nil, None, Nil)
 
-  def this(flags: Long, name: String, signature: String, names: List[ResolvedName], members: List[Signature]) =
-      this(flags, name, signature, names, members, Nil, None)
+  def this(flags: Long, name: String, signature: String, names: List[ResolvedName], 
+           members: List[Signature]) =
+      this(flags, name, signature, names, members, Nil, None, Nil)
 
-  def this(flags: Long, name: String, signature: String, names: List[ResolvedName], members: List[Signature], overrides: List[Symbol]) =
-      this(flags, name, signature, names, members, overrides, None)
+  def this(flags: Long, name: String, signature: String, names: List[ResolvedName],
+           members: List[Signature], overrides: List[Symbol]) =
+      this(flags, name, signature, names, members, overrides, None, Nil)
+
+  def this(flags: Long, name: String, signature: String, names: List[ResolvedName],
+           members: List[Signature], overrides: List[Symbol], tpe: Option[s.Type]) =
+    this(flags, name, signature, names, members, overrides, tpe, Nil)
 
   def syntax: String = {
     val s_overrides = if (overrides.isEmpty) "" else s"${EOL}  override ${overrides.head}"
+    val s_annotations =
+      if (annotations.isEmpty) ""
+      else annotations.map(annot =>s"  @$annot").mkString(EOL, EOL, "")
+
     val s_members = if (members.isEmpty) "" else s".{+${members.length} members}"
     val s_info = if (signature != "") ": " + signature else ""
     val s_names = ResolvedName.syntax(names)
@@ -37,9 +48,13 @@ final class Denotation(
 
     s"$flagSyntax $s_name" + s_info + s_members +
       s_overrides +
+      s_annotations +
       s_names
   }
   def structure = s"""Denotation($flagStructure, "$name", "$signature")"""
+
+  private val specialized = Symbol("_root_.scala.specialized#")
+  def isSpecialized: Boolean = annotations.exists(_ == specialized)
 
   // Expanded case class boilerplate
   @deprecated("Use new Denotation(...) instead.", "2.1.0")
@@ -59,6 +74,7 @@ final class Denotation(
     acc = scala.runtime.Statics.mix(acc, scala.runtime.Statics.anyHash(members))
     acc = scala.runtime.Statics.mix(acc, scala.runtime.Statics.anyHash(overrides))
     acc = scala.runtime.Statics.mix(acc, scala.runtime.Statics.anyHash(tpe))
+    acc = scala.runtime.Statics.mix(acc, scala.runtime.Statics.anyHash(annotations))
     scala.runtime.Statics.finalizeHash(acc, 4)
   }
   override def equals(x$1: scala.Any): Boolean = this.eq(x$1.asInstanceOf[Object]) || {
@@ -107,6 +123,16 @@ object Denotation extends AbstractFunction4[Long, String, String, List[ResolvedN
             overrides: List[Symbol],
             tpe: Option[s.Type]): Denotation =
     new Denotation(flags, name, signature, names, members, overrides, tpe)
+
+  def apply(flags: Long,
+            name: String,
+            signature: String,
+            names: List[ResolvedName],
+            members: List[Signature],
+            overrides: List[Symbol],
+            tpe: Option[s.Type],
+            annotations: List[Symbol]): Denotation =
+    new Denotation(flags, name, signature, names, members, overrides, tpe, annotations)
 
   @deprecated("Use `case d: Denotation` instead.", "2.1.0")
   def unapply(x$0: Denotation): Option[(Long, String, String, List[ResolvedName])] =

--- a/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/package.scala
+++ b/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/package.scala
@@ -104,7 +104,7 @@ package object semanticdb {
       }
       object sSymbolInformation {
         def unapply(ssymbolInformation: s.SymbolInformation): Option[d.ResolvedSymbol] = ssymbolInformation match {
-          case s.SymbolInformation(ssym, slanguage, skind, sproperties, sname, _, ssignature, smembers, soverrides, stpe) =>
+          case s.SymbolInformation(ssym, slanguage, skind, sproperties, sname, _, ssignature, smembers, soverrides, stpe, sannotations) =>
             val dsym = dSymbol(ssym)
             val dflags = {
               var dflags = 0L
@@ -166,7 +166,8 @@ package object semanticdb {
             }.toList
             val doverrides = soverrides.map(dSymbol).toList
             val dtpe = stpe
-            Some(d.ResolvedSymbol(dsym, d.Denotation(dflags, dname, dsignature, dnames, dmembers, doverrides, dtpe)))
+            val dannotations = sannotations.map(dSymbol).toList
+            Some(d.ResolvedSymbol(dsym, d.Denotation(dflags, dname, dsignature, dnames, dmembers, doverrides, dtpe, dannotations)))
           case other => sys.error(s"bad protobuf: unsupported symbol information $other")
         }
       }
@@ -339,8 +340,9 @@ package object semanticdb {
               }
               val smembers = ddenot.members.map(_.syntax)
               val soverrides = ddenot.overrides.map(sSymbol)
+              val sannotations = ddenot.annotations.map(sSymbol)
               val stpe = ddenot.tpe
-              Some(s.SymbolInformation(ssymbol, slanguage, skind, sproperties, sname, srange, ssignature, smembers, soverrides, stpe))
+              Some(s.SymbolInformation(ssymbol, slanguage, skind, sproperties, sname, srange, ssignature, smembers, soverrides, stpe, sannotations))
             }
           }
           object dSynthetic {

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DenotationOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DenotationOps.scala
@@ -122,24 +122,29 @@ trait DenotationOps { self: DatabaseOps =>
         if (saveOverrides && config.denotations.saveReferences) gsym.overrides
         else Nil
       }
-      config.signatures match {
-        case SignatureMode.None =>
-          val denot = m.Denotation(flags, name, "", Nil, Nil, over, None)
-          DenotationResult(denot, todoOverrides, Nil)
-        case SignatureMode.Old =>
-          val (signature, names) = oldInfo
-          val denot = m.Denotation(flags, name, signature, names, Nil, over, None)
-          DenotationResult(denot, todoOverrides, Nil)
-        case SignatureMode.New =>
-          val (tpe, todoTpe) = newInfo
-          val denot = m.Denotation(flags, name, "", Nil, Nil, over, tpe)
-          DenotationResult(denot, todoOverrides, todoTpe)
-        case SignatureMode.All =>
-          val (signature, names) = oldInfo
-          val (tpe, todoTpe) = newInfo
-          val denot = m.Denotation(flags, name, signature, names, Nil, over, tpe)
-          DenotationResult(denot, todoOverrides, todoTpe)
-      }
+      val todoAnnotations = gsym.annotations.map(_.symbol)
+      val annot = gsym.annotations.map(_.symbol.toSemantic)
+      val (denot, todoTpe) =
+        config.signatures match {
+          case SignatureMode.None =>
+            val denot = m.Denotation(flags, name, "", Nil, Nil, over, None, annot)
+            (denot, Nil)
+          case SignatureMode.Old =>
+            val (signature, names) = oldInfo
+            val denot = m.Denotation(flags, name, signature, names, Nil, over, None, annot)
+            (denot, Nil)
+          case SignatureMode.New =>
+            val (tpe, todoTpe) = newInfo
+            val denot = m.Denotation(flags, name, "", Nil, Nil, over, tpe, annot)
+            (denot, todoTpe)
+          case SignatureMode.All =>
+            val (signature, names) = oldInfo
+            val (tpe, todoTpe) = newInfo
+            val denot = m.Denotation(flags, name, signature, names, Nil, over, tpe, annot)
+            (denot, todoTpe)
+        }
+
+      DenotationResult(denot, todoOverrides, todoTpe, todoAnnotations)
     }
   }
 
@@ -147,5 +152,6 @@ trait DenotationOps { self: DatabaseOps =>
   case class DenotationResult(
       denot: m.Denotation,
       todoOverrides: List[g.Symbol],
-      todoTpe: List[g.Symbol])
+      todoTpe: List[g.Symbol],
+      todoAnnotations: List[g.Symbol])
 }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DocumentOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DocumentOps.scala
@@ -194,16 +194,22 @@ trait DocumentOps { self: DatabaseOps =>
               def saveDenotation(): Unit = {
                 def add(ms: m.Symbol, gs: g.Symbol): Unit = {
                   val saveOverrides = config.overrides.isAll && mtree.isDefinition
-                  val DenotationResult(denot, todoOverrides, todoTpe1) =
+                  val DenotationResult(denot, todoOverrides, todoTpe1, todoAnnotations) =
                     gs.toDenotation(saveOverrides)
                   denotations(ms) = denot
                   val todoTpe2 = todoOverrides.flatMap { ogs =>
-                    val DenotationResult(odenot, _, otodoTpe) =
+                    val DenotationResult(odenot, _, otodoTpe, _) =
                       ogs.toDenotation(saveOverrides = true)
                     denotations(ogs.toSemantic) = odenot
                     otodoTpe
                   }
-                  (todoTpe1 ++ todoTpe2).foreach { tgs =>
+                  val todoTpe3 = todoAnnotations.flatMap { ogs =>
+                    val DenotationResult(odenot, _, otodoTpe, _) =
+                      ogs.toDenotation(saveOverrides = false)
+                    denotations(ogs.toSemantic) = odenot
+                    otodoTpe
+                  }
+                  (todoTpe1 ++ todoTpe2 ++ todoTpe3).foreach { tgs =>
                     if (tgs.isSemanticdbLocal) {
                       val tms = tgs.toSemantic
                       assert(tms != m.Symbol.None)

--- a/semanticdb/semanticdb3/semanticdb3.md
+++ b/semanticdb/semanticdb3/semanticdb3.md
@@ -491,6 +491,7 @@ message SymbolInformation {
   repeated string members = 8;
   repeated string overrides = 9;
   Type tpe = 11;
+  repeated string annotations = 12;
 }
 ```
 
@@ -501,7 +502,7 @@ In a sense, this section is analogous to symbol tables [\[21\]][21] in compiler.
 `SymbolInformation` contains assorted metadata for a `symbol`, as explained below.
 At the moment, the supported metadata is usecase-driven and is not supposed to
 be comprehensive or language-agnostic. In the future, we may add support for
-more metadata, for example information about overriding, documentation strings
+more metadata, for example information about documentation strings
 or features from other languages.
 
 `language`. Language that defines this symbol.
@@ -682,6 +683,8 @@ specifying it, we superseded it with `ClassInfoType.members` in `SymbolInformati
 `overrides`. Symbols that are overridden by this symbol either directly or transitively.
 
 `tpe`. [Type](#type) that represents the type signature of the definition.
+
+`annotations`. Symbols of the annotation attached to the denotation. Currently does not support annotation parameters.
 
 ### SymbolOccurrence
 

--- a/semanticdb/semanticdb3/semanticdb3.proto
+++ b/semanticdb/semanticdb3/semanticdb3.proto
@@ -202,6 +202,7 @@ message SymbolInformation {
   repeated string members = 8;
   repeated string overrides = 9;
   Type tpe = 11;
+  repeated string annotations = 12;
 }
 
 message SymbolOccurrence {

--- a/tests/jvm/src/test/resources/highlevel.expect
+++ b/tests/jvm/src/test/resources/highlevel.expect
@@ -56,10 +56,17 @@ _root_.scala.Unit# => abstract final class Unit
 _root_.scala.collection. => package collection
 _root_.scala.collection.mutable. => package mutable
 _root_.scala.collection.mutable.Stack# => class Stack
+  @_root_.scala.deprecated#
+  @_root_.scala.deprecated#
 _root_.scala.collection.mutable.Stack#`<init>`()V. => secondaryctor <init>: (): Stack[A]
   [4..9): Stack => _root_.scala.collection.mutable.Stack#
   [10..11): A => _root_.scala.collection.mutable.Stack#[A]
 _root_.scala.concurrent. => package concurrent
+_root_.scala.deprecated# => class deprecated
+  @_root_.scala.annotation.meta.getter#
+  @_root_.scala.annotation.meta.setter#
+  @_root_.scala.annotation.meta.beanGetter#
+  @_root_.scala.annotation.meta.beanSetter#
 _root_.scala.reflect. => package reflect
 _root_.scala.reflect.package.classTag(Lscala/reflect/ClassTag;)Lscala/reflect/ClassTag;. => def classTag: [T] => (implicit ctag: ClassTag[T]): ClassTag[T]
   [23..31): ClassTag => _root_.scala.reflect.ClassTag#
@@ -714,8 +721,10 @@ _root_.scala.Int#`+`(I)I. => abstract def +: (x: Int): Int
   [4..7): Int => _root_.scala.Int#
   [10..13): Int => _root_.scala.Int#
 _root_.scala.Predef.locally(Ljava/lang/Object;)Ljava/lang/Object;. => def locally: [T] => (x: T): T
+  @_root_.scala.inline#
   [11..12): T => _root_.scala.Predef.locally(Ljava/lang/Object;)Ljava/lang/Object;.[T]
   [15..16): T => _root_.scala.Predef.locally(Ljava/lang/Object;)Ljava/lang/Object;.[T]
+_root_.scala.inline# => class inline
 local0_semanticdb_integration_src_main_scala_example_local_file_scala => val local: Int
   [0..3): Int => _root_.scala.Int#
 

--- a/tests/jvm/src/test/resources/lowlevel.expect
+++ b/tests/jvm/src/test/resources/lowlevel.expect
@@ -6,7 +6,7 @@ Schema => SemanticDB v3
 Uri => semanticdb/integration/src/main/scala/example/Example.scala
 Text => non-empty
 Language => Scala212
-Symbols => 18 entries
+Symbols => 19 entries
 Occurrences => 22 entries
 Diagnostics => 1 entries
 Synthetics => 1 entries
@@ -50,6 +50,9 @@ _root_.scala.collection.mutable.Stack#`<init>`()V. => secondaryctor <init>: (): 
   Stack => _root_.scala.collection.mutable.Stack#
   Stack#[A => _root_.scala.collection.mutable.Stack#[A]
 _root_.scala.concurrent. => package concurrent
+_root_.scala.deprecated# => class deprecated.{+3 decls}
+  extends Annotation
+  extends StaticAnnotation
 _root_.scala.reflect. => package reflect
 _root_.scala.reflect.package.classTag(Lscala/reflect/ClassTag;)Lscala/reflect/ClassTag;. => def classTag: [T: <?>] => (ctag: <?>): ClassTag[T]
   T => _root_.scala.reflect.package.classTag(Lscala/reflect/ClassTag;)Lscala/reflect/ClassTag;.[T]
@@ -832,7 +835,7 @@ Schema => SemanticDB v3
 Uri => semanticdb/integration/src/main/scala/example/local-file.scala
 Text => non-empty
 Language => Scala212
-Symbols => 6 entries
+Symbols => 7 entries
 Occurrences => 7 entries
 Diagnostics => 0 entries
 Synthetics => 1 entries
@@ -850,6 +853,9 @@ _root_.scala.Predef.locally(Ljava/lang/Object;)Ljava/lang/Object;. => def locall
   T => _root_.scala.Predef.locally(Ljava/lang/Object;)Ljava/lang/Object;.[T]
   x => _root_.scala.Predef.locally(Ljava/lang/Object;)Ljava/lang/Object;.(x)
   T => _root_.scala.Predef.locally(Ljava/lang/Object;)Ljava/lang/Object;.[T]
+_root_.scala.inline# => class inline.{+1 decls}
+  extends Annotation
+  extends StaticAnnotation
 local0 => val local: Int
   Int => _root_.scala.Int#
 

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/AnnotationsSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/AnnotationsSuite.scala
@@ -1,0 +1,76 @@
+package scala.meta.tests
+package semanticdb
+
+import scala.meta.internal.semanticdb.scalac._
+
+class AnnotationsSuite extends DatabaseSuite(SemanticdbMode.Slim) {
+
+  annotations(
+    """
+      |// Type annotation
+      |class A[@specialized(Int, Long) T](v: T)
+      |
+      |// Class annotation
+      |@deprecated("Use D", "1.0") class B { }
+      |
+      |object C {
+      |  // Variable annotation
+      |  @transient @volatile var m: Int = 0
+      |
+      |  // Expression annotation
+      |  def f(x: Option[String]) = (x: @unchecked) match { case Some(y) => y }
+      |}
+    """.stripMargin,
+    """
+      |_root_.scala.volatile#{
+      |  _root_.scala.annotation.meta.field#
+      |}
+      |_empty_.A#[T]{
+      |  _root_.scala.specialized#
+      |}
+      |_root_.scala.Option#{
+      |  _root_.scala.SerialVersionUID#
+      |}
+      |_empty_.B#{
+      |  _root_.scala.deprecated#
+      |}
+      |_root_.scala.transient#{
+      |  _root_.scala.annotation.meta.field#
+      |}
+      |_root_.scala.deprecated#{
+      |  _root_.scala.annotation.meta.getter#
+      |  _root_.scala.annotation.meta.setter#
+      |  _root_.scala.annotation.meta.beanGetter#
+      |  _root_.scala.annotation.meta.beanSetter#
+      |}
+    """.stripMargin
+  )
+
+  targeted(
+    "class A[@specialized(Int, Long) <<T>>](v: T)", 
+    { (db, tparam) =>
+      val symbol = db.symbols.find(_.symbol == tparam).get
+      val denotation = symbol.denotation
+      assertNoDiff(
+        symbol.syntax,
+        """|_empty_.A#[T] => typeparam T
+           |  @_root_.scala.specialized#""".stripMargin
+      )
+      assertNoDiff(
+        denotation.syntax,
+        """|typeparam T
+           |  @_root_.scala.specialized#""".stripMargin
+      )
+      assert(denotation.isSpecialized)
+    }
+  )
+
+  targeted(
+    "class A[<<T>>](v: T)", 
+    { (db, tparam) =>
+      val symbol = db.symbols.find(_.symbol == tparam).get
+      val denotation = symbol.denotation
+      assert(!denotation.isSpecialized)
+    }
+  )
+}

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/DatabaseSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/DatabaseSuite.scala
@@ -243,4 +243,16 @@ abstract class DatabaseSuite(mode: SemanticdbMode,
       assertNoDiff(obtained, expected)
     })
   }
+
+  def annotations(original: String, expected: String): Unit = {
+    targeted(original, { db =>
+      val obtained = db.symbols
+        .collect {
+          case rs if rs.denotation.annotations.nonEmpty =>
+            s"${rs.symbol}{\n  ${rs.denotation.annotations.mkString("\n  ")}\n}"
+        }
+        .mkString("\n")
+      assertNoDiff(obtained, expected)
+    })
+  }
 }

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/TargetedSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/TargetedSuite.scala
@@ -183,6 +183,7 @@ class TargetedSuite extends DatabaseSuite(SemanticdbMode.Slim) {
        |  [0..3): Int => _root_.scala.Int#
        |_root_.f.C1#m1(I)I.T# => typeparam T
        |_root_.f.C1#m2()Lscala/Nothing;. => macro m2: Nothing
+       |  @_root_.scala.reflect.macros.internal.macroImpl#
        |  [0..7): Nothing => _root_.scala.Nothing#
        |_root_.f.C2# => abstract class C2
        |_root_.f.C2#`<init>`()V. => primaryctor <init>: (): C2
@@ -239,6 +240,7 @@ class TargetedSuite extends DatabaseSuite(SemanticdbMode.Slim) {
        |_root_.scala.language.experimental. => final object experimental
        |_root_.scala.language.experimental.macros. => implicit lazy val macros: macros
        |  [0..6): macros => _root_.scala.languageFeature.experimental.macros#
+       | _root_.scala.reflect.macros.internal.macroImpl# => private class macroImpl
   """.trim.stripMargin
   )
 
@@ -390,17 +392,20 @@ class TargetedSuite extends DatabaseSuite(SemanticdbMode.Slim) {
        |  [4..10): Object => _root_.java.lang.Object#
        |_root_.scala. => package scala
        |_root_.scala.Int# => abstract final class Int
+       |_root_.scala.SerialVersionUID# => class SerialVersionUID
        |_root_.scala.collection. => package collection
        |_root_.scala.collection.generic.GenericCompanion#empty()Lscala/collection/GenTraversable;. => def empty: [A] => CC[A]
        |  [7..9): CC => _root_.scala.collection.generic.GenericCompanion#[CC]
        |  [10..11): A => _root_.scala.collection.generic.GenericCompanion#empty()Lscala/collection/GenTraversable;.[A]
        |_root_.scala.collection.mutable. => package mutable
        |_root_.scala.collection.mutable.HashSet# => class HashSet
+       |  @_root_.scala.SerialVersionUID#
        |_root_.scala.collection.mutable.HashSet. => final object HashSet
        |_root_.scala.collection.mutable.HashSet.empty()Lscala/collection/mutable/HashSet;. => def empty: [A] => HashSet[A]
        |  [7..14): HashSet => _root_.scala.collection.mutable.HashSet#
        |  [15..16): A => _root_.scala.collection.mutable.HashSet.empty()Lscala/collection/mutable/HashSet;.[A]
        |_root_.scala.collection.mutable.ListBuffer# => final class ListBuffer
+       |   @_root_.scala.SerialVersionUID#
        |_root_.scala.collection.mutable.ListBuffer. => final object ListBuffer
        |local0 => val result: b.X
        |  [0..1): b => _root_.i.a.foo(Li/B;)Ljava/lang/Object;.(b)


### PR DESCRIPTION
This only adds the AnnotationInfo.symbol, parameters are not saved.
For example, given

```scala
class A[@specialized(Int, Long) T](v: T)
//                              ^
```

The T under the carret will have the symbol `_root_.scala.specialized` in it's annotations. The parameters `Int` and `Long` are lost. Annotations parameter are available, see https://github.com/scala/scala/blob/2.12.x/src/reflect/scala/reflect/internal/AnnotationInfos.scala. The difficulty is to encode them, since they are typed as Tree.

One idea would be to special case some of the annotation with parameters under the `scala.annotation` package and the `scala` package. Here is a list of annotations with non-empty parameter list:

```scala
class SerialVersionUID(value: Long)
class elidable(level: Int)
class implicitAmbiguous(msg: String)
class implicitNotFound(msg: String)
class languageFeature(feature: String, enableRequired: Boolean)
class showAsInfix(enabled: Boolean)
class deprecated(message: String, since: String)
class deprecatedInheritance(message: String, since: String)
class deprecatedName(name: Symbol, since: String)
class deprecatedOverriding(message: String, since: String)
class throws(clazz: Class[T])
class throws[T <: Throwable](cause: String)
class specialized(types: Specializable*)
class specialized(group: SpecializedGroup)
```

simple types like `Long`, `Int`, `String` and `Boolean` can be encoded easily.

more complicated types encoding such as `Class[T]`, `[T <: Throwable]`, `Specializable` and `SpecializedGroup` can be hardcoded.

There are also arguments for java annotations!