### PR TITLE
Don't close nio.FileSystem.

### DIFF
--- a/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/Main.scala
+++ b/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/Main.scala
@@ -39,7 +39,7 @@ class Main(settings: Settings, reporter: Reporter) {
         if (cacheEntry.toFile.exists) {
           buffer.add(cacheEntry)
         } else {
-          PlatformFileIO.withJarFileSystem(cacheEntry) { out =>
+          PlatformFileIO.withJarFileSystem(cacheEntry, create = true) { out =>
             val res = convertClasspathEntry(entry, out)
             success.compareAndSet(true, res)
             buffer.add(cacheEntry)
@@ -53,7 +53,7 @@ class Main(settings: Settings, reporter: Reporter) {
       if (cacheEntry.toFile.exists) {
         buffer.add(cacheEntry)
       } else {
-        PlatformFileIO.withJarFileSystem(cacheEntry) { out =>
+        PlatformFileIO.withJarFileSystem(cacheEntry, create = true) { out =>
           val res = dumpScalaLibrarySynthetics(out)
           success.compareAndSet(true, res)
           buffer.add(cacheEntry)

--- a/tests/jvm/src/test/scala/scala/meta/tests/metacp/MetacpCacheSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/metacp/MetacpCacheSuite.scala
@@ -17,7 +17,7 @@ class MetacpCacheSuite extends BaseMetacpSuite with TimeLimitedTests {
   override val timeLimit = Span(1L, Minute)
 
   def assertDirectoryListingMatches(jar: AbsolutePath, expected: String): Unit = {
-    PlatformFileIO.withJarFileSystem(jar) { root =>
+    PlatformFileIO.withJarFileSystem(jar, create = false) { root =>
       val obtained = FileIO
         .listAllFilesRecursively(root)
         .files
@@ -59,7 +59,7 @@ class MetacpCacheSuite extends BaseMetacpSuite with TimeLimitedTests {
     val reporter = Reporter()
     Metacp.process(settings, reporter) match {
       case result @ Some(Classpath(List(scalaLibrarySemanticdbJar))) =>
-        PlatformFileIO.withJarFileSystem(scalaLibrarySemanticdbJar) { root =>
+        PlatformFileIO.withJarFileSystem(scalaLibrarySemanticdbJar, create = false) { root =>
           assert(root.resolve("META-INF/semanticdb/scala/Predef.class.semanticdb").isFile)
           assert(root.resolve("META-INF/semanticdb/scala/package.class.semanticdb").isFile)
           assert(root.resolve("META-INF/semanticdb/scala/Function16.class.semanticdb").isFile)


### PR DESCRIPTION
While testing metacp in scalafix I encountered frequent flaky test
failures due to "writing to closed file system" errors caused by
`FileSystems.getFileSystem` reusing open file systems.  This leaks
resources, but I see no alternative that does not involve refactoring
everything to java.io or global mutable state for reference counting
open file systems per zip file.