### PR TITLE
Implement utility method to print single symbol info

### DIFF
--- a/semanticdb/metap/src/main/scala/scala/meta/internal/metap/BasePrinter.scala
+++ b/semanticdb/metap/src/main/scala/scala/meta/internal/metap/BasePrinter.scala
@@ -5,7 +5,11 @@ import scala.meta.cli._
 import scala.meta.internal.semanticdb._
 import scala.meta.metap._
 
-abstract class BasePrinter(val settings: Settings, val reporter: Reporter, val doc: TextDocument) {
+abstract class BasePrinter(
+    val settings: Settings,
+    val reporter: Reporter,
+    val doc: TextDocument,
+    val symtab: PrinterSymtab) {
   def out: PrintStream = {
     reporter.out
   }

--- a/semanticdb/metap/src/main/scala/scala/meta/internal/metap/DocumentPrinter.scala
+++ b/semanticdb/metap/src/main/scala/scala/meta/internal/metap/DocumentPrinter.scala
@@ -5,12 +5,18 @@ import scala.meta.internal.semanticdb._
 import scala.meta.internal.semanticdb.Language._
 import scala.meta.metap._
 
-class DocumentPrinter(settings: Settings, reporter: Reporter, doc: TextDocument)
-    extends BasePrinter(settings, reporter, doc)
+class DocumentPrinter(
+    settings: Settings,
+    reporter: Reporter,
+    doc: TextDocument,
+    symtab: PrinterSymtab)
+    extends BasePrinter(settings, reporter, doc, symtab)
     with SymbolInformationPrinter
     with OccurrencePrinter
     with DiagnosticPrinter
     with SyntheticPrinter {
+  def this(settings: Settings, reporter: Reporter, doc: TextDocument) =
+    this(settings, reporter, doc, PrinterSymtab.fromTextDocument(doc))
 
   def print(): Unit = {
     out.println(doc.uri)

--- a/semanticdb/metap/src/main/scala/scala/meta/internal/metap/PrinterSymtab.scala
+++ b/semanticdb/metap/src/main/scala/scala/meta/internal/metap/PrinterSymtab.scala
@@ -1,0 +1,18 @@
+package scala.meta.internal.metap
+
+import scala.meta.internal.semanticdb.SymbolInformation
+import scala.meta.internal.semanticdb.TextDocument
+
+// Identical to symtab.SymbolTable but copied since symtab is JVM-only.
+trait PrinterSymtab {
+  def info(symbol: String): Option[SymbolInformation]
+}
+
+object PrinterSymtab {
+  def fromTextDocument(doc: TextDocument): PrinterSymtab = {
+    val map = doc.symbols.map(info => (info.symbol, info)).toMap
+    new PrinterSymtab {
+      override def info(symbol: String): Option[SymbolInformation] = map.get(symbol)
+    }
+  }
+}

--- a/tests/jvm/src/test/scala/scala/meta/tests/metap/SymbolInformationPrinterSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/metap/SymbolInformationPrinterSuite.scala
@@ -1,0 +1,42 @@
+package scala.meta.tests.metap
+import org.scalatest.FunSuite
+import scala.meta.internal.metap.PrinterSymtab
+import scala.meta.internal.metap.SymbolInformationPrinter
+import scala.meta.internal.semanticdb.SymbolInformation
+import scala.meta.internal.symtab.GlobalSymbolTable
+import scala.meta.testkit.DiffAssertions
+import scala.meta.tests.metacp.Library
+
+class SymbolInformationPrinterSuite extends FunSuite with DiffAssertions {
+  val symtab = GlobalSymbolTable(
+    Library.scalaLibrary.classpath() ++
+      Library.jdk.classpath()
+  )
+  val printerSymtab: PrinterSymtab = new PrinterSymtab {
+    override def info(symbol: String): Option[SymbolInformation] = symtab.info(symbol)
+  }
+
+  def check(symbol: String, expected: String): Unit = {
+    test(symbol) {
+      val info = symtab.info(symbol).get
+      val obtained = SymbolInformationPrinter.print(info, printerSymtab)
+      assertNoDiffOrPrintExpected(obtained, expected)
+    }
+  }
+
+  check(
+    "scala/Predef.assert().",
+    """SymbolInformation("scala/Predef.assert().", @elidable method assert(assertion: Boolean): Unit)"""
+  )
+
+  check(
+    "scala/Any#",
+    """SymbolInformation("scala/Any#", abstract class Any { +10 decls })"""
+  )
+
+  check(
+    "java/util/Collections#singletonList().",
+    """SymbolInformation("java/util/Collections#singletonList().", static method singletonList[T](param0: T): List[T])"""
+  )
+
+}


### PR DESCRIPTION
While working on scalafix.v1 it was suggested to re-use metap for
pretty-printing. Previously, metap required a TextDocument to eagerly
build a mini-symtab to print symbols. After this commit, it's possible to
use a lazy GlobalSymbolTable instead.