### PR TITLE
[WIP] Major updates to the SemanticDB spec to unblock our progress

### DIFF
--- a/semanticdb/semanticdb3/semanticdb3.md
+++ b/semanticdb/semanticdb3/semanticdb3.md
@@ -92,7 +92,7 @@ to produce them in the `schema` field. The following versions are supported:
     <td><b>Data model<b></td>
   </tr>
   <tr>
-    <td>LEGACY</td>
+    <td><code>LEGACY<code></td>
     <td>Legacy SemanticDB payloads</td>
     <td><a href="https://github.com/scalameta/scalameta/blob/master/semanticdb/semanticdb2/semanticdb2.proto">semanticdb2.proto</a></td>
   </tr>
@@ -668,12 +668,12 @@ documentation strings or features from other languages.
   <tr>
     <td><code>0x400</code></td>
     <td><code>VALPARAM</code></td>
-    <td>Is a `val` parameter of a primary constructor?</td>
+    <td>Is a <code>val</code> parameter of a primary constructor?</td>
   </tr>
   <tr>
     <td><code>0x800</code></td>
     <td><code>VARPARAM</code></td>
-    <td>Is a `var` parameter of a primary constructor?</td>
+    <td>Is a <code>var</code> parameter of a primary constructor?</td>
   </tr>
 </table>
 

--- a/semanticdb/semanticdb3/semanticdb3.md
+++ b/semanticdb/semanticdb3/semanticdb3.md
@@ -7,9 +7,10 @@
   * [Range](#range)
   * [Location](#location)
   * [Symbol](#symbol)
-  * [Annotation](#annotation)
   * [Type](#type)
   * [SymbolInformation](#symbolinformation)
+  * [Annotation](#annotation)
+  * [Accessibility](#accessibility)
   * [SymbolOccurrence](#symboloccurrence)
   * [Diagnostic](#diagnostic)
   * [Synthetic](#synthetic)
@@ -19,9 +20,10 @@
   * [Scala](#scala)
     * [Language](#scala-language)
     * [Symbol](#scala-symbol)
-    * [Annotation](#scala-annotation)
     * [Type](#scala-type)
     * [SymbolInformation](#scala-symbolinformation)
+    * [Annotation](#scala-annotation)
+    * [Accessibility](#scala-accessibility)
     * [Synthetic](#scala-synthetic)
 
 ## Motivation
@@ -187,7 +189,7 @@ Global symbol format accommodates scoping rules of the underlying language,
 and is therefore language-dependent. For example, the `Int` class in
 the Scala standard library must be modelled as `_root_.scala.Int#`.
 The `_root_` prefix stands for the root package defined in the Scala Language
-Specification [\[18\]][18], and the pound sign (`#`) at the end of the symbol
+Specification [\[17\]][17], and the pound sign (`#`) at the end of the symbol
 means that the symbol corresponds to a class as opposed to objects that end
 with a dot (`.`). See [Languages](#languages) for more information.
 
@@ -241,18 +243,6 @@ is not a valid symbol.
 [Synthetics](#synthetic). Must not be used outside `Synthetic.text` documents.
 Placeholder symbols are always equal to an asterisk (`*`).
 
-### Annotation
-
-```protobuf
-message Annotation {
-  Type tpe = 1;
-}
-```
-
-`Annotation` represents annotations. See [Languages](#languages) for
-information on how annotations in supported languages map onto this
-data structure.
-
 ### Type
 
 ```protobuf
@@ -292,7 +282,7 @@ message Type {
 
 The SemanticDB type system is a language-agnostic superset of the type systems
 of supported languages - currently modelled after the Scala type system
-[\[19\]][19]. This section describes the language-agnostic model, while
+[\[18\]][18]. This section describes the language-agnostic model, while
 [Languages](#languages) elaborates on how language types map onto this model.
 
 ```protobuf
@@ -456,13 +446,15 @@ message SymbolInformation {
   repeated string members = 8;
   repeated string overrides = 9;
   Type tpe = 11;
+  repeated Annotation annotations = 13;
+  Accessibility accessibility = 14;
 }
 ```
 
 "Symbols" is a section of a [TextDocument](#textdocument) that stores
 information about [Symbols](#symbol) that are defined in the underlying
 document. In a sense, this section is analogous to a symbol table
-[\[20\]][20] in a compiler.
+[\[19\]][19] in a compiler.
 
 `SymbolInformation` contains assorted metadata for a `symbol`,
 as explained below. At the moment, the supported metadata is usecase-driven
@@ -472,7 +464,7 @@ we may add support for more metadata, e.g. documentation strings.
 `language`. [Language](#language) that defines this symbol.
 
 `kind`. Enumeration that defines the kind of the symbol.
-See [Languages](#language) to learn how definitions in supported
+See [Languages](#language) for information on how definitions in supported
 languages map onto these kinds.
 
 <table>
@@ -499,12 +491,12 @@ languages map onto these kinds.
   <tr>
     <td><code>15</code></td>
     <td><code>GETTER</code></td>
-    <td>Getter method, e.g. <code>def x: Int</code> generated for <code>val x = 42</code>.</td>
+    <td>Getter, e.g. <code>def x: Int</code> generated for <code>val x = 42</code>.</td>
   </tr>
   <tr>
     <td><code>16</code></td>
     <td><code>SETTER</code></td>
-    <td>Setter method, e.g. <code>def x_=(x$1: Int): Unit</code> generated for <code>var x = 42</code>.</td>
+    <td>Setter, e.g. <code>def x_=(x$1: Int): Unit</code> generated for <code>var x = 42</code>.</td>
   </tr>
   <tr>
     <td><code>4</code></td>
@@ -564,6 +556,8 @@ languages map onto these kinds.
 </table>
 
 `properties`. Bitmask of miscellaneous bits of metadata:
+See [Languages](#language) for information on how definitions in supported
+languages map onto these properties.
 
 <table>
   <tr>
@@ -573,13 +567,13 @@ languages map onto these kinds.
   </tr>
   <tr>
     <td><code>0x1</code></td>
-    <td><code>PRIVATE</code></td>
-    <td>Has a <code>private</code> modifier?</td>
+    <td><code>RESERVED</code></td>
+    <td>Reserved for backward compatibility.</td>
   </tr>
   <tr>
     <td><code>0x2</code></td>
-    <td><code>PROTECTED</code></td>
-    <td>Has a <code>protected</code> modifier?</td>
+    <td><code>RESERVED</code></td>
+    <td>Reserved for backward compatibility.</td>
   </tr>
   <tr>
     <td><code>0x4</code></td>
@@ -623,6 +617,16 @@ languages map onto these kinds.
     <td><code>CONTRAVARIANT</code></td>
     <td>Has a contravariant (<code>-</code>) modifier?</td>
   </tr>
+  <tr>
+    <td><code>0x400</code></td>
+    <td><code>RESERVED</code></td>
+    <td>Reserved for backward compatibility.</td>
+  </tr>
+  <tr>
+    <td><code>0x800</code></td>
+    <td><code>RESERVED</code></td>
+    <td>Reserved for backward compatibility.</td>
+  </tr>
 </table>
 
 `name`. String that represents the name of the corresponding definition.
@@ -640,6 +644,47 @@ either directly or transitively.
 `tpe`. [Type](#type) that represents the type signature of the definition.
 See [Languages](#language) for more information on which definitions have
 which type signatures in supported languages.
+
+`annotation`. [Annotations](#annotation) of the corresponding definition.
+
+`accessibility`. [Accessibility](#accessibility) of the corresponding definition.
+
+### Annotation
+
+```protobuf
+message Annotation {
+  Type tpe = 1;
+}
+```
+
+`Annotation` represents annotations. See [Languages](#languages) for
+information on how annotations in supported languages map onto this
+data structure.
+
+### Accessibility
+
+```protobuf
+message Accessibility {
+  enum Tag {
+    UNKNOWN_TAG = 0;
+    PRIVATE = 1;
+    PRIVATE_THIS = 2;
+    PRIVATE_WITHIN = 3;
+    PROTECTED = 4;
+    PROTECTED_THIS = 5;
+    PROTECTED_WITHIN = 6;
+  }
+  Tag tag = 1;
+  string symbol = 2;
+}
+```
+
+`Accessibility` represents accessibility of definitions, including `PRIVATE`,
+`PROTECTED`, as well as variants thereof limited to the object instance
+(`PRIVATE_THIS` and `PROTECTED_THIS`) or to the given `symbol`
+(`PRIVATE_WITHIN` and `PROTECTED_WITHIN`).
+See [Languages](#languages) for information on how accessibilities in supported
+languages map onto this data structure.
 
 ### SymbolOccurrence
 
@@ -770,16 +815,23 @@ namely:
   * Format for global [Symbols](#symbol).
   * Supported [Annotations](#annotation).
   * Supported [Types](#type).
-  * Kinds and types of [SymbolInformation](#symbolinformation).
+  * Kinds, properties, signatures and accessibilities of [SymbolInformation](#symbolinformation).
+  * Supported [Accessibilities](#accessibility).
   * Format for [Synthetics](#synthetic).
 
-We will be using a simple notation to describe SemanticDB entities.
+We use a simple notation to describe SemanticDB entities.
 In this notation, `M(v1, v2, ...)` corresponds a Protocol Buffers message
 `M` with fields set to values `v1`, `v2`, etc. Literals correspond to
 scalar values, and `List(x1, x2, ...)` corresponds to repeated values.
 Moreover, `<X>` corresponds to a message that represents `X`.
 
 ### Scala
+
+In this section, we exhaustively map Scala language features onto SemanticDB.
+As a reference, we use the Scala Language Specification [\[17\]][17]
+(referred to as "SLS" in the text below), as well as additional resources
+[[25][25], [40][40], [56][56], [57][57]] in the areas where the SLS
+is incomplete or out of date.
 
 <a name="scala-language"></a>
 #### Language
@@ -807,16 +859,16 @@ the owner chain of the corresponding global definition, where:
 
 * The owner chain of a definition is a list of its enclosing definitions
   starting with the outermost one, with the outermost definition being
-  either `_empty_` (the special empty package [\[17\]][17]) or
-  `_root_` (the special root package [\[18\]][18]). For example,
+  either `_empty_` (the special empty package [\[20\]][20]) or
+  `_root_` (the special root package [\[21\]][21]). For example,
   for the `Int` class in the Scala standard library,
   the owner chain is `[_root_, scala, Int]`.
 * The signature of a definition is:
   * For a val, var, object, package or package object, concatenation of its
     encoded name and a dot (`.`).
-  * For a method, primary constructor, secondary constructor or macro,
-    concatenation of its encoded name, its SemanticDB method descriptor
-    and a dot (`.`). The method descriptor is used to distinguish
+  * For a method, getter, setter, primary constructor, secondary constructor
+    or macro, concatenation of its encoded name, its SemanticDB method
+    descriptor and a dot (`.`). The method descriptor is used to distinguish
     overloaded methods as described below.
   * For an abstract type, type alias, class or trait, concatenation of its
     encoded name and a pound sign (`#`).
@@ -825,7 +877,7 @@ the owner chain of the corresponding global definition, where:
   * For a type parameter, concatenation of a left bracket (`[`), its
     encoded name and a right bracket (`]`).
 * The encoded name of a definition is:
-  * For a Java identifier [\[21\]][21], the name itself.
+  * For a Java identifier [\[22\]][22], the name itself.
   * Otherwise, concatenation of a backtick, the name itself and another backtick.
 * The SemanticDB descriptor of a method is a concatenation of simplifications of
   its parameter types interspersed by a comma (`,`), where a simplification
@@ -835,7 +887,7 @@ the owner chain of the corresponding global definition, where:
   * For a structural type, `{}`.
   * For an annotated type, the simplification of the underlying type.
   * For an existential type, the simplification of the underlying type.
-  * For a type lambda, the simplification of the underlying type.
+  * For a universal type, the simplification of the underlying type.
   * For a by-name type, the concatenation of the arrow sign (`=>`) and
     the simplification of the underlying type.
   * For a repeated type, the concatenation of the simplification of the
@@ -850,30 +902,10 @@ must be modelled:
 * The `def +:[B >: A, That](elem: B)(implicit bf: CanBuildFrom[List[A], B, That]): That` method: ``_root_.scala.collection.immutable.List#`+:`(B,CanBuildFrom)``.
 * The integer addition method: ``_root_.scala.Int#`+`(Int).``
 
-<a name="scala-annotation"></a>
-#### Annotation
-
-<table>
-  <tr>
-    <td><b>Value</b></td>
-    <td><b>Explanation</b></td>
-  </tr>
-  <tr>
-    <td><code>Annotation(&lt;ann&gt;)</code></td>
-    <td>Definition annotation, e.g. <code>@ann def m: T</code>.</td>
-  </tr>
-  <tr>
-    <td><code>Annotation(&lt;ann&gt;)</code></td>
-    <td>Type annotation, e.g. <code>T @ann</code>.</td>
-  </tr>
-</table>
-
-At the moment, `Annotation` can't represent annotation arguments,
-which means that the annotation in `@ann(x, y, z) def m: T` will be represented
-as `Annotation(<ann>)`. We intend to improve on this in the future
-
 <a name="scala-type"></a>
 #### Type
+
+In Scala, `Type` represents value types and non-value types [\[18\]][18].
 
 <table>
   <tr>
@@ -881,7 +913,7 @@ as `Annotation(<ann>)`. We intend to improve on this in the future
     <td><b>Examples</b></td>
   </tr>
   <tr>
-    <td valign="top">Singleton types [<a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#singleton-types">22</a>, <a href="https://github.com/scala/scala/pull/5310">23</a>]</td>
+    <td valign="top">Singleton types [<a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#singleton-types">24</a>, <a href="https://github.com/scala/scala/pull/5310">25</a>]</td>
     <td>
       <ul>
         <li><code>x.type</code> ~ <code>SingletonType(SYMBOL, null, &lt;x&gt;, null, null)</code>.</li>
@@ -896,7 +928,7 @@ as `Annotation(<ann>)`. We intend to improve on this in the future
     </td>
   </tr>
   <tr>
-    <td valign="top">Type projections <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#type-projection">[24]</a></td>
+    <td valign="top">Type projections <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#type-projection">[26]</a></td>
     <td>
       <ul>
         <li><code>T#C</code> ~ <code>TypeRef(&lt;T&gt;, &lt;C&gt;, List())</code>.</li>
@@ -904,7 +936,7 @@ as `Annotation(<ann>)`. We intend to improve on this in the future
     </td>
   </tr>
   <tr>
-    <td valign="top">Type designators <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#type-designators">[25]</a></td>
+    <td valign="top">Type designators <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#type-designators">[27]</a></td>
     <td>
       <ul>
         <li><code>t</code> ~ <code>TypeRef(null, &lt;t&gt;, List())</code>.</li>
@@ -915,7 +947,7 @@ as `Annotation(<ann>)`. We intend to improve on this in the future
     </td>
   </tr>
   <tr>
-    <td valign="top">Parameterized types <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#parameterized-types">[26]</a></td>
+    <td valign="top">Parameterized types <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#parameterized-types">[28]</a></td>
     <td>
       <ul>
         <li><code>T#C[T1, ..., Tn]</code> ~ <code>TypeRef(&lt;T&gt;, &lt;C&gt;, List(&lt;T1&gt;, ..., &lt;Tn&gt;))</code>.</li>
@@ -927,7 +959,7 @@ as `Annotation(<ann>)`. We intend to improve on this in the future
     </td>
   </tr>
   <tr>
-    <td valign="top">Tuple types <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#tuple-types">[27]</a></td>
+    <td valign="top">Tuple types <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#tuple-types">[29]</a></td>
     <td>
       <ul>
         <li><code>(T1, ..., Tn)</code> ~ <code>TypeRef(&lt;scala.type&gt;, &lt;TupleN&gt;, List(&lt;T1&gt;, ..., &lt;Tn&gt;))</code>.</li>
@@ -935,7 +967,7 @@ as `Annotation(<ann>)`. We intend to improve on this in the future
     </td>
   </tr>
   <tr>
-    <td valign="top">Annotated types <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#annotated-types">[28]</a></td>
+    <td valign="top">Annotated types <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#annotated-types">[30]</a></td>
     <td>
       <ul>
         <li><code>T @ann1 ... @annN</code> ~ <code>AnnotatedType(List(&lt;ann1&gt;, ..., &lt;annN&gt;), &lt;T&gt;)</code>.</li>
@@ -943,7 +975,7 @@ as `Annotation(<ann>)`. We intend to improve on this in the future
     </td>
   </tr>
   <tr>
-    <td valign="top">Compound types <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#compound-types">[29]</a></td>
+    <td valign="top">Compound types <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#compound-types">[31]</a></td>
     <td>
       <ul>
         <li><code>{ M1; ...; Mm }</code> ~ <code>StructuralType(List(), List(&lt;M1&gt;, ..., &lt;Mm&gt;))</code>.</li>
@@ -953,7 +985,7 @@ as `Annotation(<ann>)`. We intend to improve on this in the future
     </td>
   </tr>
   <tr>
-    <td valign="top">Infix types <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#infix-types">[30]</a></td>
+    <td valign="top">Infix types <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#infix-types">[32]</a></td>
     <td>
       <ul>
         <li><code>A L B</code> ~ <code>TypeRef(..., &lt;L&gt;, List(&lt;A&gt;, &lt;B&gt;))</code> for left-associative <code>L</code>.</li>
@@ -962,7 +994,7 @@ as `Annotation(<ann>)`. We intend to improve on this in the future
     </td>
   </tr>
   <tr>
-    <td valign="top">Function types <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#function-types">[31]</a></td>
+    <td valign="top">Function types <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#function-types">[33]</a></td>
     <td>
       <ul>
         <li><code>(T1, ..., Tn) =&gt; R</code> ~ <code>TypeRef(&lt;scala.type&gt;, &lt;FunctionN&gt;, List(&lt;T1&gt;, ..., &lt;Tn&gt;, &lt;R&gt;))</code>.</li>
@@ -972,7 +1004,7 @@ as `Annotation(<ann>)`. We intend to improve on this in the future
     </td>
   </tr>
   <tr>
-    <td valign="top">Existential types <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#existential-types">[32]</a></td>
+    <td valign="top">Existential types <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#existential-types">[34]</a></td>
     <td>
       <ul>
         <li><code>T forSome { M1; ...; Mm }</code> ~ <code>ExistentialType(List(&lt;T&gt;), List(&lt;M1&gt;, ..., &lt;Mm&gt;))</code>.</li>
@@ -980,7 +1012,7 @@ as `Annotation(<ann>)`. We intend to improve on this in the future
     </td>
   </tr>
   <tr>
-    <td valign="top">Method types <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#method-types">[33]</a></td>
+    <td valign="top">Method types <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#method-types">[35]</a></td>
     <td>
       <ul>
         <li><code>(P1s)...(Pns)U</code> ~ <code>MethodType(List(), List(List(&lt;T11&gt;, ...), ..., List(&lt;Tn1&gt;, ...)), &lt;U&gt;)</code>.</li>
@@ -988,7 +1020,7 @@ as `Annotation(<ann>)`. We intend to improve on this in the future
     </td>
   </tr>
   <tr>
-    <td valign="top">Polymorphic method types <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#polymorphic-method-types">[34]</a></td>
+    <td valign="top">Polymorphic method types <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#polymorphic-method-types">[36]</a></td>
     <td>
       <ul>
         <li><code>[ts](P1s)...(Pns)U</code> ~ <code>MethodType(List(&lt;t1&gt;, ..., &lt;tm&gt;), List(List(&lt;T11&gt;, ...), ..., List(&lt;Tn1&gt;, ...)), &lt;U&gt;)</code>.</li>
@@ -996,7 +1028,7 @@ as `Annotation(<ann>)`. We intend to improve on this in the future
     </td>
   </tr>
   <tr>
-    <td valign="top">Type constructors <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#type-constructors">[35]</a></td>
+    <td valign="top">Type constructors <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#type-constructors">[37]</a></td>
     <td>
       <ul>
         <li><code>[ts]T</code> ~ <code>UniversalType(List(&lt;t1&gt;, ..., &lt;tm&gt;), &lt;T&gt;)</code>.</li>
@@ -1005,17 +1037,786 @@ as `Annotation(<ann>)`. We intend to improve on this in the future
   </tr>
 </table>
 
+* We leave the mapping between type syntax written in source code and
+  `Type` entities deliberately unspecified. Some producers may transform
+  types in unspecified ways (e.g. Scalac transforms all `this.type` types
+  into qualified `X.this.type` types), and our experience [\[38\]][38] shows
+  that reverse engineering these transformations is very hard. We may improve
+  on this in the future, but this is highly unlikely. In the meanwhile,
+  use [Occurrences](#symboloccurrence) for figuring out semantics of syntax
+  written in source code.
+
 <a name="scala-symbolinformation"></a>
 #### SymbolInformation
 
-TODO
+**Value declarations and definitions** [\[39\]][39] are represented by multiple
+symbols, with the exact number of symbols, their kinds, properties and
+signatures dependent on the corresponding value:
+  * `VAL` symbol is created for all non-`abstract` values.
+  * `GETTER` symbol is created for all non-`private[this]` member values.
+  * `PARAMETER` symbol is created for `val` parameters of primary constructors.
+
+```scala
+abstract class C(val xp: Int) {
+  val xm: Int = ???
+  val xam: Int
+  private[this] val xlm: Int = ???
+  def m = {
+    val xl: Int = ???
+    type S = { val xs: Int }
+    type E = xe.type forSome { val xe: AnyRef }
+  }
+}
+```
+
+<table>
+  <tr>
+    <td><b>Definition</b></td>
+    <td width="260px"><b>Symbol</b></td>
+    <td><b>Kind</b></td>
+    <td><b>Signature</b></td>
+  </tr>
+  <tr>
+    <td><code>xp</code></td>
+    <td><code>_empty_.C#xp.</code></td>
+    <td><code>VAL</code></td>
+    <td><code>TypeRef(&lt;scala.type&gt;, &lt;Int&gt;, List())</code></td>
+  </tr>
+  <tr>
+    <td><code>xp</code></td>
+    <td><code>_empty_.C#xp().</code></td>
+    <td><code>GETTER</code></td>
+    <td><code>MethodType(List(), List(), TypeRef(&lt;scala.type&gt;, &lt;Int&gt;, List()))</code></td>
+  </tr>
+  <tr>
+    <td><code>xp</code></td>
+    <td><code>_empty_.C#`&lt;init&gt;(Int)`.(xp)</code></td>
+    <td><code>PARAMETER</code></td>
+    <td><code>TypeRef(&lt;scala.type&gt;, &lt;Int&gt;, List())</code></td>
+  </tr>
+  <tr>
+    <td><code>xm</code></td>
+    <td><code>_empty_.C#xm.</code></td>
+    <td><code>VAL</code></td>
+    <td><code>TypeRef(&lt;scala.type&gt;, &lt;Int&gt;, List())</code></td>
+  </tr>
+  <tr>
+    <td><code>xm</code></td>
+    <td><code>_empty_.C#xm().</code></td>
+    <td><code>GETTER</code></td>
+    <td><code>MethodType(List(), List(), TypeRef(&lt;scala.type&gt;, &lt;Int&gt;, List()))</code></td>
+  </tr>
+  <tr>
+    <td><code>xam</code></td>
+    <td><code>_empty_.C#xam().</code></td>
+    <td><code>GETTER</code></td>
+    <td><code>MethodType(List(), List(), TypeRef(&lt;scala.type&gt;, &lt;Int&gt;, List()))</code></td>
+  </tr>
+  <tr>
+    <td><code>xlm</code></td>
+    <td><code>_empty_.C#xlm.</code></td>
+    <td><code>VAL</code></td>
+    <td><code>TypeRef(&lt;scala.type&gt;, &lt;Int&gt;, List())</code></td>
+  </tr>
+  <tr>
+    <td><code>xl</code></td>
+    <td><code>local0</code></td>
+    <td><code>VAL</code></td>
+    <td><code>TypeRef(&lt;scala.type&gt;, &lt;Int&gt;, List())</code></td>
+  </tr>
+  <tr>
+    <td><code>xs</code></td>
+    <td><code>local1</code></td>
+    <td><code>GETTER</code></td>
+    <td><code>MethodType(List(), List(), TypeRef(&lt;scala.type&gt;, &lt;Int&gt;, List()))</code></td>
+  </tr>
+  <tr>
+    <td><code>xe</code></td>
+    <td><code>local2</code></td>
+    <td><code>GETTER</code></td>
+    <td><code>TypeRef(&lt;scala.type&gt;, &lt;Int&gt;, List())</code></td>
+  </tr>
+</table>
+
+Notes:
+* As described in SLS [\[39\]][39], there are some language constructs
+  that are desugared into values. For these language constructs,
+  symbols are created from desugared values.
+    * `val p = e` (symbols are created for bound variables `x1`, ...,
+      `xm` that are defined in `p` in order of their appearance in source code;
+      symbols are NOT created for the synthetic value used in the desugaring).
+    * `val x1, ..., xn: T` (symbols are created for `x1`, ..., `xn`
+      in order of their appearance in source code).
+    * `val p1, ..., pn = e` (symbols are created for bound variables `x1`, ...,
+      `xm` that are defined in patterns `p1`, ..., `pn` in order of their
+      appearance in source code).
+    * `val p1, ..., pn: T = e` (symbols are created for bound variables `x1`,
+       ..., `xm` that are defined in patterns `p1`, ..., `pn` in order of their
+       appearance in source code).
+* Supported properties for value symbols are:
+  * `ABSTRACT`: set for getters of value declarations.
+  * `FINAL`: set for getters of `final` values.
+  * `IMPLICIT`: set for getters of `implicit` value members and for vals of
+    `implicit` local values.
+  * `LAZY`: set for getters of `lazy` value members and for vals of
+    `lazy` local values.
+* `override` relationships exist only for `GETTER` and `SETTER` symbols.
+  Corresponding `VAL` or `PARAM` symbols never override or get overridden.
+* If the type of the value is unspecified, it is inferred from the
+  right-hand side of the value according to the rules described
+  in SLS [\[39\]][39]. Corresponding signature is computed from the inferred
+  type as explained in [Type](#scala-type).
+* Depending on their meta annotations, value annotations may end up as
+  `Annotation` entities associated with multiple corresponding symbols.
+  See [\[40\]][40] for more information.
+* Supported accessibilities for value symbols are:
+  * `PRIVATE`: set for getters of `private` values.
+  * `PRIVATE_THIS`: set for vals of non-`private[this]` value members.
+  * `PRIVATE_WITHIN`: set for getters of `private[...]` values.
+  * `PROTECTED`: set for getters of `protected` values.
+  * `PROTECTED_THIS`: set for getters of `protected[this]` values.
+  * `PROTECTED_WITHIN`: set for getters of `protected[...]` values.
+
+**Variable declarations and definitions** [\[41\]][41] are represented
+similarly to values (see above). Concretely, the following rules describe
+symbols created for variables:
+  * Whenever a `VAL` symbol is created for a value, a `VAR` symbol is created
+    for a variable with the same properties, signature and accessibility.
+  * Whenever a `GETTER` symbol is created for a value, a `GETTER` symbol is
+    created for a variable with the same properties, signature and
+    accessibility.
+  * Whenever a `GETTER` symbol is created for a value, a `SETTER` symbol is
+    also created for a variable, having the same properties and accessibility
+    and (for `var x: T`) name `x_=`
+    and signature `MethodType(List(), List(List(<x$1>)), <Unit>)`
+    with the synthetic parameter `x$1` having signature `<T>`.
+  * Whenever a `PARAMETER` symbol is created for a value, a `PARAMETER` symbol
+    is created for a variable with the same properties, signature
+    and accessibility.
+
+**Type declarations and type aliases** [\[42\]][42] are represented with
+`TYPE` symbols.
+
+```scala
+class C {
+  type T1 <: Hi
+  type T2 >: Lo
+  type T = Int
+}
+```
+
+<table>
+  <tr>
+    <td><b>Definition</b></td>
+    <td><b>Symbol</b></td>
+    <td><b>Kind</b></td>
+    <td><b>Signature</b></td>
+  </tr>
+  <tr>
+    <td><code>T1</code></td>
+    <td><code>_empty_.C#T1#</code></td>
+    <td><code>TYPE</code></td>
+    <td><code>TypeType(List(), null, &lt;Hi&gt;)</code></td>
+  </tr>
+  <tr>
+    <td><code>T2</code></td>
+    <td><code>_empty_.C#T2#</code></td>
+    <td><code>TYPE</code></td>
+    <td><code>TypeType(List(), &lt;Lo&gt;, null)</code></td>
+  </tr>
+  <tr>
+    <td><code>T</code></td>
+    <td><code>_empty_.C#T#</code></td>
+    <td><code>TYPE</code></td>
+    <td><code>TypeRef(&lt;scala.type&gt;, &lt;Int&gt;, List())</code></td>
+  </tr>
+</table>
+
+Notes:
+* Supported properties for type symbols are:
+  * `ABSTRACT`: set for type declarations.
+  * `FINAL`: set for `final` type aliases.
+* We leave the mapping between type syntax written in source code and
+  `Type` entities deliberately unspecified. For example, a producer may
+  represent the signature of `T1` as `TypeType(List(), <Nothing>, <Hi>)`.
+  See [Types](#scala-type) for more information.
+* If present, type parameters of type declarations and type aliases are
+  represented as described below in order of their appearance in source code.
+* Type symbols support [all Scala accessibilities](#scala-accessibility).
+
+**Type parameters** [\[43\]][43] are represented with `TYPE_PARAMETER` symbols,
+similarly to type declarations (see above).
+
+```scala
+class C[T1] {
+  def m[T2[T3] <: Hi] = ???
+  type T[T4 >: Lo] = ???
+}
+
+```
+<table>
+  <tr>
+    <td><b>Definition</b></td>
+    <td><b>Symbol</b></td>
+    <td><b>Kind</b></td>
+    <td><b>Signature</b></td>
+  </tr>
+  <tr>
+    <td><code>T1</code></td>
+    <td><code>_empty_.C#[T1]</code></td>
+    <td><code>TYPE_PARAMETER</code></td>
+    <td><code>TypeType(List(), null, null)</code></td>
+  </tr>
+  <tr>
+    <td><code>T2</code></td>
+    <td><code>_empty_.C#m()[T2]</code></td>
+    <td><code>TYPE_PARAMETER</code></td>
+    <td><code>TypeType(List(), null, &lt;Hi&gt;)</code></td>
+  </tr>
+  <tr>
+    <td><code>T3</code></td>
+    <td><code>_empty_.C#m()[T2][T3]</code></td>
+    <td><code>TYPE_PARAMETER</code></td>
+    <td><code>TypeType(List(), null, null)</code></td>
+  </tr>
+  <tr>
+    <td><code>T4</code></td>
+    <td><code>_empty_.C#T#[T4]</code></td>
+    <td><code>TYPE_PARAMETER</code></td>
+    <td><code>TypeType(List(), &lt;Lo&gt;, null)</code></td>
+  </tr>
+</table>
+
+Notes:
+* Supported properties for type parameter symbols are:
+  * `COVARIANT`: set for covariant type parameters.
+  * `CONTRAVARIANT`: set for contravariant type parameters.
+* If present, (higher-order) type parameters of type parameters are
+  represented as described here in order of their appearance in source code.
+* We leave the mapping between type syntax written in source code and
+  `Type` entities deliberately unspecified. For example, a producer may
+  represent the signature of `T1` as `TypeType(List(), <Nothing>, <Any>)`.
+  See [Types](#scala-type) for more information.
+* If present, context bounds and value bounds are desugared into parameters
+  of the enclosing definition as described in [\[44\]][44] and are represented
+  with corresponding `PARAMETER` symbols.
+
+**Parameters** are represented with `PARAMETER` symbols. (There is no section in SLS dedicated to parameters, so we aggregate information about parameters
+from multiple sections).
+
+```scala
+class C(p1: Int) {
+  def m2(p2: Int) = ???
+  def m3(p3: Int = 42) = ???
+  def m4(p4: => Int) = ???
+  def m5(p5: Int*) = ???
+  def m6[T: C <% V] = ???
+}
+```
+
+<table>
+  <tr>
+    <td><b>Definition</b></td>
+    <td width="260px"><b>Symbol</b></td>
+    <td><b>Kind</b></td>
+    <td><b>Signature</b></td>
+  </tr>
+  <tr>
+    <td><code>p1</code></td>
+    <td><code>_empty_.C#`&lt;init&gt;`(Int).(p1)</code></td>
+    <td><code>PARAMETER</code></td>
+    <td><code>TypeRef(&lt;scala.type&gt;, &lt;Int&gt;, List())</code></td>
+  </tr>
+  <tr>
+    <td><code>p2</code></td>
+    <td><code>_empty_.C#m2(Int).(p2)</code></td>
+    <td><code>PARAMETER</code></td>
+    <td><code>TypeRef(&lt;scala.type&gt;, &lt;Int&gt;, List())</code></td>
+  </tr>
+  <tr>
+    <td><code>p3</code></td>
+    <td><code>_empty_.C#m3(Int).(p3)</code></td>
+    <td><code>PARAMETER</code></td>
+    <td><code>TypeRef(&lt;scala.type&gt;, &lt;Int&gt;, List())</code></td>
+  </tr>
+  <tr>
+    <td><code>m3$default$1</code></td>
+    <td><code>_empty_.C#m3$default$1().</code></td>
+    <td><code>DEF</code></td>
+    <td><code>TypeRef(&lt;scala.type&gt;, &lt;Int&gt;, List())</code></td>
+  </tr>
+  <tr>
+    <td><code>p4</code></td>
+    <td><code>_empty_.C#m4(=>Int).(p4)</code></td>
+    <td><code>PARAMETER</code></td>
+    <td><code>ByNameType(TypeRef(&lt;scala.type&gt;, &lt;Int&gt;, List()))</code></td>
+  </tr>
+  <tr>
+    <td><code>p5</code></td>
+    <td><code>_empty_.C#m5(Int*).(p5)</code></td>
+    <td><code>PARAMETER</code></td>
+    <td><code>RepeatedType(TypeRef(&lt;scala.type&gt;, &lt;Int&gt;, List()))</code></td>
+  </tr>
+  <tr>
+    <td>Context bound</td>
+    <td><code>_empty_.C#m6(C,V).(x$1)</code></td>
+    <td><code>PARAMETER</code></td>
+    <td><code>TypeRef(..., &lt;C&gt;, List(&lt;T&gt;))</code></td>
+  </tr>
+  <tr>
+    <td>View bound</td>
+    <td><code>_empty_.C#m7(C,V).(x$2)</code></td>
+    <td><code>PARAMETER</code></td>
+    <td><code>TypeRef(&lt;scala.type&gt;, &lt;Function1&gt;, List(&lt;T&gt;, &lt;V&gt;))</code></td>
+  </tr>
+</table>
+
+Notes:
+* As described above, some values and variables are represented with multiple
+  symbols, including parameter symbols. For more information, see
+  "Value declarations and definitions" and "Variable declarations and
+  definitions".
+* Supported properties for parameter symbols are:
+  * `IMPLICIT`: set for `implicit` parameters, as well as desugared context
+    bounds and view bounds (see below).
+* Unlike some other metaprogramming systems for Scala, we do not
+  distinguish regular parameters from parameters with default arguments
+  [\[45\]][45]. However, we do create method symbols for synthetic methods
+  that compute default arguments with names and signatures defined
+  by [\[45\]][45].
+* Signatures of by-name parameters [\[46\]][46] and repeated parameters
+  [\[47\]][47] are represented with special types (`ByNameType` and
+  `RepeatedType` correspondingly).
+* According to [\[44\]][44], context bounds and view bounds are desugared
+  as parameters of enclosing definitions. Since SLS does not specify
+  the names for such parameters (only their signatures), we also leave
+  the names unspecified.
+
+**Function declarations and definitions** [\[48\]][48] are represented
+with `DEF` symbols.
+
+```scala
+abstract class C {
+  def m1: Int = ???
+  def m2(): Int = ???
+  def m3(x: Int): Int = ???
+  def m4(x: Int)(y: Int): Int = ???
+}
+```
+<table>
+  <tr>
+    <td><b>Definition</b></td>
+    <td><b>Symbol</b></td>
+    <td><b>Kind</b></td>
+    <td><b>Signature</b></td>
+  </tr>
+  <tr>
+    <td><code>m1</code></td>
+    <td><code>_empty_.C#m1().</code></td>
+    <td><code>DEF</code></td>
+    <td><code>MethodType(List(), List(), TypeRef(&lt;scala.type&gt;, &lt;Int&gt;, List()))</code></td>
+  </tr>
+  <tr>
+    <td><code>m2</code></td>
+    <td><code>_empty_.C#m2().</code></td>
+    <td><code>DEF</code></td>
+    <td><code>MethodType(List(), List(List()), TypeRef(&lt;scala.type&gt;, &lt;Int&gt;, List()))</code></td>
+  </tr>
+  <tr>
+    <td><code>m3</code></td>
+    <td><code>_empty_.C#m3(Int).</code></td>
+    <td><code>DEF</code></td>
+    <td><code>MethodType(List(), List(List(&lt;x&gt;)), TypeRef(&lt;scala.type&gt;, &lt;Int&gt;, List()))</code></td>
+  </tr>
+  <tr>
+    <td><code>m4</code></td>
+    <td><code>_empty_.C#m4(Int,Int).</code></td>
+    <td><code>DEF</code></td>
+    <td><code>MethodType(List(), List(List(&lt;x&gt;), List(&lt;y&gt;)), TypeRef(&lt;scala.type&gt;, &lt;Int&gt;, List()))</code></td>
+  </tr>
+</table>
+
+Notes:
+* According to the SLS, some language features involve synthetic methods that
+  are not written in source code. Symbols for synthetic methods must be included
+  in SemanticDB payloads alongside normal methods. Detailed information about
+  synthetic methods is provided in various subsections of
+  [SymbolInformation](#scala-symbolinformation) together with related language
+  features, and here we provide a comprehensive list of such methods:
+    * Getters for vals and vars.
+    * Setters for vals and vars.
+    * Methods that compute default arguments.
+    * Methods synthesized for `case` classes and objects.
+    * Implicit methods synthesized for `implicit` classes.
+    * Methods synthesized for value classes.
+* Supported properties for method symbols are:
+  * `ABSTRACT`: set for function declarations.
+  * `FINAL`: set for `final` methods.
+  * `IMPLICIT`: set for `implicit` methods.
+* If present, type parameters of methods are
+  represented as described above in order of their appearance in source code.
+* If present, parameters of methods are
+  represented as described above in order of their appearance in source code.
+* For procedures [\[49\]][49], the return type is inferred as `Unit`.
+  Corresponding signature is computed using the inferred
+  type as explained in [Type](#scala-type).
+* If the return type is unspecified, it is inferred from the
+  right-hand side of the method according to the rules described
+  in SLS [\[50\]][50]. Corresponding signature is computed using the inferred
+  type as explained in [Type](#scala-type).
+* Method symbols support [all Scala accessibilities](#scala-accessibility).
+
+**Macro definitions** [\[51\]][51] are represented with `MACRO` symbols
+similarly to function definitions (see above).
+
+```scala
+object M {
+  def m: Int = macro ???
+}
+
+```
+<table>
+  <tr>
+    <td><b>Definition</b></td>
+    <td><b>Symbol</b></td>
+    <td><b>Kind</b></td>
+    <td><b>Signature</b></td>
+  </tr>
+  <tr>
+    <td><code>m1</code></td>
+    <td><code>_empty_.M.m().</code></td>
+    <td><code>MACRO</code></td>
+    <td><code>MethodType(List(), List(), TypeRef(&lt;scala.type&gt;, &lt;Int&gt;, List()))</code></td>
+  </tr>
+</table>
+
+Notes:
+* Supported properties for macro symbols are the same as for method symbols,
+  except for `ABSTRACT` because macros cannot be `abstract`.
+* Return type inference for macros is deprecated.
+* At the moment, metadata for macros does not contain information about
+  macro implementations. We intend to improve this in the future.
+* Macro symbols support [all Scala accessibilities](#scala-accessibility).
+
+**Constructors** [[52][52], [53][53]] are represented with `PRIMARY_CONSTRUCTOR`
+and `SECONDARY_CONSTRUCTOR` symbols similarly to function definitions (see
+above).
+
+```scala
+class C(x: Int) {
+  def this() = this(42)
+}
+```
+
+<table>
+  <tr>
+    <td><b>Definition</b></td>
+    <td><b>Symbol</b></td>
+    <td><b>Kind</b></td>
+    <td><b>Signature</b></td>
+  </tr>
+  <tr>
+    <td>Primary constructor</td>
+    <td><code>_empty_.C#`&lt;init&gt;`(Int).</code></td>
+    <td><code>PRIMARY_CONSTRUCTOR</code></td>
+    <td><code>MethodType(List(), List(List(&lt;x&gt;)), TypeRef(..., &lt;C&gt;, List()))</code></td>
+  </tr>
+  <tr>
+    <td>Secondary constructor</td>
+    <td><code>_empty_.C#`&lt;init&gt;`().</code></td>
+    <td><code>SECONDARY_CONSTRUCTOR</code></td>
+    <td><code>MethodType(List(), List(), TypeRef(..., &lt;C&gt;, List()))</code></td>
+  </tr>
+</table>
+
+Notes:
+* Unlike some other metaprogramming systems for Scala, we do not create
+  synthetic constructor symbols for traits and objects.
+* Constructor symbols don't support any properties.
+* Constructors don't have type parameters and return types, but we still
+  represent their signatures with `MethodType`. In these signatures,
+  type parameters are inherited from the enclosing class and the return type
+  is the type of the enclosing class parameterized with references to these
+  type parameters.
+* Primary constructor parameters with `val` and `var` modifiers give rise
+  to multiple different symbols as described above.
+* Constructor symbols support [all Scala accessibilities](#scala-accessibility).
+
+**Class definitions** [\[54\]][54] are represented with `CLASS` symbols.
+
+```scala
+class C[T](x: T, val y: T, var z: T) extends B with X {
+  def m: Int = ???
+}
+```
+
+<table>
+  <tr>
+    <td><b>Definition</b></td>
+    <td width="260px"><b>Symbol</b></td>
+    <td><b>Kind</b></td>
+    <td><b>Signature</b></td>
+  </tr>
+  <tr>
+    <td><code>C</code></td>
+    <td><code>_empty_.C#</code></td>
+    <td><code>CLASS</code></td>
+    <td><code>ClassInfoType(List(&lt;T&gt;), List(&lt;B&gt;, &lt;X&gt;), List(&lt;x&gt;, &lt;y&gt;, &lt;y&gt;, &lt;z&gt;, &lt;z&gt;, &lt;z_=&gt;, &lt;init&gt;, &lt;m&gt;))</code></td>
+  </tr>
+  <tr>
+    <td><code>T</code></td>
+    <td><code>_empty_.C#[T]</code></td>
+    <td><code>TYPE_PARAMETER</code></td>
+    <td><code>TypeType(List(), null, null)</code></td>
+  </tr>
+  <tr>
+    <td><code>x</code></td>
+    <td><code>_empty_.C#x.</code></td>
+    <td><code>VAL</code></td>
+    <td><code>TypeRef(null, &lt;T&gt;, List())</code></td>
+  </tr>
+  <tr>
+    <td><code>y</code></td>
+    <td><code>_empty_.C#y.</code></td>
+    <td><code>VAL</code></td>
+    <td><code>TypeRef(null, &lt;T&gt;, List())</code></td>
+  </tr>
+  <tr>
+    <td><code>y</code></td>
+    <td><code>_empty_.C#x().</code></td>
+    <td><code>GETTER</code></td>
+    <td><code>MethodType(List(), List(), TypeRef(null, &lt;T&gt;, List()))</code></td>
+  </tr>
+  <tr>
+    <td><code>z</code></td>
+    <td><code>_empty_.C#z.</code></td>
+    <td><code>VAL</code></td>
+    <td><code>TypeRef(null, &lt;T&gt;, List())</code></td>
+  </tr>
+  <tr>
+    <td><code>z</code></td>
+    <td><code>_empty_.C#z().</code></td>
+    <td><code>GETTER</code></td>
+    <td><code>MethodType(List(), List(), TypeRef(null, &lt;T&gt;, List()))</code></td>
+  </tr>
+  <tr>
+    <td><code>z</code></td>
+    <td><code>_empty_.C#z_=(T).</code></td>
+    <td><code>SETTER</code></td>
+    <td><code>MethodType(List(), List(List(&lt;x$1&gt;)), TypeRef(&lt;scala.type&gt;, &lt;Unit&gt;, List()))</code></td>
+  </tr>
+  <tr>
+    <td><code>z</code></td>
+    <td><code>_empty_.C#z_=(T).(x$1)</code></td>
+    <td><code>PARAMETER</code></td>
+    <td><code>TypeRef(&lt;scala.type&gt;, &lt;T&gt;, List())</code></td>
+  </tr>
+  <tr>
+    <td>Primary constructor</td>
+    <td><code>_empty_.C#`&lt;init&gt;`(T,T,T).</code></td>
+    <td><code>PRIMARY_CONSTRUCTOR</code></td>
+    <td><code>TypeRef(&lt;scala.type&gt;, &lt;Int&gt;, List())</code></td>
+  </tr>
+  <tr>
+    <td><code>x</code></td>
+    <td><code>_empty_.C#`&lt;init&gt;`(T,T,T).(x)</code></td>
+    <td><code>PARAMETER</code></td>
+    <td><code>TypeRef(null, &lt;T&gt;, List())</code></td>
+  </tr>
+  <tr>
+    <td><code>y</code></td>
+    <td><code>_empty_.C#`&lt;init&gt;`(T,T,T).(y)</code></td>
+    <td><code>PARAMETER</code></td>
+    <td><code>TypeRef(null, &lt;T&gt;, List())</code></td>
+  </tr>
+  <tr>
+    <td><code>z</code></td>
+    <td><code>_empty_.C#`&lt;init&gt;`(T,T,T).(z)</code></td>
+    <td><code>PARAMETER</code></td>
+    <td><code>TypeRef(null, &lt;T&gt;, List())</code></td>
+  </tr>
+  <tr>
+    <td>m</td>
+    <td><code>_empty_.C#m().</code></td>
+    <td><code>DEF</code></td>
+    <td><code>MethodType(List(), List(), TypeRef(&lt;scala.type&gt;, &lt;Int&gt;, List()))</code></td>
+  </tr>
+</table>
+
+Notes:
+* Supported properties for class symbols are:
+  * `ABSTRACT`: set for `abstract` classes.
+  * `FINAL`: set for `final` classes.
+  * `SEALED`: set for `sealed` classes.
+  * `IMPLICIT`: set for `implicit` classes.
+  * `CASE`: set for `case` classes.
+* We leave the mapping between parent syntax written in source code and
+  `ClassInfoType.parents` deliberately unspecified. Some producers are known
+  to insert `<AnyRef>` into `parents` under certain circumstances, so we can't
+  guarantee a one-to-one mapping of parent clauses in source code and
+  entities in `parents`. We may improve on this in the future.
+* `ClassInfoType.declarations` must be ordered as follows:
+  * For every parameter of the primary constructor, its `VAL`, then
+    its `GETTER`, then its `SETTER` (if getters and setters exist).
+  * Symbol of the primary constructor.
+  * Symbols of declared members in order of their appearance in source code.
+    (Inherited members must not be part of `declarations`.)
+  * Relative order and positions of synthetic symbols are unspecified.
+    We may improve on this in the future.
+* In some cases, SLS and its extensions mandate generation of synthetic members
+  and/or companions for certain classes. Symbols for such synthetic definitions must be included in SemanticDB payloads alongside normal definitions. For
+  details, see:
+    * Case classes [\[55\]][55].
+    * Implicit classes [\[56\]][56].
+    * Value classes [\[57\]][57].
+* Class symbols support [all Scala accessibilities](#scala-accessibility).
+
+**Traits** [\[58\]][58] are represented by `TRAIT` symbols
+similarly to class definitions (see above). Concretely, the differences
+between trait symbols and class symbols are:
+* Trait symbols only support `SEALED` property.
+* Traits don't have constructors.
+
+**Object definitions** [\[59\]][59] are represented by `OBJECT` symbols
+similarly to class definitions (see above). Concretely, the differences
+between object symbols and class symbols are:
+* Object symbols are always `FINAL`.
+* Apart from `FINAL`, object symbols only support `CASE` and `IMPLICIT`
+  properties.
+* Objects don't have type parameters, but we still represent their signatures
+  with `ClassInfoType`. In these signatures, type parameters are equal
+  to `List()`.
+* Objects don't have constructors.
+
+**Package objects** [\[60\]][60] are represented by `PACKAGE_OBJECT` symbols
+similarly to object definitions (see above). Concretely, the differences
+between package object symbols and object symbols are:
+* Package object symbols are always `FINAL`.
+* Apart from `FINAL`, package object symbols don't support any properties.
+* Package objects don't have annotations.
+* Package objects don't support any accessibilities.
+
+**Packages** [\[61\]][61] are represented by `PACKAGE` symbols.
+In Scala, `SymbolInformation` for `PACKAGE` symbols is very modest -
+the only non-empty fields must be:
+  * `symbol` (must be defined as described in [Symbol](#scala-symbol)).
+  * `language` (must be `"Scala"`).
+  * `kind` (must be `PACKAGE`).
+  * `name` (must be equal to the short name of the package).
+
+<a name="scala-annotation"></a>
+#### Annotation
+
+In Scala, `Annotation` represents annotations [\[23\]][23].
+
+<table>
+  <tr>
+    <td><b>Value</b></td>
+    <td><b>Explanation</b></td>
+  </tr>
+  <tr>
+    <td><code>Annotation(&lt;ann&gt;)</code></td>
+    <td>Definition annotation, e.g. <code>@ann def m: T</code>.</td>
+  </tr>
+  <tr>
+    <td><code>Annotation(&lt;ann&gt;)</code></td>
+    <td>Type annotation, e.g. <code>T @ann</code>.</td>
+  </tr>
+  <tr>
+    <td>Not supported</td>
+    <td>Expression annotation, e.g. <code>e: @ann</code>.</td>
+  </tr>
+</table>
+
+* At the moment, `Annotation` can't represent annotation arguments,
+  which means that the annotation in `@ann(x, y, z) def m: T` is
+  represented as `Annotation(<ann>)`. We intend to improve on this
+  in the future.
+* At the moment, SemanticDB cannot represent expressions, which means
+  that it cannot represent expression annotations as well. We do not
+  have plans to add support for expressions in SemanticDB, so it is highly
+  unlikely that expression annotations will be supported in the future.
+
+<a name="scala-accessibility"></a>
+#### Accessibility
+
+In Scala, `Accessibility` represents accessibility of definitions.
+
+<table>
+  <tr>
+    <td><b>Accessibility</b></td>
+    <td><b>Code</b></td>
+    <td><b>Explanation</b></td>
+  </tr>
+  <tr>
+    <td><code>PRIVATE</code></td>
+    <td><code>private def x = ???</code></td>
+    <td>
+      Can be accessed only from within the directly enclosing template
+      and its companion object or companion class
+      <a href="https://www.scala-lang.org/files/archive/spec/2.12/05-classes-and-objects.html#private">[62]</a>.
+    </td>
+  </tr>
+  <tr>
+    <td><code>PRIVATE_THIS</code></td>
+    <td><code>private[this] def x = ???</code></td>
+    <td>
+      Can be accessed only from within the object in which the definition
+      is defined.
+      <a href="https://www.scala-lang.org/files/archive/spec/2.12/05-classes-and-objects.html#private">[62]</a>.
+    </td>
+  </tr>
+  <tr>
+    <td><code>PRIVATE_WITHIN</code></td>
+    <td><code>private[X] def x = ???</code></td>
+    <td>
+      Can be accessed respectively only from code inside the package
+      <code>X</code> or only from code inside the class <code>X</code>
+      and its companion object.
+      <a href="https://www.scala-lang.org/files/archive/spec/2.12/05-classes-and-objects.html#private">[62]</a>.
+    </td>
+  </tr>
+  <tr>
+    <td><code>PROTECTED</code></td>
+    <td><code>protected def x = ???</code></td>
+    <td>
+      Can be accessed from within: 1) the template of the defining class,
+      2) all templates that have the defining class as a base class,
+      3) the companion object of any of those classes.
+      <a href="https://www.scala-lang.org/files/archive/spec/2.12/05-classes-and-objects.html#protected">[63]</a>.
+    </td>
+  </tr>
+  <tr>
+    <td><code>PROTECTED_THIS</code></td>
+    <td><code>protected[this] def x = ???</code></td>
+    <td>
+      Can be accessed as <code>PROTECTED</code> AND
+      only from within the object in which the definition is defined.
+      <a href="https://www.scala-lang.org/files/archive/spec/2.12/05-classes-and-objects.html#protected">[63]</a>.
+    </td>
+  </tr>
+  <tr>
+    <td><code>PROTECTED_WITHIN</code></td>
+    <td><code>protected[X] def x = ???</code></td>
+    <td>
+      Can be accessed as <code>PROTECTED</code> OR
+      from code inside the package <code>X</code> or from code inside
+      the class <code>X</code> and its companion object.
+      <a href="https://www.scala-lang.org/files/archive/spec/2.12/05-classes-and-objects.html#protected">[63]</a>.
+    </td>
+  </tr>
+</table>
+
+Notes:
+* Not all kinds of symbols support all accessibilities. See
+  [SymbolInformation](#scala-symbolinformation) for more information.
 
 <a name="scala-synthetic"></a>
 #### Synthetic
 
-Synthetics are unspecified in the Scala Language Specification, so we leave the
-synthetic format deliberately unspecified as well. Our experience [\[36\]][36]
-shows that reverse engineering Scala synthetics is very hard. We may improve
+In Scala, we leave the synthetic format deliberately unspecified.
+Synthetics are unspecified in SLS, and our experience [\[38\]][38] shows that
+reverse engineering synthetics is very hard. We may improve
 on this in the future, but this is highly unlikely.
 
 [semanticdb2.proto]: https://github.com/scalameta/scalameta/blob/master/semanticdb/semanticdb2/semanticdb2.proto
@@ -1036,9 +1837,50 @@ on this in the future, but this is highly unlikely.
 [14]: https://www.json.org/
 [15]: https://en.wikipedia.org/wiki/SQL
 [16]: http://tools.ietf.org/html/rfc3986
-[17]: https://www.scala-lang.org/files/archive/spec/2.12/09-top-level-definitions.html#packagings
-[18]: https://www.scala-lang.org/files/archive/spec/2.12/09-top-level-definitions.html#package-references
-[19]: https://www.scala-lang.org/files/archive/spec/2.11/03-types.html
-[20]: https://en.wikipedia.org/wiki/Symbol_table
-[21]: https://docs.oracle.com/javase/specs/jls/se9/html/jls-3.html#jls-3.8
-[36]: http://scalamacros.org/paperstalks/2016-02-11-WhatDidWeLearnInScalaMeta.pdf
+[17]: https://www.scala-lang.org/files/archive/spec/2.12/
+[18]: https://www.scala-lang.org/files/archive/spec/2.11/03-types.html
+[19]: https://en.wikipedia.org/wiki/Symbol_table
+[20]: https://www.scala-lang.org/files/archive/spec/2.12/09-top-level-definitions.html#packagings
+[21]: https://www.scala-lang.org/files/archive/spec/2.12/09-top-level-definitions.html#package-references
+[22]: https://docs.oracle.com/javase/specs/jls/se9/html/jls-3.html#jls-3.8
+[23]: https://www.scala-lang.org/files/archive/spec/2.12/11-annotations.html
+[24]: https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#singleton-types
+[25]: https://github.com/scala/scala/pull/5310
+[26]: https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#type-projection
+[27]: https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#type-designators
+[28]: https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#parameterized-types
+[29]: https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#tuple-types
+[30]: https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#annotated-types
+[31]: https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#compound-types
+[32]: https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#infix-types
+[33]: https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#function-types
+[34]: https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#existential-types
+[35]: https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#method-types
+[36]: https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#polymorphic-method-types
+[37]: https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#type-constructors
+[38]: http://scalamacros.org/paperstalks/2016-02-11-WhatDidWeLearnInScalaMeta.pdf
+[39]: https://www.scala-lang.org/files/archive/spec/2.12/04-basic-declarations-and-definitions.html#value-declarations-and-definitions
+[40]: http://www.scala-lang.org/api/2.12.0/scala/annotation/meta/index.html
+[41]: https://www.scala-lang.org/files/archive/spec/2.12/04-basic-declarations-and-definitions.html#variable-declarations-and-definitions
+[42]: https://www.scala-lang.org/files/archive/spec/2.12/04-basic-declarations-and-definitions.html#type-declarations-and-type-aliases
+[43]: https://www.scala-lang.org/files/archive/spec/2.12/04-basic-declarations-and-definitions.html#type-parameters
+[44]: https://www.scala-lang.org/files/archive/spec/2.12/07-implicits.html#context-bounds-and-view-bounds
+[45]: https://www.scala-lang.org/files/archive/spec/2.12/04-basic-declarations-and-definitions.html#default-arguments
+[46]: https://www.scala-lang.org/files/archive/spec/2.12/04-basic-declarations-and-definitions.html#by-name-parameters
+[47]: https://www.scala-lang.org/files/archive/spec/2.12/04-basic-declarations-and-definitions.html#repeated-parameters
+[48]: https://www.scala-lang.org/files/archive/spec/2.12/04-basic-declarations-and-definitions.html#function-declarations-and-definitions
+[49]: https://www.scala-lang.org/files/archive/spec/2.12/04-basic-declarations-and-definitions.html#procedures
+[50]: https://www.scala-lang.org/files/archive/spec/2.12/04-basic-declarations-and-definitions.html#method-return-type-inference
+[51]: https://docs.scala-lang.org/overviews/macros/overview.html
+[52]: https://www.scala-lang.org/files/archive/spec/2.12/05-classes-and-objects.html#class-definitions
+[53]: https://www.scala-lang.org/files/archive/spec/2.12/05-classes-and-objects.html#constructor-definitions
+[54]: https://www.scala-lang.org/files/archive/spec/2.12/05-classes-and-objects.html#class-definitions
+[55]: https://www.scala-lang.org/files/archive/spec/2.12/05-classes-and-objects.html#case-classes
+[56]: https://docs.scala-lang.org/overviews/core/implicit-classes.html
+[57]: https://docs.scala-lang.org/overviews/core/value-classes.html
+[58]: https://www.scala-lang.org/files/archive/spec/2.12/05-classes-and-objects.html#traits
+[59]: https://www.scala-lang.org/files/archive/spec/2.12/05-classes-and-objects.html#object-definitions
+[60]: https://www.scala-lang.org/files/archive/spec/2.12/09-top-level-definitions.html#package-objects
+[61]: https://www.scala-lang.org/files/archive/spec/2.12/09-top-level-definitions.html#packagings
+[62]: https://www.scala-lang.org/files/archive/spec/2.12/05-classes-and-objects.html#private
+[63]: https://www.scala-lang.org/files/archive/spec/2.12/05-classes-and-objects.html#protected

--- a/semanticdb/semanticdb3/semanticdb3.md
+++ b/semanticdb/semanticdb3/semanticdb3.md
@@ -875,68 +875,135 @@ as `Annotation(<ann>)`. We intend to improve on this in the future
 <a name="scala-type"></a>
 #### Type
 
-In Scala, `TypeRef` represents identifiers, paths [\[22\]][22], 
-parameterized types [\[23\]][23] and type projections [\[24\]][24]. 
-Infix types [\[25\]][25], tuple types [\[26\]][26] and
-function types [\[27\]][27] are also represented by typerefs via desugaring
-to their canonical parameterized form:
-
-* `C` ~ `TypeRef(null, <C>, List())`.
-* `p.C` ~ `TypeRef(<p.type>, <C>, List())`.
-* `T#C` ~ `TypeRef(<T>, <C>, List())`.
-* `C[T1, ..., Tn]` ~ `TypeRef(null, <C>, List(<T1>, ..., <Tn>))`.
-* `p.C[T1, ..., Tn]` ~ `TypeRef(<p.type>, <C>, List(<T1>, ..., <Tn>))`.
-* `T#C[T1, ..., Tn]` ~ `TypeRef(<T>, <C>, List(<T1>, ..., <Tn>))`.
-* `A T B` ~ `TypeRef(null, <T>, List(<A>, ..., <B>))`
-* `(T1, ..., Tn)` ~ `TypeRef(<scala.type>, <TupleN>, List(<T1>, ..., <Tn>))`.
-* `(T1, ..., Tn) => R` ~ `TypeRef(<scala.type>, <FunctionN>, List(<T1>, ..., <Tn>, <R>))`.
-
-In Scala, `SingletonType` represents singleton types [\[28\]][28]
-from Scala Language Specification, as well as the recently introduced
-literal types [\[29\]][29].
-
-* `x.type` ~ `SingletonType(SYMBOL, null, <x>, null, null)`.
-* `p.x.type` ~ `SingletonType(SYMBOL, <p.type>, <x>, null, null)`.
-* `this.type` ~ `SingletonType(THIS, null, null, null, null)`.
-* `C.this.type` ~ `SingletonType(THIS, <C>, null, null, null)`.
-* Type of the qualifier in `super.x` ~ `SingletonType(SUPER, ThisType(...), null, null, null)`.
-* Type of the qualifier in `super[M].x` ~ `SingletonType(SUPER, ThisType(...), <M>, null, null)`.
-* Type of the qualifier in `C.super[M].x` ~ `SingletonType(SUPER, ThisType(<C>), <M>, null, null)`.
-* Literal type ~ `SingletonType(<TAG>, null, null, <value>, null)` or `SingletonType(<TAG>, null, null, null, <value>)`.
-
-In Scala, `StructuralType` represents compound types [\[30\]][30].
-
-* `{ M1; ...; Mm }` ~ `StructuralType(List(), List(<M1>, ..., <Mm>))`.
-* `T1 with ... with Tn` ~ `StructuralType(List(<T1>, ..., <Tn>), List())`.
-* `T1 with ... with Tn { M1; ...; Mm }` ~ `StructuralType(List(<T1>, ..., <Tn>), List(<M1>, ..., <Mm>))`.
-
-In Scala, `AnnotatedType` represents annotated types [\[31\]][31].
-
-* `T @ann1 ... @annN` ~ `AnnotatedType(List(<ann1>, ..., <annN>), <T>)`.
-
-In Scala, `ExistentialType` represents existential types [\[32\]][32].
-
-* `T forSome { type T }` ~ `ExistentialType(List(<T>), <T>)`.
-
-In Scala, `UniversalType` represents types that are colloquially called 
-"type lambdas" in the community [\[33\]][33]. There is no surface syntax
-for these types in Scala 2.x.
-
-In Scala, `ByNameType` represents signatures of by-name parameters [\[34\]][34]
-as well as by-name type arguments of function types [\[27\]][27].
-
-* Signature of `x` in `def m(x: => T): T` ~ `ByNameType(<T>)`.
-* `(=> T) => T` ~ `TypeRef(<scala.this>, <Function1>, List(ByNameType(<T>))`.
-
-In Scala, `RepeatedType` represents signatures of repeated parameters 
-[\[35\]][35] as well as repeated type arguments of function types [\[27\]][27].
-
-* Signature of `xs` in `def m(xs: T*): T` ~ `RepeatedType(<T>)`.
-* `(T*) => T` ~ `TypeRef(<scala.this>, <Function1>, List(RepeatedType(<T>))`.
-
-In Scala, `ClassInfoType`, `MethodType`, and `TypeType` can only occur in type
-signatures of definitions. See [SymbolInformation](#scala-symbolinformation) 
-for more information about which definitions have which signatures.
+<table>
+  <tr>
+    <td width="220px"><b>Category</b></td>
+    <td><b>Examples</b></td>
+  </tr>
+  <tr>
+    <td valign="top">Singleton types [<a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#singleton-types">22</a>, <a href="https://github.com/scala/scala/pull/5310">23</a>]</td>
+    <td>
+      <ul>
+        <li><code>x.type</code> ~ <code>SingletonType(SYMBOL, null, &lt;x&gt;, null, null)</code>.</li>
+        <li><code>p.x.type</code> ~ <code>SingletonType(SYMBOL, &lt;p.type&gt;, &lt;x&gt;, null, null)</code>.</li>
+        <li><code>this.type</code> ~ <code>SingletonType(THIS, null, null, null, null)</code>.</li>
+        <li><code>C.this.type</code> ~ <code>SingletonType(THIS, &lt;C&gt;, null, null, null)</code>.</li>
+        <li>Type of <code>super</code> ~ <code>SingletonType(SUPER, ThisType(...), null, null, null)</code>.</li>
+        <li>Type of <code>super[M]</code> ~ <code>SingletonType(SUPER, ThisType(...), &lt;M&gt;, null, null)</code>.</li>
+        <li>Type of <code>C.super[M]</code> ~ <code>SingletonType(SUPER, ThisType(&lt;C&gt;), &lt;M&gt;, null, null)</code>.</li>
+        <li>Literal type ~ <code>SingletonType(&lt;TAG&gt;, null, null, &lt;value&gt;, null)</code> or <code>SingletonType(&lt;TAG&gt;, null, null, null, &lt;value&gt;)</code>.</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">Type projections <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#type-projection">[24]</a></td>
+    <td>
+      <ul>
+        <li><code>T#C</code> ~ <code>TypeRef(&lt;T&gt;, &lt;C&gt;, List())</code>.</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">Type designators <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#type-designators">[25]</a></td>
+    <td>
+      <ul>
+        <li><code>t</code> ~ <code>TypeRef(null, &lt;t&gt;, List())</code>.</li>
+        <li><code>Int</code> ~ <code>TypeRef(&lt;scala.type&gt;, &lt;Int&gt;, List())</code>.</li>
+        <li><code>scala.Int</code> ~ <code>TypeRef(&lt;scala.type&gt;, &lt;Int&gt;, List())</code>.</li>
+        <li><code>p.C</code> ~ <code>TypeRef(&lt;p.type&gt;, &lt;C&gt;, List())</code>.</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">Parameterized types <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#parameterized-types">[26]</a></td>
+    <td>
+      <ul>
+        <li><code>T#C[T1, ..., Tn]</code> ~ <code>TypeRef(&lt;T&gt;, &lt;C&gt;, List(&lt;T1&gt;, ..., &lt;Tn&gt;))</code>.</li>
+        <li><code>M[T1, ..., Tn]</code> ~ <code>TypeRef(null, &lt;M&gt;, List(&lt;T1&gt;, ..., &lt;Tn&gt;))</code>.</li>
+        <li><code>List[Int]</code> ~ <code>TypeRef(&lt;scala.type&gt;, &lt;List&gt;, List(&lt;Int&gt;))</code>.</li>
+        <li><code>scala.List[Int]</code> ~ <code>TypeRef(&lt;scala.type&gt;, &lt;List&gt;, List(&lt;Int&gt;))</code>.</li>
+        <li><code>p.C[T1, ..., Tn]</code> ~ <code>TypeRef(&lt;p.type&gt;, &lt;C&gt;, List(&lt;T1&gt;, ..., &lt;Tn&gt;))</code>.</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">Tuple types <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#tuple-types">[27]</a></td>
+    <td>
+      <ul>
+        <li><code>(T1, ..., Tn)</code> ~ <code>TypeRef(&lt;scala.type&gt;, &lt;TupleN&gt;, List(&lt;T1&gt;, ..., &lt;Tn&gt;))</code>.</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">Annotated types <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#annotated-types">[28]</a></td>
+    <td>
+      <ul>
+        <li><code>T @ann1 ... @annN</code> ~ <code>AnnotatedType(List(&lt;ann1&gt;, ..., &lt;annN&gt;), &lt;T&gt;)</code>.</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">Compound types <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#compound-types">[29]</a></td>
+    <td>
+      <ul>
+        <li><code>{ M1; ...; Mm }</code> ~ <code>StructuralType(List(), List(&lt;M1&gt;, ..., &lt;Mm&gt;))</code>.</li>
+        <li><code>T1 with ... with Tn</code> ~ <code>StructuralType(List(&lt;T1&gt;, ..., &lt;Tn&gt;), List())</code>.</li>
+        <li><code>T1 with ... with Tn { M1; ...; Mm }</code> ~ <code>StructuralType(List(&lt;T1&gt;, ..., &lt;Tn&gt;), List(&lt;M1&gt;, ..., &lt;Mm&gt;))</code>.</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">Infix types <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#infix-types">[30]</a></td>
+    <td>
+      <ul>
+        <li><code>A L B</code> ~ <code>TypeRef(..., &lt;L&gt;, List(&lt;A&gt;, &lt;B&gt;))</code> for left-associative <code>L</code>.</li>
+        <li><code>A R B</code> ~ <code>TypeRef(..., &lt;R&gt;, List(&lt;B&gt;, &lt;A&gt;))</code> for right-associative <code>R</code>.</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">Function types <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#function-types">[31]</a></td>
+    <td>
+      <ul>
+        <li><code>(T1, ..., Tn) =&gt; R</code> ~ <code>TypeRef(&lt;scala.type&gt;, &lt;FunctionN&gt;, List(&lt;T1&gt;, ..., &lt;Tn&gt;, &lt;R&gt;))</code>.</li>
+        <li><code>=&gt; Ti</code> ~ <code>ByNameType(&lt;Ti&gt;)</code>.</li>
+        <li><code>Ti*</code> ~ <code>RepeatedType(&lt;Ti&gt;)</code>.</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">Existential types <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#existential-types">[32]</a></td>
+    <td>
+      <ul>
+        <li><code>T forSome { M1; ...; Mm }</code> ~ <code>ExistentialType(List(&lt;T&gt;), List(&lt;M1&gt;, ..., &lt;Mm&gt;))</code>.</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">Method types <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#method-types">[33]</a></td>
+    <td>
+      <ul>
+        <li><code>(P1s)...(Pns)U</code> ~ <code>MethodType(List(), List(List(&lt;T11&gt;, ...), ..., List(&lt;Tn1&gt;, ...)), &lt;U&gt;)</code>.</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">Polymorphic method types <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#polymorphic-method-types">[34]</a></td>
+    <td>
+      <ul>
+        <li><code>[ts](P1s)...(Pns)U</code> ~ <code>MethodType(List(&lt;t1&gt;, ..., &lt;tm&gt;), List(List(&lt;T11&gt;, ...), ..., List(&lt;Tn1&gt;, ...)), &lt;U&gt;)</code>.</li>
+      </ul>
+    </td>
+  </tr>
+  <tr>
+    <td valign="top">Type constructors <a href="https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#type-constructors">[35]</a></td>
+    <td>
+      <ul>
+        <li><code>[ts]T</code> ~ <code>UniversalType(List(&lt;t1&gt;, ..., &lt;tm&gt;), &lt;T&gt;)</code>.</li>
+      </ul>
+    </td>
+  </tr>
+</table>
 
 <a name="scala-symbolinformation"></a>
 #### SymbolInformation
@@ -974,18 +1041,4 @@ on this in the future, but this is highly unlikely.
 [19]: https://www.scala-lang.org/files/archive/spec/2.11/03-types.html
 [20]: https://en.wikipedia.org/wiki/Symbol_table
 [21]: https://docs.oracle.com/javase/specs/jls/se9/html/jls-3.html#jls-3.8
-[22]: https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#paths
-[23]: https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#parameterized-types
-[24]: https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#type-projection
-[25]: https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#infix-types
-[26]: https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#tuple-types
-[27]: https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#function-types
-[28]: https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#singleton-types
-[29]: https://github.com/scala/scala/pull/5310
-[30]: https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#compound-types
-[31]: https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#annotated-types
-[32]: https://www.scala-lang.org/files/archive/spec/2.12/03-types.html#existential-types
-[33]: https://stackoverflow.com/questions/8736164/what-are-type-lambdas-in-scala-and-what-are-their-benefits
-[34]: https://www.scala-lang.org/files/archive/spec/2.12/04-basic-declarations-and-definitions.html#by-name-parameters
-[35]: https://www.scala-lang.org/files/archive/spec/2.12/04-basic-declarations-and-definitions.html#repeated-parameters
 [36]: http://scalamacros.org/paperstalks/2016-02-11-WhatDidWeLearnInScalaMeta.pdf

--- a/semanticdb/semanticdb3/semanticdb3.md
+++ b/semanticdb/semanticdb3/semanticdb3.md
@@ -1,18 +1,18 @@
 # SemanticDB Specification
 
-  * [Motivation](#motivation)
-  * [Data Model](#data-model)
-    * [TextDocument](#textdocument)
-    * [Range](#range)
-    * [Location](#location)
-    * [Symbol](#symbol)
-    * [Type](#type)
-    * [SymbolInformation](#symbolinformation)
-    * [SymbolOccurrence](#symboloccurrence)
-    * [Diagnostic](#diagnostic)
-    * [Synthetic](#synthetic)
-  * [Data Schemas](#data-schemas)
-    * [Protobuf](#protobuf)
+* [Motivation](#motivation)
+* [Data Model](#data-model)
+  * [TextDocument](#textdocument)
+  * [Range](#range)
+  * [Location](#location)
+  * [Symbol](#symbol)
+  * [Type](#type)
+  * [SymbolInformation](#symbolinformation)
+  * [SymbolOccurrence](#symboloccurrence)
+  * [Diagnostic](#diagnostic)
+  * [Synthetic](#synthetic)
+* [Data Schemas](#data-schemas)
+  * [Protobuf](#protobuf)
 
 ## Motivation
 
@@ -153,35 +153,36 @@ symbol categories.
 the compilation unit where the definition is defined.
 Global symbol format is a concatenation of signatures of the owner chain
 of the corresponding global definition, where:
-  * The owner chain of a definition is a list of its enclosing definitions
-    starting with the outermost one, with the outermost definition being
-    either `_empty_` (the special empty package [\[17\]][17]) or
-    `_root_` (the special root package [\[18\]][18]). For example,
-    for the standard `Int` class, the owner chain is `[_root_, scala, Int]`.
-  * The signature of a definition is:
-    * For a val, var, object, package or package object, concatenation of its
+
+* The owner chain of a definition is a list of its enclosing definitions
+  starting with the outermost one, with the outermost definition being
+  either `_empty_` (the special empty package [\[17\]][17]) or
+  `_root_` (the special root package [\[18\]][18]). For example,
+  for the standard `Int` class, the owner chain is `[_root_, scala, Int]`.
+* The signature of a definition is:
+  * For a val, var, object, package or package object, concatenation of its
     encoded name and a dot (`.`).
-    * For a method, primary constructor, secondary constructor or macro,
+  * For a method, primary constructor, secondary constructor or macro,
     concatenation of its encoded name, its JVM method descriptor [\[19\]][19]
     and a dot (`.`). The JVM method descriptor is used to distinguish overloaded
     methods as mandated by the Scala Language Specification [\[20\]][20].
-    * For an abstract type, type alias, class or trait, concatenation of its
+  * For an abstract type, type alias, class or trait, concatenation of its
     encoded name and a pound sign (`#`).
-    * For a parameter, concatenation of a left parenthesis (`(`), its
+  * For a parameter, concatenation of a left parenthesis (`(`), its
     encoded name and a right parenthesis (`)`).
-    * For a type parameter, concatenation of an left bracket (`[`), its
+  * For a type parameter, concatenation of an left bracket (`[`), its
     encoded name and a right bracket (`]`).
-  * The encoded name of a definition is:
-    * For a Java identifier [\[25\]][25], the name itself.
-    * Otherwise, concatenation of a backtick (`````), the name itself and
-    another backtick (`````).
+* The encoded name of a definition is:
+  * For a Java identifier [\[25\]][25], the name itself.
+  * Otherwise, concatenation of a backtick (`), the name itself and another backtick (`).
 
 For example, this is how some of the definitions from the Scala standard library
 must be modelled:
-  * The `scala` package: `_root_.scala.`
-  * The `Int` class: `_root_.scala.Int#`
-  * The single-parameter `println` method: `_root_.scala.Predef.println(Ljava/lang/Object;)V.`
-  * The integer addition method: ``_root_.scala.Int#`+`(I)I.``.
+
+* The `scala` package: `_root_.scala.`
+* The `Int` class: `_root_.scala.Int#`
+* The single-parameter `println` method: `_root_.scala.Predef.println(Ljava/lang/Object;)V.`
+* The integer addition method: `` _root_.scala.Int#`+`(I)I. ``.
 
 Global symbols must be unique across the universe of documents that
 a tool is working with at any given time. For example, if in such a universe,
@@ -197,9 +198,10 @@ accompany global symbols with `SymbolInformation.location`.
 
 **Local symbols**. Correspond to a definition that isn't global (see above).
 Local symbol format is defined by the following two rules:
-  * Local symbols must start with `local`, so that they can be easily
-    distinguished from global symbols.
-  * Local symbols must be unique within the underlying document.
+
+* Local symbols must start with `local`, so that they can be easily
+  distinguished from global symbols.
+* Local symbols must be unique within the underlying document.
 
 For example, `x` in `def identity[T](x: T): T` may be modelled by local symbols
 `local0`, `local_x`, `local_identity_x`, as long as these names are unique within
@@ -299,12 +301,13 @@ paths [\[28\]][28], parameterized types [\[29\]][29] and type projections
 [\[30\]][30]. Infix types [\[31\]][31], tuple types [\[32\]][32] and
 function types [\[33\]][33] are also represented by typerefs via desugaring
 to their canonical parameterized form:
-  * `C` ~ `TypeRef(null, <C>, List())`.
-  * `p.C` ~ `TypeRef(<p.type>, <C>, List())`.
-  * `T#C` ~ `TypeRef(<T>, <C>, List())`.
-  * `C[T1, ... Tn]` ~ `TypeRef(null, <C>, List(<T1>, ..., <TN>))`.
-  * `p.C[T1, ... Tn]` ~ `TypeRef(<p.type>, <C>, List(<T1>, ..., <TN>))`.
-  * `T#C[T1, ... Tn]` ~ `TypeRef(<T>, <C>, List(<T1>, ..., <TN>))`.
+
+* `C` ~ `TypeRef(null, <C>, List())`.
+* `p.C` ~ `TypeRef(<p.type>, <C>, List())`.
+* `T#C` ~ `TypeRef(<T>, <C>, List())`.
+* `C[T1, ... Tn]` ~ `TypeRef(null, <C>, List(<T1>, ..., <TN>))`.
+* `p.C[T1, ... Tn]` ~ `TypeRef(<p.type>, <C>, List(<T1>, ..., <TN>))`.
+* `T#C[T1, ... Tn]` ~ `TypeRef(<T>, <C>, List(<T1>, ..., <TN>))`.
 
 ```protobuf
 message SingleType {
@@ -314,8 +317,9 @@ message SingleType {
 ```
 
 `SingleType` represents the majority of singleton types [\[34\]][34]:
-  * `x.type` ~ `SingleType(null, <x>)`.
-  * `p.x.type` ~ `SingleType(<p.type>, <x>)`.
+
+* `x.type` ~ `SingleType(null, <x>)`.
+* `p.x.type` ~ `SingleType(<p.type>, <x>)`.
 
 ```protobuf
 message ThisType {
@@ -324,8 +328,9 @@ message ThisType {
 ```
 
 `ThisType` represents `this.type`:
-  * `this.type` ~ `ThisType(null)`.
-  * `C.this.type` ~ `ThisType(<C>)`.
+
+* `this.type` ~ `ThisType(null)`.
+* `C.this.type` ~ `ThisType(<C>)`.
 
 ```protobuf
 message SuperType {
@@ -335,9 +340,10 @@ message SuperType {
 ```
 
 `SuperType` represents types of `super` qualifiers [\[28\]][28]:
-  * Type of the qualifier in `super.x` ~ `SuperType(ThisType(...), null)`.
-  * Type of the qualifier in `super[M].x` ~ `SuperType(ThisType(...), <M>)`.
-  * Type of the qualifier in `C.super[M].x` ~ `SuperType(ThisType(<C>), <M>)`.
+
+* Type of the qualifier in `super.x` ~ `SuperType(ThisType(...), null)`.
+* Type of the qualifier in `super[M].x` ~ `SuperType(ThisType(...), <M>)`.
+* Type of the qualifier in `C.super[M].x` ~ `SuperType(ThisType(<C>), <M>)`.
 
 ```protobuf
 message LiteralType {
@@ -371,9 +377,10 @@ message CompoundType {
 ```
 
 `CompoundType` represents compound types [\[36\]][36]:
-  * `{ M1; ...; Mm }` ~ `CompoundType(List(), List(<M1>, ..., <Mm>))`.
-  * `T1 with ... with Tn` ~ `CompoundType(List(<T1>, ..., <Tn>), List())`.
-  * `T1 with ... with Tn { M1; ...; Mm }` ~ `CompoundType(List(<T1>, ..., <Tn>), List(<M1>, ..., <Mm>))`.
+
+* `{ M1; ...; Mm }` ~ `CompoundType(List(), List(<M1>, ..., <Mm>))`.
+* `T1 with ... with Tn` ~ `CompoundType(List(<T1>, ..., <Tn>), List())`.
+* `T1 with ... with Tn { M1; ...; Mm }` ~ `CompoundType(List(<T1>, ..., <Tn>), List(<M1>, ..., <Mm>))`.
 
 ```protobuf
 message AnnotatedType {
@@ -385,8 +392,9 @@ message AnnotatedType {
 `AnnotatedType` represents annotated types [\[37\]][37] with the caveat
 that annotation arguments are not represented in the corresponding payload.
 We may remove this limitation in the future:
-  * `T @ann(x1, ... xM)` ~ `AnnotatedType(<T>, List(<ann>))`.
-  * `T @ann1 ... @annN` ~ `AnnotatedType(<T>, List(<ann1>, ..., <annN>))`.
+
+* `T @ann(x1, ... xM)` ~ `AnnotatedType(<T>, List(<ann>))`.
+* `T @ann1 ... @annN` ~ `AnnotatedType(<T>, List(<ann1>, ..., <annN>))`.
 
 ```protobuf
 message ExistentialType {
@@ -396,7 +404,8 @@ message ExistentialType {
 ```
 
 `ExistentialType` represents existential types [\[38\]][38]:
-  * `T forSome { type T }` ~ `ExistentialType(<T>, List(<T>))`.
+
+* `T forSome { type T }` ~ `ExistentialType(<T>, List(<T>))`.
 
 ```protobuf
 message TypeLambda {
@@ -418,9 +427,10 @@ message ClassInfoType {
 
 `ClassInfoType` represents signatures of objects, package objects, classes
 and traits. It works along the same lines as `CompoundType`:
-  * Signature of `object M` ~ `ClassInfoType(List(), List(), List())`.
-  * Signature of `class C extends B { def x = 42 }` ~ `ClassInfoType(List(), List(<B>), List(<m>))`.
-  * Signature of `trait X[T]` ~ `ClassInfoType(List(<T>), List(), List())`.
+
+* Signature of `object M` ~ `ClassInfoType(List(), List(), List())`.
+* Signature of `class C extends B { def x = 42 }` ~ `ClassInfoType(List(), List(<B>), List(<m>))`.
+* Signature of `trait X[T]` ~ `ClassInfoType(List(<T>), List(), List())`.
 
 ```protobuf
 message MethodType {
@@ -435,12 +445,13 @@ message MethodType {
 
 `MethodType` represents signatures of vals, vars, methods, primary constructors,
 secondary constructors and macros:
-  * Signature of `val x: Int` ~ `MethodType(List(), List(), <Int>)`
-  * Signature of `var x: Int` ~ `MethodType(List(), List(), <Int>)`
-  * Signature of `def m: Int` ~ `MethodType(List(), List(), <Int>)`.
-  * Signature of `def m(): Int` ~ `MethodType(List(), List(List()), <Int>)`.
-  * Signature of `def m(x: Int): Int` ~ `MethodType(List(), List(List(<x>)), <Int>)`.
-  * Signature of `def m[T](x: T): T` ~ `MethodType(List(<T>), List(List(<x>)), <T>)`.
+
+* Signature of `val x: Int` ~ `MethodType(List(), List(), <Int>)`
+* Signature of `var x: Int` ~ `MethodType(List(), List(), <Int>)`
+* Signature of `def m: Int` ~ `MethodType(List(), List(), <Int>)`.
+* Signature of `def m(): Int` ~ `MethodType(List(), List(List()), <Int>)`.
+* Signature of `def m(x: Int): Int` ~ `MethodType(List(), List(List(<x>)), <Int>)`.
+* Signature of `def m[T](x: T): T` ~ `MethodType(List(<T>), List(List(<x>)), <T>)`.
 
 ```protobuf
 message ByNameType {
@@ -449,7 +460,8 @@ message ByNameType {
 ```
 
 `ByNameType` represents signatures of by-name parameters [\[40\]][40]:
-  * Signature of `x` in `def m(x: => Int): Int` ~ `ByNameType(<Int>)`.
+
+* Signature of `x` in `def m(x: => Int): Int` ~ `ByNameType(<Int>)`.
 
 ```protobuf
 message RepeatedType {
@@ -458,7 +470,8 @@ message RepeatedType {
 ```
 
 `RepeatedType` represents signatures of repeated parameters [\[41\]][41]:
-  * Signature of `xs` in `def m(xs: Int*): Int` ~ `RepeatedType(<Int>)`.
+
+* Signature of `xs` in `def m(xs: Int*): Int` ~ `RepeatedType(<Int>)`.
 
 ```protobuf
 message TypeType {
@@ -470,11 +483,12 @@ message TypeType {
 
 `TypeType` represents signatures of abstract type members and type parameters,
 but not type aliases:
-  * Signature of `type T` ~ `TypeBounds(List(), null, null)`.
-  * Signature of `T` in `def m[T <: C]` ~ `TypeBounds(List(), null, <C>)`.
-  * Signature of `M` in `def m[M[_]]` ~ `TypeBounds(List(<_>), null, null)`.
-  * Signature of `type T = C` ~ `TypeRef(..., <C>, List())`.
-  * Signature of `type T[U] = U` ~ `TypeLambda(List(<U>), TypeRef(null, <U>, List())`.
+
+* Signature of `type T` ~ `TypeBounds(List(), null, null)`.
+* Signature of `T` in `def m[T <: C]` ~ `TypeBounds(List(), null, <C>)`.
+* Signature of `M` in `def m[M[_]]` ~ `TypeBounds(List(<_>), null, null)`.
+* Signature of `type T = C` ~ `TypeRef(..., <C>, List())`.
+* Signature of `type T[U] = U` ~ `TypeLambda(List(<U>), TypeRef(null, <U>, List())`.
 
 ### SymbolInformation
 
@@ -507,6 +521,7 @@ or features from other languages.
 `language`. Language that defines this symbol.
 
 `kind`. Enumeration that defines the kind of the symbol:
+
 <table>
   <tr>
     <td width="100px"><b>Value</b></td>
@@ -778,19 +793,21 @@ of code synthesized by compilers, code rewriters and other developer tools.
 
 `range` refers to a [Range](#range) in the original code of the underlying document,
 and its value is determined as follows:
-  * If the synthetic replaces a snippet of code (e.g. if it represents an
-    implicit conversion applied to an expression), then its range must be equal
-    to that snippet's range.
-  * If the synthetic inserts new code (e.g. if it represents an inferred type argument
-    or implicit argument), then its range must be an empty range specifying the insertion point.
+
+* If the synthetic replaces a snippet of code (e.g. if it represents an
+  implicit conversion applied to an expression), then its range must be equal
+  to that snippet's range.
+* If the synthetic inserts new code (e.g. if it represents an inferred type argument
+  or implicit argument), then its range must be an empty range specifying the insertion point.
 
 `text` is a [TextDocument](#textdocument) that represents a synthetic snippet
 of code as follows:
-  * Its text contains a string prettyprinted by a producer.
-  * Its sections, e.g. [Occurences](#symboloccurrence), contain semantic information
-    associated with that string.
-  * An occurrence of a placeholder symbol means that the snippet of code includes
-    the fragment of the original code defined by `Synthetic.range`.
+
+* Its text contains a string prettyprinted by a producer.
+* Its sections, e.g. [Occurences](#symboloccurrence), contain semantic information
+  associated with that string.
+* An occurrence of a placeholder symbol means that the snippet of code includes
+  the fragment of the original code defined by `Synthetic.range`.
 
 Synthetics are unspecified in the Scala Language Specification, so we leave the
 synthetic format deliberately unspecified as well. Our experience [\[22\]][22] shows

--- a/semanticdb/semanticdb3/semanticdb3.md
+++ b/semanticdb/semanticdb3/semanticdb3.md
@@ -16,27 +16,30 @@
 
 ## Motivation
 
-Nowadays, there is a clear trend towards standards for communication between developer tools.
-Language Server Protocol (LSP) [\[2\]][2], a protocol that connects programming
-language implementations and text editors, has gained strong industrial support
-and at the time of writing has implementations for many programming languages and editors.
-Build Server Protocol (BSP) [\[3\]][3] follows in LSP's tracks with an ambition to
-define a protocol for communication between language servers and build tools.
+Nowadays, there is a clear trend towards standards for communication between
+developer tools. Language Server Protocol (LSP) [\[2\]][2], a protocol
+that connects programming language implementations and text editors, has gained
+strong industrial support and at the time of writing has implementations
+for many programming languages and editors. Build Server Protocol (BSP)
+[\[3\]][3] follows in LSP's tracks with an ambition to define a protocol
+for communication between language servers and build tools.
 
 While lots of work in the open-source community has been invested in unifying
 user experience (by codifying commonly used operations like go to definition or
-find all references), relatively less work went into unifying implementor experience.
-For example, at the moment, there exist five different LSP implementations for Scala
-[[4][4], [5][5], [6][6], [7][7], [8][8]]. They all implement the same protocol
-that works with code, but they all use different data structures to represent that code.
+find all references), relatively less work went into unifying implementor
+experience. For example, at the moment, there exist five different LSP
+implementations for Scala [[4][4], [5][5], [6][6], [7][7], [8][8]].
+They all implement the same protocol that works with code, but they all use
+different data structures to represent that code.
 
 Without a standard way to share information between tools, implementors have
 two unpleasant choices. First, they can use compiler internals, which are often
 underdocumented and lack compatibility guarantees. Otherwise, they reimplement
-compiler internals, which usually leads to duplication of effort and inconsistent UX.
-For example, Scala IDE [\[9\]][9] uses Scala compiler internals, which has known
-stability problems in interactive mode. To the contrast, IntelliJ [\[10\]][10] has
-its own Scala typechecker, which is more stable but is known for spurious red squiggles.
+compiler internals, which usually leads to duplication of effort and
+inconsistent UX. For example, Scala IDE [\[9\]][9] uses Scala compiler internals,
+which has known stability problems in interactive mode. To the contrast,
+IntelliJ [\[10\]][10] has its own Scala typechecker, which is more stable but
+is known for spurious red squiggles.
 
 This demonstrates the necessity for portable metaprogramming APIs -
 something that we have been working on within Scalameta [\[11\]][11].
@@ -47,8 +50,8 @@ SemanticDB is our take on portable semantic APIs.
 ## Data Model
 
 SemanticDB is a data model for semantic information about programs in Scala and
-other languages. SemanticDB decouples production and consumption of semantic information,
-establishing documented means for communication between tools.
+other languages. SemanticDB decouples production and consumption of semantic
+information, establishing documented means for communication between tools.
 
 In this section, we describe the SemanticDB data model by going through the
 individual sections of the associated Protocol Buffers [\[13\]][13] schema.
@@ -106,8 +109,8 @@ in one of three ways: 1) via a URI [\[16\]][16] provided in `uri`,
 
 Semantic information is stored in so called sections - repeated fields within
 the message definition - as described below. These sections are optional, which
-means that documents providing only part of semantic information for the corresponding snippet
-(or no semantic information at all) are completely legal.
+means that documents providing only part of semantic information for the
+corresponding snippet (or no semantic information at all) are completely legal.
 
 ### Range
 
@@ -140,8 +143,8 @@ It represents a location inside a document, such as a line inside a text file.
 ### Symbol
 
 Symbols are tokens that are used to correlate references and definitions.
-In the SemanticDB model, symbols are represented as strings.
-At the moment, the symbol format is defined by the needs of the Scala implementations.
+In the SemanticDB model, symbols are represented as strings. At the moment, 
+the symbol format is defined by the needs of the Scala implementations.
 In the future, we are planning to pay more attention to other languages.
 
 At the moment, symbols are not guaranteed to be globally unique, which means
@@ -174,7 +177,7 @@ of the corresponding global definition, where:
     encoded name and a right bracket (`]`).
 * The encoded name of a definition is:
   * For a Java identifier [\[25\]][25], the name itself.
-  * Otherwise, concatenation of a backtick (`), the name itself and another backtick (`).
+  * Otherwise, concatenation of a backtick, the name itself and another backtick.
 
 For example, this is how some of the definitions from the Scala standard library
 must be modelled:
@@ -189,7 +192,8 @@ a tool is working with at any given time. For example, if in such a universe,
 there exist multiple definitions of `Int` - e.g. coming from multiple different
 versions of Scala - then all references to those definitions will have
 `SymbolOccurrence.symbol` equal to the same `_root_.scala.Int#` symbol,
-and SemanticDB will not be able to provide information to disambiguate these references.
+and SemanticDB will not be able to provide information to disambiguate
+these references.
 
 In the future, we may extend SemanticDB to allow for multiple definitions
 that under current rules would correspond to the same global symbol.
@@ -218,22 +222,23 @@ but we haven't yet found a way to do that without sacrificing performance
 and payload size. In the meanwhile, when global uniqueness is required,
 tool authors are advised to accompany local symbols with `TextDocument.uri`.
 
-**Multi symbols**. Are used to model references to a set of multiple definitions at once.
-This is occasionally useful to support corner cases of Scala, e.g. identifiers
-in imports that can refer to both a class and an object with the same name,
-or references to unresolved overloaded methods.
+**Multi symbols**. Are used to model references to a set of multiple definitions
+at once. For example, this is occasionally useful to support corner cases
+of Scala, e.g. identifiers in imports that can refer to both a class and
+an object with the same name, or references to unresolved overloaded methods.
 
 Multi symbol format is a concatentation of the underlying symbol formats
 interspersed with a semicolon (`;`). Within a multi symbol, the underlying
 symbols must be ordered lexicographically in ascending order.
 
-For example, a reference to both the standard `Int` class and its companion object
-must be modelled by `_root_.scala.Int#;_root_.scala.Int.`. Because of the order
-requirement, `_root_.scala.Int.;_root_.scala.Int#` is not a valid symbol.
+For example, a reference to both the standard `Int` class and its companion
+object must be modelled by `_root_.scala.Int#;_root_.scala.Int.`. 
+Because of the order requirement, `_root_.scala.Int.;_root_.scala.Int#` 
+is not a valid symbol.
 
-**Placeholder symbols**. Are used to model original snippets of code in [Synthetics](#synthetic).
-Must not be used outside `Synthetic.text` documents. Placeholder symbols are
-always equal to an asterisk (`*`).
+**Placeholder symbols**. Are used to model original snippets of code in
+[Synthetics](#synthetic). Must not be used outside `Synthetic.text` documents.
+Placeholder symbols are always equal to an asterisk (`*`).
 
 ### Type
 
@@ -282,11 +287,11 @@ In this section, we describe various alternatives of `Type`, providing example
 SemanticDB data that corresponds to different Scala types,
 inspired by the scala.reflect documentation [\[27\]][27].
 
-In these examples, we will be using a simple notation to describe SemanticDB data.
-In this notation, `M(v1, v2, ...)` corresponds a message `M` with fields set to values
-`v1`, `v2`, etc. Literals correspond to scalar values, and `List(x1, x2, ...)`
-corresponds to repeated values. Moreover, `<X>` corresponds to a message that
-represents `X`.
+In these examples, we will be using a simple notation to describe 
+SemanticDB data.In this notation, `M(v1, v2, ...)` corresponds a message 
+`M` with fields set to values `v1`, `v2`, etc. Literals correspond to 
+scalar values, and `List(x1, x2, ...)` corresponds to repeated values. 
+Moreover, `<X>` corresponds to a message that represents `X`.
 
 ```protobuf
 message TypeRef {
@@ -512,11 +517,11 @@ message SymbolInformation {
 about [Symbols](#symbol) that are defined in the underlying snippet of code.
 In a sense, this section is analogous to symbol tables [\[21\]][21] in compiler.
 
-`SymbolInformation` contains assorted metadata for a `symbol`, as explained below.
-At the moment, the supported metadata is usecase-driven and is not supposed to
-be comprehensive or language-agnostic. In the future, we may add support for
-more metadata, for example information about overriding, documentation strings
-or features from other languages.
+`SymbolInformation` contains assorted metadata for a `symbol`, 
+as explained below. At the moment, the supported metadata is usecase-driven 
+and is not supposed to be comprehensive or language-agnostic. In the future, 
+we may add support for more metadata, for example information about overriding,
+documentation strings or features from other languages.
 
 `language`. Language that defines this symbol.
 
@@ -674,17 +679,20 @@ or features from other languages.
 
 `name`. String that represents the name of the symbol.
 
-`location`. [Location](#location) that represents the extent of the definition of the symbol.
+`location`. [Location](#location) that represents the extent of 
+the definition of the symbol.
 
-`signature`. [TextDocument](#textdocument) that represents the type signature of the definition.
-In this document, `text` contains a string prettyprinted by a producer and various
-sections, e.g. [Occurrences](#symboloccurrence), contain semantic information associated
-with that string. This document does not correspond to any compilation unit and
-is created solely for the purposes of storing an attributed snippet of text.
+`signature`. [TextDocument](#textdocument) that represents the type signature 
+of the definition. In this document, `text` contains a string prettyprinted 
+by a producer and various sections, e.g. [Occurrences](#symboloccurrence),
+contain semantic information associated with that string. This document does not
+correspond to any compilation unit and is created solely for the purposes of
+storing an attributed snippet of text.
 
 For example, for `def x = 42`, the corresponding signature may be a document with
 `text` equal to `Int` and `occurrences` featuring an identifier with `range`
-equal to `0:0..0:3`, `symbol` equal `_root_.scala.Int#` and `role` equal to `Reference`.
+equal to `0:0..0:3`, `symbol` equal `_root_.scala.Int#` and `role` equal to
+`Reference`.
 
 The signature format was historically unspecified. When we got around
 to specifying the format, we found out that representing type signatures
@@ -694,7 +702,8 @@ field with `tpe`.
 `members`. This field was historically unspecified. When we got around to
 specifying it, we superseded it with `ClassInfoType.members` in `SymbolInformation.tpe`.
 
-`overrides`. Symbols that are overridden by this symbol either directly or transitively.
+`overrides`. Symbols that are overridden by this symbol either 
+directly or transitively.
 
 `tpe`. [Type](#type) that represents the type signature of the definition.
 
@@ -711,10 +720,11 @@ message SymbolOccurrence {
 "Occurrences" is a section of a [TextDocument](#textdocument) that represents
 the results of name resolution for identifiers in the underlying snippet of code.
 
-`SymbolOccurrence` refers to a [Range](#range) in the code and has a symbol as explained
-in [Symbol](#symbol). `role` is an enumeration that describes the semantic role
-that the identifier performs in the snippet of code. Like many other enumerations
-in SemanticDB, this one is usecase-driven and will likely be updated in the future.
+`SymbolOccurrence` refers to a [Range](#range) in the code and has a symbol
+as explained in [Symbol](#symbol). `role` is an enumeration that describes
+the semantic role that the identifier performs in the snippet of code.
+Like many other enumerations in SemanticDB, this one is usecase-driven
+and will likely be updated in the future.
 
 <table>
   <tr>
@@ -747,9 +757,10 @@ message Diagnostic {
 "Diagnostics" is a section of a [TextDocument](#textdocument) that stores
 diagnostic messages produced by compilers, linters and other developer tools.
 
-`Diagnostic` in SemanticDB directly corresponds to `Diagnostic` in LSP [\[2\]][2].
-It has a [Range](#range), a severity and an associated message. If the severity
-is unknown, it is up to the consumer to interpret diagnostics as error, warning, info or hint.
+`Diagnostic` in SemanticDB directly correspond to `Diagnostic`
+in LSP [\[2\]][2]. It has a [Range](#range), a severity and an associated
+message. If the severity is unknown, it is up to the consumer to interpret
+diagnostics as error, warning, info or hint.
 
 <table>
   <tr>
@@ -788,31 +799,32 @@ message Synthetic {
 }
 ```
 
-"Synthetics" is a section of a [TextDocument](#textdocument) that stores snippets
-of code synthesized by compilers, code rewriters and other developer tools.
+"Synthetics" is a section of a [TextDocument](#textdocument) that stores
+code snippets synthesized by compilers, code rewriters and other
+developer tools.
 
-`range` refers to a [Range](#range) in the original code of the underlying document,
-and its value is determined as follows:
+`range` refers to a [Range](#range) in the original code of
+the underlying document, and its value is determined as follows:
 
-* If the synthetic replaces a snippet of code (e.g. if it represents an
+* If the synthetic replaces a code snippet (e.g. if it represents an
   implicit conversion applied to an expression), then its range must be equal
   to that snippet's range.
-* If the synthetic inserts new code (e.g. if it represents an inferred type argument
-  or implicit argument), then its range must be an empty range specifying the insertion point.
+* If the synthetic inserts new code (e.g. if it represents an inferred type
+  argument or implicit argument), then its range must be an empty range specifying the insertion point.
 
-`text` is a [TextDocument](#textdocument) that represents a synthetic snippet
-of code as follows:
+`text` is a [TextDocument](#textdocument) that represents a synthetic code
+snippet as follows:
 
 * Its text contains a string prettyprinted by a producer.
-* Its sections, e.g. [Occurences](#symboloccurrence), contain semantic information
-  associated with that string.
+* Its sections, e.g. [Occurences](#symboloccurrence), contain semantic
+  information associated with that string.
 * An occurrence of a placeholder symbol means that the snippet of code includes
   the fragment of the original code defined by `Synthetic.range`.
 
 Synthetics are unspecified in the Scala Language Specification, so we leave the
-synthetic format deliberately unspecified as well. Our experience [\[22\]][22] shows
-that reverse engineering Scala synthetics is very hard. We may improve on this
-in the future, but this is highly unlikely.
+synthetic format deliberately unspecified as well. Our experience [\[22\]][22] 
+shows that reverse engineering Scala synthetics is very hard. We may improve 
+on this in the future, but this is highly unlikely.
 
 ## Data Schemas
 

--- a/semanticdb/semanticdb3/semanticdb3.md
+++ b/semanticdb/semanticdb3/semanticdb3.md
@@ -91,8 +91,8 @@ message TextDocument {
   string uri = 2;
   string text = 3;
   Language language = 9;
-  repeated SymbolOccurrence occurrences = 5;
-  repeated SymbolInformation symbols = 6;
+  repeated SymbolInformation symbols = 5;
+  repeated SymbolOccurrence occurrences = 6;
   repeated Diagnostic diagnostics = 7;
   repeated Synthetic synthetics = 8;
 }
@@ -203,8 +203,8 @@ these references.
 
 In the future, we may extend SemanticDB to allow for multiple definitions
 that under current rules would correspond to the same global symbol.
-In the meanwhile, when global uniqueness is required, tool authors are advised to
-accompany global symbols with `SymbolInformation.location`.
+In the meanwhile, when global uniqueness is required, tool authors are advised
+to accompany global symbols with `SymbolInformation.location`.
 
 **Local symbols**. Correspond to a definition that isn't global (see above).
 
@@ -391,7 +391,7 @@ message MethodType {
   }
   repeated string type_parameters = 1;
   repeated ParameterList parameters = 2;
-  Type returnType = 3;
+  Type return_type = 3;
 }
 ```
 

--- a/semanticdb/semanticdb3/semanticdb3.proto
+++ b/semanticdb/semanticdb3/semanticdb3.proto
@@ -48,7 +48,7 @@ message Type {
     STRUCTURAL_TYPE = 6;
     ANNOTATED_TYPE = 7;
     EXISTENTIAL_TYPE = 8;
-    TYPE_LAMBDA = 9;
+    UNIVERSAL_TYPE = 9;
     CLASS_INFO_TYPE = 10;
     METHOD_TYPE = 11;
     BY_NAME_TYPE = 12;
@@ -102,8 +102,9 @@ message SingletonType {
 }
 
 message StructuralType {
-  repeated Type parents = 1;
-  repeated string declarations = 2;
+  repeated string type_parameters = 1;
+  repeated Type parents = 2;
+  repeated string declarations = 3;
 }
 
 message AnnotatedType {

--- a/semanticdb/semanticdb3/semanticdb3.proto
+++ b/semanticdb/semanticdb3/semanticdb3.proto
@@ -17,8 +17,8 @@ message TextDocument {
   string uri = 2;
   string text = 3;
   Language language = 9;
-  repeated SymbolOccurrence occurrences = 5;
-  repeated SymbolInformation symbols = 6;
+  repeated SymbolInformation symbols = 5;
+  repeated SymbolOccurrence occurrences = 6;
   repeated Diagnostic diagnostics = 7;
   repeated Synthetic synthetics = 8;
 }
@@ -39,13 +39,9 @@ message Location {
   Range range = 2;
 }
 
-message Annotation {
-  Type tpe = 1;
-}
-
 message Type {
   enum Tag {
-    reserved 2, 3, 4, 5;
+    // reserved 2, 3, 4, 5;
     UNKNOWN_TAG = 0;
     TYPE_REF = 1;
     SINGLETON_TYPE = 15;
@@ -160,6 +156,8 @@ message SymbolInformation {
     UNKNOWN_KIND = 0;
     VAL = 1;
     VAR = 2;
+    GETTER = 15;
+    SETTER = 16;
     DEF = 3;
     PRIMARY_CONSTRUCTOR = 4;
     SECONDARY_CONSTRUCTOR = 5;
@@ -175,8 +173,8 @@ message SymbolInformation {
   }
   enum Property {
     UNKNOWN_PROPERTY = 0;
-    PRIVATE = 0x1;
-    PROTECTED = 0x2;
+    // reserved 0x1;
+    // reserved 0x2;
     ABSTRACT = 0x4;
     FINAL = 0x8;
     SEALED = 0x10;
@@ -185,9 +183,8 @@ message SymbolInformation {
     CASE = 0x80;
     COVARIANT = 0x100;
     CONTRAVARIANT = 0x200;
-    reserved 0x400;
-    reserved 0x800;
-    LOCAL = 0x1000;
+    // reserved 0x400;
+    // reserved 0x800;
   }
   reserved 2, 6;
   string symbol = 1;
@@ -200,6 +197,26 @@ message SymbolInformation {
   repeated string members = 8;
   repeated string overrides = 9;
   Type tpe = 11;
+  repeated Annotation annotations = 13;
+  Accessibility accessibility = 14;
+}
+
+message Annotation {
+  Type tpe = 1;
+}
+
+message Accessibility {
+  enum Tag {
+    UNKNOWN_TAG = 0;
+    PRIVATE = 1;
+    PRIVATE_THIS = 2;
+    PRIVATE_WITHIN = 3;
+    PROTECTED = 4;
+    PROTECTED_THIS = 5;
+    PROTECTED_WITHIN = 6;
+  }
+  Tag tag = 1;
+  string symbol = 2;
 }
 
 message SymbolOccurrence {

--- a/semanticdb/semanticdb3/semanticdb3.proto
+++ b/semanticdb/semanticdb3/semanticdb3.proto
@@ -12,14 +12,19 @@ message TextDocuments {
 }
 
 message TextDocument {
+  reserved 4;
   Schema schema = 1;
   string uri = 2;
   string text = 3;
-  string language = 4;
-  repeated SymbolInformation symbols = 5;
-  repeated SymbolOccurrence occurrences = 6;
+  Language language = 9;
+  repeated SymbolOccurrence occurrences = 5;
+  repeated SymbolInformation symbols = 6;
   repeated Diagnostic diagnostics = 7;
   repeated Synthetic synthetics = 8;
+}
+
+message Language {
+  string name = 1;
 }
 
 message Range {
@@ -34,15 +39,17 @@ message Location {
   Range range = 2;
 }
 
+message Annotation {
+  Type tpe = 1;
+}
+
 message Type {
   enum Tag {
+    reserved 2, 3, 4, 5;
     UNKNOWN_TAG = 0;
     TYPE_REF = 1;
-    SINGLE_TYPE = 2;
-    THIS_TYPE = 3;
-    SUPER_TYPE = 4;
-    LITERAL_TYPE = 5;
-    COMPOUND_TYPE = 6;
+    SINGLETON_TYPE = 15;
+    STRUCTURAL_TYPE = 6;
     ANNOTATED_TYPE = 7;
     EXISTENTIAL_TYPE = 8;
     TYPE_LAMBDA = 9;
@@ -52,16 +59,14 @@ message Type {
     REPEATED_TYPE = 13;
     TYPE_TYPE = 14;
   }
+  reserved 3, 4, 5, 6;
   Tag tag = 1;
   TypeRef typeRef = 2;
-  SingleType singleType = 3;
-  ThisType thisType = 4;
-  SuperType superType = 5;
-  LiteralType literalType = 6;
-  CompoundType compoundType = 7;
+  SingletonType singletonType = 16;
+  StructuralType structuralType = 7;
   AnnotatedType annotatedType = 8;
   ExistentialType existentialType = 9;
-  TypeLambda typeLambda = 10;
+  UniversalType universalType = 10;
   ClassInfoType classInfoType = 11;
   MethodType methodType = 12;
   ByNameType byNameType = 13;
@@ -72,59 +77,51 @@ message Type {
 message TypeRef {
   Type prefix = 1;
   string symbol = 2;
-  repeated Type arguments = 3;
+  repeated Type type_arguments = 3;
 }
 
-message SingleType {
-  Type prefix = 1;
-  string symbol = 2;
-}
-
-message ThisType {
-  string symbol = 1;
-}
-
-message SuperType {
-  Type prefix = 1;
-  Type mix = 2;
-}
-
-message LiteralType {
+message SingletonType {
   enum Tag {
     UNKNOWN_TAG = 0;
-    UNIT = 1;
-    BOOLEAN = 2;
-    BYTE = 3;
-    SHORT = 4;
-    CHAR = 5;
-    INT = 6;
-    LONG = 7;
-    FLOAT = 8;
-    DOUBLE = 9;
-    STRING = 10;
-    NULL = 11;
+    SYMBOL = 1;
+    THIS = 2;
+    SUPER = 3;
+    UNIT = 4;
+    BOOLEAN = 5;
+    BYTE = 6;
+    SHORT = 7;
+    CHAR = 8;
+    INT = 9;
+    LONG = 10;
+    FLOAT = 11;
+    DOUBLE = 12;
+    STRING = 13;
+    NULL = 14;
   }
   Tag tag = 1;
-  int64 primitive = 2;
-  string string = 3;
+  Type prefix = 2;
+  string symbol = 3;
+  int64 primitive = 4;
+  string string = 5;
 }
 
-message CompoundType {
+message StructuralType {
   repeated Type parents = 1;
   repeated string declarations = 2;
 }
 
 message AnnotatedType {
+  reserved 2;
+  repeated Annotation annotations = 3;
   Type tpe = 1;
-  repeated Type annotations = 2;
 }
 
 message ExistentialType {
+  repeated string type_parameters = 2;
   Type tpe = 1;
-  repeated string declarations = 2;
 }
 
-message TypeLambda {
+message UniversalType {
   repeated string type_parameters = 1;
   Type tpe = 2;
 }
@@ -141,7 +138,7 @@ message MethodType {
   }
   repeated string type_parameters = 1;
   repeated ParameterList parameters = 2;
-  Type result = 3;
+  Type return_type = 3;
 }
 
 message ByNameType {
@@ -188,12 +185,12 @@ message SymbolInformation {
     CASE = 0x80;
     COVARIANT = 0x100;
     CONTRAVARIANT = 0x200;
-    VALPARAM = 0x400;
-    VARPARAM = 0x800;
+    reserved 0x400;
+    reserved 0x800;
   }
-  reserved 6;
+  reserved 2, 6;
   string symbol = 1;
-  string language = 2;
+  Language language = 12;
   Kind kind = 3;
   int32 properties = 4;
   string name = 5;

--- a/semanticdb/semanticdb3/semanticdb3.proto
+++ b/semanticdb/semanticdb3/semanticdb3.proto
@@ -187,6 +187,7 @@ message SymbolInformation {
     CONTRAVARIANT = 0x200;
     reserved 0x400;
     reserved 0x800;
+    LOCAL = 0x1000;
   }
   reserved 2, 6;
   string symbol = 1;


### PR DESCRIPTION
This pull request only contains updates to the SemanticDB specification and the associated schema. It does not contain any implementation. Still, I think it's worth reviewing, since the changes are huge already. The build is going to fail, and that's expected.

Summary:
  * Added `Language`.
  * Separated language-agnostic and language-dependent parts of the spec.
  * Changed method symbols (https://github.com/scalameta/scalameta/issues/1295).
  * Refactored `Type` to be language-agnostic by merging all singleton types into `SINGLETON_TYPE`, renaming `COMPOUND_TYPE` to `STRUCTURAL_TYPE` and renaming `TYPE_LAMBDA` to `UNIVERSAL_TYPE`. This uses the terminology that is shared across languages.
  * Added `Kind.GETTER` and `Kind.SETTER` (https://github.com/scalameta/scalameta/issues/1293 and https://github.com/scalameta/scalameta/issues/1294).
  * Removed `Property.VALPARAM` and `Property.VARPARAM` (https://github.com/scalameta/scalameta/issues/1294).
  * Added `SymbolInformation.annotations` (https://github.com/scalameta/scalameta/issues/1308).
  * Removed `Property.PRIVATE` and `Property.PROTECTED` (https://github.com/scalameta/scalameta/issues/1309).
  * Added `SymbolInformation.accessibility` (https://github.com/scalameta/scalameta/issues/1309).
  * Exhaustively documented how Scala language features map onto SemanticDB.