### PR TITLE
Make Denotation.{tpe, accessibility, annotations} package private.

### DIFF
--- a/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/Denotation.scala
+++ b/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/Denotation.scala
@@ -13,9 +13,11 @@ final class Denotation(
     val names: List[ResolvedName],
     val members: List[Signature],
     val overrides: List[Symbol],
-    val tpe: Option[s.Type],
-    val annotations: List[s.Annotation],
-    val accessibility: Option[s.Accessibility],
+    // These fields are package private because ScalaPB generated classes are not part of the
+    // Scalameta public API. See https://github.com/scalameta/scalameta/blob/master/COMPATIBILITY.md
+    private[langmeta] val tpe: Option[s.Type],
+    private[langmeta] val annotations: List[s.Annotation],
+    private[langmeta] val accessibility: Option[s.Accessibility],
     val owner: Symbol
 ) extends HasFlags
     with Product

--- a/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/package.scala
+++ b/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/internal/package.scala
@@ -5,6 +5,7 @@ import scala.util.control.NonFatal
 import org.langmeta.inputs.{Input => dInput}
 import org.langmeta.inputs.{Position => dPosition}
 import org.langmeta.semanticdb.{Synthetic => dSynthetic}
+import org.langmeta.semanticdb.{Denotation => dDenotation}
 import org.langmeta.internal.io.PathIO
 import org.langmeta.internal.semanticdb.{vfs => v}
 import org.langmeta.io._
@@ -427,5 +428,14 @@ package object semanticdb {
   // append the URI to the ID.
   private def localSymbolSuffix(uri: String): String = {
     "_" + uri.replaceAll("[^A-Za-z0-9]", "_")
+  }
+
+  // ScalaPB generated classes are not part of the Scalameta public API so Denotation.{tpe,annotations,accessibility} are
+  // package private to langmeta. However, we need to access these fields from scala.meta.internal so these extension
+  // methods are here to open access.
+  implicit class XtensionDenotationsInternal(denot: dDenotation) {
+    def tpeInternal: Option[s.Type] = denot.tpe
+    def annotationsInternal: List[s.Annotation] = denot.annotations
+    def accessibilityInternal: Option[s.Accessibility] = denot.accessibility
   }
 }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DocumentOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DocumentOps.scala
@@ -1,7 +1,7 @@
 package scala.meta.internal.semanticdb.scalac
 
 import org.langmeta.internal.io.PathIO
-import org.langmeta.internal.semanticdb.vfs.SemanticdbPaths
+import org.langmeta.internal.semanticdb._
 import scala.collection.mutable
 import scala.reflect.internal._
 import scala.reflect.internal.util._
@@ -550,9 +550,9 @@ trait DocumentOps { self: DatabaseOps =>
               denot.names,
               members,
               denot.overrides,
-              denot.tpe,
-              denot.annotations,
-              denot.accessibility,
+              denot.tpeInternal,
+              denot.annotationsInternal,
+              denot.accessibilityInternal,
               denot.owner)
           }
           m.ResolvedSymbol(sym, denotationWithMembers)


### PR DESCRIPTION
We do not want to expose these fields in the Scalameta/Scalafix public API.