### PR TITLE
Add a dependency on pprint.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -206,7 +206,8 @@ lazy val langmeta = crossProject(JSPlatform, JVMPlatform)
   .in(file("langmeta/langmeta"))
   .settings(
     publishableSettings,
-    description := "Langmeta umbrella module that includes all public APIs"
+    description := "Langmeta umbrella module that includes all public APIs",
+    libraryDependencies += "com.lihaoyi" %% "pprint" % "0.5.3"
   )
   .jvmSettings(
     crossScalaVersions := List(LatestScala210, LatestScala211, LatestScala212)


### PR DESCRIPTION
pprint is indispensable for my productivity, it's a small module that
deserves inclusion in the standard library. This commit adds an explicit
dependency on pprint because I'm tired of adding this dependency in my
private local setup causing compilation errors when other people try my
WIP branches.