### PR TITLE
Fix crlf after quasiquotes causing InvariantFailedException

### DIFF
--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/CharArrayReader.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/CharArrayReader.scala
@@ -114,9 +114,6 @@ class CharArrayReader(input: Input, dialect: Dialect, reporter: Reporter) extend
   private def skipCR() =
     if (ch == CR && charOffset < buf.length)
       buf(charOffset) match {
-        case LF =>
-          charOffset += 1
-          ch = LF
         case '\\' =>
           if (lookaheadReader.getu == LF)
             potentialUnicode()

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
@@ -721,6 +721,19 @@ class TokenizerSuite extends BaseTokenizerSuite {
     """.trim.stripMargin.replace("QQQ", "\"\"\""))
   }
 
+  test("interpolation start & end - episode 09") {
+    assert(tokenize("q\"a\"\r\n").map(_.structure).mkString("\n") === """
+      |BOF [0..0)
+      |q [0..1)
+      |" [1..2)
+      |a [2..3)
+      |" [3..4)
+      |\r [4..5)
+      |\n [5..6)
+      |EOF [6..6)
+    """.trim.stripMargin)
+  }
+
   test("$this") {
     assert(tokenize("q\"$this\"").map(_.structure).mkString("\n") === """
       |BOF [0..0)
@@ -854,6 +867,21 @@ class TokenizerSuite extends BaseTokenizerSuite {
   test("Interpolation.Part.value") {
     val Tokens(bof, _, _, _, part: Interpolation.Part, _, _, eof) = """ q"foo" """.tokenize.get
     assert(part.value === "foo")
+  }
+
+  test("Interpolated tree parsed succesfully with windows newline") {
+    val foo = (""" q"foo"""" + "\r\n").tokenize.get
+    println(foo)
+    val Tokens(bof, _, _, _, part: Interpolation.Part, _, cr: CR, lf: LF, eof) = foo
+    assert(part.value === "foo")
+    assert(cr.syntax === "\r")
+    assert(lf.syntax === "\n")
+  }
+
+  test("Interpolated tree parsed succesfully with unix newline") {
+    val Tokens(bof, _, _, _, part: Interpolation.Part, _, lf: LF, eof) = (""" q"foo"""" + "\n").tokenize.get
+    assert(part.value === "foo")
+    assert(lf.syntax === "\n")
   }
 
   test("Comment.value") {


### PR DESCRIPTION
Fixes #1177 & #1597 (duplicate)

Seemed to be an off-by-one error from the exception message to me. With the offset being set wrong somewhere, and Scalameta crashing on that somewhere later on. 

Would love to hear from someone with more experience in the codebase to see what further steps can be.