### PR TITLE
Run metacp on scala-library

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -436,6 +436,12 @@ lazy val tests = crossProject(JSPlatform, JVMPlatform)
     buildInfoPackage := "scala.meta.tests",
     libraryDependencies += "org.scalatest" %%% "scalatest" % "3.0.1" % "test"
   )
+  .jvmSettings(
+    libraryDependencies ++= List(
+      "io.get-coursier" %% "coursier" % coursier.util.Properties.version,
+      "io.get-coursier" %% "coursier-cache" % coursier.util.Properties.version
+    )
+  )
   .jvmConfigure(_.dependsOn(testkit, interactive, metac, metacp))
   .enablePlugins(BuildInfoPlugin)
   .dependsOn(scalameta, contrib, metap)

--- a/langmeta/langmeta/shared/src/main/scala/org/langmeta/io/Fragment.scala
+++ b/langmeta/langmeta/shared/src/main/scala/org/langmeta/io/Fragment.scala
@@ -2,12 +2,17 @@ package org.langmeta
 package io
 
 import java.net._
+import org.langmeta.internal.io.PathIO
 
 final case class Fragment(base: AbsolutePath, name: RelativePath) {
   def uri: URI = {
     val baseuri = base.toURI.normalize
-    if (baseuri.toString.endsWith(".jar")) new URI(s"jar:$baseuri!/$name")
-    else base.resolve(name).toURI.normalize
+    if (baseuri.toString.endsWith(".jar")) {
+      val reluri = PathIO.toUnix(name.toString)
+      new URI(s"jar:$baseuri!/$reluri")
+    } else {
+      base.resolve(name).toURI.normalize
+    }
   }
   def syntax: String = uri.toString
   def structure: String = s"""Fragment(${base.structure}, ${name.structure})"""

--- a/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/Main.scala
+++ b/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/Main.scala
@@ -24,6 +24,7 @@ object Main {
   }
 
   def process(settings: Settings): Int = {
+    val semanticdbRoot = AbsolutePath(settings.d).resolve("META-INF").resolve("semanticdb")
     var failed = false
     val classpath = Classpath(settings.cps.mkString(File.pathSeparator))
     val fragments = classpath.deep.filter(_.uri.toString.endsWith(".class"))
@@ -41,17 +42,16 @@ object Main {
               case sym: SymbolInfoSymbol => sinfo(sym)
               case _ => None
             }
-            val semanticdbRoot = Paths.get(settings.d, "META-INF", "semanticdb")
             val className = NameTransformer.decode(PathIO.toUnix(fragment.name.toString))
-            val semanticdbName = className + ".semanticdb"
-            val semanticdbPath = AbsolutePath(semanticdbRoot.resolve(semanticdbName))
+            val semanticdbRelpath = fragment.name.resolveSibling(_ + ".semanticdb")
+            val semanticdbAbspath = semanticdbRoot.resolve(semanticdbRelpath)
             val semanticdbDocument = s.TextDocument(
               schema = s.Schema.SEMANTICDB3,
               uri = className,
               language = "Scala",
               symbols = semanticdbInfos)
             val semanticdbDocuments = s.TextDocuments(List(semanticdbDocument))
-            FileIO.write(semanticdbPath, semanticdbDocuments)
+            FileIO.write(semanticdbAbspath, semanticdbDocuments)
           case None =>
             // NOTE: If a classfile doesn't contain ScalaSignature,
             // we skip it for the time being. In the future, we may add support

--- a/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/Main.scala
+++ b/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/Main.scala
@@ -69,6 +69,7 @@ object Main {
   }
 
   private def sinfo(sym: SymbolInfoSymbol): Option[s.SymbolInformation] = {
+    if (sym.parent.get == NoSymbol) return None
     if (sym.isSynthetic) return None
     if (sym.isModuleClass) return None
     if (sym.name.endsWith(" ")) return None
@@ -168,8 +169,15 @@ object Main {
       case sym: ExternalSymbol =>
         // NOTE: Object and package external symbols
         // are indistinguishable from each other.
-        val nameEntryType = sym.entry.scalaSig.table(sym.entry.index + 1)._1
-        val hasTermName = nameEntryType == 1
+        val hasTermName = {
+          val idx = sym.entry.index + 1
+          if (sym.entry.scalaSig.hasEntry(idx)) {
+            val nameEntryType = sym.entry.scalaSig.table(idx)._1
+            nameEntryType == 1
+          } else {
+            false
+          }
+        }
         val isModuleClass = sym.entry.entryType == 10
         if (hasTermName || isModuleClass) k.OBJECT
         else k.CLASS

--- a/tests/jvm/src/test/scala/scala/meta/tests/cli/BaseCliSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/cli/BaseCliSuite.scala
@@ -1,0 +1,9 @@
+package scala.meta.tests.cli
+
+import scala.meta.testkit.DiffAssertions
+import org.scalatest.FunSuite
+
+abstract class BaseCliSuite extends FunSuite with DiffAssertions  {
+  val scalaLibraryJar = sys.props("sbt.paths.scalalibrary.classes")
+  if (scalaLibraryJar == null) sys.error("sbt.paths.scalalibrary.classes not set. broken build?")
+}

--- a/tests/jvm/src/test/scala/scala/meta/tests/cli/CliSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/cli/CliSuite.scala
@@ -9,7 +9,7 @@ import scala.meta.internal.metac.{Main => Metac}
 import scala.meta.internal.metap.{Main => Metap}
 import scala.meta.testkit.DiffAssertions
 
-class CliSuite extends FunSuite with DiffAssertions {
+class CliSuite extends BaseCliSuite {
   val sourceroot = Files.createTempDirectory("sourceroot_")
   val helloWorldScala = sourceroot.resolve("HelloWorld.scala")
   Files.write(helloWorldScala, """
@@ -23,8 +23,6 @@ class CliSuite extends FunSuite with DiffAssertions {
   val helloWorldSemanticdb = target.resolve("META-INF/semanticdb/HelloWorld.scala.semanticdb")
 
   test("metac " + helloWorldScala) {
-    val scalaLibraryJar = sys.props("sbt.paths.scalalibrary.classes")
-    if (scalaLibraryJar == null) sys.error("sbt.paths.scalalibrary.classes not set. broken build?")
     val (exitcode, output) = CliSuite.communicate {
       Metac.process(Array(
         "-cp",

--- a/tests/jvm/src/test/scala/scala/meta/tests/metacp/Jars.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/metacp/Jars.scala
@@ -1,0 +1,86 @@
+package scala.meta.tests.metacp
+
+import java.io.OutputStreamWriter
+import java.io.PrintStream
+import coursier._
+import scala.meta.AbsolutePath
+
+case class ModuleID(organization: String, name: String, version: String) {
+  def toCoursier: Dependency = Dependency(Module(organization, name), version)
+  override def toString: String = s"$organization:$name:$version"
+}
+object ModuleID {
+  def fromString(string: String): List[ModuleID] = {
+    string
+      .split(";")
+      .iterator
+      .flatMap { moduleId =>
+        moduleId.split(":") match {
+          case Array(org, name, rev) =>
+            ModuleID(org, name, rev) :: Nil
+          case _ => Nil
+        }
+      }
+      .toList
+  }
+}
+object Jars  {
+  def fetch(
+      org: String,
+      artifact: String,
+      version: String,
+      out: PrintStream = System.out,
+      // If true, fetches the -sources.jar files instead of regular jar with classfiles.
+      fetchSourceJars: Boolean = false
+  ): List[AbsolutePath] =
+    fetch(ModuleID(org, artifact, version) :: Nil, out, fetchSourceJars)
+
+  def fetch(
+      modules: Iterable[ModuleID],
+      out: PrintStream,
+      fetchSourceJars: Boolean
+  ): List[AbsolutePath] = {
+    val classifier = if (fetchSourceJars) "sources" :: Nil else Nil
+    val res = Resolution(modules.toIterator.map(_.toCoursier).toSet)
+    val repositories = Seq(
+      Cache.ivy2Local,
+      MavenRepository("https://repo1.maven.org/maven2")
+    )
+    val term =
+      new TermDisplay(new OutputStreamWriter(out), fallbackMode = true)
+    term.init()
+    val fetch = Fetch.from(repositories, Cache.fetch(logger = Some(term)))
+    val resolution = res.process.run(fetch).unsafePerformSync
+    val errors = resolution.metadataErrors
+    if (errors.nonEmpty) {
+      sys.error(errors.mkString("\n"))
+    }
+    val artifacts: Seq[Artifact] =
+      if (fetchSourceJars) {
+        resolution
+          .dependencyClassifiersArtifacts(classifier)
+          .map(_._2)
+      } else resolution.artifacts
+    val localArtifacts = scalaz.concurrent.Task
+      .gatherUnordered(
+        artifacts.map(artifact => Cache.file(artifact).run)
+      )
+      .unsafePerformSync
+      .map(_.toEither)
+    val jars = localArtifacts.flatMap {
+      case Left(e) =>
+        if (fetchSourceJars) {
+          // There is no need to fail fast here if we are fetching source jars.
+          println(e.describe)
+          Nil
+        } else {
+          throw new IllegalArgumentException(e.describe)
+        }
+      case Right(jar) if jar.getName.endsWith(".jar") =>
+        AbsolutePath(jar) :: Nil
+      case _ => Nil
+    }
+    term.stop()
+    jars
+  }
+}

--- a/tests/jvm/src/test/scala/scala/meta/tests/metacp/MetacpSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/metacp/MetacpSuite.scala
@@ -1,0 +1,22 @@
+package scala.meta.tests.metacp
+
+import java.nio.file.Files
+import scala.meta.internal.metacp._
+import scala.meta.tests.cli.BaseCliSuite
+
+class MetacpSuite extends BaseCliSuite {
+  private val tmp = Files.createTempDirectory("metacp")
+  tmp.toFile.deleteOnExit()
+  test("basic") {
+    val args = Array[String](
+      "-cp",
+      scalaLibraryJar,
+      "-d",
+      tmp.toString
+    )
+    val settings = Settings.parse(args.toList).get
+    val exit = Main.process(settings)
+    assert(exit == 0)
+  }
+
+}

--- a/tests/jvm/src/test/scala/scala/meta/tests/metacp/MetacpSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/metacp/MetacpSuite.scala
@@ -1,22 +1,48 @@
 package scala.meta.tests.metacp
 
+import java.io.File
 import java.nio.file.Files
 import scala.meta.internal.metacp._
 import scala.meta.tests.cli.BaseCliSuite
 
 class MetacpSuite extends BaseCliSuite {
+
   private val tmp = Files.createTempDirectory("metacp")
   tmp.toFile.deleteOnExit()
-  test("basic") {
-    val args = Array[String](
-      "-cp",
-      scalaLibraryJar,
-      "-d",
-      tmp.toString
-    )
-    val settings = Settings.parse(args.toList).get
-    val exit = Main.process(settings)
-    assert(exit == 0)
+
+  def check(name: String, classpath: () => String): Unit = {
+    test(name) {
+      val cp = classpath()
+      val args = Array[String](
+        "-cp",
+        cp,
+        "-d",
+        tmp.toString
+      )
+      val settings = Settings.parse(args.toList).get
+      val exit = Main.process(settings)
+      assert(exit == 0)
+    }
   }
+
+  def checkLibrary(organization: String, artifact: String, version: String): Unit = {
+    check(
+      List(organization, artifact, version).mkString(File.pathSeparator), { () =>
+        val jars = Jars
+          .fetch(organization, artifact, version)
+          .filterNot(_.toString.contains("scala-lang"))
+        jars.mkString(File.pathSeparator)
+      }
+    )
+  }
+
+  check("scala-library", () => scalaLibraryJar)
+  checkLibrary("org.scalameta", "scalameta_2.12", "3.2.0")
+
+  // Akka is blocked by https://github.com/scalameta/scalameta/issues/1306
+  // checkLibrary("com.typesafe.akka", "akka-testkit_2.12", "2.5.9")
+
+  // Spark is blocked by https://github.com/scalameta/scalameta/issues/1305
+  // checkLibrary("org.apache.spark", "spark-sql_2.11", "2.2.1")
 
 }


### PR DESCRIPTION
This commit adds a test suite for running metacp on scala-library and
fixes the following two crashes

- Fix #1303 Fix IndexOutOfBounds
- Fix #1302 Handle NoSymbol