### PR TITLE
Fully automate enforcement of the compatibility policy

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,8 +1,9 @@
 ## Public API
 
 "Public API" means all public definitions in the artifacts under the
-`org.scalameta` Maven groupId whose fully-qualified name does not include
-`internal` and `contrib`, e.g. `scala.meta.Tree` or `org.langmeta.Position`:
+`org.scalameta` Maven groupId whole fully-qualified name starts with
+`scala.meta.` or `org.langmeta.`, but does not include `.internal.` and `.contrib.`,
+e.g. `scala.meta.Tree` or `org.langmeta.Position`:
   * `{x+1}.0.0` is strongly encouraged to be backward compatible with `x.y.z`
     modulo deprecation warnings:
     * It is desirable for every program compilable against `x.y.z`

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -6,13 +6,14 @@ import com.typesafe.tools.mima.core._
 // More details about Mima:
 // https://github.com/typesafehub/migration-manager/wiki/sbt-plugin#basic-usage
 object Mima {
-  val ignoredABIProblems: Seq[ProblemFilter] = {
-    Seq(
-      ProblemFilters.exclude[Problem]("org.langmeta.internal.*"),
-      ProblemFilters.exclude[Problem]("scala.meta.internal.*"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.meta.parsers.Parsed.*"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.meta.contrib.*"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.meta.tokenizers.Tokenized.*")
-    )
+  val compatibilityPolicy: ProblemFilter = (problem: Problem) => {
+    val (ref, fullName) = problem match {
+      case problem: TemplateRef => (problem.ref, problem.ref.fullName)
+      case problem: MemberRef => (problem.ref, problem.ref.fullName)
+    }
+    val public = ref.isPublic
+    val include = fullName.startsWith("scala.meta.") || fullName.startsWith("org.langmeta.")
+    val exclude = fullName.contains(".internal.") || fullName.contains(".contrib.")
+    public && include && !exclude
   }
 }


### PR DESCRIPTION
We should strive for the compatibility policy to be enforced
completely automatically - without easy-to-reach blanket overrides
like ignoreMimaSettings.