### PR TITLE
Add tests to validate symbol parser behavior for _root_. prefix.

### DIFF
--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/SymbolSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/SymbolSuite.scala
@@ -1,0 +1,22 @@
+package scala.meta.tests.semanticdb
+
+import scala.meta.Symbol
+import scala.meta.Signature
+import org.scalatest.FunSuite
+
+class SymbolSuite extends FunSuite {
+  def check(original: String, expected: Symbol): Unit = {
+    test(original) {
+      val obtained = Symbol(original)
+      assert(obtained == expected)
+    }
+  }
+  val root = Symbol.Global(Symbol.None, Signature.Term("_root_"))
+  val a = Symbol.Global(root, Signature.Term("a"))
+
+  check("_root_.", root)
+  check("_root_.a.", a)
+  check("a.", a)
+  check("_root_._root_.a.", Symbol.Global(Symbol.Global(root, Signature.Term("_root_")), Signature.Term("a")))
+
+}


### PR DESCRIPTION
While working on fixing #1424 I discovered that the symbol parser
already works as I expected. A `_root_.` prefix is discarded.  This
commit introduces no functional changes to the symbol parser, just adds
test to validate the current existing behavior. Fixes #1424