### PR TITLE
Support SymbolInformation.annotations in metacp (fix #1315)

### DIFF
--- a/semanticdb/integration/src/main/java/com/javacp/annot/ClassAnnotation.java
+++ b/semanticdb/integration/src/main/java/com/javacp/annot/ClassAnnotation.java
@@ -1,0 +1,10 @@
+package com.javacp.annot;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE)
+public @interface ClassAnnotation{}

--- a/semanticdb/integration/src/main/java/com/javacp/annot/ConstructorAnnotation.java
+++ b/semanticdb/integration/src/main/java/com/javacp/annot/ConstructorAnnotation.java
@@ -1,0 +1,10 @@
+package com.javacp.annot;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.CONSTRUCTOR)
+public @interface ConstructorAnnotation{}

--- a/semanticdb/integration/src/main/java/com/javacp/annot/FieldAnnotation.java
+++ b/semanticdb/integration/src/main/java/com/javacp/annot/FieldAnnotation.java
@@ -1,0 +1,10 @@
+package com.javacp.annot;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.FIELD)
+public @interface FieldAnnotation{}

--- a/semanticdb/integration/src/main/java/com/javacp/annot/InterfaceAnnotation.java
+++ b/semanticdb/integration/src/main/java/com/javacp/annot/InterfaceAnnotation.java
@@ -1,0 +1,10 @@
+package com.javacp.annot;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE)
+public @interface InterfaceAnnotation{}

--- a/semanticdb/integration/src/main/java/com/javacp/annot/LocalAnnotation.java
+++ b/semanticdb/integration/src/main/java/com/javacp/annot/LocalAnnotation.java
@@ -1,0 +1,10 @@
+package com.javacp.annot;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.LOCAL_VARIABLE)
+public @interface LocalAnnotation{}

--- a/semanticdb/integration/src/main/java/com/javacp/annot/MacroAnnotation.java
+++ b/semanticdb/integration/src/main/java/com/javacp/annot/MacroAnnotation.java
@@ -1,0 +1,10 @@
+package com.javacp.annot;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.METHOD)
+public @interface MacroAnnotation{}

--- a/semanticdb/integration/src/main/java/com/javacp/annot/MethodAnnotation.java
+++ b/semanticdb/integration/src/main/java/com/javacp/annot/MethodAnnotation.java
@@ -1,0 +1,10 @@
+package com.javacp.annot;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.METHOD)
+public @interface MethodAnnotation{}

--- a/semanticdb/integration/src/main/java/com/javacp/annot/ObjectAnnotation.java
+++ b/semanticdb/integration/src/main/java/com/javacp/annot/ObjectAnnotation.java
@@ -1,0 +1,10 @@
+package com.javacp.annot;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE)
+public @interface ObjectAnnotation{}

--- a/semanticdb/integration/src/main/java/com/javacp/annot/PackageAnnotation.java
+++ b/semanticdb/integration/src/main/java/com/javacp/annot/PackageAnnotation.java
@@ -1,0 +1,10 @@
+package com.javacp.annot;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.PACKAGE)
+public @interface PackageAnnotation{}

--- a/semanticdb/integration/src/main/java/com/javacp/annot/PackageObjectAnnotation.java
+++ b/semanticdb/integration/src/main/java/com/javacp/annot/PackageObjectAnnotation.java
@@ -1,0 +1,10 @@
+package com.javacp.annot;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.PACKAGE)
+public @interface PackageObjectAnnotation{}

--- a/semanticdb/integration/src/main/java/com/javacp/annot/ParameterAnnotation.java
+++ b/semanticdb/integration/src/main/java/com/javacp/annot/ParameterAnnotation.java
@@ -1,0 +1,10 @@
+package com.javacp.annot;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.PARAMETER)
+public @interface ParameterAnnotation{}

--- a/semanticdb/integration/src/main/java/com/javacp/annot/SelfParameterAnnotation.java
+++ b/semanticdb/integration/src/main/java/com/javacp/annot/SelfParameterAnnotation.java
@@ -1,0 +1,10 @@
+package com.javacp.annot;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.PARAMETER)
+public @interface SelfParameterAnnotation{}

--- a/semanticdb/integration/src/main/java/com/javacp/annot/TraitAnnotation.java
+++ b/semanticdb/integration/src/main/java/com/javacp/annot/TraitAnnotation.java
@@ -1,0 +1,10 @@
+package com.javacp.annot;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE)
+public @interface TraitAnnotation{}

--- a/semanticdb/integration/src/main/java/com/javacp/annot/TypeAnnotation.java
+++ b/semanticdb/integration/src/main/java/com/javacp/annot/TypeAnnotation.java
@@ -1,0 +1,10 @@
+package com.javacp.annot;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE)
+public @interface TypeAnnotation{}

--- a/semanticdb/integration/src/main/java/com/javacp/annot/TypeParameterAnnotation.java
+++ b/semanticdb/integration/src/main/java/com/javacp/annot/TypeParameterAnnotation.java
@@ -1,0 +1,10 @@
+package com.javacp.annot;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE_PARAMETER)
+public @interface TypeParameterAnnotation{}

--- a/semanticdb/integration/src/main/java/com/javacp/annot/usage/AnnotatedInterface.java
+++ b/semanticdb/integration/src/main/java/com/javacp/annot/usage/AnnotatedInterface.java
@@ -1,0 +1,4 @@
+package com.javacp.annot.usage;
+
+@com.javacp.annot.InterfaceAnnotation
+public @interface AnnotatedInterface{}

--- a/semanticdb/integration/src/main/java/com/javacp/annot/usage/AnnotatedPackage.java
+++ b/semanticdb/integration/src/main/java/com/javacp/annot/usage/AnnotatedPackage.java
@@ -1,0 +1,5 @@
+// compiler crash
+// @annot.ParameterAnnotation
+package com.javacp.annot.usage;
+
+public class AnnotatedPackage{}

--- a/semanticdb/integration/src/main/scala/example/Annotations.scala
+++ b/semanticdb/integration/src/main/scala/example/Annotations.scala
@@ -1,0 +1,34 @@
+package annot
+
+import scala.language.experimental.macros
+
+import com.javacp.annot._
+
+@ClassAnnotation
+class Annotations[@TypeParameterAnnotation T](@ParameterAnnotation x: T) { self: AnyRef =>
+  @FieldAnnotation
+  val field = 42
+
+  @MethodAnnotation
+  def method = {
+    @LocalAnnotation
+    val local = 42
+    local
+  }
+  @TypeAnnotation
+  type T
+}
+
+class B @ConstructorAnnotation()(x: Int) {
+  @ConstructorAnnotation
+  def this() = this(42)
+}
+
+@ObjectAnnotation
+object M {
+  @MacroAnnotation
+  def m[TT] = macro ???
+}
+
+@TraitAnnotation
+trait T

--- a/semanticdb/metacp/src/main/scala/scala/meta/internal/scalacp/SymbolInformationOps.scala
+++ b/semanticdb/metacp/src/main/scala/scala/meta/internal/scalacp/SymbolInformationOps.scala
@@ -215,9 +215,29 @@ trait SymbolInformationOps { self: Scalacp =>
       }
     }
 
+    private val syntheticAnnotationsSymbols = Set(
+      "scala.reflect.macros.internal.macroImpl#"
+    )
+    private def syntheticAnnotations(annot: s.Annotation): Boolean = {
+      annot.tpe match {
+        case s.TypeRef(_, sym, _) => syntheticAnnotationsSymbols.contains(sym)
+        case _ => false
+      }
+    }
+
     private def annotations: List[s.Annotation] = {
-      // FIXME: https://github.com/scalameta/scalameta/issues/1315
-      Nil
+      sym match {
+        case c: ScalaSigSymbol =>
+          val annots =
+            c.attributes
+              .map(attribute => s.Annotation(attribute.typeRef.toSemanticTpe))
+              .toList
+
+          annots.filterNot(syntheticAnnotations)
+
+        case _ =>
+          Nil
+      }
     }
 
     private def accessibility: Option[s.Accessibility] = {

--- a/tests/jvm/src/test/resources/metac-metacp.diff
+++ b/tests/jvm/src/test/resources/metac-metacp.diff
@@ -144,6 +144,22 @@ advanced/Test.s3().
                      name: "x"
 
 
+============
+annot/M.m().
+============
+--- metac
++++ metacp
++annotations {
++  tpe {
++    typeRef {
++      prefix {
++      symbol: "scala/reflect/macros/internal/macroImpl#"
++}
+ accessibility {
+   tag: PUBLIC
+   symbol: ""
+
+
 ============================
 classes/C3#copy$default$1().
 ============================
@@ -956,6 +972,454 @@ com/javacp/Test#wildcard(+1).(b)
 -                    symbol: "scala/Any#"
 
 
+=================================
+com/javacp/annot/ClassAnnotation#
+=================================
+--- metac
++++ metacp
+ symbol: "com/javacp/annot/ClassAnnotation#"
+-kind: CLASS
+-properties: 0
++kind: INTERFACE
++properties: 4
+ name: "ClassAnnotation"
+ accessibility {
+   tag: PUBLIC
+       typeRef {
+         prefix {
+-        symbol: "scala/annotation/Annotation#"
++        symbol: "java/lang/Object#"
+     parents {
+         symbol: "java/lang/annotation/Annotation#"
+-    parents {
+-      typeRef {
+-        prefix {
+-        symbol: "scala/annotation/ClassfileAnnotation#"
+     self {
+     declarations {
+-      symlinks: "com/javacp/annot/ClassAnnotation#`<init>`()."
+
+
+=======================================
+com/javacp/annot/ConstructorAnnotation#
+=======================================
+--- metac
++++ metacp
+ symbol: "com/javacp/annot/ConstructorAnnotation#"
+-kind: CLASS
+-properties: 0
++kind: INTERFACE
++properties: 4
+ name: "ConstructorAnnotation"
+ accessibility {
+   tag: PUBLIC
+       typeRef {
+         prefix {
+-        symbol: "scala/annotation/Annotation#"
++        symbol: "java/lang/Object#"
+     parents {
+         symbol: "java/lang/annotation/Annotation#"
+-    parents {
+-      typeRef {
+-        prefix {
+-        symbol: "scala/annotation/ClassfileAnnotation#"
+     self {
+     declarations {
+-      symlinks: "com/javacp/annot/ConstructorAnnotation#`<init>`()."
+
+
+=================================
+com/javacp/annot/FieldAnnotation#
+=================================
+--- metac
++++ metacp
+ symbol: "com/javacp/annot/FieldAnnotation#"
+-kind: CLASS
+-properties: 0
++kind: INTERFACE
++properties: 4
+ name: "FieldAnnotation"
+ accessibility {
+   tag: PUBLIC
+       typeRef {
+         prefix {
+-        symbol: "scala/annotation/Annotation#"
++        symbol: "java/lang/Object#"
+     parents {
+         symbol: "java/lang/annotation/Annotation#"
+-    parents {
+-      typeRef {
+-        prefix {
+-        symbol: "scala/annotation/ClassfileAnnotation#"
+     self {
+     declarations {
+-      symlinks: "com/javacp/annot/FieldAnnotation#`<init>`()."
+
+
+=====================================
+com/javacp/annot/InterfaceAnnotation#
+=====================================
+--- metac
++++ metacp
+ symbol: "com/javacp/annot/InterfaceAnnotation#"
+-kind: CLASS
+-properties: 0
++kind: INTERFACE
++properties: 4
+ name: "InterfaceAnnotation"
+ accessibility {
+   tag: PUBLIC
+       typeRef {
+         prefix {
+-        symbol: "scala/annotation/Annotation#"
++        symbol: "java/lang/Object#"
+     parents {
+         symbol: "java/lang/annotation/Annotation#"
+-    parents {
+-      typeRef {
+-        prefix {
+-        symbol: "scala/annotation/ClassfileAnnotation#"
+     self {
+     declarations {
+-      symlinks: "com/javacp/annot/InterfaceAnnotation#`<init>`()."
+
+
+=================================
+com/javacp/annot/LocalAnnotation#
+=================================
+--- metac
++++ metacp
+ symbol: "com/javacp/annot/LocalAnnotation#"
+-kind: CLASS
+-properties: 0
++kind: INTERFACE
++properties: 4
+ name: "LocalAnnotation"
+ accessibility {
+   tag: PUBLIC
+       typeRef {
+         prefix {
+-        symbol: "scala/annotation/Annotation#"
++        symbol: "java/lang/Object#"
+     parents {
+         symbol: "java/lang/annotation/Annotation#"
+-    parents {
+-      typeRef {
+-        prefix {
+-        symbol: "scala/annotation/ClassfileAnnotation#"
+     self {
+     declarations {
+-      symlinks: "com/javacp/annot/LocalAnnotation#`<init>`()."
+
+
+=================================
+com/javacp/annot/MacroAnnotation#
+=================================
+--- metac
++++ metacp
+ symbol: "com/javacp/annot/MacroAnnotation#"
+-kind: CLASS
+-properties: 0
++kind: INTERFACE
++properties: 4
+ name: "MacroAnnotation"
+ accessibility {
+   tag: PUBLIC
+       typeRef {
+         prefix {
+-        symbol: "scala/annotation/Annotation#"
++        symbol: "java/lang/Object#"
+     parents {
+         symbol: "java/lang/annotation/Annotation#"
+-    parents {
+-      typeRef {
+-        prefix {
+-        symbol: "scala/annotation/ClassfileAnnotation#"
+     self {
+     declarations {
+-      symlinks: "com/javacp/annot/MacroAnnotation#`<init>`()."
+
+
+==================================
+com/javacp/annot/MethodAnnotation#
+==================================
+--- metac
++++ metacp
+ symbol: "com/javacp/annot/MethodAnnotation#"
+-kind: CLASS
+-properties: 0
++kind: INTERFACE
++properties: 4
+ name: "MethodAnnotation"
+ accessibility {
+   tag: PUBLIC
+       typeRef {
+         prefix {
+-        symbol: "scala/annotation/Annotation#"
++        symbol: "java/lang/Object#"
+     parents {
+         symbol: "java/lang/annotation/Annotation#"
+-    parents {
+-      typeRef {
+-        prefix {
+-        symbol: "scala/annotation/ClassfileAnnotation#"
+     self {
+     declarations {
+-      symlinks: "com/javacp/annot/MethodAnnotation#`<init>`()."
+
+
+==================================
+com/javacp/annot/ObjectAnnotation#
+==================================
+--- metac
++++ metacp
+ symbol: "com/javacp/annot/ObjectAnnotation#"
+-kind: CLASS
+-properties: 0
++kind: INTERFACE
++properties: 4
+ name: "ObjectAnnotation"
+ accessibility {
+   tag: PUBLIC
+       typeRef {
+         prefix {
+-        symbol: "scala/annotation/Annotation#"
++        symbol: "java/lang/Object#"
+     parents {
+         symbol: "java/lang/annotation/Annotation#"
+-    parents {
+-      typeRef {
+-        prefix {
+-        symbol: "scala/annotation/ClassfileAnnotation#"
+     self {
+     declarations {
+-      symlinks: "com/javacp/annot/ObjectAnnotation#`<init>`()."
+
+
+===================================
+com/javacp/annot/PackageAnnotation#
+===================================
+--- metac
++++ metacp
+ symbol: "com/javacp/annot/PackageAnnotation#"
+-kind: CLASS
+-properties: 0
++kind: INTERFACE
++properties: 4
+ name: "PackageAnnotation"
+ accessibility {
+   tag: PUBLIC
+       typeRef {
+         prefix {
+-        symbol: "scala/annotation/Annotation#"
++        symbol: "java/lang/Object#"
+     parents {
+         symbol: "java/lang/annotation/Annotation#"
+-    parents {
+-      typeRef {
+-        prefix {
+-        symbol: "scala/annotation/ClassfileAnnotation#"
+     self {
+     declarations {
+-      symlinks: "com/javacp/annot/PackageAnnotation#`<init>`()."
+
+
+=========================================
+com/javacp/annot/PackageObjectAnnotation#
+=========================================
+--- metac
++++ metacp
+ symbol: "com/javacp/annot/PackageObjectAnnotation#"
+-kind: CLASS
+-properties: 0
++kind: INTERFACE
++properties: 4
+ name: "PackageObjectAnnotation"
+ accessibility {
+   tag: PUBLIC
+       typeRef {
+         prefix {
+-        symbol: "scala/annotation/Annotation#"
++        symbol: "java/lang/Object#"
+     parents {
+         symbol: "java/lang/annotation/Annotation#"
+-    parents {
+-      typeRef {
+-        prefix {
+-        symbol: "scala/annotation/ClassfileAnnotation#"
+     self {
+     declarations {
+-      symlinks: "com/javacp/annot/PackageObjectAnnotation#`<init>`()."
+
+
+=====================================
+com/javacp/annot/ParameterAnnotation#
+=====================================
+--- metac
++++ metacp
+ symbol: "com/javacp/annot/ParameterAnnotation#"
+-kind: CLASS
+-properties: 0
++kind: INTERFACE
++properties: 4
+ name: "ParameterAnnotation"
+ accessibility {
+   tag: PUBLIC
+       typeRef {
+         prefix {
+-        symbol: "scala/annotation/Annotation#"
++        symbol: "java/lang/Object#"
+     parents {
+         symbol: "java/lang/annotation/Annotation#"
+-    parents {
+-      typeRef {
+-        prefix {
+-        symbol: "scala/annotation/ClassfileAnnotation#"
+     self {
+     declarations {
+-      symlinks: "com/javacp/annot/ParameterAnnotation#`<init>`()."
+
+
+=========================================
+com/javacp/annot/SelfParameterAnnotation#
+=========================================
+--- metac
++++ metacp
+ symbol: "com/javacp/annot/SelfParameterAnnotation#"
+-kind: CLASS
+-properties: 0
++kind: INTERFACE
++properties: 4
+ name: "SelfParameterAnnotation"
+ accessibility {
+   tag: PUBLIC
+       typeRef {
+         prefix {
+-        symbol: "scala/annotation/Annotation#"
++        symbol: "java/lang/Object#"
+     parents {
+         symbol: "java/lang/annotation/Annotation#"
+-    parents {
+-      typeRef {
+-        prefix {
+-        symbol: "scala/annotation/ClassfileAnnotation#"
+     self {
+     declarations {
+-      symlinks: "com/javacp/annot/SelfParameterAnnotation#`<init>`()."
+
+
+=================================
+com/javacp/annot/TraitAnnotation#
+=================================
+--- metac
++++ metacp
+ symbol: "com/javacp/annot/TraitAnnotation#"
+-kind: CLASS
+-properties: 0
++kind: INTERFACE
++properties: 4
+ name: "TraitAnnotation"
+ accessibility {
+   tag: PUBLIC
+       typeRef {
+         prefix {
+-        symbol: "scala/annotation/Annotation#"
++        symbol: "java/lang/Object#"
+     parents {
+         symbol: "java/lang/annotation/Annotation#"
+-    parents {
+-      typeRef {
+-        prefix {
+-        symbol: "scala/annotation/ClassfileAnnotation#"
+     self {
+     declarations {
+-      symlinks: "com/javacp/annot/TraitAnnotation#`<init>`()."
+
+
+================================
+com/javacp/annot/TypeAnnotation#
+================================
+--- metac
++++ metacp
+ symbol: "com/javacp/annot/TypeAnnotation#"
+-kind: CLASS
+-properties: 0
++kind: INTERFACE
++properties: 4
+ name: "TypeAnnotation"
+ accessibility {
+   tag: PUBLIC
+       typeRef {
+         prefix {
+-        symbol: "scala/annotation/Annotation#"
++        symbol: "java/lang/Object#"
+     parents {
+         symbol: "java/lang/annotation/Annotation#"
+-    parents {
+-      typeRef {
+-        prefix {
+-        symbol: "scala/annotation/ClassfileAnnotation#"
+     self {
+     declarations {
+-      symlinks: "com/javacp/annot/TypeAnnotation#`<init>`()."
+
+
+=========================================
+com/javacp/annot/TypeParameterAnnotation#
+=========================================
+--- metac
++++ metacp
+ symbol: "com/javacp/annot/TypeParameterAnnotation#"
+-kind: CLASS
+-properties: 0
++kind: INTERFACE
++properties: 4
+ name: "TypeParameterAnnotation"
+ accessibility {
+   tag: PUBLIC
+       typeRef {
+         prefix {
+-        symbol: "scala/annotation/Annotation#"
++        symbol: "java/lang/Object#"
+     parents {
+         symbol: "java/lang/annotation/Annotation#"
+-    parents {
+-      typeRef {
+-        prefix {
+-        symbol: "scala/annotation/ClassfileAnnotation#"
+     self {
+     declarations {
+-      symlinks: "com/javacp/annot/TypeParameterAnnotation#`<init>`()."
+
+
+==========================================
+com/javacp/annot/usage/AnnotatedInterface#
+==========================================
+--- metac
++++ metacp
+ symbol: "com/javacp/annot/usage/AnnotatedInterface#"
+-kind: CLASS
+-properties: 0
++kind: INTERFACE
++properties: 4
+ name: "AnnotatedInterface"
+ accessibility {
+   tag: PUBLIC
+       typeRef {
+         prefix {
+-        symbol: "scala/annotation/Annotation#"
++        symbol: "java/lang/Object#"
+     parents {
+         symbol: "java/lang/annotation/Annotation#"
+-    parents {
+-      typeRef {
+-        prefix {
+-        symbol: "scala/annotation/ClassfileAnnotation#"
+     self {
+     declarations {
+-      symlinks: "com/javacp/annot/usage/AnnotatedInterface#`<init>`()."
+
+
 ============
 example/Acc#
 ============
@@ -1028,20 +1492,20 @@ flags/p/package.
        symlinks: "flags/p/package.xs1()."
 
 
-=====================
-flags/p/package.S#[T]
-=====================
+====================
+flags/p/package.m().
+====================
 --- metac
 +++ metacp
- kind: TYPE_PARAMETER
+ kind: MACRO
  properties: 0
- name: "T"
--annotations {
--  tpe {
--    typeRef {
--      prefix {
--      symbol: "scala/specialized#"
--}
+ name: "m"
++annotations {
++  tpe {
++    typeRef {
++      prefix {
++      symbol: "scala/reflect/macros/internal/macroImpl#"
++}
  accessibility {
    tag: PUBLIC
    symbol: ""

--- a/tests/jvm/src/test/resources/metac.expect
+++ b/tests/jvm/src/test/resources/metac.expect
@@ -1,3 +1,290 @@
+semanticdb/integration/src/main/java/com/javacp/annot/ClassAnnotation.java
+--------------------------------------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => semanticdb/integration/src/main/java/com/javacp/annot/ClassAnnotation.java
+Text => non-empty
+Language => Java
+Symbols => 2 entries
+
+Symbols:
+com/javacp/annot/ClassAnnotation# => class ClassAnnotation extends Annotation with Annotation with ClassfileAnnotation { +1 decls }
+  Annotation => scala/annotation/Annotation#
+  Annotation => java/lang/annotation/Annotation#
+  ClassfileAnnotation => scala/annotation/ClassfileAnnotation#
+com/javacp/annot/ClassAnnotation#`<init>`(). => ctor <init>()
+
+semanticdb/integration/src/main/java/com/javacp/annot/ConstructorAnnotation.java
+--------------------------------------------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => semanticdb/integration/src/main/java/com/javacp/annot/ConstructorAnnotation.java
+Text => non-empty
+Language => Java
+Symbols => 2 entries
+
+Symbols:
+com/javacp/annot/ConstructorAnnotation# => class ConstructorAnnotation extends Annotation with Annotation with ClassfileAnnotation { +1 decls }
+  Annotation => scala/annotation/Annotation#
+  Annotation => java/lang/annotation/Annotation#
+  ClassfileAnnotation => scala/annotation/ClassfileAnnotation#
+com/javacp/annot/ConstructorAnnotation#`<init>`(). => ctor <init>()
+
+semanticdb/integration/src/main/java/com/javacp/annot/FieldAnnotation.java
+--------------------------------------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => semanticdb/integration/src/main/java/com/javacp/annot/FieldAnnotation.java
+Text => non-empty
+Language => Java
+Symbols => 2 entries
+
+Symbols:
+com/javacp/annot/FieldAnnotation# => class FieldAnnotation extends Annotation with Annotation with ClassfileAnnotation { +1 decls }
+  Annotation => scala/annotation/Annotation#
+  Annotation => java/lang/annotation/Annotation#
+  ClassfileAnnotation => scala/annotation/ClassfileAnnotation#
+com/javacp/annot/FieldAnnotation#`<init>`(). => ctor <init>()
+
+semanticdb/integration/src/main/java/com/javacp/annot/InterfaceAnnotation.java
+------------------------------------------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => semanticdb/integration/src/main/java/com/javacp/annot/InterfaceAnnotation.java
+Text => non-empty
+Language => Java
+Symbols => 2 entries
+
+Symbols:
+com/javacp/annot/InterfaceAnnotation# => class InterfaceAnnotation extends Annotation with Annotation with ClassfileAnnotation { +1 decls }
+  Annotation => scala/annotation/Annotation#
+  Annotation => java/lang/annotation/Annotation#
+  ClassfileAnnotation => scala/annotation/ClassfileAnnotation#
+com/javacp/annot/InterfaceAnnotation#`<init>`(). => ctor <init>()
+
+semanticdb/integration/src/main/java/com/javacp/annot/LocalAnnotation.java
+--------------------------------------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => semanticdb/integration/src/main/java/com/javacp/annot/LocalAnnotation.java
+Text => non-empty
+Language => Java
+Symbols => 2 entries
+
+Symbols:
+com/javacp/annot/LocalAnnotation# => class LocalAnnotation extends Annotation with Annotation with ClassfileAnnotation { +1 decls }
+  Annotation => scala/annotation/Annotation#
+  Annotation => java/lang/annotation/Annotation#
+  ClassfileAnnotation => scala/annotation/ClassfileAnnotation#
+com/javacp/annot/LocalAnnotation#`<init>`(). => ctor <init>()
+
+semanticdb/integration/src/main/java/com/javacp/annot/MacroAnnotation.java
+--------------------------------------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => semanticdb/integration/src/main/java/com/javacp/annot/MacroAnnotation.java
+Text => non-empty
+Language => Java
+Symbols => 2 entries
+
+Symbols:
+com/javacp/annot/MacroAnnotation# => class MacroAnnotation extends Annotation with Annotation with ClassfileAnnotation { +1 decls }
+  Annotation => scala/annotation/Annotation#
+  Annotation => java/lang/annotation/Annotation#
+  ClassfileAnnotation => scala/annotation/ClassfileAnnotation#
+com/javacp/annot/MacroAnnotation#`<init>`(). => ctor <init>()
+
+semanticdb/integration/src/main/java/com/javacp/annot/MethodAnnotation.java
+---------------------------------------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => semanticdb/integration/src/main/java/com/javacp/annot/MethodAnnotation.java
+Text => non-empty
+Language => Java
+Symbols => 2 entries
+
+Symbols:
+com/javacp/annot/MethodAnnotation# => class MethodAnnotation extends Annotation with Annotation with ClassfileAnnotation { +1 decls }
+  Annotation => scala/annotation/Annotation#
+  Annotation => java/lang/annotation/Annotation#
+  ClassfileAnnotation => scala/annotation/ClassfileAnnotation#
+com/javacp/annot/MethodAnnotation#`<init>`(). => ctor <init>()
+
+semanticdb/integration/src/main/java/com/javacp/annot/ObjectAnnotation.java
+---------------------------------------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => semanticdb/integration/src/main/java/com/javacp/annot/ObjectAnnotation.java
+Text => non-empty
+Language => Java
+Symbols => 2 entries
+
+Symbols:
+com/javacp/annot/ObjectAnnotation# => class ObjectAnnotation extends Annotation with Annotation with ClassfileAnnotation { +1 decls }
+  Annotation => scala/annotation/Annotation#
+  Annotation => java/lang/annotation/Annotation#
+  ClassfileAnnotation => scala/annotation/ClassfileAnnotation#
+com/javacp/annot/ObjectAnnotation#`<init>`(). => ctor <init>()
+
+semanticdb/integration/src/main/java/com/javacp/annot/PackageAnnotation.java
+----------------------------------------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => semanticdb/integration/src/main/java/com/javacp/annot/PackageAnnotation.java
+Text => non-empty
+Language => Java
+Symbols => 2 entries
+
+Symbols:
+com/javacp/annot/PackageAnnotation# => class PackageAnnotation extends Annotation with Annotation with ClassfileAnnotation { +1 decls }
+  Annotation => scala/annotation/Annotation#
+  Annotation => java/lang/annotation/Annotation#
+  ClassfileAnnotation => scala/annotation/ClassfileAnnotation#
+com/javacp/annot/PackageAnnotation#`<init>`(). => ctor <init>()
+
+semanticdb/integration/src/main/java/com/javacp/annot/PackageObjectAnnotation.java
+----------------------------------------------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => semanticdb/integration/src/main/java/com/javacp/annot/PackageObjectAnnotation.java
+Text => non-empty
+Language => Java
+Symbols => 2 entries
+
+Symbols:
+com/javacp/annot/PackageObjectAnnotation# => class PackageObjectAnnotation extends Annotation with Annotation with ClassfileAnnotation { +1 decls }
+  Annotation => scala/annotation/Annotation#
+  Annotation => java/lang/annotation/Annotation#
+  ClassfileAnnotation => scala/annotation/ClassfileAnnotation#
+com/javacp/annot/PackageObjectAnnotation#`<init>`(). => ctor <init>()
+
+semanticdb/integration/src/main/java/com/javacp/annot/ParameterAnnotation.java
+------------------------------------------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => semanticdb/integration/src/main/java/com/javacp/annot/ParameterAnnotation.java
+Text => non-empty
+Language => Java
+Symbols => 2 entries
+
+Symbols:
+com/javacp/annot/ParameterAnnotation# => class ParameterAnnotation extends Annotation with Annotation with ClassfileAnnotation { +1 decls }
+  Annotation => scala/annotation/Annotation#
+  Annotation => java/lang/annotation/Annotation#
+  ClassfileAnnotation => scala/annotation/ClassfileAnnotation#
+com/javacp/annot/ParameterAnnotation#`<init>`(). => ctor <init>()
+
+semanticdb/integration/src/main/java/com/javacp/annot/SelfParameterAnnotation.java
+----------------------------------------------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => semanticdb/integration/src/main/java/com/javacp/annot/SelfParameterAnnotation.java
+Text => non-empty
+Language => Java
+Symbols => 2 entries
+
+Symbols:
+com/javacp/annot/SelfParameterAnnotation# => class SelfParameterAnnotation extends Annotation with Annotation with ClassfileAnnotation { +1 decls }
+  Annotation => scala/annotation/Annotation#
+  Annotation => java/lang/annotation/Annotation#
+  ClassfileAnnotation => scala/annotation/ClassfileAnnotation#
+com/javacp/annot/SelfParameterAnnotation#`<init>`(). => ctor <init>()
+
+semanticdb/integration/src/main/java/com/javacp/annot/TraitAnnotation.java
+--------------------------------------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => semanticdb/integration/src/main/java/com/javacp/annot/TraitAnnotation.java
+Text => non-empty
+Language => Java
+Symbols => 2 entries
+
+Symbols:
+com/javacp/annot/TraitAnnotation# => class TraitAnnotation extends Annotation with Annotation with ClassfileAnnotation { +1 decls }
+  Annotation => scala/annotation/Annotation#
+  Annotation => java/lang/annotation/Annotation#
+  ClassfileAnnotation => scala/annotation/ClassfileAnnotation#
+com/javacp/annot/TraitAnnotation#`<init>`(). => ctor <init>()
+
+semanticdb/integration/src/main/java/com/javacp/annot/TypeAnnotation.java
+-------------------------------------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => semanticdb/integration/src/main/java/com/javacp/annot/TypeAnnotation.java
+Text => non-empty
+Language => Java
+Symbols => 2 entries
+
+Symbols:
+com/javacp/annot/TypeAnnotation# => class TypeAnnotation extends Annotation with Annotation with ClassfileAnnotation { +1 decls }
+  Annotation => scala/annotation/Annotation#
+  Annotation => java/lang/annotation/Annotation#
+  ClassfileAnnotation => scala/annotation/ClassfileAnnotation#
+com/javacp/annot/TypeAnnotation#`<init>`(). => ctor <init>()
+
+semanticdb/integration/src/main/java/com/javacp/annot/TypeParameterAnnotation.java
+----------------------------------------------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => semanticdb/integration/src/main/java/com/javacp/annot/TypeParameterAnnotation.java
+Text => non-empty
+Language => Java
+Symbols => 2 entries
+
+Symbols:
+com/javacp/annot/TypeParameterAnnotation# => class TypeParameterAnnotation extends Annotation with Annotation with ClassfileAnnotation { +1 decls }
+  Annotation => scala/annotation/Annotation#
+  Annotation => java/lang/annotation/Annotation#
+  ClassfileAnnotation => scala/annotation/ClassfileAnnotation#
+com/javacp/annot/TypeParameterAnnotation#`<init>`(). => ctor <init>()
+
+semanticdb/integration/src/main/java/com/javacp/annot/usage/AnnotatedInterface.java
+-----------------------------------------------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => semanticdb/integration/src/main/java/com/javacp/annot/usage/AnnotatedInterface.java
+Text => non-empty
+Language => Java
+Symbols => 2 entries
+
+Symbols:
+com/javacp/annot/usage/AnnotatedInterface# => class AnnotatedInterface extends Annotation with Annotation with ClassfileAnnotation { +1 decls }
+  Annotation => scala/annotation/Annotation#
+  Annotation => java/lang/annotation/Annotation#
+  ClassfileAnnotation => scala/annotation/ClassfileAnnotation#
+com/javacp/annot/usage/AnnotatedInterface#`<init>`(). => ctor <init>()
+
+semanticdb/integration/src/main/java/com/javacp/annot/usage/AnnotatedPackage.java
+---------------------------------------------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => semanticdb/integration/src/main/java/com/javacp/annot/usage/AnnotatedPackage.java
+Text => non-empty
+Language => Java
+Symbols => 2 entries
+
+Symbols:
+com/javacp/annot/usage/AnnotatedPackage# => class AnnotatedPackage extends Object { +1 decls }
+  Object => java/lang/Object#
+com/javacp/annot/usage/AnnotatedPackage#`<init>`(). => ctor <init>()
+
 semanticdb/integration/src/main/java/com/javacp/ClassSuffix.java
 ----------------------------------------------------------------
 
@@ -781,6 +1068,127 @@ Synthetics:
 [39:9..39:9):  => *[Unit]
   [0:0..0:1): * => _star_.
   [0:2..0:6): Unit => scala/Unit#
+
+semanticdb/integration/src/main/scala/example/Annotations.scala
+---------------------------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => semanticdb/integration/src/main/scala/example/Annotations.scala
+Text => non-empty
+Language => Scala
+Symbols => 19 entries
+Occurrences => 54 entries
+
+Symbols:
+annot/Annotations# => @ClassAnnotation class Annotations[@TypeParameterAnnotation T] extends AnyRef { self: AnyRef => +5 decls }
+  ClassAnnotation => com/javacp/annot/ClassAnnotation#
+  T => annot/Annotations#[T]
+  TypeParameterAnnotation => com/javacp/annot/TypeParameterAnnotation#
+  AnyRef => scala/AnyRef#
+annot/Annotations#T# => @TypeAnnotation abstract type T
+  TypeAnnotation => com/javacp/annot/TypeAnnotation#
+annot/Annotations#[T] => @TypeParameterAnnotation typeparam T
+  TypeParameterAnnotation => com/javacp/annot/TypeParameterAnnotation#
+annot/Annotations#`<init>`(). => primary ctor <init>(@ParameterAnnotation x: T)
+  x => annot/Annotations#`<init>`().(x)
+  ParameterAnnotation => com/javacp/annot/ParameterAnnotation#
+  T => annot/Annotations#[T]
+annot/Annotations#`<init>`().(x) => @ParameterAnnotation param x: T
+  ParameterAnnotation => com/javacp/annot/ParameterAnnotation#
+  T => annot/Annotations#[T]
+annot/Annotations#field(). => val method field: Int
+  Int => scala/Int#
+annot/Annotations#method(). => @MethodAnnotation method method: Int
+  MethodAnnotation => com/javacp/annot/MethodAnnotation#
+  Int => scala/Int#
+annot/Annotations#x(). => @ParameterAnnotation private[this] val method x: T
+  ParameterAnnotation => com/javacp/annot/ParameterAnnotation#
+  T => annot/Annotations#[T]
+annot/B# => class B extends AnyRef { +3 decls }
+  AnyRef => scala/AnyRef#
+annot/B#`<init>`(). => @ConstructorAnnotation primary ctor <init>(x: Int)
+  ConstructorAnnotation => com/javacp/annot/ConstructorAnnotation#
+  x => annot/B#`<init>`().(x)
+  Int => scala/Int#
+annot/B#`<init>`().(x) => param x: Int
+  Int => scala/Int#
+annot/B#`<init>`(+1). => @ConstructorAnnotation ctor <init>()
+  ConstructorAnnotation => com/javacp/annot/ConstructorAnnotation#
+annot/B#x(). => private[this] val method x: Int
+  Int => scala/Int#
+annot/M. => @ObjectAnnotation final object M extends AnyRef { +1 decls }
+  ObjectAnnotation => com/javacp/annot/ObjectAnnotation#
+  AnyRef => scala/AnyRef#
+annot/M.m(). => @MacroAnnotation macro m[TT]: Nothing
+  MacroAnnotation => com/javacp/annot/MacroAnnotation#
+  TT => annot/M.m().[TT]
+  Nothing => scala/Nothing#
+annot/M.m().[TT] => typeparam TT
+annot/T# => @TraitAnnotation trait T extends AnyRef
+  TraitAnnotation => com/javacp/annot/TraitAnnotation#
+  AnyRef => scala/AnyRef#
+local0 => selfparam self: AnyRef
+  AnyRef => scala/AnyRef#
+local1 => @LocalAnnotation val local local: Int
+  LocalAnnotation => com/javacp/annot/LocalAnnotation#
+  Int => scala/Int#
+
+Occurrences:
+[0:8..0:13): annot <= annot/
+[2:7..2:12): scala => scala/
+[2:13..2:21): language => scala/language.
+[2:22..2:34): experimental => scala/language.experimental.
+[2:35..2:41): macros => scala/language.experimental.macros().
+[4:7..4:10): com => com/
+[4:11..4:17): javacp => com/javacp/
+[4:18..4:23): annot => com/javacp/annot/
+[6:1..6:16): ClassAnnotation => com/javacp/annot/ClassAnnotation#
+[6:16..6:16):  => com/javacp/annot/ClassAnnotation#`<init>`().
+[7:6..7:17): Annotations <= annot/Annotations#
+[7:19..7:42): TypeParameterAnnotation => com/javacp/annot/TypeParameterAnnotation#
+[7:43..7:43):  => com/javacp/annot/TypeParameterAnnotation#`<init>`().
+[7:43..7:44): T <= annot/Annotations#[T]
+[7:45..7:45):  <= annot/Annotations#`<init>`().
+[7:47..7:66): ParameterAnnotation => com/javacp/annot/ParameterAnnotation#
+[7:67..7:67):  => com/javacp/annot/ParameterAnnotation#`<init>`().
+[7:67..7:68): x <= annot/Annotations#x().
+[7:70..7:71): T => annot/Annotations#[T]
+[7:75..7:79): self <= local0
+[7:81..7:87): AnyRef => scala/AnyRef#
+[8:3..8:18): FieldAnnotation => com/javacp/annot/FieldAnnotation#
+[8:18..8:18):  => com/javacp/annot/FieldAnnotation#`<init>`().
+[9:6..9:11): field <= annot/Annotations#field().
+[11:3..11:19): MethodAnnotation => com/javacp/annot/MethodAnnotation#
+[11:19..11:19):  => com/javacp/annot/MethodAnnotation#`<init>`().
+[12:6..12:12): method <= annot/Annotations#method().
+[13:5..13:20): LocalAnnotation => com/javacp/annot/LocalAnnotation#
+[13:20..13:20):  => com/javacp/annot/LocalAnnotation#`<init>`().
+[14:8..14:13): local <= local1
+[15:4..15:9): local => local1
+[17:3..17:17): TypeAnnotation => com/javacp/annot/TypeAnnotation#
+[17:17..17:17):  => com/javacp/annot/TypeAnnotation#`<init>`().
+[18:7..18:8): T <= annot/Annotations#T#
+[21:6..21:7): B <= annot/B#
+[21:9..21:30): ConstructorAnnotation => com/javacp/annot/ConstructorAnnotation#
+[21:30..21:30):  => com/javacp/annot/ConstructorAnnotation#`<init>`().
+[21:32..21:32):  <= annot/B#`<init>`().
+[21:33..21:34): x <= annot/B#x().
+[21:36..21:39): Int => scala/Int#
+[22:3..22:24): ConstructorAnnotation => com/javacp/annot/ConstructorAnnotation#
+[22:24..22:24):  => com/javacp/annot/ConstructorAnnotation#`<init>`().
+[23:19..23:19):  => annot/B#`<init>`().
+[26:1..26:17): ObjectAnnotation => com/javacp/annot/ObjectAnnotation#
+[26:17..26:17):  => com/javacp/annot/ObjectAnnotation#`<init>`().
+[27:7..27:8): M <= annot/M.
+[28:3..28:18): MacroAnnotation => com/javacp/annot/MacroAnnotation#
+[28:18..28:18):  => com/javacp/annot/MacroAnnotation#`<init>`().
+[29:6..29:7): m <= annot/M.m().
+[29:8..29:10): TT <= annot/M.m().[TT]
+[29:20..29:23): ??? => scala/Predef.`???`().
+[32:1..32:16): TraitAnnotation => com/javacp/annot/TraitAnnotation#
+[32:16..32:16):  => com/javacp/annot/TraitAnnotation#`<init>`().
+[33:6..33:7): T <= annot/T#
 
 semanticdb/integration/src/main/scala/example/Anonymous.scala
 -------------------------------------------------------------

--- a/tests/jvm/src/test/resources/metac.index
+++ b/tests/jvm/src/test/resources/metac.index
@@ -6,6 +6,7 @@ _empty_/
 _root_/
   _empty_/
   advanced/
+  annot/
   classes/
   com/
   example/
@@ -21,6 +22,11 @@ advanced/
   advanced/Existential#
   advanced/Structural#
   advanced/Test.
+annot/
+  annot/Annotations#
+  annot/B#
+  annot/M.
+  annot/T#
 classes/
   classes/C1#
   classes/C2#
@@ -47,6 +53,27 @@ com/javacp/
   com/javacp/NonGeneric#
   com/javacp/Recursive#
   com/javacp/Test#
+  com/javacp/annot/
+com/javacp/annot/
+  com/javacp/annot/ClassAnnotation#
+  com/javacp/annot/ConstructorAnnotation#
+  com/javacp/annot/FieldAnnotation#
+  com/javacp/annot/InterfaceAnnotation#
+  com/javacp/annot/LocalAnnotation#
+  com/javacp/annot/MacroAnnotation#
+  com/javacp/annot/MethodAnnotation#
+  com/javacp/annot/ObjectAnnotation#
+  com/javacp/annot/PackageAnnotation#
+  com/javacp/annot/PackageObjectAnnotation#
+  com/javacp/annot/ParameterAnnotation#
+  com/javacp/annot/SelfParameterAnnotation#
+  com/javacp/annot/TraitAnnotation#
+  com/javacp/annot/TypeAnnotation#
+  com/javacp/annot/TypeParameterAnnotation#
+  com/javacp/annot/usage/
+com/javacp/annot/usage/
+  com/javacp/annot/usage/AnnotatedInterface#
+  com/javacp/annot/usage/AnnotatedPackage#
 example/
   example/A#
   example/Acc#
@@ -106,6 +133,10 @@ advanced/D# => semanticdb/integration/src/main/scala/example/Advanced.scala.sema
 advanced/Existential# => semanticdb/integration/src/main/scala/example/Advanced.scala.semanticdb
 advanced/Structural# => semanticdb/integration/src/main/scala/example/Advanced.scala.semanticdb
 advanced/Test. => semanticdb/integration/src/main/scala/example/Advanced.scala.semanticdb
+annot/Annotations# => semanticdb/integration/src/main/scala/example/Annotations.scala.semanticdb
+annot/B# => semanticdb/integration/src/main/scala/example/Annotations.scala.semanticdb
+annot/M. => semanticdb/integration/src/main/scala/example/Annotations.scala.semanticdb
+annot/T# => semanticdb/integration/src/main/scala/example/Annotations.scala.semanticdb
 classes/C1# => semanticdb/integration/src/main/scala/example/Classes.scala.semanticdb
 classes/C2# => semanticdb/integration/src/main/scala/example/Classes.scala.semanticdb
 classes/C2. => semanticdb/integration/src/main/scala/example/Classes.scala.semanticdb
@@ -128,6 +159,23 @@ com/javacp/MetacJava# => semanticdb/integration/src/main/java/com/javacp/MetacJa
 com/javacp/NonGeneric# => semanticdb/integration/src/main/java/com/javacp/NonGeneric.java.semanticdb
 com/javacp/Recursive# => semanticdb/integration/src/main/java/com/javacp/Recursive.java.semanticdb
 com/javacp/Test# => semanticdb/integration/src/main/java/com/javacp/Test.java.semanticdb
+com/javacp/annot/ClassAnnotation# => semanticdb/integration/src/main/java/com/javacp/annot/ClassAnnotation.java.semanticdb
+com/javacp/annot/ConstructorAnnotation# => semanticdb/integration/src/main/java/com/javacp/annot/ConstructorAnnotation.java.semanticdb
+com/javacp/annot/FieldAnnotation# => semanticdb/integration/src/main/java/com/javacp/annot/FieldAnnotation.java.semanticdb
+com/javacp/annot/InterfaceAnnotation# => semanticdb/integration/src/main/java/com/javacp/annot/InterfaceAnnotation.java.semanticdb
+com/javacp/annot/LocalAnnotation# => semanticdb/integration/src/main/java/com/javacp/annot/LocalAnnotation.java.semanticdb
+com/javacp/annot/MacroAnnotation# => semanticdb/integration/src/main/java/com/javacp/annot/MacroAnnotation.java.semanticdb
+com/javacp/annot/MethodAnnotation# => semanticdb/integration/src/main/java/com/javacp/annot/MethodAnnotation.java.semanticdb
+com/javacp/annot/ObjectAnnotation# => semanticdb/integration/src/main/java/com/javacp/annot/ObjectAnnotation.java.semanticdb
+com/javacp/annot/PackageAnnotation# => semanticdb/integration/src/main/java/com/javacp/annot/PackageAnnotation.java.semanticdb
+com/javacp/annot/PackageObjectAnnotation# => semanticdb/integration/src/main/java/com/javacp/annot/PackageObjectAnnotation.java.semanticdb
+com/javacp/annot/ParameterAnnotation# => semanticdb/integration/src/main/java/com/javacp/annot/ParameterAnnotation.java.semanticdb
+com/javacp/annot/SelfParameterAnnotation# => semanticdb/integration/src/main/java/com/javacp/annot/SelfParameterAnnotation.java.semanticdb
+com/javacp/annot/TraitAnnotation# => semanticdb/integration/src/main/java/com/javacp/annot/TraitAnnotation.java.semanticdb
+com/javacp/annot/TypeAnnotation# => semanticdb/integration/src/main/java/com/javacp/annot/TypeAnnotation.java.semanticdb
+com/javacp/annot/TypeParameterAnnotation# => semanticdb/integration/src/main/java/com/javacp/annot/TypeParameterAnnotation.java.semanticdb
+com/javacp/annot/usage/AnnotatedInterface# => semanticdb/integration/src/main/java/com/javacp/annot/usage/AnnotatedInterface.java.semanticdb
+com/javacp/annot/usage/AnnotatedPackage# => semanticdb/integration/src/main/java/com/javacp/annot/usage/AnnotatedPackage.java.semanticdb
 example/A# => semanticdb/integration/src/main/scala/example/Overrides.scala.semanticdb
 example/Acc# => semanticdb/integration/src/main/scala/example/Accessibility.scala.semanticdb
 example/Anonymous# => semanticdb/integration/src/main/scala/example/Anonymous.scala.semanticdb

--- a/tests/jvm/src/test/resources/metacp.expect
+++ b/tests/jvm/src/test/resources/metacp.expect
@@ -173,6 +173,110 @@ advanced/Test.s3(). => val method s3: AnyRef { def m(x: Int): Int }
 advanced/Test.s3x(). => val method s3x: Int
   Int => scala/Int#
 
+annot/Annotations.class
+-----------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => annot/Annotations.class
+Text => empty
+Language => Scala
+Symbols => 10 entries
+
+Symbols:
+_root_/ => package _root_
+annot/ => package annot
+annot/Annotations# => @ClassAnnotation class Annotations[@TypeParameterAnnotation T] extends AnyRef { self: AnyRef => +5 decls }
+  ClassAnnotation => com/javacp/annot/ClassAnnotation#
+  T => annot/Annotations#[T]
+  TypeParameterAnnotation => com/javacp/annot/TypeParameterAnnotation#
+  AnyRef => scala/AnyRef#
+annot/Annotations#T# => @TypeAnnotation abstract type T
+  TypeAnnotation => com/javacp/annot/TypeAnnotation#
+annot/Annotations#[T] => @TypeParameterAnnotation typeparam T
+  TypeParameterAnnotation => com/javacp/annot/TypeParameterAnnotation#
+annot/Annotations#`<init>`(). => primary ctor <init>(@ParameterAnnotation x: T)
+  x => annot/Annotations#`<init>`().(x)
+  ParameterAnnotation => com/javacp/annot/ParameterAnnotation#
+  T => annot/Annotations#[T]
+annot/Annotations#`<init>`().(x) => @ParameterAnnotation param x: T
+  ParameterAnnotation => com/javacp/annot/ParameterAnnotation#
+  T => annot/Annotations#[T]
+annot/Annotations#field(). => val method field: Int
+  Int => scala/Int#
+annot/Annotations#method(). => @MethodAnnotation method method: Int
+  MethodAnnotation => com/javacp/annot/MethodAnnotation#
+  Int => scala/Int#
+annot/Annotations#x(). => @ParameterAnnotation private[this] val method x: T
+  ParameterAnnotation => com/javacp/annot/ParameterAnnotation#
+  T => annot/Annotations#[T]
+
+annot/B.class
+-------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => annot/B.class
+Text => empty
+Language => Scala
+Symbols => 7 entries
+
+Symbols:
+_root_/ => package _root_
+annot/ => package annot
+annot/B# => class B extends AnyRef { +3 decls }
+  AnyRef => scala/AnyRef#
+annot/B#`<init>`(). => @ConstructorAnnotation primary ctor <init>(x: Int)
+  ConstructorAnnotation => com/javacp/annot/ConstructorAnnotation#
+  x => annot/B#`<init>`().(x)
+  Int => scala/Int#
+annot/B#`<init>`().(x) => param x: Int
+  Int => scala/Int#
+annot/B#`<init>`(+1). => @ConstructorAnnotation ctor <init>()
+  ConstructorAnnotation => com/javacp/annot/ConstructorAnnotation#
+annot/B#x(). => private[this] val method x: Int
+  Int => scala/Int#
+
+annot/M.class
+-------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => annot/M.class
+Text => empty
+Language => Scala
+Symbols => 5 entries
+
+Symbols:
+_root_/ => package _root_
+annot/ => package annot
+annot/M. => @ObjectAnnotation final object M extends AnyRef { +1 decls }
+  ObjectAnnotation => com/javacp/annot/ObjectAnnotation#
+  AnyRef => scala/AnyRef#
+annot/M.m(). => @MacroAnnotation @macroImpl macro m[TT]: Nothing
+  MacroAnnotation => com/javacp/annot/MacroAnnotation#
+  macroImpl => scala/reflect/macros/internal/macroImpl#
+  TT => annot/M.m().[TT]
+  Nothing => scala/Nothing#
+annot/M.m().[TT] => typeparam TT
+
+annot/T.class
+-------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => annot/T.class
+Text => empty
+Language => Scala
+Symbols => 3 entries
+
+Symbols:
+_root_/ => package _root_
+annot/ => package annot
+annot/T# => @TraitAnnotation trait T extends AnyRef
+  TraitAnnotation => com/javacp/annot/TraitAnnotation#
+  AnyRef => scala/AnyRef#
+
 B.class
 -------
 
@@ -632,6 +736,331 @@ classes/N.anonClass(). => val method anonClass: C7 { val def local: Nothing }
 classes/N.anonFun(). => val method anonFun: List[Int]
   List => scala/collection/immutable/List#
   Int => scala/Int#
+
+com/javacp/annot/ClassAnnotation.class
+--------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => com/javacp/annot/ClassAnnotation.class
+Text => empty
+Language => Java
+Symbols => 5 entries
+
+Symbols:
+_root_/ => package _root_
+com/ => package com
+com/javacp/ => package javacp
+com/javacp/annot/ => package annot
+com/javacp/annot/ClassAnnotation# => abstract interface ClassAnnotation extends Object with Annotation
+  Object => java/lang/Object#
+  Annotation => java/lang/annotation/Annotation#
+
+com/javacp/annot/ConstructorAnnotation.class
+--------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => com/javacp/annot/ConstructorAnnotation.class
+Text => empty
+Language => Java
+Symbols => 5 entries
+
+Symbols:
+_root_/ => package _root_
+com/ => package com
+com/javacp/ => package javacp
+com/javacp/annot/ => package annot
+com/javacp/annot/ConstructorAnnotation# => abstract interface ConstructorAnnotation extends Object with Annotation
+  Object => java/lang/Object#
+  Annotation => java/lang/annotation/Annotation#
+
+com/javacp/annot/FieldAnnotation.class
+--------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => com/javacp/annot/FieldAnnotation.class
+Text => empty
+Language => Java
+Symbols => 5 entries
+
+Symbols:
+_root_/ => package _root_
+com/ => package com
+com/javacp/ => package javacp
+com/javacp/annot/ => package annot
+com/javacp/annot/FieldAnnotation# => abstract interface FieldAnnotation extends Object with Annotation
+  Object => java/lang/Object#
+  Annotation => java/lang/annotation/Annotation#
+
+com/javacp/annot/InterfaceAnnotation.class
+------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => com/javacp/annot/InterfaceAnnotation.class
+Text => empty
+Language => Java
+Symbols => 5 entries
+
+Symbols:
+_root_/ => package _root_
+com/ => package com
+com/javacp/ => package javacp
+com/javacp/annot/ => package annot
+com/javacp/annot/InterfaceAnnotation# => abstract interface InterfaceAnnotation extends Object with Annotation
+  Object => java/lang/Object#
+  Annotation => java/lang/annotation/Annotation#
+
+com/javacp/annot/LocalAnnotation.class
+--------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => com/javacp/annot/LocalAnnotation.class
+Text => empty
+Language => Java
+Symbols => 5 entries
+
+Symbols:
+_root_/ => package _root_
+com/ => package com
+com/javacp/ => package javacp
+com/javacp/annot/ => package annot
+com/javacp/annot/LocalAnnotation# => abstract interface LocalAnnotation extends Object with Annotation
+  Object => java/lang/Object#
+  Annotation => java/lang/annotation/Annotation#
+
+com/javacp/annot/MacroAnnotation.class
+--------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => com/javacp/annot/MacroAnnotation.class
+Text => empty
+Language => Java
+Symbols => 5 entries
+
+Symbols:
+_root_/ => package _root_
+com/ => package com
+com/javacp/ => package javacp
+com/javacp/annot/ => package annot
+com/javacp/annot/MacroAnnotation# => abstract interface MacroAnnotation extends Object with Annotation
+  Object => java/lang/Object#
+  Annotation => java/lang/annotation/Annotation#
+
+com/javacp/annot/MethodAnnotation.class
+---------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => com/javacp/annot/MethodAnnotation.class
+Text => empty
+Language => Java
+Symbols => 5 entries
+
+Symbols:
+_root_/ => package _root_
+com/ => package com
+com/javacp/ => package javacp
+com/javacp/annot/ => package annot
+com/javacp/annot/MethodAnnotation# => abstract interface MethodAnnotation extends Object with Annotation
+  Object => java/lang/Object#
+  Annotation => java/lang/annotation/Annotation#
+
+com/javacp/annot/ObjectAnnotation.class
+---------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => com/javacp/annot/ObjectAnnotation.class
+Text => empty
+Language => Java
+Symbols => 5 entries
+
+Symbols:
+_root_/ => package _root_
+com/ => package com
+com/javacp/ => package javacp
+com/javacp/annot/ => package annot
+com/javacp/annot/ObjectAnnotation# => abstract interface ObjectAnnotation extends Object with Annotation
+  Object => java/lang/Object#
+  Annotation => java/lang/annotation/Annotation#
+
+com/javacp/annot/PackageAnnotation.class
+----------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => com/javacp/annot/PackageAnnotation.class
+Text => empty
+Language => Java
+Symbols => 5 entries
+
+Symbols:
+_root_/ => package _root_
+com/ => package com
+com/javacp/ => package javacp
+com/javacp/annot/ => package annot
+com/javacp/annot/PackageAnnotation# => abstract interface PackageAnnotation extends Object with Annotation
+  Object => java/lang/Object#
+  Annotation => java/lang/annotation/Annotation#
+
+com/javacp/annot/PackageObjectAnnotation.class
+----------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => com/javacp/annot/PackageObjectAnnotation.class
+Text => empty
+Language => Java
+Symbols => 5 entries
+
+Symbols:
+_root_/ => package _root_
+com/ => package com
+com/javacp/ => package javacp
+com/javacp/annot/ => package annot
+com/javacp/annot/PackageObjectAnnotation# => abstract interface PackageObjectAnnotation extends Object with Annotation
+  Object => java/lang/Object#
+  Annotation => java/lang/annotation/Annotation#
+
+com/javacp/annot/ParameterAnnotation.class
+------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => com/javacp/annot/ParameterAnnotation.class
+Text => empty
+Language => Java
+Symbols => 5 entries
+
+Symbols:
+_root_/ => package _root_
+com/ => package com
+com/javacp/ => package javacp
+com/javacp/annot/ => package annot
+com/javacp/annot/ParameterAnnotation# => abstract interface ParameterAnnotation extends Object with Annotation
+  Object => java/lang/Object#
+  Annotation => java/lang/annotation/Annotation#
+
+com/javacp/annot/SelfParameterAnnotation.class
+----------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => com/javacp/annot/SelfParameterAnnotation.class
+Text => empty
+Language => Java
+Symbols => 5 entries
+
+Symbols:
+_root_/ => package _root_
+com/ => package com
+com/javacp/ => package javacp
+com/javacp/annot/ => package annot
+com/javacp/annot/SelfParameterAnnotation# => abstract interface SelfParameterAnnotation extends Object with Annotation
+  Object => java/lang/Object#
+  Annotation => java/lang/annotation/Annotation#
+
+com/javacp/annot/TraitAnnotation.class
+--------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => com/javacp/annot/TraitAnnotation.class
+Text => empty
+Language => Java
+Symbols => 5 entries
+
+Symbols:
+_root_/ => package _root_
+com/ => package com
+com/javacp/ => package javacp
+com/javacp/annot/ => package annot
+com/javacp/annot/TraitAnnotation# => abstract interface TraitAnnotation extends Object with Annotation
+  Object => java/lang/Object#
+  Annotation => java/lang/annotation/Annotation#
+
+com/javacp/annot/TypeAnnotation.class
+-------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => com/javacp/annot/TypeAnnotation.class
+Text => empty
+Language => Java
+Symbols => 5 entries
+
+Symbols:
+_root_/ => package _root_
+com/ => package com
+com/javacp/ => package javacp
+com/javacp/annot/ => package annot
+com/javacp/annot/TypeAnnotation# => abstract interface TypeAnnotation extends Object with Annotation
+  Object => java/lang/Object#
+  Annotation => java/lang/annotation/Annotation#
+
+com/javacp/annot/TypeParameterAnnotation.class
+----------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => com/javacp/annot/TypeParameterAnnotation.class
+Text => empty
+Language => Java
+Symbols => 5 entries
+
+Symbols:
+_root_/ => package _root_
+com/ => package com
+com/javacp/ => package javacp
+com/javacp/annot/ => package annot
+com/javacp/annot/TypeParameterAnnotation# => abstract interface TypeParameterAnnotation extends Object with Annotation
+  Object => java/lang/Object#
+  Annotation => java/lang/annotation/Annotation#
+
+com/javacp/annot/usage/AnnotatedInterface.class
+-----------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => com/javacp/annot/usage/AnnotatedInterface.class
+Text => empty
+Language => Java
+Symbols => 6 entries
+
+Symbols:
+_root_/ => package _root_
+com/ => package com
+com/javacp/ => package javacp
+com/javacp/annot/ => package annot
+com/javacp/annot/usage/ => package usage
+com/javacp/annot/usage/AnnotatedInterface# => abstract interface AnnotatedInterface extends Object with Annotation
+  Object => java/lang/Object#
+  Annotation => java/lang/annotation/Annotation#
+
+com/javacp/annot/usage/AnnotatedPackage.class
+---------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => com/javacp/annot/usage/AnnotatedPackage.class
+Text => empty
+Language => Java
+Symbols => 7 entries
+
+Symbols:
+_root_/ => package _root_
+com/ => package com
+com/javacp/ => package javacp
+com/javacp/annot/ => package annot
+com/javacp/annot/usage/ => package usage
+com/javacp/annot/usage/AnnotatedPackage# => class AnnotatedPackage extends Object { +1 decls }
+  Object => java/lang/Object#
+com/javacp/annot/usage/AnnotatedPackage#`<init>`(). => ctor <init>()
 
 com/javacp/ClassSuffix.class
 ----------------------------
@@ -1916,10 +2345,12 @@ flags/p/package.C#y(). => private[this] val method y: U
   U => flags/p/package.C#[U]
 flags/p/package.C#z(). => private[this] val method z: V
   V => flags/p/package.C#[V]
-flags/p/package.S# => class S[T] extends AnyRef { +1 decls }
+flags/p/package.S# => class S[@specialized T] extends AnyRef { +1 decls }
   T => flags/p/package.S#[T]
+  specialized => scala/specialized#
   AnyRef => scala/AnyRef#
-flags/p/package.S#[T] => typeparam T
+flags/p/package.S#[T] => @specialized typeparam T
+  specialized => scala/specialized#
 flags/p/package.S#`<init>`(). => primary ctor <init>()
 flags/p/package.T1# => type T1 = Int
   Int => scala/Int#
@@ -1971,7 +2402,8 @@ flags/p/package.`y_=`(). => protected var method y_=(x$1: Int): Unit
   Unit => scala/Unit#
 flags/p/package.`y_=`().(x$1) => param x$1: Int
   Int => scala/Int#
-flags/p/package.m(). => macro m[TT]: Nothing
+flags/p/package.m(). => @macroImpl macro m[TT]: Nothing
+  macroImpl => scala/reflect/macros/internal/macroImpl#
   TT => flags/p/package.m().[TT]
   Nothing => scala/Nothing#
 flags/p/package.m().[TT] => typeparam TT

--- a/tests/jvm/src/test/resources/metacp.index
+++ b/tests/jvm/src/test/resources/metacp.index
@@ -7,6 +7,7 @@ _empty_/
 _root_/
   _empty_.
   advanced/
+  annot/
   classes/
   com/
   example/
@@ -23,6 +24,11 @@ advanced/
   advanced/Existential#
   advanced/Structural#
   advanced/Test.
+annot/
+  annot/Annotations#
+  annot/B#
+  annot/M.
+  annot/T#
 classes/
   classes/C1#
   classes/C2#
@@ -49,6 +55,27 @@ com/javacp/
   com/javacp/NonGeneric#
   com/javacp/Recursive#
   com/javacp/Test#
+  com/javacp/annot/
+com/javacp/annot/
+  com/javacp/annot/ClassAnnotation#
+  com/javacp/annot/ConstructorAnnotation#
+  com/javacp/annot/FieldAnnotation#
+  com/javacp/annot/InterfaceAnnotation#
+  com/javacp/annot/LocalAnnotation#
+  com/javacp/annot/MacroAnnotation#
+  com/javacp/annot/MethodAnnotation#
+  com/javacp/annot/ObjectAnnotation#
+  com/javacp/annot/PackageAnnotation#
+  com/javacp/annot/PackageObjectAnnotation#
+  com/javacp/annot/ParameterAnnotation#
+  com/javacp/annot/SelfParameterAnnotation#
+  com/javacp/annot/TraitAnnotation#
+  com/javacp/annot/TypeAnnotation#
+  com/javacp/annot/TypeParameterAnnotation#
+  com/javacp/annot/usage/
+com/javacp/annot/usage/
+  com/javacp/annot/usage/AnnotatedInterface#
+  com/javacp/annot/usage/AnnotatedPackage#
 example/
   example/A#
   example/Acc#
@@ -110,6 +137,10 @@ advanced/D# => advanced/D.class.semanticdb
 advanced/Existential# => advanced/Existential.class.semanticdb
 advanced/Structural# => advanced/Structural.class.semanticdb
 advanced/Test. => advanced/Test.class.semanticdb
+annot/Annotations# => annot/Annotations.class.semanticdb
+annot/B# => annot/B.class.semanticdb
+annot/M. => annot/M.class.semanticdb
+annot/T# => annot/T.class.semanticdb
 classes/C1# => classes/C1.class.semanticdb
 classes/C2# => classes/C2.class.semanticdb
 classes/C2. => classes/C2.class.semanticdb
@@ -132,6 +163,23 @@ com/javacp/MetacJava# => com/javacp/MetacJava.class.semanticdb
 com/javacp/NonGeneric# => com/javacp/NonGeneric.class.semanticdb
 com/javacp/Recursive# => com/javacp/Recursive.class.semanticdb
 com/javacp/Test# => com/javacp/Test.class.semanticdb
+com/javacp/annot/ClassAnnotation# => com/javacp/annot/ClassAnnotation.class.semanticdb
+com/javacp/annot/ConstructorAnnotation# => com/javacp/annot/ConstructorAnnotation.class.semanticdb
+com/javacp/annot/FieldAnnotation# => com/javacp/annot/FieldAnnotation.class.semanticdb
+com/javacp/annot/InterfaceAnnotation# => com/javacp/annot/InterfaceAnnotation.class.semanticdb
+com/javacp/annot/LocalAnnotation# => com/javacp/annot/LocalAnnotation.class.semanticdb
+com/javacp/annot/MacroAnnotation# => com/javacp/annot/MacroAnnotation.class.semanticdb
+com/javacp/annot/MethodAnnotation# => com/javacp/annot/MethodAnnotation.class.semanticdb
+com/javacp/annot/ObjectAnnotation# => com/javacp/annot/ObjectAnnotation.class.semanticdb
+com/javacp/annot/PackageAnnotation# => com/javacp/annot/PackageAnnotation.class.semanticdb
+com/javacp/annot/PackageObjectAnnotation# => com/javacp/annot/PackageObjectAnnotation.class.semanticdb
+com/javacp/annot/ParameterAnnotation# => com/javacp/annot/ParameterAnnotation.class.semanticdb
+com/javacp/annot/SelfParameterAnnotation# => com/javacp/annot/SelfParameterAnnotation.class.semanticdb
+com/javacp/annot/TraitAnnotation# => com/javacp/annot/TraitAnnotation.class.semanticdb
+com/javacp/annot/TypeAnnotation# => com/javacp/annot/TypeAnnotation.class.semanticdb
+com/javacp/annot/TypeParameterAnnotation# => com/javacp/annot/TypeParameterAnnotation.class.semanticdb
+com/javacp/annot/usage/AnnotatedInterface# => com/javacp/annot/usage/AnnotatedInterface.class.semanticdb
+com/javacp/annot/usage/AnnotatedPackage# => com/javacp/annot/usage/AnnotatedPackage.class.semanticdb
 example/A# => example/A.class.semanticdb
 example/Acc# => example/Acc.class.semanticdb
 example/Anonymous# => example/Anonymous.class.semanticdb


### PR DESCRIPTION
It was pretty easy after all. There is two limitations:
* scalap does not keep annotations parameter
* scalap does not tell me if the annotation is synthetic (ex: macro)