### PR TITLE
Change metap macro synthetic printout to explain the expandee

### DIFF
--- a/semanticdb/metap/src/main/scala/scala/meta/internal/metap/SyntheticPrinter.scala
+++ b/semanticdb/metap/src/main/scala/scala/meta/internal/metap/SyntheticPrinter.scala
@@ -54,7 +54,7 @@ trait SyntheticPrinter extends BasePrinter with RangePrinter with SymbolInformat
         case tree: LiteralTree =>
           pprint(tree.const)
         case tree: MacroExpansionTree =>
-          out.print("(??? : ")
+          out.print("(`macro-expandee` : ")
           pprint(tree.tpe)
           out.print(")")
         case tree: OriginalTree =>

--- a/tests/jvm/src/test/resources/metac.expect
+++ b/tests/jvm/src/test/resources/metac.expect
@@ -1785,7 +1785,7 @@ Diagnostics:
 [2:24..2:30) [warning] Unused import
 
 Synthetics:
-[9:10..9:37): scala.reflect.classTag[Int] => *((??? : ClassTag[Int]))
+[9:10..9:37): scala.reflect.classTag[Int] => *((`macro-expandee` : ClassTag[Int]))
   ClassTag => scala/reflect/ClassTag#
   Int => scala/Int#
 semanticdb/integration/src/main/scala/example/Example.scala
@@ -3257,7 +3257,7 @@ Synthetics:
   Int => scala/Int#
 [4:2..4:18): Array.empty[Int] => intArrayOps(*)
   intArrayOps => scala/Predef.intArrayOps().
-[4:2..4:18): Array.empty[Int] => *((??? : ClassTag[Int]))
+[4:2..4:18): Array.empty[Int] => *((`macro-expandee` : ClassTag[Int]))
   ClassTag => scala/reflect/ClassTag#
   Int => scala/Int#
 [5:2..5:8): "fooo" => augmentString(*)


### PR DESCRIPTION
Continuing discussion from #1712, this changes the metap printout to be a backticked identifier. The goal is to have a printout that explains what is happening, is syntactically valid and can parse, but shouldn't compile.