### PR TITLE
add escape hatch allow building on JDK 9+

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,8 +28,10 @@ version.in(ThisBuild) ~= { old =>
 }
 name := {
   println(s"[info] Welcome to scalameta ${version.value}")
-  val javaVersion = sys.props("java.specification.version")
-  if (javaVersion != "1.8") sys.error(s"Obtained Java version $javaVersion. Expected 1.8")
+  if (!sys.props.isDefinedAt("scalameta.allow-any-jdk")) { // escape hatch for Scala community build
+    val javaVersion = sys.props("java.specification.version")
+    if (javaVersion != "1.8") sys.error(s"Obtained Java version $javaVersion. Expected 1.8")
+  }
   "scalametaRoot"
 }
 nonPublishableSettings


### PR DESCRIPTION
this is needed for the Scala community build. we at least need every
build definition to be loadable on JDK 9+ (even if the project doesn't
actually build, tests pass, etc)