### PR TITLE
Handle constant classOf types.

### DIFF
--- a/semanticdb/integration/src/main/scala/example/Types.scala
+++ b/semanticdb/integration/src/main/scala/example/Types.scala
@@ -104,5 +104,6 @@ object Test {
     final val bool = true
     final val unit = ()
     final val javaEnum = java.nio.file.LinkOption.NOFOLLOW_LINKS
+    final val clazzOf = classOf[Option[Int]]
   }
 }

--- a/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/Main.scala
+++ b/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/Main.scala
@@ -249,6 +249,13 @@ object Main {
         //   val spre = loop(pre)
         //   val smix = loop(gmix)
         //   Some(s.Type(tag = stag, superType = Some(s.SuperType(spre, smix))))
+        case ConstantType(underlying: Type) =>
+          loop(underlying).map { sarg =>
+            val stag = t.TYPE_REF
+            val ssym = "_root_.java.lang.Class#"
+            val sargs = sarg :: Nil
+            s.Type(tag = stag, typeRef = Some(s.TypeRef(None, ssym, sargs)))
+          }
         case ConstantType(const) =>
           def floatBits(x: Float) = java.lang.Float.floatToRawIntBits(x).toLong
           def doubleBits(x: Double) = java.lang.Double.doubleToRawLongBits(x)

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TypeOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TypeOps.scala
@@ -45,6 +45,8 @@ trait TypeOps { self: DatabaseOps =>
             val spre = loop(gpre)
             val smix = loop(gmix)
             Some(s.Type(tag = stag, superType = Some(s.SuperType(spre, smix))))
+          case g.ConstantType(g.Constant(underlying: g.Type)) =>
+            loop(gtpe.widen)
           case g.ConstantType(gconst) =>
             def floatBits(x: Float) = java.lang.Float.floatToRawIntBits(x).toLong
             def doubleBits(x: Double) = java.lang.Double.doubleToRawLongBits(x)

--- a/tests/jvm/src/test/resources/highlevel.expect
+++ b/tests/jvm/src/test/resources/highlevel.expect
@@ -543,6 +543,10 @@ Names:
 [2087..2091): file => _root_.java.nio.file.
 [2092..2102): LinkOption => _root_.java.nio.file.LinkOption.
 [2103..2117): NOFOLLOW_LINKS => _root_.java.nio.file.LinkOption.NOFOLLOW_LINKS.
+[2132..2139): clazzOf <= _root_.types.Test.Literal.clazzOf.
+[2142..2149): classOf => _root_.scala.Predef.classOf()Ljava/lang/Class;.
+[2150..2156): Option => _root_.scala.Option#
+[2157..2160): Int => _root_.scala.Int#
 
 Symbols:
 _root_.java. => package java
@@ -553,8 +557,12 @@ _root_.java.nio.file.LinkOption.NOFOLLOW_LINKS. => final javadefined val NOFOLLO
   [0..10): LinkOption => _root_.java.nio.file.LinkOption#
 _root_.scala. => package scala
 _root_.scala.Int# => abstract final class Int
+_root_.scala.Option# => abstract sealed class Option
 _root_.scala.Predef.`???`()Lscala/Nothing;. => def ???: Nothing
   [0..7): Nothing => _root_.scala.Nothing#
+_root_.scala.Predef.classOf()Ljava/lang/Class;. => def classOf: [T] => Class[T]
+  [7..12): Class => _root_.scala.Predef.Class#
+  [13..14): T => _root_.scala.Predef.classOf()Ljava/lang/Class;.[T]
 _root_.scala.annotation. => package annotation
 _root_.scala.annotation.StaticAnnotation# => trait StaticAnnotation
 _root_.scala.collection.SeqLike#length()I. => abstract def length: Int
@@ -724,6 +732,10 @@ _root_.types.Test.Literal.bool. => final val bool: Boolean
   [0..7): Boolean => _root_.scala.Boolean#
 _root_.types.Test.Literal.char. => final val char: Char
   [0..4): Char => _root_.scala.Char#
+_root_.types.Test.Literal.clazzOf. => final val clazzOf: Class[Option[Int]]
+  [0..5): Class => _root_.java.lang.Class#
+  [6..12): Option => _root_.scala.Option#
+  [13..16): Int => _root_.scala.Int#
 _root_.types.Test.Literal.double. => final val double: Double
   [0..6): Double => _root_.scala.Double#
 _root_.types.Test.Literal.float. => final val float: Float

--- a/tests/jvm/src/test/resources/lowlevel.expect
+++ b/tests/jvm/src/test/resources/lowlevel.expect
@@ -388,8 +388,8 @@ Schema => SemanticDB v3
 Uri => semanticdb/integration/src/main/scala/example/Types.scala
 Text => non-empty
 Language => Scala212
-Symbols => 120 entries
-Occurrences => 220 entries
+Symbols => 123 entries
+Occurrences => 224 entries
 
 Symbols:
 _root_.java. => package java
@@ -401,8 +401,16 @@ _root_.java.nio.file.LinkOption.NOFOLLOW_LINKS. => final val NOFOLLOW_LINKS: NOF
 _root_.scala. => package scala
 _root_.scala.Int# => abstract final class Int.{+111 decls}
   extends AnyVal
+_root_.scala.Option# => abstract sealed class Option.{+25 decls}
+  extends AnyRef
+  extends Product
+  extends Serializable
 _root_.scala.Predef.`???`()Lscala/Nothing;. => def ???: : Nothing
   Nothing => _root_.scala.Nothing#
+_root_.scala.Predef.classOf()Ljava/lang/Class;. => def classOf: [T: <?>] => : Class[T]
+  T => _root_.scala.Predef.classOf()Ljava/lang/Class;.[T]
+  Class => _root_.scala.Predef.Class#
+  T => _root_.scala.Predef.classOf()Ljava/lang/Class;.[T]
 _root_.scala.annotation. => package annotation
 _root_.scala.annotation.StaticAnnotation# => trait StaticAnnotation
 _root_.scala.collection.SeqLike#length()I. => abstract def length: : Int
@@ -621,6 +629,10 @@ _root_.types.Test.C#x. => val x: : C.this.p.X
 _root_.types.Test.Literal. => final object Literal
 _root_.types.Test.Literal.bool. => final val bool: : true
 _root_.types.Test.Literal.char. => final val char: : 'a'
+_root_.types.Test.Literal.clazzOf. => final val clazzOf: : Class[Option[Int]]
+  Class => _root_.java.lang.Class#
+  Option => _root_.scala.Option#
+  Int => _root_.scala.Int#
 _root_.types.Test.Literal.double. => final val double: : 2.0
 _root_.types.Test.Literal.float. => final val float: : 1.0f
 _root_.types.Test.Literal.int. => final val int: : 1
@@ -886,6 +898,10 @@ Occurrences:
 [105:34..105:38): file => _root_.java.nio.file.
 [105:39..105:49): LinkOption => _root_.java.nio.file.LinkOption.
 [105:50..105:64): NOFOLLOW_LINKS => _root_.java.nio.file.LinkOption.NOFOLLOW_LINKS.
+[106:14..106:21): clazzOf <= _root_.types.Test.Literal.clazzOf.
+[106:24..106:31): classOf => _root_.scala.Predef.classOf()Ljava/lang/Class;.
+[106:32..106:38): Option => _root_.scala.Option#
+[106:39..106:42): Int => _root_.scala.Int#
 
 semanticdb/integration/src/main/scala/example/local-file.scala
 --------------------------------------------------------------

--- a/tests/jvm/src/test/resources/metacp.expect
+++ b/tests/jvm/src/test/resources/metacp.expect
@@ -301,7 +301,7 @@ Schema => SemanticDB v3
 Uri => types/Test.class
 Text => empty
 Language => Scala
-Symbols => 84 entries
+Symbols => 85 entries
 
 Symbols:
 types.Test. => final object Test
@@ -473,6 +473,10 @@ types.Test.C#x. => val x: : C.this.p.X
 types.Test.Literal. => final object Literal
 types.Test.Literal.bool. => final val bool: : true
 types.Test.Literal.char. => final val char: : 'a'
+types.Test.Literal.clazzOf. => final val clazzOf: : Class[Option[Int]]
+  Class => _root_.java.lang.Class#
+  Option => scala.Option#
+  Int => scala.Int#
 types.Test.Literal.double. => final val double: : 2.0
 types.Test.Literal.float. => final val float: : 1.0f
 types.Test.Literal.int. => final val int: : 1

--- a/tests/jvm/src/test/scala/scala/meta/tests/metacp/BaseMetacpSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/metacp/BaseMetacpSuite.scala
@@ -1,0 +1,39 @@
+package scala.meta.tests.metacp
+
+import java.io.File
+import java.nio.file.Files
+import scala.meta.internal.metacp.Main
+import scala.meta.internal.metacp.Settings
+import scala.meta.tests.cli.BaseCliSuite
+
+abstract class BaseMetacpSuite extends BaseCliSuite {
+
+  private val tmp = Files.createTempDirectory("metacp")
+  tmp.toFile.deleteOnExit()
+
+  def check(name: String, classpath: () => String): Unit = {
+    test(name) {
+      val cp = classpath()
+      val args = Array[String](
+        "-cp",
+        cp,
+        "-d",
+        tmp.toString
+      )
+      val settings = Settings.parse(args.toList).get
+      val exit = Main.process(settings)
+      assert(exit == 0)
+    }
+  }
+
+  def checkLibrary(organization: String, artifact: String, version: String): Unit = {
+    check(
+      List(organization, artifact, version).mkString(File.pathSeparator), { () =>
+        val jars = Jars
+          .fetch(organization, artifact, version)
+          .filterNot(_.toString.contains("scala-lang"))
+        jars.mkString(File.pathSeparator)
+      }
+    )
+  }
+}

--- a/tests/jvm/src/test/scala/scala/meta/tests/metacp/MetacpSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/metacp/MetacpSuite.scala
@@ -1,43 +1,10 @@
 package scala.meta.tests.metacp
 
-import java.io.File
-import java.nio.file.Files
-import scala.meta.internal.metacp._
-import scala.meta.tests.cli.BaseCliSuite
-
-class MetacpSuite extends BaseCliSuite {
-
-  private val tmp = Files.createTempDirectory("metacp")
-  tmp.toFile.deleteOnExit()
-
-  def check(name: String, classpath: () => String): Unit = {
-    test(name) {
-      val cp = classpath()
-      val args = Array[String](
-        "-cp",
-        cp,
-        "-d",
-        tmp.toString
-      )
-      val settings = Settings.parse(args.toList).get
-      val exit = Main.process(settings)
-      assert(exit == 0)
-    }
-  }
-
-  def checkLibrary(organization: String, artifact: String, version: String): Unit = {
-    check(
-      List(organization, artifact, version).mkString(File.pathSeparator), { () =>
-        val jars = Jars
-          .fetch(organization, artifact, version)
-          .filterNot(_.toString.contains("scala-lang"))
-        jars.mkString(File.pathSeparator)
-      }
-    )
-  }
+class MetacpSuite extends BaseMetacpSuite {
 
   check("scala-library", () => scalaLibraryJar)
   checkLibrary("org.scalameta", "scalameta_2.12", "3.2.0")
+  checkLibrary("com.typesafe.akka", "akka-testkit_2.12", "2.5.9")
 
   // Akka is blocked by https://github.com/scalameta/scalameta/issues/1306
   // checkLibrary("com.typesafe.akka", "akka-testkit_2.12", "2.5.9")


### PR DESCRIPTION
Scalac encoded `classOf[T]` singleton types as `ConstantType(Type)`.
This commit adds custom handling for this type in metacp and metac
encoding them instead their widened representation `Class[T]`.

Fixes #1306