### PR TITLE
Include diagnostics with offset positions

### DIFF
--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/ReporterOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/ReporterOps.scala
@@ -14,7 +14,6 @@ trait ReporterOps { self: SemanticdbOps =>
         case r: StoreReporter =>
           object RelevantMessage {
             def unapply(info: r.Info): Option[(gPosition, Int, String)] = {
-              if (!info.pos.isRange) return None
               if (info.pos.source != unit.source) return None
               Some((info.pos, info.severity.id, info.msg))
             }

--- a/tests/jvm/src/test/scala-2.11/scala/meta/tests/semanticdb/TargetedSuite2_11.scala
+++ b/tests/jvm/src/test/scala-2.11/scala/meta/tests/semanticdb/TargetedSuite2_11.scala
@@ -1,0 +1,28 @@
+package scala.meta.tests.semanticdb
+
+class TargetedSuite2_11 extends SemanticdbSuite() {
+
+  diagnostics(
+    """
+      |package l2
+      |class A {
+      |  private val a = 1
+      |}
+      |object B {
+      |  private val a = 1
+      |}
+      |package object C {
+      |  private val a = 1
+      |}
+      |trait D {
+      |  private val a = 1
+      |}
+    """.stripMargin.trim,
+    """|[2:14..2:14)[warning] private val in class A is never used
+       |[5:14..5:14)[warning] private val in object B is never used
+       |[8:14..8:14)[warning] private val in package object C is never used
+       |[11:14..11:14)[warning] private val in trait D is never used
+    """.stripMargin.trim
+  )
+
+}

--- a/tests/jvm/src/test/scala-2.12/scala/meta/tests/semanticdb/TargetedSuite2_12.scala
+++ b/tests/jvm/src/test/scala-2.12/scala/meta/tests/semanticdb/TargetedSuite2_12.scala
@@ -1,0 +1,28 @@
+package scala.meta.tests.semanticdb
+
+class TargetedSuite2_12 extends SemanticdbSuite() {
+
+  diagnostics(
+    """
+      |package l2
+      |class A {
+      |  private val a = 1
+      |}
+      |object B {
+      |  private val a = 1
+      |}
+      |package object C {
+      |  private val a = 1
+      |}
+      |trait D {
+      |  private val a = 1
+      |}
+    """.stripMargin.trim,
+    """|[2:14..2:14)[warning] private val a in class A is never used
+       |[5:14..5:14)[warning] private val a in object B is never used
+       |[8:14..8:14)[warning] private val a in package object C is never used
+       |[11:2..11:19)[warning] private val a in trait D is never used
+    """.stripMargin.trim
+  )
+
+}

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/SemanticdbSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/SemanticdbSuite.scala
@@ -33,7 +33,7 @@ abstract class SemanticdbSuite(
     if (classpath == null) fail("classpath not set. broken build?")
     val pluginjar = sys.props("sbt.paths.semanticdb-scalac-plugin.compile.jar")
     if (pluginjar == null) fail("pluginjar not set. broken build?")
-    val options = "-Yrangepos -Ywarn-unused-import -cp " + classpath + " -Xplugin:" + pluginjar + " -Xplugin-require:semanticdb"
+    val options = "-Yrangepos -Ywarn-unused-import -Ywarn-unused -cp " + classpath + " -Xplugin:" + pluginjar + " -Xplugin-require:semanticdb"
     val args = CommandLineParser.tokenize(options)
     val emptySettings = new Settings(error => fail(s"couldn't apply settings because $error"))
     val reporter = new StoreReporter()

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/TargetedSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/TargetedSuite.scala
@@ -515,6 +515,7 @@ class TargetedSuite extends SemanticdbSuite() {
 
   diagnostics(
     """
+      |package l2
       |class A {
       |  private val a = 1
       |}
@@ -528,10 +529,10 @@ class TargetedSuite extends SemanticdbSuite() {
       |  private val a = 1
       |}
     """.stripMargin.trim,
-    """|[1:14..1:14)[warning] private val a in class A is never used
-       |[4:14..4:14)[warning] private val a in object B is never used
-       |[7:14..7:14)[warning] private val a in package object C is never used
-       |[10:2..10:19)[warning] private val a in trait D is never used
+    """|[2:14..2:14)[warning] private val a in class A is never used
+       |[5:14..5:14)[warning] private val a in object B is never used
+       |[8:14..8:14)[warning] private val a in package object C is never used
+       |[11:2..11:19)[warning] private val a in trait D is never used
     """.stripMargin.trim
   )
 

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/TargetedSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/TargetedSuite.scala
@@ -513,29 +513,6 @@ class TargetedSuite extends SemanticdbSuite() {
     """.stripMargin.trim
   )
 
-  diagnostics(
-    """
-      |package l2
-      |class A {
-      |  private val a = 1
-      |}
-      |object B {
-      |  private val a = 1
-      |}
-      |package object C {
-      |  private val a = 1
-      |}
-      |trait D {
-      |  private val a = 1
-      |}
-    """.stripMargin.trim,
-    """|[2:14..2:14)[warning] private val a in class A is never used
-       |[5:14..5:14)[warning] private val a in object B is never used
-       |[8:14..8:14)[warning] private val a in package object C is never used
-       |[11:2..11:19)[warning] private val a in trait D is never used
-    """.stripMargin.trim
-  )
-
   occurrences(
     s"""
        |package m

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/TargetedSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/TargetedSuite.scala
@@ -513,6 +513,28 @@ class TargetedSuite extends SemanticdbSuite() {
     """.stripMargin.trim
   )
 
+  diagnostics(
+    """
+      |class A {
+      |  private val a = 1
+      |}
+      |object B {
+      |  private val a = 1
+      |}
+      |package object C {
+      |  private val a = 1
+      |}
+      |trait D {
+      |  private val a = 1
+      |}
+    """.stripMargin.trim,
+    """|[1:14..1:14)[warning] private val a in class A is never used
+       |[4:14..4:14)[warning] private val a in object B is never used
+       |[7:14..7:14)[warning] private val a in package object C is never used
+       |[10:2..10:19)[warning] private val a in trait D is never used
+    """.stripMargin.trim
+  )
+
   occurrences(
     s"""
        |package m


### PR DESCRIPTION
Relax RelevantMessage condition to forward unused local warnings.

Fix #1530