### PR TITLE
Make Symbol.Multi.syntax safe.

### DIFF
--- a/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/Symbol.scala
+++ b/langmeta/langmeta/shared/src/main/scala/org/langmeta/semanticdb/Symbol.scala
@@ -31,7 +31,7 @@ object Symbol {
 
   final case class Multi(symbols: List[Symbol]) extends Symbol {
     override def toString = syntax
-    override def syntax = throw new UnsupportedOperationException("No longer supported.")
+    override def syntax = symbols.mkString(";")
     override def structure = s"""Symbol.Multi(${symbols.map(_.structure).mkString(", ")})"""
   }
 


### PR DESCRIPTION
Exception throwing toString/syntax makes it difficult to even debug why
you have a Symbol.Multi in the first place.  Given that we use
Symbol.Multi in both semanticdb-scalac and in scalafix and we don't see
a path forward how to deprecate it, I think it's fair to make toString
safe to run.  The parser fails on multi symbols, so they still won't
sneak into applications.