### PR TITLE
Upgrade to directories-jvm 10.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -191,7 +191,7 @@ lazy val metacp = project
     description := "Scala 2.x classpath to SemanticDB converter",
     libraryDependencies ++= List(
       "org.scala-lang" % "scalap" % scalaVersion.value,
-      "io.github.soc" % "directories" % "5"
+      "io.github.soc" % "directories" % "10"
     ),
     mainClass := Some("scala.meta.cli.Metacp"),
     buildInfoKeys := Seq[BuildInfoKey](version),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6" exclude("org.apache.mave
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
 
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % coursier.util.Properties.version)
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
 

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M4")

--- a/semanticdb/metacp/src/main/scala/scala/meta/metacp/Settings.scala
+++ b/semanticdb/metacp/src/main/scala/scala/meta/metacp/Settings.scala
@@ -82,7 +82,8 @@ object Settings {
   }
 
   def defaultCacheDir: AbsolutePath = {
-    val cacheRoot = AbsolutePath(ProjectDirectories.fromProjectName("semanticdb").projectCacheDir)
+    val projectDirectories = ProjectDirectories.from("org.scalameta", "", "SemanticDB")
+    val cacheRoot = AbsolutePath(projectDirectories.cacheDir)
     cacheRoot.resolve(BuildInfo.version)
   }
 


### PR DESCRIPTION
To follow Windows and macOS conventions, we are expected to qualify the
project name with a domain name.  Given that "SemanticDB" is also used
in Emacs, there's a valid risk of conflict.

Fixes #1599
