### PR TITLE
Extract SymbolInformation.{Kind,Properties} conversion logic.

### DIFF
--- a/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/package.scala
+++ b/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/package.scala
@@ -252,6 +252,45 @@ package object semanticdb {
       d.Database(dentries.toList)
     }
   }
+  implicit class XtensionDenotation(ddenot: d.Denotation) {
+    def dtest(bit: Long) = (ddenot.flags & bit) == bit
+    def sproperties: Int = {
+        var sproperties = 0
+        def sflip(sprop: s.SymbolInformation.Property) = sproperties ^= sprop.value
+        if (dtest(d.ABSTRACT)) sflip(p.ABSTRACT)
+        if (dtest(d.FINAL)) sflip(p.FINAL)
+        if (dtest(d.SEALED)) sflip(p.SEALED)
+        if (dtest(d.IMPLICIT)) sflip(p.IMPLICIT)
+        if (dtest(d.LAZY)) sflip(p.LAZY)
+        if (dtest(d.CASE)) sflip(p.CASE)
+        if (dtest(d.COVARIANT)) sflip(p.COVARIANT)
+        if (dtest(d.CONTRAVARIANT)) sflip(p.CONTRAVARIANT)
+        if (dtest(d.VAL)) sflip(p.VAL)
+        if (dtest(d.VAR)) sflip(p.VAR)
+        if (dtest(d.STATIC)) sflip(p.STATIC)
+        if (dtest(d.PRIMARY)) sflip(p.PRIMARY)
+        if (dtest(d.ENUM)) sflip(p.ENUM)
+        sproperties
+      }
+    def skind: s.SymbolInformation.Kind = {
+        if (dtest(d.LOCAL)) k.LOCAL
+        else if (dtest(d.FIELD)) k.FIELD
+        else if (dtest(d.METHOD)) k.METHOD
+        else if (dtest(d.CTOR)) k.CONSTRUCTOR
+        else if (dtest(d.MACRO)) k.MACRO
+        else if (dtest(d.TYPE)) k.TYPE
+        else if (dtest(d.PARAM)) k.PARAMETER
+        else if (dtest(d.SELFPARAM)) k.SELF_PARAMETER
+        else if (dtest(d.TYPEPARAM)) k.TYPE_PARAMETER
+        else if (dtest(d.OBJECT)) k.OBJECT
+        else if (dtest(d.PACKAGE)) k.PACKAGE
+        else if (dtest(d.PACKAGEOBJECT)) k.PACKAGE_OBJECT
+        else if (dtest(d.CLASS)) k.CLASS
+        else if (dtest(d.TRAIT)) k.TRAIT
+        else if (dtest(d.INTERFACE)) k.INTERFACE
+        else k.UNKNOWN_KIND
+      }
+  }
 
   implicit class XtensionDatabase(ddatabase: d.Database) {
     def toSchema(sourceroot: AbsolutePath): s.TextDocuments = {
@@ -309,45 +348,10 @@ package object semanticdb {
           object dResolvedSymbol {
             def unapply(dresolvedSymbol: d.ResolvedSymbol): Option[s.SymbolInformation] = {
               val d.ResolvedSymbol(dsymbol, ddenot) = dresolvedSymbol
-              def dtest(bit: Long) = (ddenot.flags & bit) == bit
               val ssymbol = sSymbol(dsymbol)
-              val ssymbolLanguage = if (dtest(d.JAVADEFINED)) l.JAVA else l.SCALA
-              val skind = {
-                if (dtest(d.LOCAL)) k.LOCAL
-                else if (dtest(d.FIELD)) k.FIELD
-                else if (dtest(d.METHOD)) k.METHOD
-                else if (dtest(d.CTOR)) k.CONSTRUCTOR
-                else if (dtest(d.MACRO)) k.MACRO
-                else if (dtest(d.TYPE)) k.TYPE
-                else if (dtest(d.PARAM)) k.PARAMETER
-                else if (dtest(d.SELFPARAM)) k.SELF_PARAMETER
-                else if (dtest(d.TYPEPARAM)) k.TYPE_PARAMETER
-                else if (dtest(d.OBJECT)) k.OBJECT
-                else if (dtest(d.PACKAGE)) k.PACKAGE
-                else if (dtest(d.PACKAGEOBJECT)) k.PACKAGE_OBJECT
-                else if (dtest(d.CLASS)) k.CLASS
-                else if (dtest(d.TRAIT)) k.TRAIT
-                else if (dtest(d.INTERFACE)) k.INTERFACE
-                else k.UNKNOWN_KIND
-              }
-              val sproperties = {
-                var sproperties = 0
-                def sflip(sprop: s.SymbolInformation.Property) = sproperties ^= sprop.value
-                if (dtest(d.ABSTRACT)) sflip(p.ABSTRACT)
-                if (dtest(d.FINAL)) sflip(p.FINAL)
-                if (dtest(d.SEALED)) sflip(p.SEALED)
-                if (dtest(d.IMPLICIT)) sflip(p.IMPLICIT)
-                if (dtest(d.LAZY)) sflip(p.LAZY)
-                if (dtest(d.CASE)) sflip(p.CASE)
-                if (dtest(d.COVARIANT)) sflip(p.COVARIANT)
-                if (dtest(d.CONTRAVARIANT)) sflip(p.CONTRAVARIANT)
-                if (dtest(d.VAL)) sflip(p.VAL)
-                if (dtest(d.VAR)) sflip(p.VAR)
-                if (dtest(d.STATIC)) sflip(p.STATIC)
-                if (dtest(d.PRIMARY)) sflip(p.PRIMARY)
-                if (dtest(d.ENUM)) sflip(p.ENUM)
-                sproperties
-              }
+              val ssymbolLanguage = if (ddenot.dtest(d.JAVADEFINED)) l.JAVA else l.SCALA
+              val skind = ddenot.skind
+              val sproperties = ddenot.sproperties
               val sname = ddenot.name
               val ssignature = {
                 if (ddenot.signature.nonEmpty) {


### PR DESCRIPTION
These methods are useful for scalafix to convert Denotation to
SymbolInformation.