### PR TITLE
Add a cross-compat dialect

### DIFF
--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -220,6 +220,18 @@ package object dialects {
     allowXmlLiterals = false // Dotty parser doesn't have the corresponding code, so it can't really support xml literals
   )
 
+  /** Dialect that tries to be compatible with all language versions. */
+  implicit val CrossCompat = Scala210.copy(
+    allowAtForExtractorVarargs = false, // Removed in Dotty
+    allowCaseClassWithoutParameterList = false, // Removed in 2.11
+    allowInlineIdents = false, // Only in Paradise
+    allowMultilinePrograms = true, // Remains true, as this only affect quasiquotes
+    allowViewBounds = false,  // Removed in Dotty
+    allowWithTypes = false,   // Only in Dotty
+    allowXmlLiterals = false, // Removed in Dotty
+    toplevelSeparator = "" // Technically will break with Sbt 0.13.6, but it cannot be helped.
+  )
+
   // TODO: https://github.com/scalameta/scalameta/issues/380
   private[meta] def QuasiquoteTerm(underlying: Dialect, multiline: Boolean) = {
     require(!underlying.allowUnquotes)
@@ -237,6 +249,7 @@ object Dialect extends InternalDialect {
   // NOTE: Spinning up a macro just for this is too hard.
   // Using JVM reflection won't be portable to Scala.js.
   private[meta] lazy val standards: Map[String, Dialect] = Map(
+    "CrossCompat" -> CrossCompat,
     "Dotty" -> Dotty,
     "Paradise211" -> Paradise211,
     "Paradise212" -> Paradise212,

--- a/tests/jvm/src/test/scala/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/api/SurfaceSuite.scala
@@ -51,6 +51,7 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.common.Convert *
       |scala.meta.common.Optional *
       |scala.meta.dialects
+      |scala.meta.dialects.CrossCompat *
       |scala.meta.dialects.Dotty *
       |scala.meta.dialects.Paradise211 *
       |scala.meta.dialects.Paradise212 *


### PR DESCRIPTION
Name up for discussion.

Introduce a restricted subset of all dialects to retain cross-compatibility. 
This is the exact opposite of what scalafmt needs (To support every feature)

This is important for code generation, as we want to generate code to a shared folder, and have it compiled by multiple targets, including Dotty.

This allows longevity of code generators, as they will not need to be updated when scala's version changes.

Note: We lose Sbt 0.13.5 here, but I would expect very few people will target sbt with code gen, and even fewer will be using 0.13.5 rather than 0.13.6.