### PR TITLE
Re-enable par on metacp

### DIFF
--- a/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/Main.scala
+++ b/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/Main.scala
@@ -15,7 +15,7 @@ class Main(settings: Settings, reporter: Reporter) {
   def process(): Option[Classpath] = {
     var success = true
     val outs = {
-      settings.classpath.shallow.flatMap { in =>
+      settings.classpath.shallow.par.flatMap { in =>
         if (in.isDirectory) {
           val out = AbsolutePath(Files.createTempDirectory("semanticdb"))
           success &= convertClasspathEntry(in, out)
@@ -54,7 +54,7 @@ class Main(settings: Settings, reporter: Reporter) {
         Nil
       }
     }
-    if (success) Some(Classpath(outs ++ synthetics))
+    if (success) Some(Classpath(outs.toList ++ synthetics))
     else None
   }
 

--- a/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/Main.scala
+++ b/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/Main.scala
@@ -10,15 +10,17 @@ import scala.meta.metacp._
 import scala.util.control.NonFatal
 import org.langmeta.internal.io._
 import org.langmeta.io._
+import java.util.concurrent.atomic.AtomicBoolean
 
 class Main(settings: Settings, reporter: Reporter) {
   def process(): Option[Classpath] = {
-    var success = true
+    val success = new AtomicBoolean(true)
     val outs = {
       settings.classpath.shallow.par.flatMap { in =>
         if (in.isDirectory) {
           val out = AbsolutePath(Files.createTempDirectory("semanticdb"))
-          success &= convertClasspathEntry(in, out)
+          val res = convertClasspathEntry(in, out)
+          success.compareAndSet(true, res)
           List(out)
         } else if (in.isFile) {
           val cacheEntry = {
@@ -30,7 +32,8 @@ class Main(settings: Settings, reporter: Reporter) {
             List(cacheEntry)
           } else {
             PlatformFileIO.withJarFileSystem(cacheEntry) { out =>
-              success &= convertClasspathEntry(in, out)
+              val res = convertClasspathEntry(in, out)
+              success.compareAndSet(true, res)
               List(cacheEntry)
             }
           }
@@ -46,7 +49,8 @@ class Main(settings: Settings, reporter: Reporter) {
           List(cacheEntry)
         } else {
           PlatformFileIO.withJarFileSystem(cacheEntry) { out =>
-            success &= dumpScalaLibrarySynthetics(out)
+            val res = dumpScalaLibrarySynthetics(out)
+            success.compareAndSet(true, res)
             List(cacheEntry)
           }
         }
@@ -54,7 +58,7 @@ class Main(settings: Settings, reporter: Reporter) {
         Nil
       }
     }
-    if (success) Some(Classpath(outs.toList ++ synthetics))
+    if (success.get) Some(Classpath(outs.toList ++ synthetics))
     else None
   }
 


### PR DESCRIPTION
Closes #1398 

I've essentially reverted 1cd839e462a7cf9ac1414d9dc553d2e220d44e86, plus I've refactored it to use an `AtomicBoolean` instead of a `Boolean` to prevent ghost writes (i.e. using a `Boolean` a thread could accidentally override a `false` value written by another thread with a `true`)

On my machine, this leads to a speedup of about 1.4x when running `testsJVM/testOnly scala.meta.tests.metacp.*`.

I'm unsure on how to test this further: I wasn't able to reproduce the deadlock, so I don't really know what I'm looking for here.

Thoughts, @olafurpg / @xeno-by?