### PR TITLE
Transcribing scalac parsing logic into cantBeWrittenWithoutBackquotes

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -120,7 +120,76 @@ object TreeSyntax {
 
       def guessIsBackquoted(t: Name): Boolean = {
         def cantBeWrittenWithoutBackquotes(t: Name): Boolean = {
-          t.value != "this" && (keywords.contains(t.value) || t.value.contains(" "))
+          // Fold over codepoints for a given string
+          def foldCodepoints[T](value: String, start: T)(f: (Int, T, Int) => T): T = {
+            val length = value.length
+            @annotation.tailrec
+            def work(offset: Int, acc: T): T = {
+              if (offset >= length) acc
+              else {
+                val codepoint = value.codePointAt(offset)
+                work(offset + Character.charCount(codepoint), f(offset, acc, codepoint))
+              }
+            }
+            work(0, start)
+          }
+          // These rules are transcribed from
+          // https://github.com/scala/scala/blob/2.13.x/spec/01-lexical-syntax.md#lexical-syntax
+          def lexicalWhitespace(codepoint: Int): Boolean = Set[Int]('\u0020', '\u0009', '\u000D', '\u000A').contains(codepoint)
+          def lexicalLetter(codepoint: Int): Boolean = (
+             Set[Int]('\u0024', '\u005F').contains(codepoint)
+          || Set[Int](Character.LOWERCASE_LETTER, Character.UPPERCASE_LETTER, Character.TITLECASE_LETTER, Character.OTHER_LETTER, Character.LETTER_NUMBER).contains(Character.getType(codepoint))
+          )
+          def lexicalDigit(codepoint: Int): Boolean = Set[Int]('0', '1', '2', '3', '4', '5', '6', '7', '8', '9').contains(codepoint)
+          def lexicalParentheses(codepoint: Int): Boolean = Set[Int]('(', ')', '[', ']', '{', '}').contains(codepoint)
+          def lexicalDelimiter(codepoint: Int): Boolean = Set[Int]('`', '\'', '"', '.', ';', ',').contains(codepoint)
+          def lexicalOperator(codepoint: Int): Boolean = (
+             '\u0020' <= codepoint && codepoint <= '\u007E'
+          && (
+               !lexicalWhitespace(codepoint)
+            && !lexicalLetter(codepoint)
+            && !lexicalDigit(codepoint)
+            && !lexicalParentheses(codepoint)
+            && !lexicalDelimiter(codepoint))
+          || Set[Int](Character.MATH_SYMBOL, Character.OTHER_SYMBOL).contains(Character.getType(codepoint))
+          )
+
+          sealed trait OperatorState
+          case object Accepted extends OperatorState
+          case object Required extends OperatorState
+          case object Forbidden extends OperatorState
+
+          sealed trait ValidityState
+          case object Valid extends ValidityState
+          case object Invalid extends ValidityState
+
+          def validPlainid(string: String): Boolean = {
+            val (_, validity) = foldCodepoints[(OperatorState, ValidityState)](string, (Accepted, Valid))({
+              // Any invalid state is invalid
+              case (offset   , (_        , Invalid), _   )                          => (Forbidden, Invalid)
+              // Must start with either a letter or an operator
+              case (offset@0 , (Accepted ,   Valid), next) if lexicalLetter(next)   => (Forbidden, Valid)
+              case (offset@0 , (Accepted ,   Valid), next) if lexicalOperator(next) => (Required , Valid)
+              // Non-leading underscores reset operator validity
+              case (offset   , (Forbidden,   Valid), next) if next == '_'           => (Accepted , Valid)
+              // Non-leading operators are accepted only after underscores
+              case (offset   , (Accepted ,   Valid), next) if lexicalOperator(next) => (Required , Valid)
+              // Operators must not be followed by non-operators
+              case (offset   , (Required ,   Valid), next) if lexicalOperator(next) => (Required , Valid)
+              // Lexical letters and digits can follow underscores
+              case (offset   , (Accepted ,   Valid), next) if lexicalLetter(next)   => (Forbidden, Valid)
+              case (offset   , (Accepted ,   Valid), next) if lexicalDigit(next)    => (Forbidden, Valid)
+              // Non-operators must not be followed by operators
+              case (offset   , (Forbidden,   Valid), next) if lexicalLetter(next)   => (Forbidden, Valid)
+              case (offset   , (Forbidden,   Valid), next) if lexicalDigit(next)    => (Forbidden, Valid)
+              // Bail on anything not matched here
+              case (_        , (_        , _      ), next)                          => (Forbidden, Invalid)
+            })
+
+            validity == Valid
+          }
+
+          t.value != "this" && (keywords.contains(t.value) || !validPlainid(t.value))
         }
         def isAmbiguousWithPatVarTerm(t: Term.Name, p: Tree): Boolean = {
           val looksLikePatVar = t.value.head.isLower && t.value.head.isLetter

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -189,7 +189,7 @@ object TreeSyntax {
             validity == Valid
           }
 
-          t.value != "this" && (keywords.contains(t.value) || !validPlainid(t.value))
+          t.value != "this" && (keywords.contains(t.value) || t.value.contains("//") || t.value.contains("/*") || t.value.contains("*/") || !validPlainid(t.value))
         }
         def isAmbiguousWithPatVarTerm(t: Term.Name, p: Tree): Boolean = {
           val looksLikePatVar = t.value.head.isLower && t.value.head.isLetter

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -624,5 +624,28 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     assert(q"val `a b` = 2".syntax == "val `a b` = 2")
   }
 
-}
+  test("#1661 Names outside ") {
+    // Must start with either a letter or an operator
+    assert(q"val `foo` = 2".syntax == "val foo = 2")
+    assert(q"val `++++` = 2".syntax == "val ++++ = 2")
+    assert(q"val `_+` = 2".syntax == "val `_+` = 2")
 
+    // Non-leading operators are accepted only after underscores
+    assert(q"val `a_+` = 2".syntax == "val a_+ = 2")
+    assert(q"val `a_a_+` = 2".syntax == "val a_a_+ = 2")
+
+    // Operators must not be followed by non-operators
+    assert(q"val `+_a` = 2".syntax == "val `+_a` = 2")
+    assert(q"val `a_++` = 2".syntax == "val a_++ = 2")
+    assert(q"val `a_++a` = 2".syntax == "val `a_++a` = 2")
+
+    // Lexical letters and digits can follow underscores
+    assert(q"val `_a` = 2".syntax == "val _a = 2")
+    assert(q"val `a_a` = 2".syntax == "val a_a = 2")
+
+    // Non-operators must not be followed by operators
+    assert(q"val `a+` = 2".syntax == "val `a+` = 2")
+    assert(q"val `a-b` = 2".syntax == "val `a-b` = 2")
+    assert(q"val `a:b` = 2".syntax == "val `a:b` = 2")
+  }
+}

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -647,5 +647,10 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     assert(q"val `a+` = 2".syntax == "val `a+` = 2")
     assert(q"val `a-b` = 2".syntax == "val `a-b` = 2")
     assert(q"val `a:b` = 2".syntax == "val `a:b` = 2")
+
+    // Comments must be handled carefully
+    assert(q"val `/*` = 2".syntax == "val `/*` = 2")
+    assert(q"val `//` = 2".syntax == "val `//` = 2")
+    assert(q"val `a_//` = 2".syntax == "val `a_//` = 2")
   }
 }


### PR DESCRIPTION
Resolves #1661 

Motivation: There are many rules to govern whether or not a sequence of characters is legal for a term or type name in scalac, as defined by [scala/scala's spec/01-lexical-syntax.md](https://github.com/scala/scala/blob/2.13.x/spec/01-lexical-syntax.md#lexical-syntax).

This PR is an attempt at bringing `cantBeWrittenWithoutBackquotes` in line with scalac's expectations.

With this change, I can remove a workaround in [twilio/guardrail](https://github.com/twilio/guardrail/blob/cbf9acd9e8ff226cc0f4bbf2f278669071126d5e/modules/codegen/src/main/scala/com/twilio/guardrail/SwaggerUtil.scala#L269-L333)

```
// 100k iterations
scala> benchmark(100000) { assert(cantBeWrittenWithoutBackquotes(Term.Name("this is a very long test"))) }
Average: 0.01088

// 1M iterations
scala> benchmark(1000000) { assert(cantBeWrittenWithoutBackquotes(Term.Name("this is a very long test"))) }
Average: 0.005877

// 100k iterations with a longer string
scala> benchmark(100000) { assert(cantBeWrittenWithoutBackquotes(Term.Name("this is a very long test foo bar baz blix '"))) }
Average: 0.00904
```

vs the original function:
```
// 100k iterations
scala> benchmark(100000) { assert(cantBeWrittenWithoutBackquotesO(Term.Name("this is a very long test foo bar baz blix '"))) }
Average: 7.0E-5
```