### PR TITLE
Revert "Prefix cache file by metacp version."

### DIFF
--- a/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/Main.scala
+++ b/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/Main.scala
@@ -21,8 +21,9 @@ class Main(settings: Settings, reporter: Reporter) {
           List(out)
         } else if (in.isFile) {
           val cacheEntry = {
+            val base = settings.cacheDir
             val checksum = Checksum(in)
-            cacheFile(in.toFile.getName.stripSuffix(".jar") + "-" + checksum + ".jar")
+            base.resolve(in.toFile.getName.stripSuffix(".jar") + "-" + checksum + ".jar")
           }
           if (cacheEntry.toFile.exists) {
             List(cacheEntry)
@@ -39,7 +40,7 @@ class Main(settings: Settings, reporter: Reporter) {
     }
     val synthetics = {
       if (settings.scalaLibrarySynthetics) {
-        val cacheEntry = cacheFile("scala-library-synthetics.jar")
+        val cacheEntry = settings.cacheDir.resolve("scala-library-synthetics.jar")
         if (cacheEntry.toFile.exists) {
           List(cacheEntry)
         } else {
@@ -102,9 +103,6 @@ class Main(settings: Settings, reporter: Reporter) {
     index.save(out)
     success
   }
-
-  private def cacheFile(name: String): AbsolutePath =
-    settings.cacheDir.resolve(BuildInfo.version).resolve(name)
 
   private def dumpScalaLibrarySynthetics(out: AbsolutePath): Boolean = {
     val index = new Index


### PR DESCRIPTION
This reverts commit 7eb7ce8567ea801d06eb7499268a8cc52bd7b0e3. The version number was apparently already included in `defaultCacheDir`.