### PR TITLE
Trigger compilation when a macro change. (fix #1347)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -314,6 +314,7 @@ lazy val tokensJS = tokens.js
 lazy val transversers = crossProject(JSPlatform, JVMPlatform)
   .in(file("scalameta/transversers"))
   .settings(
+    requiresMacrosSetting,
     publishableSettings,
     description := "Scalameta traversal and transformation infrastructure for abstract syntax trees",
     enableMacros
@@ -497,6 +498,51 @@ lazy val bench = project
 // ==========================================
 // Settings
 // ==========================================
+
+lazy val requiresMacrosSetting = Def.settings(
+  scalacOptions += {
+    val base = file("scalameta/common/shared/src/main/scala")
+    val filesWithWhiteboxMacros =
+      List(
+        "org/scalameta" -> List(
+          "adt/Adt.scala",
+          "adt/Liftables.scala",
+          "data/data.scala",
+          "data/Macros.scala",
+          "explore/Macros.scala",
+          "internal/DebugFinder.scala",
+          "internal/FreeLocalFinder.scala",
+          "internal/ImplTransformers.scala",
+          "internal/MacroHelpers.scala",
+          "invariants/package.scala",
+          "package.scala"
+        ),
+        "scala/meta/internal" -> List(
+          "classifiers/Macros.scala",
+          "prettyprinters/ShowMacros.scala",
+          "tokens/root.scala",
+          "tokens/token.scala",
+          "transversers/transformer.scala",
+          "transversers/transverser.scala",
+          "transversers/traverser.scala",
+          "trees/ast.scala",
+          "trees/branch.scala",
+          "trees/Liftables.scala",
+          "trees/NamerMacros.scala",
+          "trees/quasiquote.scala",
+          "trees/registry.scala",
+          "trees/root.scala",
+          "trees/TyperMacros.scala"
+        )
+      )
+
+    val flat = filesWithWhiteboxMacros.flatMap{
+      case (k, vs) => vs.map(v => (base / k / v).lastModified)
+    }
+
+    "-J" + flat.hashCode
+  }
+)
 
 lazy val sharedSettings = Def.settings(
   scalaVersion := LanguageVersion,


### PR DESCRIPTION
```
~;cls;testsJVM/testOnly scala.meta.tests.trees.ParentSuite

print("+") in `transformer.scala`

[info] Compiling 1 Scala source to /home/gui/scalameta/scalameta/common/jvm/target/scala-2.12/classes...
[info] Compiling 4 Scala sources to /home/gui/scalameta/scalameta/transversers/jvm/target/scala-2.12/classes...
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++[info] ParentSuite:
[info] - Tree.transform does not preserve parent chain origins *** FAILED ***
[info]   5 did not equal 1 (ParentSuite.scala:24)
[info] Run completed in 252 milliseconds.
[info] Total number of tests run: 1
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 0, failed 1, canceled 0, ignored 0, pending 0
[info] *** 1 TEST FAILED ***
[error] Failed tests:
[error]         scala.meta.tests.trees.ParentSuite
[error] (testsJVM/test:testOnly) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 5 s, completed Feb 19, 2018 2:53:17 PM
3. Waiting for source changes... (press enter to interrupt)

print("*") in `transformer.scala`

[info] Compiling 1 Scala source to /home/gui/scalameta/scalameta/common/jvm/target/scala-2.12/classes...
[info] Compiling 4 Scala sources to /home/gui/scalameta/scalameta/transversers/jvm/target/scala-2.12/classes...
*****************************************************************************************************[info] ParentSuite:
[info] - Tree.transform does not preserve parent chain origins *** FAILED ***
[info]   5 did not equal 1 (ParentSuite.scala:24)
[info] Run completed in 258 milliseconds.
[info] Total number of tests run: 1
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 0, failed 1, canceled 0, ignored 0, pending 0
[info] *** 1 TEST FAILED ***
[error] Failed tests:
[error]         scala.meta.tests.trees.ParentSuite
[error] (testsJVM/test:testOnly) sbt.TestsFailedException: Tests unsuccessful
[error] Total time: 5 s, completed Feb 19, 2018 2:54:47 PM
4. Waiting for source changes... (press enter to interrupt)
```

I'm really happy with this result, the edit / compile / test loop is now **5s**