### PR TITLE
use latest geny version (& bump sbt version)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -427,7 +427,7 @@ lazy val testkit = project
     hasLargeIntegrationTests,
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % "3.2.0-SNAP10",
-      "com.lihaoyi" %% "geny" % "0.1.1",
+      "com.lihaoyi" %% "geny" % "0.1.2",
       // These are used to download and extract a corpus tar.gz
       "org.rauschig" % "jarchivelib" % "0.7.1",
       "commons-io" % "commons-io" % "2.5",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=0.13.17

--- a/scalameta/testkit/src/main/scala/scala/meta/testkit/Corpus.scala
+++ b/scalameta/testkit/src/main/scala/scala/meta/testkit/Corpus.scala
@@ -110,7 +110,7 @@ object Corpus {
       throw new IllegalStateException(
         s"${repos.getAbsolutePath} is not a directory! Please delete if it's a file and retry.")
     }
-    Generator.fromIterable(files.toIterable).flatMap { repo =>
+    Generator.from(files.toIterable).flatMap { repo =>
       val commit = FileOps.readFile(new File(repo, "COMMIT")).trim
       val url = FileOps.readFile(new File(repo, "URL")).trim
       FileOps


### PR DESCRIPTION
since there is a source-incompatible change in 0.1.2, this upgrade helps
the Scala community build, where we are normally on the latest versions of
things

sbt version bump is just for good measure