### PR TITLE
Add metadiff semanticdb tool

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,10 @@ import scalapb.compiler.Version.scalapbVersion
 lazy val LanguageVersions = Seq(LatestScala212, LatestScala211)
 lazy val LanguageVersion = LanguageVersions.head
 
+lazy val V = new {
+  val diffutils = "1.3.0"
+}
+
 // ==========================================
 // Projects
 // ==========================================
@@ -223,6 +227,18 @@ lazy val metacp = project
     buildInfoPackage := "scala.meta.internal.metacp"
   )
   .enablePlugins(BuildInfoPlugin)
+  // FIXME: https://github.com/scalameta/scalameta/issues/1688
+  .disablePlugins(BackgroundRunPlugin)
+  .dependsOn(semanticdbJVM, cliJVM, ioJVM)
+
+lazy val metadiff = project
+  .in(file("semanticdb/metadiff"))
+  .settings(
+    publishableSettings,
+    moduleName := "metadiff",
+    libraryDependencies += "com.googlecode.java-diff-utils" % "diffutils" % V.diffutils,
+    mainClass := Some("scala.meta.cli.Metadiff")
+  )
   // FIXME: https://github.com/scalameta/scalameta/issues/1688
   .disablePlugins(BackgroundRunPlugin)
   .dependsOn(semanticdbJVM, cliJVM, ioJVM)
@@ -504,7 +520,7 @@ lazy val testkit = project
       // These are used to download and extract a corpus tar.gz
       "org.rauschig" % "jarchivelib" % "0.7.1",
       "commons-io" % "commons-io" % "2.5",
-      "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0"
+      "com.googlecode.java-diff-utils" % "diffutils" % V.diffutils
     ),
     libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value % Test,
     description := "Testing utilities for scalameta APIs"

--- a/semanticdb/metadiff/src/main/scala/scala/meta/cli/Metadiff.scala
+++ b/semanticdb/metadiff/src/main/scala/scala/meta/cli/Metadiff.scala
@@ -1,0 +1,23 @@
+package scala.meta.cli
+
+import scala.meta.internal.metadiff.Main
+import scala.meta.metadiff.Settings
+
+object Metadiff {
+  def main(args: Array[String]): Unit = {
+    val reporter = Reporter().withOut(System.out).withErr(System.err)
+    Settings.parse(args.toList, reporter) match {
+      case Some(settings) =>
+        if (process(settings, reporter)) sys.exit(0)
+        else sys.exit(1)
+      case None =>
+        sys.exit(1)
+    }
+  }
+
+  def process(settings: Settings, reporter: Reporter): Boolean = {
+    val main = new Main(settings, reporter)
+    main.process()
+  }
+
+}

--- a/semanticdb/metadiff/src/main/scala/scala/meta/internal/metadiff/Main.scala
+++ b/semanticdb/metadiff/src/main/scala/scala/meta/internal/metadiff/Main.scala
@@ -1,0 +1,157 @@
+package scala.meta.internal.metadiff
+
+import java.nio.file.Path
+import scala.meta.cli._
+import scala.meta.internal.semanticdb.Locator
+import scala.meta.metadiff.Settings
+import scala.meta.internal.{semanticdb => s}
+import scala.meta.internal.metadiff.diff._
+
+class Main(settings: Settings, reporter: Reporter) {
+
+  private def collectPayloads(root: Path): Map[String, s.TextDocument] = {
+    val builder = Map.newBuilder[String, s.TextDocument]
+    Locator(root) { (path, payload) =>
+      payload.documents foreach { doc =>
+        builder += doc.uri -> doc
+      }
+    }
+    builder.result()
+  }
+
+  private def diffDocument(
+      docFrom: s.TextDocument,
+      docTo: s.TextDocument): Diff = {
+
+    val diffSymbols =
+      if (settings.compareSymbols) {
+
+        val symsFrom = docFrom.symbols.map(s => s.symbol -> s).toMap
+        val symsTo = docTo.symbols.map(s => s.symbol -> s).toMap
+
+        val orderDiff = diffLines(
+          docFrom.symbols.map(_.symbol).toList,
+          docTo.symbols.map(_.symbol).toList)
+
+        val fullDiff = diffConcat(
+          orderDiff.extractLines.getOrElse(docFrom.symbols.map(_.symbol)).map {
+            sym =>
+              val symDiff =
+                if (symsFrom.contains(sym) && symsTo.contains(sym))
+                  diffLines(symsFrom(sym).toProtoString.lines, symsTo(sym).toProtoString.lines)
+                else if (symsFrom.contains(sym))
+                  diffPatch('-', Some(symsFrom(sym).toProtoString))
+                else
+                  diffPatch('+', Some(symsTo(sym).toProtoString))
+              symDiff.name(s"symbol '$sym'")
+          }
+        )
+
+        diffConcat(
+          if (settings.compareOrder) orderDiff.name("symbol info order")
+          else None,
+          fullDiff
+        )
+      } else None
+
+    val diffOccs =
+      if (settings.compareOccurrences) {
+
+        val occsFrom = docFrom.occurrences.groupBy(_.symbol)
+        val occsTo = docTo.occurrences.groupBy(_.symbol)
+
+        val occsOrderFrom =
+          if (settings.compareOrder) docFrom.occurrences
+          else docFrom.occurrences.sortBy(_.range)
+        val occsOrderTo =
+          if (settings.compareOrder) docTo.occurrences
+          else docTo.occurrences.sortBy(_.range)
+
+        val orderDiff = diffLines(
+          occsOrderFrom.map(occ => occ.symbol + " " + occ.role).toList,
+          occsOrderTo.map(occ => occ.symbol + " " + occ.role).toList
+        )
+        def display(occ: s.SymbolOccurrence): String =
+          s"${occ.role} ${occ.range.str}"
+        def displayEOL(occ: s.SymbolOccurrence): String =
+          s"${occ.role} ${occ.range.str}$EOL"
+
+        val fullDiff = diffConcat(
+          orderDiff.extractLines
+            .map { lines =>
+              lines.map { line =>
+                line.substring(0, line.lastIndexOf(' '))
+              }.distinct
+            }
+            .getOrElse(occsOrderFrom.map(_.symbol).distinct)
+            .map { occ =>
+              val occDiff =
+                if (occsFrom.contains(occ) && occsTo.contains(occ))
+                  diffLines(
+                    occsFrom(occ).map(display),
+                    occsTo(occ).map(display))
+                else if (occsFrom.contains(occ))
+                  diffPatch('-', Some(occsFrom(occ).map(displayEOL).mkString))
+                else
+                  diffPatch('-', Some(occsTo(occ).map(displayEOL).mkString))
+              occDiff.name(s"occurrence symbol '$occ'")
+            }
+        )
+
+        diffConcat(
+          orderDiff.name("occurrence order"),
+          fullDiff
+        )
+      } else None
+
+    val diffSynths =
+      if (settings.compareSynthetics) {
+        val linesSynthsFrom = s.TextDocument(synthetics = docFrom.synthetics).toProtoString.lines
+        val linesSynthsTo = s.TextDocument(synthetics = docTo.synthetics).toProtoString.lines
+        diffLines(linesSynthsFrom, linesSynthsTo, contextSize = 5).name("synthetics")
+      } else None
+
+    diffConcat(
+      diffObj(docFrom.schema, docTo.schema).name("schema"),
+      diffObj(docFrom.language, docTo.language).name("language"),
+      diffSymbols,
+      diffOccs,
+      diffSynths
+    )
+  }
+
+  def process(): Boolean = {
+    val List(rootFrom, rootTo) = settings.paths
+    val payloadsFrom = collectPayloads(rootFrom)
+    val payloadsTo = collectPayloads(rootTo)
+    val pathsFrom = payloadsFrom.keySet
+    val pathsTo = payloadsTo.keySet
+    val pathsShared = pathsFrom & pathsTo
+    (pathsFrom | pathsTo).toSeq.sorted foreach { path =>
+      if (pathsShared(path)) {
+        val payloadFrom = payloadsFrom(path)
+        val payloadTo = payloadsTo(path)
+        val diff = diffHeader(path, path, diffDocument(payloadFrom, payloadTo))
+        diff.foreach(reporter.out.print)
+      } else if (pathsFrom(path)) {
+        reporter.out.println(s"--- $path")
+        reporter.out.println(s"+++")
+      } else if (pathsTo(path)) {
+        reporter.out.println("---")
+        reporter.out.println(s"+++ $path")
+      }
+    }
+    true
+  }
+
+  implicit val pathOrdering: Ordering[Path] = Ordering.by(_.toString)
+  implicit val rangeOrdering: Ordering[Option[s.Range]] = Ordering.by(
+    _.map(r => (r.startLine, r.startCharacter, r.endLine, r.endCharacter)))
+
+  implicit class OptRangeOps(rOpt: Option[s.Range]) {
+    def str: String = rOpt.fold("") { r =>
+      s"${r.startLine}:${r.startCharacter}-${r.endLine}:${r.endCharacter}"
+    }
+  }
+
+}

--- a/semanticdb/metadiff/src/main/scala/scala/meta/internal/metadiff/Main.scala
+++ b/semanticdb/metadiff/src/main/scala/scala/meta/internal/metadiff/Main.scala
@@ -19,9 +19,7 @@ class Main(settings: Settings, reporter: Reporter) {
     builder.result()
   }
 
-  private def diffDocument(
-      docFrom: s.TextDocument,
-      docTo: s.TextDocument): Diff = {
+  private def diffDocument(docFrom: s.TextDocument, docTo: s.TextDocument): Diff = {
 
     val diffSymbols =
       if (settings.compareSymbols) {
@@ -29,21 +27,19 @@ class Main(settings: Settings, reporter: Reporter) {
         val symsFrom = docFrom.symbols.map(s => s.symbol -> s).toMap
         val symsTo = docTo.symbols.map(s => s.symbol -> s).toMap
 
-        val orderDiff = diffLines(
-          docFrom.symbols.map(_.symbol).toList,
-          docTo.symbols.map(_.symbol).toList)
+        val orderDiff =
+          diffLines(docFrom.symbols.map(_.symbol).toList, docTo.symbols.map(_.symbol).toList)
 
         val fullDiff = diffConcat(
-          orderDiff.extractLines.getOrElse(docFrom.symbols.map(_.symbol)).map {
-            sym =>
-              val symDiff =
-                if (symsFrom.contains(sym) && symsTo.contains(sym))
-                  diffLines(symsFrom(sym).toProtoString.lines, symsTo(sym).toProtoString.lines)
-                else if (symsFrom.contains(sym))
-                  diffPatch('-', Some(symsFrom(sym).toProtoString))
-                else
-                  diffPatch('+', Some(symsTo(sym).toProtoString))
-              symDiff.name(s"symbol '$sym'")
+          orderDiff.extractLines.getOrElse(docFrom.symbols.map(_.symbol)).map { sym =>
+            val symDiff =
+              if (symsFrom.contains(sym) && symsTo.contains(sym))
+                diffLines(symsFrom(sym).toProtoString.lines, symsTo(sym).toProtoString.lines)
+              else if (symsFrom.contains(sym))
+                diffPatch('-', Some(symsFrom(sym).toProtoString))
+              else
+                diffPatch('+', Some(symsTo(sym).toProtoString))
+            symDiff.name(s"symbol '$sym'")
           }
         )
 
@@ -87,9 +83,7 @@ class Main(settings: Settings, reporter: Reporter) {
             .map { occ =>
               val occDiff =
                 if (occsFrom.contains(occ) && occsTo.contains(occ))
-                  diffLines(
-                    occsFrom(occ).map(display),
-                    occsTo(occ).map(display))
+                  diffLines(occsFrom(occ).map(display), occsTo(occ).map(display))
                 else if (occsFrom.contains(occ))
                   diffPatch('-', Some(occsFrom(occ).map(displayEOL).mkString))
                 else
@@ -145,8 +139,8 @@ class Main(settings: Settings, reporter: Reporter) {
   }
 
   implicit val pathOrdering: Ordering[Path] = Ordering.by(_.toString)
-  implicit val rangeOrdering: Ordering[Option[s.Range]] = Ordering.by(
-    _.map(r => (r.startLine, r.startCharacter, r.endLine, r.endCharacter)))
+  implicit val rangeOrdering: Ordering[Option[s.Range]] =
+    Ordering.by(_.map(r => (r.startLine, r.startCharacter, r.endLine, r.endCharacter)))
 
   implicit class OptRangeOps(rOpt: Option[s.Range]) {
     def str: String = rOpt.fold("") { r =>

--- a/semanticdb/metadiff/src/main/scala/scala/meta/internal/metadiff/diff/package.scala
+++ b/semanticdb/metadiff/src/main/scala/scala/meta/internal/metadiff/diff/package.scala
@@ -33,7 +33,10 @@ package object diff {
 
   }
 
-  def diffLines(linesFrom: TraversableOnce[String], linesTo: TraversableOnce[String], contextSize: Int = 1000000): Diff = {
+  def diffLines(
+      linesFrom: TraversableOnce[String],
+      linesTo: TraversableOnce[String],
+      contextSize: Int = 1000000): Diff = {
     val origLines = linesFrom.toSeq.asJava
     val patch = DiffUtils.diff(origLines, linesTo.toSeq.asJava)
     if (patch.getDeltas.isEmpty) None

--- a/semanticdb/metadiff/src/main/scala/scala/meta/internal/metadiff/diff/package.scala
+++ b/semanticdb/metadiff/src/main/scala/scala/meta/internal/metadiff/diff/package.scala
@@ -1,0 +1,81 @@
+package scala.meta.internal.metadiff
+
+import difflib.DiffUtils
+import java.util.regex.Pattern
+import scala.collection.JavaConverters._
+
+package object diff {
+
+  val EOL = System.lineSeparator()
+
+  type Diff = Option[String]
+
+  implicit class DiffOps(diff: Diff) {
+
+    def name(name: String): Diff =
+      diff.map { d =>
+        val headerBar = "=" * name.length
+        s"$name$EOL" +
+          s"$headerBar$EOL" +
+          d
+      }
+
+    def concat(that: Diff): Diff = diffConcat(diff, that)
+
+    def extractLines: Option[Seq[String]] = diff.map { text =>
+      text.lines
+        .filterNot(_.startsWith("@@"))
+        .map { line =>
+          line.substring(1)
+        }
+        .toSeq
+    }
+
+  }
+
+  def diffLines(linesFrom: TraversableOnce[String], linesTo: TraversableOnce[String], contextSize: Int = 1000000): Diff = {
+    val origLines = linesFrom.toSeq.asJava
+    val patch = DiffUtils.diff(origLines, linesTo.toSeq.asJava)
+    if (patch.getDeltas.isEmpty) None
+    else {
+      val diffStr = DiffUtils
+        .generateUnifiedDiff("", "", origLines, patch, contextSize)
+        .asScala
+        .drop(3)
+        .mkString(EOL)
+      Some(diffStr + EOL)
+    }
+  }
+
+  def diffObj[T](objFrom: T, objTo: T): Diff =
+    if (objFrom == objTo) None
+    else
+      diffPatch('-', Some(objFrom.toString)) concat
+        diffPatch('+', Some(objTo.toString))
+
+  def diffPatch(char: Char, diff: Diff): Diff =
+    diff.map { d =>
+      val sb = new StringBuilder
+      d.split(Pattern.quote(EOL)).foreach { line =>
+        sb += char
+        sb ++= line
+        sb ++= EOL
+      }
+      sb.toString()
+    }
+
+  def diffConcat(diffs: Diff*): Diff =
+    diffs.flatten match {
+      case Seq() => None
+      case s => Some(s.mkString)
+    }
+
+  def diffConcat(diffs: Iterable[Diff]): Diff = diffConcat(diffs.toSeq: _*)
+
+  def diffHeader(headerFrom: String, headerTo: String, diff: Diff): Diff =
+    diff.map { d =>
+      s"--- $headerFrom$EOL" +
+        s"+++ $headerTo$EOL" + d
+    }
+
+}

--- a/semanticdb/metadiff/src/main/scala/scala/meta/metadiff/Settings.scala
+++ b/semanticdb/metadiff/src/main/scala/scala/meta/metadiff/Settings.scala
@@ -14,10 +14,7 @@ final case class Settings(
 
 object Settings {
   def parse(args: List[String], reporter: Reporter): Option[Settings] = {
-    def loop(
-        settings: Settings,
-        allowOptions: Boolean,
-        args: List[String]): Option[Settings] = {
+    def loop(settings: Settings, allowOptions: Boolean, args: List[String]): Option[Settings] = {
       args match {
         case "--" +: rest =>
           loop(settings, false, rest)

--- a/semanticdb/metadiff/src/main/scala/scala/meta/metadiff/Settings.scala
+++ b/semanticdb/metadiff/src/main/scala/scala/meta/metadiff/Settings.scala
@@ -1,0 +1,57 @@
+package scala.meta.metadiff
+
+import java.io.File
+import java.nio.file.{Path, Paths}
+import scala.meta.cli.Reporter
+
+final case class Settings(
+    paths: List[Path] = List(),
+    compareSymbols: Boolean = true,
+    compareOccurrences: Boolean = true,
+    compareSynthetics: Boolean = true,
+    compareOrder: Boolean = true
+)
+
+object Settings {
+  def parse(args: List[String], reporter: Reporter): Option[Settings] = {
+    def loop(
+        settings: Settings,
+        allowOptions: Boolean,
+        args: List[String]): Option[Settings] = {
+      args match {
+        case "--" +: rest =>
+          loop(settings, false, rest)
+        case "--syms" +: rest if allowOptions =>
+          loop(settings.copy(compareSymbols = true), true, rest)
+        case "--no-syms" +: rest if allowOptions =>
+          loop(settings.copy(compareSymbols = false), true, rest)
+        case "--occs" +: rest if allowOptions =>
+          loop(settings.copy(compareOccurrences = true), true, rest)
+        case "--no-occs" +: rest if allowOptions =>
+          loop(settings.copy(compareOccurrences = false), true, rest)
+        case "--synths" +: rest if allowOptions =>
+          loop(settings.copy(compareSynthetics = true), true, rest)
+        case "--no-synths" +: rest if allowOptions =>
+          loop(settings.copy(compareSynthetics = false), true, rest)
+        case "--order" +: rest if allowOptions =>
+          loop(settings.copy(compareOrder = true), true, rest)
+        case "--no-order" +: rest if allowOptions =>
+          loop(settings.copy(compareOrder = false), true, rest)
+        case flag +: rest if allowOptions && flag.startsWith("-") =>
+          reporter.out.println(s"unknown flag $flag")
+          None
+        case pathStr +: rest =>
+          val path = pathStr.split(File.pathSeparator).map(Paths.get(_))
+          val paths1 = settings.paths ++ path
+          loop(settings.copy(paths = paths1), true, rest)
+        case Nil =>
+          Some(settings)
+      }
+    }
+    loop(Settings(), true, args).filter { settings =>
+      if (settings.paths.length != 2)
+        reporter.out.println("Expected exactly two paths to diff")
+      settings.paths.length == 2
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a tool called metadiff that takes two directories of SemanticDB and produces a diff comparing them. Just plaintext diffing the source of text documents is way too slow, so I make a best effort to speed up the diffing by doing semantic diffs wherever possible. The order diffs can slow it a down a lot, so the `--no-order`flag ignores order of symbol information and occurrences. Diffs for symbol information, occurrences, and synthetics can also be turned off with flags.

I am currently actively using this tool, and it seems like it could be useful for the future as part of the SemanticDB toolchain ecosystem. I have not made any tests for this, because I'm not sure how to test it.