### PR TITLE
Add docstring to protobuf schema

### DIFF
--- a/semanticdb/semanticdb3/semanticdb3.md
+++ b/semanticdb/semanticdb3/semanticdb3.md
@@ -1201,6 +1201,7 @@ message SymbolInformation {
   Kind kind = 3;
   int32 properties = 4;
   string name = 5;
+  string docstring = 17;
   Type tpe = 11;
   repeated Annotation annotations = 13;
   Accessibility accessibility = 14;
@@ -1232,6 +1233,10 @@ message SymbolInformation {
   <tr>
     <td><code>name</code></td>
     <td>See <a href="#scala-symbol">Symbol</a>.</td>
+  </tr>
+  <tr>
+    <td><code>docstring</code></td>
+    <td>The plaintext docstring associated with the symbol</td>
   </tr>
   <tr>
     <td><code>tpe</code></td>

--- a/semanticdb/semanticdb3/semanticdb3.proto
+++ b/semanticdb/semanticdb3/semanticdb3.proto
@@ -216,6 +216,7 @@ message SymbolInformation {
   Kind kind = 3;
   int32 properties = 4;
   string name = 5;
+  string docstring = 17;
   Type tpe = 11;
   repeated Annotation annotations = 13;
   Accessibility accessibility = 14;

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/SemanticdbSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/SemanticdbSuite.scala
@@ -56,7 +56,7 @@ abstract class SemanticdbSuite(
     types = types
   )
 
-  private def computeDatabaseFromSnippet(code: String): s.TextDocument = {
+  protected def computeDatabaseFromSnippet(code: String): s.TextDocument = {
     val javaFile = File.createTempFile("paradise", ".scala")
     val writer = new PrintWriter(javaFile)
     try writer.write(code)

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/SymbolDocstringSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/SymbolDocstringSuite.scala
@@ -1,0 +1,59 @@
+package scala.meta.tests.semanticdb
+
+class SymbolDocstringSuite extends SemanticdbSuite {
+
+  test("Class-level docstrings should be associated with the class symbol") {
+    val document = computeDatabaseFromSnippet(
+      """
+        |/**
+        | * This is a docstring for the class
+        | */
+        |case class Person(
+        |  name: String,
+        |  age: Int
+        |)
+      """.trim.stripMargin
+    )
+    assert(document.symbols.toList == Nil)
+  }
+
+  test(
+    """
+      | @param annotations on a class should be associated with the symbols for the associated
+      | parameters of the constructor
+    """.stripMargin
+  ) {
+    val document = computeDatabaseFromSnippet(
+      """
+        |/**
+        | * This is a docstring for the class
+        | *
+        | * @param name this documents a parameter
+        | * @param age
+        | */
+        |case class Person(
+        |  name: String,
+        |  age: Int
+        |)
+      """.trim.stripMargin
+    )
+    assert(document.symbols.toList == Nil)
+  }
+
+  test("@param annotations for a method should be associated with the symbols for parameters") {
+    val document = computeDatabaseFromSnippet(
+      """
+        |object A {
+        |  /**
+        |   * This is a docstring for the class
+        |   *
+        |   * @param name this documents a parameter
+        |   * @param age
+        |   */
+        |  def foobar(name: String, age: Int)
+        |}
+      """.trim.stripMargin
+    )
+    assert(document.symbols.toList == Nil)
+  }
+}


### PR DESCRIPTION
**Goal**: Get docstrings into the semanticdb schema. I intend to use this information in metals to show documentation for symbols on hover.

**WIP**: This is, as you can see, very much a work in progress. I just wanted to float the idea by you early to make sure I'm not going down a wrong path. My next step would be to find all the places we create an instance of `SymbolInformation` and include the docstring once I've figured out how to get ahold of it :wink:

