### PR TITLE
Make metac index incremental.

### DIFF
--- a/scalameta/testkit/src/main/scala/scala/meta/testkit/StringFS.scala
+++ b/scalameta/testkit/src/main/scala/scala/meta/testkit/StringFS.scala
@@ -1,0 +1,94 @@
+package scala.meta.testkit
+
+import scala.meta.io.AbsolutePath
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import scala.meta.internal.io.FileIO
+import scala.meta.io.RelativePath
+
+object StringFS {
+
+  /**
+    * Creates a temporary directory with a layout matching the markup in the string.
+    *
+    * Example syntax of the expected markup in the string:
+    * {{{
+    *   fromString("""
+    *   /build.sbt
+    *   lazy val core = project
+    *   /src/main/scala/core/Foo.scala
+    *   package core
+    *   object Foo.scala
+    *   """)
+    * }}}
+    *
+    * Use `asString` for the inverse, go from a temporary directory to a string.
+    *
+    * @param layout the string representing the directory layout.
+    *               NOTE. Lines starting with forward slash / are always interpreted
+    *               as the start of a new file entry.
+    * @param root the temporary directory to apply the layout markup.
+    *             If not provided, defaults to a fresh temporary directory.
+    */
+  def fromString(
+      layout: String,
+      root: AbsolutePath = AbsolutePath(Files.createTempDirectory("scalameta"))
+  ): AbsolutePath = {
+    if (!layout.trim.isEmpty) {
+      layout.split("(?=\n/)").foreach { row =>
+        row.stripPrefix("\n").split("\n", 2).toList match {
+          case path :: contents :: Nil =>
+            val file = root.resolve(path.stripPrefix("/"))
+            Files.createDirectories(file.toNIO.getParent)
+            Files.write(
+              file.toNIO,
+              contents.getBytes,
+              StandardOpenOption.CREATE,
+              StandardOpenOption.TRUNCATE_EXISTING
+            )
+          case els =>
+            throw new IllegalArgumentException(
+              s"Unable to split argument info path/contents! \n$els")
+
+        }
+      }
+    }
+    root
+  }
+
+  /** Gives a string representation of a directory.
+    *
+    * Performs the inverse as fromString.
+    *
+    * Example:
+    * {{{
+    * val layout = """
+    * /Main.scala
+    * object A { def foo() = print("foo") }
+    * """
+    * assert(asString(fromString(layout)) == layout)
+    * }}}
+    *
+    * @param root the directory to print as a string
+    * @param includePath an optional filter function to exclude files
+    */
+  def asString(root: AbsolutePath, includePath: RelativePath => Boolean = _ => true): String = {
+    import scala.collection.JavaConverters._
+    FileIO
+      .listAllFilesRecursively(root)
+      .files
+      .filter(includePath)
+      .sortBy(_.toNIO)
+      .map { path =>
+        val contents = FileIO.slurp(root.resolve(path), StandardCharsets.UTF_8)
+        s"""|/$path
+            |$contents""".stripMargin
+      }
+      .mkString("\n")
+      .replace(File.separatorChar, '/') // ensure original separators
+  }
+
+}

--- a/semanticdb/metacp/src/main/scala/scala/meta/internal/index/Index.scala
+++ b/semanticdb/metacp/src/main/scala/scala/meta/internal/index/Index.scala
@@ -1,5 +1,8 @@
 package scala.meta.internal.index
 
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
 import scala.collection.mutable
 import scala.meta.internal.io._
 import scala.meta.internal.{semanticdb3 => s}
@@ -17,20 +20,61 @@ class Index {
       toplevels(info.symbol) = uri
       info.symbol.ownerChain.sliding(2).foreach {
         case List(owner, decl) =>
-          val decls = packages.getOrElse(owner, mutable.Set[String]())
-          decls += decl
-          packages(owner) = decls
+          addPackageMember(owner, decl)
       }
     }
   }
 
   def save(out: AbsolutePath): Unit = {
+    save(out, None)
+  }
+  def save(out: AbsolutePath, sourceroot: AbsolutePath): Unit = {
+    save(out, Some(sourceroot))
+  }
+
+  private def save(out: AbsolutePath, sourceroot: Option[AbsolutePath]): Unit = {
     val indexAbspath = out.resolve("META-INF").resolve("semanticdb.semanticidx")
+    val baseIndex = sourceroot match {
+      case Some(root) if indexAbspath.isFile => getBaseIndex(indexAbspath, root)
+      case _ => s.Index()
+    }
     val indexMessage = {
       val spackages = packages.map(kv => s.PackageEntry(symbol = kv._1, members = kv._2.toList))
       val stoplevels = toplevels.map(kv => s.ToplevelEntry(symbol = kv._1, uri = kv._2))
-      s.Index(packages = spackages.toList, toplevels = stoplevels.toList)
+      baseIndex
+        .addAllPackages(spackages)
+        .addAllToplevels(stoplevels)
     }
     FileIO.write(indexAbspath, indexMessage)
+  }
+
+  private def addPackageMember(pkg: String, decl: String): Unit = {
+    val decls = packages.getOrElseUpdate(pkg, mutable.Set[String]())
+    decls += decl
+  }
+
+  private def getBaseIndex(indexPath: AbsolutePath, sourceroot: AbsolutePath): s.Index = {
+    val in = Files.newInputStream(indexPath.toNIO)
+    val old =
+      try s.Index.parseFrom(indexPath.readAllBytes)
+      finally in.close()
+    val fileCache = mutable.Map.empty[String, Boolean]
+    def isFile(uri: String): Boolean =
+      fileCache.getOrElseUpdate(uri, {
+        val relpath =
+          URLDecoder.decode(uri, StandardCharsets.UTF_8.name()).stripSuffix(".semanticdb")
+        val abspath = sourceroot.resolve(relpath)
+        abspath.isFile
+      })
+    val newToplevels = old.toplevels.filter(t => isFile(t.uri) && !toplevels.contains(t.symbol))
+    val isNewToplevel = newToplevels.iterator.map(_.symbol).toSet
+    old.packages.foreach { pkg =>
+      pkg.members.foreach { member =>
+        if (isNewToplevel(member)) {
+          addPackageMember(pkg.symbol, member)
+        }
+      }
+    }
+    s.Index(packages = Nil, toplevels = newToplevels)
   }
 }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SemanticdbPipeline.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SemanticdbPipeline.scala
@@ -64,8 +64,7 @@ trait SemanticdbPipeline extends SemanticdbOps { self: SemanticdbPlugin =>
       }
 
       private def synchronizeSourcesAndSemanticdbIndex(): Unit = {
-        // FIXME: https://github.com/scalameta/scalameta/issues/1528
-        index.save(config.targetroot)
+        index.save(config.targetroot, config.sourceroot)
       }
 
       override def run(): Unit = {

--- a/tests/jvm/src/test/scala-2.12/scala/meta/tests/semanticdb/IncrementalSuite.scala
+++ b/tests/jvm/src/test/scala-2.12/scala/meta/tests/semanticdb/IncrementalSuite.scala
@@ -1,0 +1,125 @@
+package scala.meta.tests.semanticdb
+
+import java.nio.file.Files
+import org.scalatest.FunSuite
+import org.scalatest.tagobjects.Slow
+import org.scalatest.BeforeAndAfterEach
+import scala.meta.internal.semanticdb.scalac.SemanticdbPaths
+import scala.meta.internal.semanticdb3.Index
+import scala.meta.io.RelativePath
+import scala.meta.testkit.DiffAssertions._
+
+class IncrementalSuite extends FunSuite with BeforeAndAfterEach {
+
+  var zinc: ZincProject = _
+
+  override def beforeEach(): Unit = {
+    zinc = new ZincProject(debug = false)
+  }
+
+  def assertIndexMatches(expected: String): Unit = {
+    val path = zinc.targetroot.resolve("META-INF").resolve("semanticdb.semanticidx")
+    val index = Index.parseFrom(path.readAllBytes)
+    val obtained = MetacpIndexExpect.printIndex(index)
+    assertNoDiff(obtained, expected)
+  }
+
+  val A: String =
+    """|Packages:
+       |=========
+       |_empty_.
+       |  _empty_.A.
+       |_root_.
+       |  _empty_.
+       |
+       |Toplevels:
+       |==========
+       |_empty_.A. => src/A.scala.semanticdb
+       |""".stripMargin
+
+  val AB: String =
+    """|Packages:
+       |=========
+       |_empty_.
+       |  _empty_.A.
+       |  _empty_.B.
+       |_root_.
+       |  _empty_.
+       |
+       |Toplevels:
+       |==========
+       |_empty_.A. => src/A.scala.semanticdb
+       |_empty_.B. => src/B.scala.semanticdb
+       |""".stripMargin
+
+  val ABC: String =
+    """|Packages:
+       |=========
+       |_empty_.
+       |  _empty_.A.
+       |  _empty_.B.
+       |  _empty_.C.
+       |_root_.
+       |  _empty_.
+       |
+       |Toplevels:
+       |==========
+       |_empty_.A. => src/A.scala.semanticdb
+       |_empty_.B. => src/B.scala.semanticdb
+       |_empty_.C. => src/A.scala.semanticdb
+       |""".stripMargin
+
+  test("update file", Slow) {
+    zinc.assertCompiles(
+      """|/src/A.scala
+         |object A
+         |/src/B.scala
+         |object B
+         |""".stripMargin
+    )
+    assertIndexMatches(AB)
+    zinc.assertCompiles(
+      """|/src/A.scala
+         |object A
+         |object C
+         |/src/B.scala
+         |object B
+         |""".stripMargin
+    )
+    assertIndexMatches(ABC)
+  }
+
+  test("add new file", Slow) {
+    zinc.assertCompiles(
+      """|/src/A.scala
+         |object A
+         |""".stripMargin
+    )
+    assertIndexMatches(A)
+    zinc.assertCompiles(
+      """|/src/B.scala
+         |object B
+         |""".stripMargin
+    )
+    assertIndexMatches(AB)
+  }
+
+  test("delete file", Slow) {
+    val B = RelativePath("src/B.scala")
+    val Bsemanticdb = SemanticdbPaths.toSemanticdb(B, zinc.targetroot)
+    zinc.assertCompiles(
+      """|/src/A.scala
+         |object A
+         |/src/B.scala
+         |object B
+         |""".stripMargin
+    )
+    Files.delete(zinc.sourceroot.resolve(B).toNIO)
+    assertIndexMatches(AB)
+    assert(Bsemanticdb.isFile)
+    zinc.assertCompiles("")
+    assert(!Bsemanticdb.isFile, "orphan SemanticDB was not removed")
+    assertIndexMatches(A)
+  }
+
+}

--- a/tests/jvm/src/test/scala-2.12/scala/meta/tests/semanticdb/ZincProject.scala
+++ b/tests/jvm/src/test/scala-2.12/scala/meta/tests/semanticdb/ZincProject.scala
@@ -1,0 +1,127 @@
+package scala.meta.tests.semanticdb
+
+import bloop.Cli
+import bloop.cli.CommonOptions
+import bloop.cli.ExitStatus
+import bloop.config.Config.Mixed
+import bloop.engine.NoPool
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.net.URLClassLoader
+import java.nio.file.Files
+import java.nio.file.Paths
+import scala.meta.io.AbsolutePath
+import scala.meta.testkit.StringFS
+import bloop.config.{Config => C}
+import scala.meta.internal.io.FileIO
+import scala.meta.internal.semanticdb3.Index
+
+/**
+  * Utility class to reproduce incremental compilation with Zinc via Bloop.
+  *
+  * @param debug If true, prints out compilation logs to stdout.
+  *              If false, is silent and prints nothing to stdout.
+  */
+class ZincProject(debug: Boolean = false) {
+  private val tmp = Files.createTempDirectory("scalameta")
+  val sourceroot: AbsolutePath = AbsolutePath(tmp)
+  private val out = tmp.resolve("out")
+  val targetroot: AbsolutePath = AbsolutePath(out.resolve("classes"))
+  private val project: String = "name"
+  setupBloop()
+
+  /** Compile and throw error if compilation succeeded. */
+  def assertDoesNotCompile(layout: String): Unit = {
+    assertCompilesWithExitStatus(layout, ExitStatus.CompilationError)
+  }
+
+  /** Compile and throw error if compilation was not successful. */
+  def assertCompiles(layout: String): Unit = {
+    assertCompilesWithExitStatus(layout, ExitStatus.Ok)
+  }
+
+  /** Apply the StringFS markup changes to the sourceroot directory. */
+  def applyFileChanges(changes: String): AbsolutePath = {
+    StringFS.fromString(changes, sourceroot)
+  }
+
+  private def run(args: String*): (ExitStatus, String) = {
+    val out = new ByteArrayOutputStream()
+    val ps = new PrintStream(out)
+    val common = CommonOptions(
+      workingDirectory = tmp.toString,
+      out = ps,
+      err = ps,
+      ngout = ps,
+      ngerr = ps
+    )
+    val action = Cli.parse(args.toArray, common)
+    val exit = Cli.run(action, NoPool, args.toArray)
+    exit -> out.toString()
+  }
+
+  private def compile(): ExitStatus = {
+    val (exit, out) = run("compile", project)
+    if (debug) {
+      println(out)
+    }
+    exit
+  }
+
+  private def assertCompilesWithExitStatus(layout: String, expected: ExitStatus): Unit = {
+    applyFileChanges(layout)
+    val exit = compile()
+    assert(exit == expected, s"Expected $expected. Obtained $exit")
+  }
+
+  private def setupBloop(): Unit = {
+    val classpath = this.getClass.getClassLoader match {
+      case u: URLClassLoader =>
+        u.getURLs.map(url => Paths.get(url.toURI))
+    }
+    val pluginjar = sys.props("sbt.paths.semanticdb-scalac-plugin.compile.jar")
+    val scalacOptions = Array(
+      "-Yrangepos",
+      s"-P:semanticdb:sourceroot:$tmp",
+      "-P:semanticdb:failures:error",
+      "-Xplugin:" + pluginjar,
+      "-Xplugin-require:semanticdb"
+    )
+    val file = new C.File(
+      "1.0.0",
+      C.Project(
+        name = project,
+        directory = tmp,
+        sources = Array(tmp.resolve("src")),
+        dependencies = Array(),
+        classpath = classpath,
+        out = out,
+        analysisOut = out.resolve("analysis"),
+        classesDir = targetroot.toNIO,
+        scala = C.Scala(
+          organization = "org.scala-lang",
+          name = "scala-compiler",
+          version = scala.util.Properties.versionNumberString,
+          options = scalacOptions,
+          jars = Array()),
+        java = C.Java(Array()),
+        sbt = C.Sbt("1.2.0", Nil),
+        test = C.Test(Array(), C.TestOptions(Nil, Nil)),
+        platform = C.Platform.Jvm(C.JvmConfig(None, Nil)),
+        compileSetup = C.CompileSetup(
+          Mixed,
+          addLibraryToBootClasspath = true,
+          addCompilerToClasspath = false,
+          addExtraJarsToClasspath = false,
+          manageBootClasspath = true,
+          filterLibraryFromClasspath = true
+        ),
+        resolution = C.Resolution(Nil)
+      )
+    )
+    val configDir = tmp.resolve(".bloop")
+    Files.createDirectories(configDir)
+    bloop.config.write(file, configDir.resolve("bloop.json"))
+  }
+
+}

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/ExpectSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/ExpectSuite.scala
@@ -154,24 +154,29 @@ trait ExpectHelpers extends FunSuiteLike {
     val semanticdbSemanticidx = path.resolve("META-INF/semanticdb.semanticidx")
     if (Files.exists(semanticdbSemanticidx)) {
       val index = FileIO.readIndex(AbsolutePath(semanticdbSemanticidx))
-      val buf = new StringBuilder
-      buf.append("Packages:" + EOL)
-      buf.append("=========" + EOL)
-      index.packages.sortBy(_.symbol).foreach { entry =>
-        buf.append(entry.symbol + EOL)
-        entry.members.sorted.foreach(member => buf.append("  " + member + EOL))
-      }
-      buf.append(EOL)
-      buf.append("Toplevels:" + EOL)
-      buf.append("==========" + EOL)
-      index.toplevels.sortBy(_.symbol).foreach { entry =>
-        buf.append(s"${entry.symbol} => ${entry.uri}" + EOL)
-      }
-      buf.toString
+      printIndex(index)
     } else {
       ""
     }
   }
+
+  def printIndex(index: s.Index): String = {
+    val buf = new StringBuilder
+    buf.append("Packages:" + EOL)
+    buf.append("=========" + EOL)
+    index.packages.sortBy(_.symbol).foreach { entry =>
+      buf.append(entry.symbol + EOL)
+      entry.members.sorted.foreach(member => buf.append("  " + member + EOL))
+    }
+    buf.append(EOL)
+    buf.append("Toplevels:" + EOL)
+    buf.append("==========" + EOL)
+    index.toplevels.sortBy(_.symbol).foreach { entry =>
+      buf.append(s"${entry.symbol} => ${entry.uri}" + EOL)
+    }
+    buf.toString
+  }
+
 }
 
 object ScalalibExpect extends ExpectHelpers {


### PR DESCRIPTION
This commit fixes a bug in metac so that it plays nicely with
incremental compilation under zinc. We use bloop in the tests to
simplify the integration with zinc and reproduce the bug. This
setup provides a modestly rapid edit/test/debug workflow.

Notes:

- To make semanticdb.semanticidx incremental, we merge an existing index
  file if it exists with the index metadata that we are about to
  persist. Along the way, we prune outdated data that references
  non-existing URIs.
- Zinc depends on an outdated version of ScalaPB (v0.6), which we
  exclude in build.sbt in favor of the latest version of ScalaPB (v0.7).
  Fortunately, Zinc uses only ScalaPB APIs that are available in v0.7
- Zinc is only compiled against 2.12 so the incremental tests run only
  for 2.12.
- The incremental tests take ~10-15s to run so they're labeled as slow.
- Thanks to the new testing infrastructure, we're able to integration test
  that orphan SemanticDB files are indeed removed by metac.

Fixes #1528