### PR TITLE
Preserve declaration order of methods in javacp.

### DIFF
--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/JavacpSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/JavacpSuite.scala
@@ -1,0 +1,20 @@
+package scala.meta.tests.semanticdb
+
+import org.scalatest.FunSuite
+import scala.meta.internal.semanticdb.ClassSignature
+import scala.meta.internal.semanticdb.Scala._
+
+class JavacpSuite extends FunSuite {
+  test("ClassSignature.declarations order") {
+    val info = MetacMetacpExpectDiffExpect.metacpSymbols("com.javacp.MetacJava#")
+    val ClassSignature(_, _, _, Some(declarations)) = info.signature
+    val obtained = declarations.symlinks.filter(_.desc.name == "overload")
+    val expected = List(
+      "com.javacp.MetacJava#overload().",
+      "com.javacp.MetacJava#overload(+2).",
+      "com.javacp.MetacJava#overload(+1)."
+    )
+    assert(obtained == expected, info.toProtoString)
+  }
+
+}

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/JavacpSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/JavacpSuite.scala
@@ -5,16 +5,43 @@ import scala.meta.internal.semanticdb.ClassSignature
 import scala.meta.internal.semanticdb.Scala._
 
 class JavacpSuite extends FunSuite {
-  test("ClassSignature.declarations order") {
-    val info = MetacMetacpExpectDiffExpect.metacpSymbols("com.javacp.MetacJava#")
-    val ClassSignature(_, _, _, Some(declarations)) = info.signature
-    val obtained = declarations.symlinks.filter(_.desc.name == "overload")
-    val expected = List(
+  private val infos = MetacMetacpExpectDiffExpect.metacpSymbols
+
+  def checkOrder(
+      name: String,
+      symbol: String,
+      filter: String => Boolean,
+      expected: List[String]): Unit =
+    test(name) {
+      val info = infos(symbol)
+      val ClassSignature(_, _, _, Some(declarations)) = info.signature
+      val obtained = declarations.symlinks.filter(filter)
+      assert(obtained == expected, info.toProtoString)
+    }
+
+  checkOrder(
+    "methods",
+    "com.javacp.MetacJava#",
+    _.desc.name == "overload",
+    List(
       "com.javacp.MetacJava#overload().",
       "com.javacp.MetacJava#overload(+2).",
       "com.javacp.MetacJava#overload(+1)."
     )
-    assert(obtained == expected, info.toProtoString)
-  }
+  )
+
+  checkOrder(
+    "fields",
+    "com.javacp.Test#", { s =>
+      s.desc.name == "Int" ||
+      s.desc.name == "Long" ||
+      s.desc.name == "Float"
+    },
+    List(
+      "com.javacp.Test#Int.",
+      "com.javacp.Test#Long.",
+      "com.javacp.Test#Float."
+    )
+  )
 
 }


### PR DESCRIPTION
Fixes https://github.com/scalameta/scalameta/issues/1460.
Note that we can't preserve interleaved order of fields/methods since
ASM separates them in different lists. If we write a custom ASM
ClassNodeVisitor we could probably retrieve it but that can be left for
another PR.