### PR TITLE
Progress towards ammonite support

### DIFF
--- a/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/vfs/SemanticdbPaths.scala
+++ b/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/vfs/SemanticdbPaths.scala
@@ -9,6 +9,7 @@ object SemanticdbPaths {
   private val semanticdbPrefix = RelativePath("META-INF").resolve("semanticdb")
   private val semanticdbExtension = "semanticdb"
   private val scalaExtension = "scala"
+  private val scalaScriptExtension = "sc"
 
   def isSemanticdb(path: RelativePath): Boolean = {
     path.toNIO.startsWith(semanticdbPrefix.toNIO) &&
@@ -22,7 +23,8 @@ object SemanticdbPaths {
   }
 
   def isScala(path: RelativePath): Boolean = {
-    PathIO.extension(path.toNIO) == scalaExtension
+    val extension = PathIO.extension(path.toNIO)
+    extension == scalaExtension || extension == scalaScriptExtension
   }
 
   def fromScala(path: RelativePath): RelativePath = {

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/ConfigOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/ConfigOps.scala
@@ -6,6 +6,7 @@ import scala.util.matching.Regex
 
 case class SemanticdbConfig(
     sourceroot: AbsolutePath,
+    targetroot: AbsolutePath,
     mode: SemanticdbMode,
     failures: FailureMode,
     denotations: DenotationMode,
@@ -21,6 +22,7 @@ case class SemanticdbConfig(
     val p = SemanticdbPlugin.name
     List(
       "sourceroot" -> sourceroot,
+      "targetroot" -> targetroot,
       "mode" -> mode.name,
       "failures" -> failures.name,
       "signatures" -> signatures.name,
@@ -39,6 +41,7 @@ case class SemanticdbConfig(
 }
 object SemanticdbConfig {
   def default = SemanticdbConfig(
+    PathIO.workingDirectory,
     PathIO.workingDirectory,
     SemanticdbMode.Fat,
     FailureMode.Warning,

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DocumentOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DocumentOps.scala
@@ -16,15 +16,16 @@ trait DocumentOps { self: DatabaseOps =>
     if (!g.settings.Yrangepos.value) {
       sys.error("the compiler instance must have -Yrangepos enabled")
     }
-    // for some reason this fails with ammonite, even though the first Yrangepos == true
-//    if (g.useOffsetPositions) {
-//      sys.error("the compiler instance must use range positions")
-//    }
+    if (g.useOffsetPositions) {
+      sys.error("the compiler instance must use range positions")
+    }
     if (!g.settings.plugin.value.exists(_.contains("semanticdb"))) {
       sys.error("the compiler instance must use the semanticdb plugin")
     }
-    if (!g.analyzer.getClass.getName.contains("HijackAnalyzer")) {
-      sys.error("the compiler instance must use a hijacked analyzer")
+    val analyzerClassName = g.analyzer.getClass.getName
+    if (!analyzerClassName.contains("HijackAnalyzer")) {
+      sys.error(
+        s"the compiler instance must use a hijacked analyzer, instead of $analyzerClassName")
     }
     if (g.currentRun.phaseNamed("typer") != NoPhase) {
       if (g.phase.id < g.currentRun.phaseNamed("typer").id) {

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DocumentOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DocumentOps.scala
@@ -23,10 +23,9 @@ trait DocumentOps { self: DatabaseOps =>
     if (!g.settings.plugin.value.exists(_.contains("semanticdb"))) {
       sys.error("the compiler instance must use the semanticdb plugin")
     }
-    // in ammonite, this is ammonite.interp.CompilerCompatibility$$anon$2
-//    if (!g.analyzer.getClass.getName.contains("HijackAnalyzer")) {
-//      sys.error("the compiler instance must use a hijacked analyzer")
-//    }
+    if (!g.analyzer.getClass.getName.contains("HijackAnalyzer")) {
+      sys.error("the compiler instance must use a hijacked analyzer")
+    }
     if (g.currentRun.phaseNamed("typer") != NoPhase) {
       if (g.phase.id < g.currentRun.phaseNamed("typer").id) {
         sys.error("the compiler phase must be not earlier than typer")

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DocumentOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DocumentOps.scala
@@ -16,16 +16,17 @@ trait DocumentOps { self: DatabaseOps =>
     if (!g.settings.Yrangepos.value) {
       sys.error("the compiler instance must have -Yrangepos enabled")
     }
-    if (g.useOffsetPositions) {
-      sys.error("the compiler instance must use range positions")
-    }
+    // for some reason this fails with ammonite, even though the first Yrangepos == true
+//    if (g.useOffsetPositions) {
+//      sys.error("the compiler instance must use range positions")
+//    }
     if (!g.settings.plugin.value.exists(_.contains("semanticdb"))) {
       sys.error("the compiler instance must use the semanticdb plugin")
     }
-    if (!g.analyzer.getClass.getName.contains("HijackAnalyzer")) {
-      println(g.analyzer.getClass.getName)
-      sys.error("the compiler instance must use a hijacked analyzer")
-    }
+    // in ammonite, this is ammonite.interp.CompilerCompatibility$$anon$2
+//    if (!g.analyzer.getClass.getName.contains("HijackAnalyzer")) {
+//      sys.error("the compiler instance must use a hijacked analyzer")
+//    }
     if (g.currentRun.phaseNamed("typer") != NoPhase) {
       if (g.phase.id < g.currentRun.phaseNamed("typer").id) {
         sys.error("the compiler phase must be not earlier than typer")

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/HijackAnalyzer.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/HijackAnalyzer.scala
@@ -27,7 +27,7 @@ trait HijackAnalyzer extends SemanticdbAnalyzer { self: SemanticdbPlugin =>
     val newAnalyzer = new { val global: self.global.type = self.global } with SemanticdbAnalyzer {
       override def findMacroClassLoader() = oldMacroClassLoader
     }
-    val analyzerField = classOf[NscGlobal].getDeclaredField("analyzer")
+    val analyzerField = global.getClass.getDeclaredField("analyzer")
     analyzerField.setAccessible(true)
     analyzerField.set(global, newAnalyzer)
     // Restore macro and analyzer plugins from old analyzer, see https://github.com/scalameta/scalameta/issues/1135

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/HijackAnalyzer.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/HijackAnalyzer.scala
@@ -27,12 +27,11 @@ trait HijackAnalyzer extends SemanticdbAnalyzer { self: SemanticdbPlugin =>
     val newAnalyzer = new { val global: self.global.type = self.global } with SemanticdbAnalyzer {
       override def findMacroClassLoader() = oldMacroClassLoader
     }
-    val analyzerField = try {
-      // ammonite compatibility
-      global.getClass.getDeclaredField("analyzer")
-    } catch {
-      case _: NoSuchFieldException => classOf[NscGlobal].getDeclaredField("analyzer")
-    }
+
+    val analyzerField =
+      (if (self.isAmmonite()) global.getClass
+       else classOf[NscGlobal]).getDeclaredField("analyzer")
+
     analyzerField.setAccessible(true)
     analyzerField.set(global, newAnalyzer)
     // Restore macro and analyzer plugins from old analyzer, see https://github.com/scalameta/scalameta/issues/1135

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/HijackAnalyzer.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/HijackAnalyzer.scala
@@ -27,7 +27,12 @@ trait HijackAnalyzer extends SemanticdbAnalyzer { self: SemanticdbPlugin =>
     val newAnalyzer = new { val global: self.global.type = self.global } with SemanticdbAnalyzer {
       override def findMacroClassLoader() = oldMacroClassLoader
     }
-    val analyzerField = global.getClass.getDeclaredField("analyzer")
+    val analyzerField = try {
+      // ammonite compatibility
+      global.getClass.getDeclaredField("analyzer")
+    } catch {
+      case _: NoSuchFieldException => classOf[NscGlobal].getDeclaredField("analyzer")
+    }
     analyzerField.setAccessible(true)
     analyzerField.set(global, newAnalyzer)
     // Restore macro and analyzer plugins from old analyzer, see https://github.com/scalameta/scalameta/issues/1135

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SemanticdbPipeline.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SemanticdbPipeline.scala
@@ -17,9 +17,12 @@ trait SemanticdbPipeline extends DatabaseOps { self: SemanticdbPlugin =>
       config.mode.isDisabled || {
         !unit.source.file.name.endsWith(".scala") && !unit.source.file.name.endsWith(".sc")
       } || {
-        Option(unit.source.file).flatMap(f => Option(f.file)).map(_.getAbsolutePath).exists(
-          fullName => !config.fileFilter.matches(fullName)
-        )
+        Option(unit.source.file)
+          .flatMap(f => Option(f.file))
+          .map(_.getAbsolutePath)
+          .exists(
+            fullName => !config.fileFilter.matches(fullName)
+          )
       }
     }
   }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SemanticdbPlugin.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SemanticdbPlugin.scala
@@ -36,7 +36,7 @@ class SemanticdbPlugin(val global: Global)
 
   private def amendTargetRoot(config: SemanticdbConfig): SemanticdbConfig = {
     val targetRoot = if (isAmmonite()) {
-      PathIO.workingDirectory.resolve("out")
+      PathIO.workingDirectory.resolve("out/semanticdb-scalac")
     } else
       AbsolutePath {
         global.settings.outputDirs.getSingleOutput


### PR DESCRIPTION
* Added custom targetroot that checks whether the compilation is occurring in an ammonite context. If it's the case, targetroot is now set to $pwd/out (to keep consistency with mill)

* Added various checks to allow `sc` files in addition to `scala files`

This PR, combined with the following `~/.ammonite/predefScript.sc`, results in semanticdb outputting something under `$pwd/out` when running `amm` on a script. 

```
import $plugin.$ivy.`org.spire-math::kind-projector:0.9.4`
import $plugin.$ivy.`org.scalameta:semanticdb-scalac_2.12.4:3.4.0-5-86720f75-20180307-2220`
val scalacOptions = List(
  "-Yrangepos:true",
  "-Xplugin:semanticdb",
  "-Xplugin-require:semanticdb"
)
interp.configureCompiler(_.settings.processArguments(scalacOptions, true))
```

The content of the semanticdb is far from perfect : ammonite wraps the script with some additional code (namely imports, etc) which have an impact on the position of occurrences. Moreover, the only symbols shown are the top level ones (namely the scala object that reflects the file name, which ammonite wraps the script with to make top level statements compile). 

I however think that the small changes contained by this PR, provided they do not impact the current behaviour of semanticdb, exhibit enough progress towards the support of ammonite to make their way to master 