### PR TITLE
Fix: handle comments before EOF

### DIFF
--- a/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/AssociatedComments.scala
+++ b/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/AssociatedComments.scala
@@ -59,16 +59,22 @@ object AssociatedComments {
         if (isLeading) leading += c
         else trailing += c
       case Token.LF() => isLeading = true
+      case Token.EOF() =>
+        val l = leading.result()
+        val t = trailing.result()
+        if (l.nonEmpty || t.nonEmpty) {
+          trailingBuilder += lastToken -> (l ::: t)
+        }
       case Trivia() =>
       case currentToken =>
         val t = trailing.result()
         if (t.nonEmpty) {
-          trailingBuilder += lastToken -> trailing.result()
+          trailingBuilder += lastToken -> t
           trailing.clear()
         }
         val l = leading.result()
         if (l.nonEmpty) {
-          leadingBuilder += currentToken -> leading.result()
+          leadingBuilder += currentToken -> l
           leading.clear()
         }
         if (!currentToken.is[Comma]) {

--- a/tests/shared/src/test/scala/scala/meta/tests/contrib/AssociatedCommentsTest.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/contrib/AssociatedCommentsTest.scala
@@ -3,7 +3,6 @@ package contrib
 
 import scala.meta._
 import scala.meta.contrib._
-import scala.meta.tokens.Token
 import org.scalatest.FunSuite
 
 class AssociatedCommentsTest extends FunSuite {
@@ -39,19 +38,234 @@ class AssociatedCommentsTest extends FunSuite {
                    |/** Scaladoc for object A
                    |  */
                    |object A""".stripMargin.parse[Source].get
-    val comments = AssociatedComments(input.tokens)
-    val source @ Source(stats) = input
-    val result = stats.map(comments.leading)
-    assert(result.forall(_.nonEmpty))
-    assert(
-      comments.syntax ===
-        """AssociatedComments(
-          |  Leading =
-          |    class [30..35) => List(/**∙Scaladoc∙for∙class∙A¶∙∙*/)
-          |    object [69..75) => List(/**∙Scaladoc∙for∙object∙A¶∙∙*/)
-          |
-          |  Trailing =
-          |
-          |)""".stripMargin)
+
+    val defnClass = input.find(_.is[Defn.Class]).get
+    val defnObject = input.find(_.is[Defn.Object]).get
+
+    assertExpectations(input)(
+      leading = Map(
+        defnClass -> Set(
+          """|/** Scaladoc for class A
+             |  */""".stripMargin
+        ),
+        defnObject -> Set(
+          """|/** Scaladoc for object A
+             |  */""".stripMargin
+        )
+      )
+    )
+  }
+
+  test("single leading comment at the beginning of a file") {
+    val input =
+      """|// leading
+         |object A
+         |""".stripMargin.parse[Source].get
+
+    val defnObject = input.find(_.is[Defn.Object]).get
+
+    assertExpectations(input)(
+      leading = Map(
+        defnObject -> Set("// leading")
+      )
+    )
+  }
+
+  test("multiple leading comments in a single line at the beginning of a file") {
+    val input =
+      """|/** leading 1 */ /* leading 2 */ // leading 3
+         |class A
+         |""".stripMargin.parse[Source].get
+
+    val defnClass = input.find(_.is[Defn.Class]).get
+
+    assertExpectations(input)(
+      leading = Map(
+        defnClass -> Set("/** leading 1 */", "/* leading 2 */", "// leading 3")
+      )
+    )
+  }
+
+  ignore("multiple leading comments in different lines at the beginning of a file") {
+    val input =
+      """|/** leading 1 */
+         |/* leading 2 */
+         |// leading 3
+         |trait A
+         |""".stripMargin.parse[Source].get
+
+    val defnTrait = input.find(_.is[Defn.Trait]).get
+
+    assertExpectations(input)(
+      leading = Map(
+        defnTrait -> Set("/** leading 1 */", "/* leading 2 */", "// leading 3")
+      )
+    )
+  }
+
+  ignore("single trailing comment at the end of a file") {
+    val input =
+      """|object A {
+         |} // trailing
+         |""".stripMargin.parse[Source].get
+
+    val defnObject = input.find(_.is[Defn.Object]).get
+    val template = input.find(_.is[Template]).get // overlaps with `object`
+
+    assertExpectations(input)(
+      trailing = Map(
+        defnObject -> Set("// trailing"),
+        template -> Set("// trailing")
+      )
+    )
+  }
+
+  test("multiple trailing comments in a single line at the end of a file") {
+    val input =
+      """|class A {
+         |} /** trailing 1 */ /* trailing 2 */ // trailing 3
+         |""".stripMargin.parse[Source].get
+
+    val defnClass = input.find(_.is[Defn.Class]).get
+    val template = input.find(_.is[Template]).get // overlaps with `class`
+
+    val expectedComments = Set("/** trailing 1 */", "/* trailing 2 */", "// trailing 3")
+    assertExpectations(input)(
+      trailing = Map(
+        defnClass -> expectedComments,
+        template -> expectedComments
+      )
+    )
+  }
+
+  test("multiple trailing comments in different lines at the end of a file") {
+    val input =
+      """|trait A {
+         |} /** trailing 1 */
+         |/* trailing 2 */
+         |// trailing 3
+         |""".stripMargin.parse[Source].get
+
+    val defnTrait = input.find(_.is[Defn.Trait]).get
+    val template = input.find(_.is[Template]).get // overlaps with `trait`
+
+    val expectedComments = Set("/** trailing 1 */", "/* trailing 2 */", "// trailing 3")
+    assertExpectations(input)(
+      trailing = Map(
+        defnTrait -> expectedComments,
+        template -> expectedComments
+      )
+    )
+  }
+
+  test("comment not associated to any tree") {
+    val input =
+      """|object A {
+         | // foo
+         |}
+         |""".stripMargin.parse[Source].get
+
+    assertExpectations(input)(
+      leading = Map.empty,
+      trailing = Map.empty
+    )
+  }
+
+  test("tree with both leading and trailing comments") {
+    val input =
+      """|object A {
+         | // leading
+         | val x = 0 // trailing
+         | var y = false
+         |}
+         |""".stripMargin.parse[Source].get
+
+    val defnVal = input.find(_.is[Defn.Val]).get
+    val litInt = input.find(_.is[Lit.Int]).get // overlaps with `val`
+
+    assertExpectations(input)(
+      leading = Map(
+        defnVal -> Set("// leading")
+      ),
+      trailing = Map(
+        defnVal -> Set("// trailing"),
+        litInt -> Set("// trailing")
+      )
+    )
+  }
+
+  test("multiple comments interleaved with trees in a single line") {
+    val input =
+      """|object A {
+         | /* comment 1 */ val /* comment 2 */ foo = /* comment 3 */ 0 /* comment 4 */
+         |}
+         |""".stripMargin.parse[Source].get
+
+    val defnVal = input.find(_.is[Defn.Val]).get
+    val litInt = input.find(_.is[Lit.Int]).get
+
+    assertExpectations(input)(
+      leading = Map(
+        defnVal -> Set("/* comment 1 */")
+      ),
+      trailing = Map(
+        defnVal -> Set("/* comment 4 */"),
+        litInt -> Set("/* comment 4 */")
+      )
+    )
+  }
+
+  test("lone comment in a file") {
+    val input = "// foo".parse[Source].get
+
+    assertExpectations(input)(
+      leading = Map.empty,
+      trailing = Map.empty
+    )
+  }
+
+  test("comment after comma should be associated to preceding tree") {
+    val input =
+      """|object Foo {
+         | (
+         |   None, // trailing
+         |   Some(0)
+         | )
+         |}
+         |""".stripMargin.parse[Source].get
+
+    val none = input.collectFirst { case t @ Name("None") => t }.get
+
+    assertExpectations(input)(
+      trailing = Map(
+        none -> Set("// trailing")
+      )
+    )
+  }
+
+
+  private def assertExpectations(input: Source)
+                                (leading: Map[Tree, Set[String]] = Map.empty, trailing: Map[Tree, Set[String]] = Map.empty): Unit = {
+    val associatedComments = AssociatedComments(input.tokens)
+    // check expected leading comments
+    for ((t, comments) <- leading) {
+      assert(associatedComments.leading(t).map(_.text) === comments,
+        s"actual leading comments didn't match expectation for ${t.syntax}")
+    }
+    // check unexpected leading comments
+    input.foreach { t =>
+      if (!leading.contains(t))
+        assert(associatedComments.leading(t).isEmpty, s"unexpected leading comments for ${t.syntax}")
+    }
+    // check expected trailing comments
+    for ((t, comments) <- trailing) {
+      assert(associatedComments.trailing(t).map(_.text) === comments,
+        s"actual trailing comments didn't match expectation for ${t.syntax}")
+    }
+    // check unexpected trailing comments
+    input.foreach { t =>
+      if (!trailing.contains(t))
+        assert(associatedComments.trailing(t).isEmpty, s"unexpected trailing comments for ${t.getClass}")
+    }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/scalacenter/scalafix/issues/627

This issue is similar to #897, but affecting comments at the bottom of a file (== ignored).

/cc. @olafurpg 