### PR TITLE
Fix vanishing unicode literals in pattern position or other cases

### DIFF
--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
@@ -474,14 +474,7 @@ class LegacyScanner(input: Input, dialect: Dialect) {
       case ')' =>
         nextChar(); token = RPAREN
       case '}' =>
-        // save the end of the current token (exclusive) in case nextChar
-        // advances the offset more than once. See UnicodeEscapeSuite for a
-        // and https://github.com/scalacenter/scalafix/issues/593 for
-        // an example why this this is necessary.
-        val end = charOffset + 1
         nextChar(); token = RBRACE
-        // restore the charOffset to the saved position
-        if (end < buf.length) charOffset = end
       case '[' =>
         nextChar(); token = LBRACKET
       case ']' =>

--- a/tests/jvm/src/test/resources/unicode.txt
+++ b/tests/jvm/src/test/resources/unicode.txt
@@ -1,2 +1,5 @@
 s"${x}\uef17"
 s"]2;SBT${titleName}${titleBranch}\u0007"
+case (r, \u03c6) =>
+case (r,\u03c6) =>
+scala.meta.\u03c6


### PR DESCRIPTION
See https://github.com/scalameta/scalameta/issues/1574 https://github.com/scalacenter/scalafix/issues/619
In addition to the case specified in the issue (vanishing unicode literals in pattern position), I found some other cases (see `tests/jvm/src/test/resources/unicode.txt`)

Now we have some kind of cases that occur the bug,
It maybe reasonable to do that for any call of `potentialUnicode` which may be called by `nextChar` as [@avdv says in the original issue](https://github.com/scalameta/scalameta/issues/819#issuecomment-363248268).

Tested in sbt console.

```
$ cat target/foo.scala
case (r, \u03c6) =>

$ sbt console
...

scala> import scala.meta._
import scala.meta._

scala> Input.File(AbsolutePath("target/foo.scala")).text.parse[Case].get.tokens.map(_.syntax)
res0: scala.collection.immutable.IndexedSeq[String] =
Vector("", case, " ", (, r, ,, " ", \u03c6, ), " ", =>, "
", "")
```