### PR TITLE
Fix an oversight in newJarFileSystem

### DIFF
--- a/langmeta/langmeta/jvm/src/main/scala/org/langmeta/internal/io/PlatformFileIO.scala
+++ b/langmeta/langmeta/jvm/src/main/scala/org/langmeta/internal/io/PlatformFileIO.scala
@@ -84,7 +84,9 @@ object PlatformFileIO {
   }
 
   def newJarFileSystem(path: AbsolutePath, create: Boolean): FileSystem = {
-    Files.createDirectories(path.toNIO.getParent)
+    if (create && !Files.exists(path.toNIO.getParent)) {
+      Files.createDirectories(path.toNIO.getParent)
+    }
     val map = new util.HashMap[String, String]()
     if (create) {
       map.put("create", "true")


### PR DESCRIPTION
Files.createDirectories doesn't throw if a parent exists and is a dir,
but it does throw if a parent exists and is a symlink.