### PR TITLE
Use `.par.foreach` and introduce metacp --par option.

### DIFF
--- a/semanticdb/metacp/src/main/scala/scala/meta/metacp/Settings.scala
+++ b/semanticdb/metacp/src/main/scala/scala/meta/metacp/Settings.scala
@@ -8,13 +8,15 @@ import scala.meta.internal.metacp.BuildInfo
 final class Settings private (
     val cacheDir: AbsolutePath,
     val classpath: Classpath,
-    val scalaLibrarySynthetics: Boolean
+    val scalaLibrarySynthetics: Boolean,
+    val par: Boolean
 ) {
   private def this() = {
     this(
       cacheDir = Settings.defaultCacheDir,
       classpath = Classpath(Nil),
-      scalaLibrarySynthetics = false
+      scalaLibrarySynthetics = false,
+      par = false
     )
   }
 
@@ -30,14 +32,21 @@ final class Settings private (
     copy(scalaLibrarySynthetics = include)
   }
 
+  def withPar(par: Boolean): Settings = {
+    copy(par = par)
+  }
+
   private def copy(
       cacheDir: AbsolutePath = cacheDir,
       classpath: Classpath = classpath,
-      scalaLibrarySynthetics: Boolean = scalaLibrarySynthetics): Settings = {
+      scalaLibrarySynthetics: Boolean = scalaLibrarySynthetics,
+      par: Boolean = par
+  ): Settings = {
     new Settings(
       cacheDir = cacheDir,
       classpath = classpath,
-      scalaLibrarySynthetics = scalaLibrarySynthetics
+      scalaLibrarySynthetics = scalaLibrarySynthetics,
+      par = par
     )
   }
 }
@@ -54,6 +63,8 @@ object Settings {
           loop(settings.copy(scalaLibrarySynthetics = false), true, rest)
         case "--include-scala-library-synthetics" +: rest if allowOptions =>
           loop(settings.copy(scalaLibrarySynthetics = true), true, rest)
+        case "--par" +: rest if allowOptions =>
+          loop(settings.copy(par = true), true, rest)
         case flag +: _ if allowOptions && flag.startsWith("-") =>
           reporter.out.println(s"unsupported flag $flag")
           None

--- a/tests/jvm/src/test/scala/scala/meta/tests/metacp/BaseMetacpSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/metacp/BaseMetacpSuite.scala
@@ -1,8 +1,5 @@
 package scala.meta.tests.metacp
 
-import java.io.File
-import java.io.OutputStream
-import java.io.PrintStream
 import java.nio.file.Files
 import org.langmeta.io.AbsolutePath
 import org.langmeta.io.Classpath
@@ -17,7 +14,7 @@ abstract class BaseMetacpSuite extends BaseCliSuite {
 
   def checkMetacp(name: String, classpath: () => Classpath): Unit = {
     test(name) {
-      val settings = Settings().withClasspath(classpath()).withCacheDir(tmp)
+      val settings = Settings().withClasspath(classpath()).withCacheDir(tmp).withPar(true)
       val reporter = Reporter().withOut(System.out).withErr(System.err)
       val result = Metacp.process(settings, reporter)
       assert(result.nonEmpty)


### PR DESCRIPTION
This commit replaces the usage of `.par.flatMap` with `.par.foreach` as
an attempt to prevent a difficult-to-reproduce deadlock problem in
parallel collections.  The parallel behavior is disabled by default and
can be enabled with the --par option.

Using --par seems to yield ~40-50% faster performance in
MetacpCrashSuite on my Macbook. It takes ~36s to run with --par and ~57s
without --par.

The theory for why `.par.foreach` is better than `.par.flatMap` is based
on the experience in scalafmt/scalafix where I've used that same pattern
for over two years and have not seen reports of deadlock behavior.
I have never used `.par.flatMap` in my applications.

Fixes #1398 