### PR TITLE
Improve metacp global cache handling

### DIFF
--- a/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/Main.scala
+++ b/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/Main.scala
@@ -30,40 +30,6 @@ class Main(settings: Settings, reporter: Reporter) {
       Files.createDirectories(settings.cacheDir.toNIO)
     }
 
-    // Writes to a temporary jar file and atomically moves the resulting jar file to cacheEntry once processing
-    // completes. This guarantees the cached jar is never available in half-processed form.
-    def createCachedJar(cacheEntry: AbsolutePath)(f: AbsolutePath => Boolean): Unit = {
-      val tmp = Files.createTempDirectory("metacp").resolve(cacheEntry.toNIO.getFileName)
-      PlatformFileIO.withJarFileSystem(AbsolutePath(tmp), create = true) { out =>
-        val res = f(out)
-        success.compareAndSet(true, res)
-        buffer.add(cacheEntry)
-      }
-      try {
-        Files.move(
-          tmp,
-          cacheEntry.toNIO,
-          StandardCopyOption.ATOMIC_MOVE,
-          StandardCopyOption.REPLACE_EXISTING
-        )
-      } catch {
-        case _: AtomicMoveNotSupportedException =>
-          Files.move(
-            tmp,
-            cacheEntry.toNIO,
-            StandardCopyOption.REPLACE_EXISTING
-          )
-        case _: AccessDeniedException if scala.util.Properties.isWin =>
-          // AccessDeniedException seems to be thrown on Windows when ATOMIC_MOVE is provided
-          // and the target file is being used elsewhere, see https://github.com/scalameta/scalameta/issues/1499
-          Files.move(
-            tmp,
-            cacheEntry.toNIO,
-            StandardCopyOption.REPLACE_EXISTING
-          )
-      }
-    }
-
     classpath.foreach { entry =>
       if (entry.isDirectory) {
         val out = AbsolutePath(Files.createTempDirectory("semanticdb"))
@@ -81,7 +47,7 @@ class Main(settings: Settings, reporter: Reporter) {
         if (cacheEntry.toFile.exists) {
           buffer.add(cacheEntry)
         } else {
-          createCachedJar(cacheEntry) { out =>
+          createCachedJar(success, buffer, cacheEntry) { out =>
             val index = new Index
             def loop(entry: AbsolutePath): Boolean = {
               var result = convertClasspathEntry(entry, out, index)
@@ -113,7 +79,7 @@ class Main(settings: Settings, reporter: Reporter) {
       if (cacheEntry.toFile.exists) {
         buffer.add(cacheEntry)
       } else {
-        createCachedJar(cacheEntry)(dumpScalaLibrarySynthetics)
+        createCachedJar(success, buffer, cacheEntry)(dumpScalaLibrarySynthetics)
       }
     }
 
@@ -122,6 +88,40 @@ class Main(settings: Settings, reporter: Reporter) {
       Some(Classpath(buffer.iterator().asScala.toList))
     } else {
       None
+    }
+  }
+
+  // Writes to a temporary jar file and atomically moves the resulting jar file to cacheEntry once processing
+  // completes. This guarantees the cached jar is never available in half-processed form.
+  private def createCachedJar(
+      success: AtomicBoolean,
+      buffer: ConcurrentLinkedQueue[AbsolutePath],
+      cacheEntry: AbsolutePath)(f: AbsolutePath => Boolean): Unit = {
+    val tmp = Files.createTempDirectory("metacp").resolve(cacheEntry.toNIO.getFileName)
+    PlatformFileIO.withJarFileSystem(AbsolutePath(tmp), create = true) { out =>
+      val res = f(out)
+      success.compareAndSet(true, res)
+      buffer.add(cacheEntry)
+    }
+
+    if (Files.exists(cacheEntry.toNIO)) {
+      // Do nothing, the file has been processed by another thread
+      ()
+    } else {
+      try {
+        Files.move(tmp, cacheEntry.toNIO, StandardCopyOption.ATOMIC_MOVE)
+      } catch {
+        case _: AtomicMoveNotSupportedException =>
+          Files.move(tmp, cacheEntry.toNIO, StandardCopyOption.REPLACE_EXISTING)
+        case _: AccessDeniedException if scala.util.Properties.isWin =>
+          // AccessDeniedException seems to be thrown on Windows when ATOMIC_MOVE is provided
+          // and the target file is being used elsewhere, see https://github.com/scalameta/scalameta/issues/1499
+          Files.move(tmp, cacheEntry.toNIO, StandardCopyOption.REPLACE_EXISTING)
+        case e: FileSystemException
+            if scala.util.Properties.isWin &&
+              // See https://github.com/scalameta/scalameta/issues/1521
+              e.getMessage.contains("being used by another process") =>
+      }
     }
   }
 

--- a/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/Main.scala
+++ b/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/Main.scala
@@ -26,6 +26,15 @@ class Main(settings: Settings, reporter: Reporter) {
 
     val buffer = new ConcurrentLinkedQueue[AbsolutePath]()
 
+    def createCachedJar(cacheEntry: AbsolutePath)(f: AbsolutePath => Boolean): Unit =
+      MetacpGlobalCache.computeIfAbsent(cacheEntry.toNIO) { tmp =>
+        PlatformFileIO.withJarFileSystem(AbsolutePath(tmp), create = true) { out =>
+          val res = f(out)
+          success.compareAndSet(true, res)
+          buffer.add(cacheEntry)
+        }
+      }
+
     if (!Files.exists(Files.createDirectories(settings.cacheDir.toNIO))) {
       Files.createDirectories(settings.cacheDir.toNIO)
     }
@@ -47,7 +56,7 @@ class Main(settings: Settings, reporter: Reporter) {
         if (cacheEntry.toFile.exists) {
           buffer.add(cacheEntry)
         } else {
-          createCachedJar(success, buffer, cacheEntry) { out =>
+          createCachedJar(cacheEntry) { out =>
             val index = new Index
             def loop(entry: AbsolutePath): Boolean = {
               var result = convertClasspathEntry(entry, out, index)
@@ -75,11 +84,11 @@ class Main(settings: Settings, reporter: Reporter) {
     }
 
     if (settings.scalaLibrarySynthetics) {
-      val cacheEntry = settings.cacheDir.resolve("scala-library-synthetics.jar")
-      if (cacheEntry.toFile.exists) {
-        buffer.add(cacheEntry)
+      val cacheTarget = settings.cacheDir.resolve("scala-library-synthetics.jar")
+      if (cacheTarget.toFile.exists) {
+        buffer.add(cacheTarget)
       } else {
-        createCachedJar(success, buffer, cacheEntry)(dumpScalaLibrarySynthetics)
+        createCachedJar(cacheTarget)(dumpScalaLibrarySynthetics)
       }
     }
 
@@ -88,40 +97,6 @@ class Main(settings: Settings, reporter: Reporter) {
       Some(Classpath(buffer.iterator().asScala.toList))
     } else {
       None
-    }
-  }
-
-  // Writes to a temporary jar file and atomically moves the resulting jar file to cacheEntry once processing
-  // completes. This guarantees the cached jar is never available in half-processed form.
-  private def createCachedJar(
-      success: AtomicBoolean,
-      buffer: ConcurrentLinkedQueue[AbsolutePath],
-      cacheEntry: AbsolutePath)(f: AbsolutePath => Boolean): Unit = {
-    val tmp = Files.createTempDirectory("metacp").resolve(cacheEntry.toNIO.getFileName)
-    PlatformFileIO.withJarFileSystem(AbsolutePath(tmp), create = true) { out =>
-      val res = f(out)
-      success.compareAndSet(true, res)
-      buffer.add(cacheEntry)
-    }
-
-    if (Files.exists(cacheEntry.toNIO)) {
-      // Do nothing, the file has been processed by another thread
-      ()
-    } else {
-      try {
-        Files.move(tmp, cacheEntry.toNIO, StandardCopyOption.ATOMIC_MOVE)
-      } catch {
-        case _: AtomicMoveNotSupportedException =>
-          Files.move(tmp, cacheEntry.toNIO, StandardCopyOption.REPLACE_EXISTING)
-        case _: AccessDeniedException if scala.util.Properties.isWin =>
-          // AccessDeniedException seems to be thrown on Windows when ATOMIC_MOVE is provided
-          // and the target file is being used elsewhere, see https://github.com/scalameta/scalameta/issues/1499
-          Files.move(tmp, cacheEntry.toNIO, StandardCopyOption.REPLACE_EXISTING)
-        case e: FileSystemException
-            if scala.util.Properties.isWin &&
-              // See https://github.com/scalameta/scalameta/issues/1521
-              e.getMessage.contains("being used by another process") =>
-      }
     }
   }
 

--- a/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/MetacpGlobalCache.scala
+++ b/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/MetacpGlobalCache.scala
@@ -1,0 +1,82 @@
+package scala.meta.internal.metacp
+
+import java.nio.file.AccessDeniedException
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.FileAlreadyExistsException
+import java.nio.file.FileSystemException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.util.concurrent.ConcurrentHashMap
+import java.util.function
+
+object MetacpGlobalCache {
+
+  private val cacheTargetLocks = new ConcurrentHashMap[Path, Object]()
+
+  def clear(): Unit = cacheTargetLocks.clear()
+
+  /**
+    * Perform an expensive computation and cache the results on disk.
+    *
+    * Does a best-effort to:
+    * - invoke the compute function at most once by using locks.
+    * - ensure the cache file is always either non-existent or
+    *   fully available by using files system atomic moves when
+    *   supported by the file system.
+    *
+    * @param cacheTarget The path to store the cached results.
+    * @param computeFunction The expensive compute function that writes it's results into
+    *                        the callback argument path. The argument is a path to a non-existing
+    *                        temporary file. Once the compute function has completed, the temporary
+    *                        file is moved to the final cache location.
+    */
+  def computeIfAbsent(cacheTarget: Path)(computeFunction: Path => Unit): Unit = {
+    val lock = cacheTargetLocks.computeIfAbsent(cacheTarget, new function.Function[Path, Object] {
+      override def apply(t: Path): AnyRef = new Object
+    })
+    lock.synchronized {
+      if (!Files.exists(cacheTarget)) {
+        val tmpdir = Files.createTempDirectory("metacp")
+        val tmp = tmpdir.resolve(cacheTarget.getFileName)
+        computeFunction(tmp)
+        if (Files.exists(cacheTarget)) {
+          () // In case for example another JVM-process completed before us.
+        } else {
+          tryAtomicMove(tmp, cacheTarget)
+        }
+      }
+    }
+  }
+
+  private object WindowsOnly {
+    def unapply(e: Throwable): Option[Throwable] =
+      if (scala.util.Properties.isWin) Some(e)
+      else None
+  }
+
+  private def tryAtomicMove(source: Path, target: Path): Unit = {
+    try {
+      try Files.move(source, target, StandardCopyOption.ATOMIC_MOVE)
+      catch {
+        // If atomic moves are not supported we must do our best with non-atomic moves.
+        case _: AtomicMoveNotSupportedException =>
+          Files.move(source, target)
+        // See https://github.com/scalameta/scalameta/issues/1499
+        // AccessDeniedException seems to be thrown on Windows when ATOMIC_MOVE is provided
+        // and the target file is already in use.
+        case WindowsOnly(_: AccessDeniedException) =>
+          ()
+        // See https://github.com/scalameta/scalameta/issues/1521
+        case WindowsOnly(e: FileSystemException)
+            if e.getMessage.contains("being used by another process") =>
+          ()
+      }
+    } catch {
+      // If the target file already exists, do nothing.
+      case _: FileAlreadyExistsException =>
+        ()
+    }
+  }
+
+}

--- a/semanticdb/semanticdb/guide.md
+++ b/semanticdb/semanticdb/guide.md
@@ -438,7 +438,7 @@ following scheme:
     The default cache location depends on the OS and is computed using
     [directories-jvm](https://github.com/soc/directories-jvm).
     For example, on macOS the location for scala-library would be
-    `$HOME/Library/Caches/semanticdb/3.7.4/scala-library-FINGERPRINT.jar`.
+    `$HOME/Library/Caches/org.scalameta.SemanticDB/3.7.4/scala-library-FINGERPRINT.jar`.
   * Class directories. Never cached to avoid overflowing the cache with
     transient results.
 


### PR DESCRIPTION
I've encountered several difficult-to-reproduce bugs related to the global metacp cache while testing scalafix on larger project. This PR should hopefully improve the situation, but unfortunately I don't know how to best test it so there are no accompanying tests.