### PR TITLE
Use nio file visitors in metacp.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -621,6 +621,7 @@ lazy val publishableSettings = Def.settings(
     }
   },
   mimaBinaryIssueFilters += Mima.compatibilityPolicy,
+  mimaBinaryIssueFilters ++= Mima.exceptions,
   licenses += "BSD" -> url("https://github.com/scalameta/scalameta/blob/master/LICENSE.md"),
   pomExtra := (
     <url>https://github.com/scalameta/scalameta</url>

--- a/langmeta/langmeta/js/src/main/scala/org/langmeta/internal/io/PlatformFileIO.scala
+++ b/langmeta/langmeta/js/src/main/scala/org/langmeta/internal/io/PlatformFileIO.scala
@@ -74,4 +74,7 @@ object PlatformFileIO {
     loop(root)
     new ListFiles(root, builder.result())
   }
+
+  def jarRootPath(jarFile: AbsolutePath): AbsolutePath =
+    throw new UnsupportedOperationException("Can't expand jar file in Scala.js")
 }

--- a/langmeta/langmeta/jvm/src/main/scala/org/langmeta/internal/io/PlatformFileIO.scala
+++ b/langmeta/langmeta/jvm/src/main/scala/org/langmeta/internal/io/PlatformFileIO.scala
@@ -2,6 +2,8 @@ package org.langmeta.internal.io
 
 import java.net.URI
 import java.nio.charset.Charset
+import java.nio.file.FileSystemAlreadyExistsException
+import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.stream.Collectors
@@ -53,4 +55,14 @@ object PlatformFileIO {
       }
     new ListFiles(root, relativeFiles.toList)
   }
+
+  def jarRootPath(jarFile: AbsolutePath): AbsolutePath = {
+    val uri = URI.create("jar:file:" + jarFile.toNIO.toUri.getPath)
+    val roo = newFileSystem(uri, new java.util.HashMap[String, Any]()).getPath("/")
+    AbsolutePath(roo)
+  }
+
+  private def newFileSystem(uri: URI, map: java.util.Map[String, Any]) =
+    try FileSystems.newFileSystem(uri, map)
+    catch { case _: FileSystemAlreadyExistsException => FileSystems.getFileSystem(uri) }
 }

--- a/langmeta/langmeta/shared/src/main/scala/org/langmeta/internal/io/FileIO.scala
+++ b/langmeta/langmeta/shared/src/main/scala/org/langmeta/internal/io/FileIO.scala
@@ -31,5 +31,7 @@ object FileIO {
   def listAllFilesRecursively(path: AbsolutePath): ListFiles =
     PlatformFileIO.listAllFilesRecursively(path)
 
+  def jarRootPath(jarFile: AbsolutePath): AbsolutePath =
+    PlatformFileIO.jarRootPath(jarFile)
 }
 

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -16,4 +16,8 @@ object Mima {
     val exclude = fullName.contains(".internal.") || fullName.contains(".contrib.")
     public && include && !exclude
   }
+
+  def exceptions: List[ProblemFilter] = List(
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("org.langmeta.io.Multipath.visit")
+  )
 }

--- a/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/Main.scala
+++ b/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/Main.scala
@@ -30,9 +30,7 @@ object Main {
     var failed = false
     def fail(file: Path, ex: Throwable): FileVisitResult = {
       println(s"error: can't convert $file")
-      if (ex != null) {
-        ex.printStackTrace()
-      }
+      ex.printStackTrace()
       failed = true
       FileVisitResult.CONTINUE
     }
@@ -85,7 +83,8 @@ object Main {
         }
 
         override def postVisitDirectory(dir: Path, e: IOException): FileVisitResult = {
-          fail(dir, e)
+          if (e != null) fail(dir, e)
+          else FileVisitResult.CONTINUE
         }
 
         override def visitFileFailed(file: Path, e: IOException): FileVisitResult = {

--- a/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/Main.scala
+++ b/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/Main.scala
@@ -28,6 +28,14 @@ object Main {
     val semanticdbRoot = AbsolutePath(settings.d).resolve("META-INF").resolve("semanticdb")
     Files.createDirectories(semanticdbRoot.toNIO)
     var failed = false
+    def fail(file: Path, ex: Throwable): FileVisitResult = {
+      println(s"error: can't convert $file")
+      if (ex != null) {
+        ex.printStackTrace()
+      }
+      failed = true
+      FileVisitResult.CONTINUE
+    }
     val classpath = Classpath(settings.cps.mkString(File.pathSeparator))
     classpath.visit { root =>
       new FileVisitor[Path] {
@@ -71,19 +79,18 @@ object Main {
             }
           } catch {
             case NonFatal(ex) =>
-              println(s"error: can't convert $file")
-              ex.printStackTrace()
-              failed = true
+              fail(file, ex)
           }
           FileVisitResult.CONTINUE
         }
 
         override def postVisitDirectory(dir: Path, e: IOException): FileVisitResult = {
-          if (e != null) throw e
-          FileVisitResult.CONTINUE
+          fail(dir, e)
         }
 
-        override def visitFileFailed(file: Path, e: IOException): FileVisitResult = throw e
+        override def visitFileFailed(file: Path, e: IOException): FileVisitResult = {
+          fail(file, e)
+        }
       }
     }
     if (failed) 1 else 0

--- a/tests/jvm/src/test/scala/scala/meta/tests/metacp/MetacpSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/metacp/MetacpSuite.scala
@@ -5,11 +5,6 @@ class MetacpSuite extends BaseMetacpSuite {
   check("scala-library", () => scalaLibraryJar)
   checkLibrary("org.scalameta", "scalameta_2.12", "3.2.0")
   checkLibrary("com.typesafe.akka", "akka-testkit_2.12", "2.5.9")
-
-  // Akka is blocked by https://github.com/scalameta/scalameta/issues/1306
-  // checkLibrary("com.typesafe.akka", "akka-testkit_2.12", "2.5.9")
-
-  // Spark is blocked by https://github.com/scalameta/scalameta/issues/1305
-  // checkLibrary("org.apache.spark", "spark-sql_2.11", "2.2.1")
+  checkLibrary("org.apache.spark", "spark-sql_2.11", "2.2.1")
 
 }


### PR DESCRIPTION
Previously, metacp did a custom traversal of the classpath using a mix
of java.io and custom solutions via Fragment.  This commit adds
`Classpath.visit` which simplifies the implementations by using built-in
`java.nio.Files.walkFileTree`. This automatically fixes #1305.