### PR TITLE
Refine Scalafmt project.excludeFilters.

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -22,7 +22,7 @@ project.excludeFilters = [
   scalac-plugin.xml
   SemanticdbAnalyzer.scala
   Scalalib.scala
-  .java
+  /java/
   .proto
   .md
 ]

--- a/semanticdb/metacp/src/main/scala/scala/meta/internal/javacp/JavaTypeSignature.scala
+++ b/semanticdb/metacp/src/main/scala/scala/meta/internal/javacp/JavaTypeSignature.scala
@@ -77,8 +77,7 @@ case class TypeVariableSignature(identifier: String)
   }
 }
 
-case class ArrayTypeSignature(javaTypeSignature: JavaTypeSignature)
-    extends ReferenceTypeSignature {
+case class ArrayTypeSignature(javaTypeSignature: JavaTypeSignature) extends ReferenceTypeSignature {
   override def print(sb: StringBuilder): Unit = {
     sb.append("[")
     javaTypeSignature.print(sb)


### PR DESCRIPTION
It was excluding everything in the `javacp` package due to the `.java`
rule.