### PR TITLE
Add pretty-printers for synthetic/signature/tree/constant

### DIFF
--- a/semanticdb/metap/src/main/scala/scala/meta/internal/metap/SymbolInformationPrinter.scala
+++ b/semanticdb/metap/src/main/scala/scala/meta/internal/metap/SymbolInformationPrinter.scala
@@ -302,7 +302,7 @@ trait SymbolInformationPrinter extends BasePrinter {
       else out.print("<?>")
     }
 
-    protected def pprint(const: Constant): Unit = {
+    def pprint(const: Constant): Unit = {
       const match {
         case NoConstant =>
           out.print("<?>")

--- a/semanticdb/metap/src/main/scala/scala/meta/internal/metap/SyntheticPrinter.scala
+++ b/semanticdb/metap/src/main/scala/scala/meta/internal/metap/SyntheticPrinter.scala
@@ -34,8 +34,7 @@ trait SyntheticPrinter extends BasePrinter with RangePrinter with SymbolInformat
 
   implicit def syntheticOrder: Ordering[Synthetic] = Ordering.by(_.range)
 
-  private class TreePrinter(notes: InfoNotes, originalRange: Option[Range])
-      extends InfoPrinter(notes) {
+  class TreePrinter(notes: InfoNotes, originalRange: Option[Range]) extends InfoPrinter(notes) {
 
     def pprint(tree: Tree): Unit = {
       tree match {

--- a/semanticdb/metap/src/main/scala/scala/meta/internal/semanticdb/Print.scala
+++ b/semanticdb/metap/src/main/scala/scala/meta/internal/semanticdb/Print.scala
@@ -10,23 +10,70 @@ import scala.meta.metap._
 object Print {
 
   def document(format: Format, doc: TextDocument): String = {
-    val baos = new ByteArrayOutputStream()
-    val ps = new PrintStream(baos)
-    val settings = Settings().withFormat(format)
-    val reporter = Reporter().withOut(ps).withErr(ps)
-    val printer = new DocumentPrinter(settings, reporter, doc)
-    printer.print()
-    baos.toString()
+    val symtab = PrinterSymtab.fromTextDocument(TextDocument())
+    withPrinter(format, doc, symtab) { printer =>
+      printer.print()
+    }
+  }
+
+  def tpe(format: Format, tpe: Type, symtab: PrinterSymtab): String = {
+    withInfoPrinter(format, TextDocument(), symtab) { printer =>
+      printer.pprint(tpe)
+    }.trim
+  }
+
+  def constant(constant: Constant): String = {
+    val symtab = PrinterSymtab.fromTextDocument(TextDocument())
+    withInfoPrinter(Format.Detailed, TextDocument(), symtab) { printer =>
+      printer.pprint(constant)
+    }.trim
+  }
+
+  def signature(format: Format, signature: Signature, symtab: PrinterSymtab): String = {
+    withInfoPrinter(format, TextDocument(), symtab) { printer =>
+      printer.pprint(signature)
+    }.trim
   }
 
   def info(format: Format, info: SymbolInformation, symtab: PrinterSymtab): String = {
+    withPrinter(format, TextDocument().addSymbols(info), symtab) { printer =>
+      printer.pprint(info)
+    }.trim
+  }
+
+  def synthetic(
+      format: Format,
+      doc: TextDocument,
+      synthetic: Synthetic,
+      symtab: PrinterSymtab): String = {
+    withPrinter(format, doc, symtab) { printer =>
+      printer.pprint(synthetic)
+    }.trim
+  }
+
+  def tree(format: Format, doc: TextDocument, tree: Tree, symtab: PrinterSymtab): String = {
+    withPrinter(format, doc, symtab) { printer =>
+      printer.pprint(tree, None)
+    }.trim
+  }
+
+  def withInfoPrinter(format: Format, doc: TextDocument, symtab: PrinterSymtab)(
+      fn: DocumentPrinter#InfoPrinter => Unit): String = {
+    withPrinter(format, TextDocument(), symtab) { printer =>
+      val notes = new printer.InfoNotes()
+      val infoPrinter = new printer.InfoPrinter(notes)
+      fn(infoPrinter)
+    }.trim
+  }
+
+  def withPrinter(format: Format, doc: TextDocument, symtab: PrinterSymtab)(
+      fn: DocumentPrinter => Unit): String = {
     val baos = new ByteArrayOutputStream()
     val ps = new PrintStream(baos)
     val settings = Settings().withFormat(format)
     val reporter = Reporter().withOut(ps).withSilentErr()
-    val doc = TextDocument().addSymbols(info)
     val printer = new DocumentPrinter(settings, reporter, doc, symtab)
-    printer.pprint(info)
+    fn(printer)
     baos.toString().trim
   }
 

--- a/semanticdb/metap/src/main/scala/scala/meta/internal/semanticdb/Print.scala
+++ b/semanticdb/metap/src/main/scala/scala/meta/internal/semanticdb/Print.scala
@@ -57,7 +57,7 @@ object Print {
     }.trim
   }
 
-  def withInfoPrinter(format: Format, doc: TextDocument, symtab: PrinterSymtab)(
+  private def withInfoPrinter(format: Format, doc: TextDocument, symtab: PrinterSymtab)(
       fn: DocumentPrinter#InfoPrinter => Unit): String = {
     withPrinter(format, TextDocument(), symtab) { printer =>
       val notes = new printer.InfoNotes()
@@ -66,7 +66,7 @@ object Print {
     }.trim
   }
 
-  def withPrinter(format: Format, doc: TextDocument, symtab: PrinterSymtab)(
+  private def withPrinter(format: Format, doc: TextDocument, symtab: PrinterSymtab)(
       fn: DocumentPrinter => Unit): String = {
     val baos = new ByteArrayOutputStream()
     val ps = new PrintStream(baos)

--- a/semanticdb/metap/src/main/scala/scala/meta/internal/semanticdb/Print.scala
+++ b/semanticdb/metap/src/main/scala/scala/meta/internal/semanticdb/Print.scala
@@ -10,7 +10,7 @@ import scala.meta.metap._
 object Print {
 
   def document(format: Format, doc: TextDocument): String = {
-    val symtab = PrinterSymtab.fromTextDocument(TextDocument())
+    val symtab = PrinterSymtab.fromTextDocument(doc)
     withPrinter(format, doc, symtab) { printer =>
       printer.print()
     }

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/PrintSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/PrintSuite.scala
@@ -1,8 +1,10 @@
 package scala.meta.tests.semanticdb
 
 import org.scalatest.FunSuite
+import scala.meta.interactive.InteractiveSemanticdb
 import scala.meta.internal.metap.PrinterSymtab
 import scala.meta.internal.metap.SymbolInformationPrinter
+import scala.meta.internal.{semanticdb => s}
 import scala.meta.internal.semanticdb.Print
 import scala.meta.internal.semanticdb.SymbolInformation
 import scala.meta.internal.symtab.GlobalSymbolTable
@@ -15,31 +17,133 @@ class PrintSuite extends FunSuite with DiffAssertions {
     Library.scalaLibrary.classpath() ++
       Library.jdk.classpath()
   )
+
+  val compiler = InteractiveSemanticdb.newCompiler()
   val printerSymtab: PrinterSymtab = new PrinterSymtab {
     override def info(symbol: String): Option[SymbolInformation] = symtab.info(symbol)
   }
 
+  def checkDocument(
+      name: String,
+      original: String,
+      expected: String,
+      fn: s.TextDocument => Unit): Unit = {
+    test(name) {
+      val wrapped =
+        s"""
+object Wrapped {
+$original
+}
+""".stripMargin
+      val doc = InteractiveSemanticdb.toTextDocument(
+        compiler = compiler,
+        code = wrapped,
+        options = List(
+          "-P:semanticdb:synthetics:on",
+          "-P:semanticdb:text:on"
+        )
+      )
+      fn(doc)
+    }
+  }
+
+  def checkType(symbol: String, expected: String): Unit = {
+    test("type - " + symbol) {
+      val info = symtab.info(symbol).get
+      val tpe = info.signature match {
+        case s.ValueSignature(tpe) => tpe
+        case s.MethodSignature(_, _, tpe) => tpe
+        case e => throw new MatchError(e)
+      }
+      val obtained = Print.tpe(Format.Compact, tpe, printerSymtab)
+      assertNoDiffOrPrintExpected(obtained, expected)
+    }
+  }
+
+  def checkConstant(constant: s.Constant, expected: String): Unit = {
+    test(constant.toString) {
+      val obtained = Print.constant(constant)
+      assertNoDiffOrPrintExpected(obtained, expected)
+    }
+  }
+
+  def checkSignature(symbol: String, expected: String): Unit = {
+    test("signature - " + symbol) {
+      val info = symtab.info(symbol).get
+      val obtained = Print.signature(Format.Compact, info.signature, printerSymtab)
+      assertNoDiffOrPrintExpected(obtained, expected)
+    }
+  }
+
   def checkInfo(symbol: String, expected: String): Unit = {
-    test(symbol) {
+    test("info - " + symbol) {
       val info = symtab.info(symbol).get
       val obtained = Print.info(Format.Compact, info, printerSymtab)
       assertNoDiffOrPrintExpected(obtained, expected)
     }
   }
 
-  checkInfo(
-    "scala/Predef.assert().",
-    """scala/Predef.assert(). => @elidable method assert(assertion: Boolean): Unit"""
+  def checkSynthetics(original: String, expected: String): Unit = {
+    checkDocument("synthetic - " + original, original, expected, { doc =>
+      val obtained = doc.synthetics.map { synthetic =>
+        Print.synthetic(Format.Compact, doc, synthetic, printerSymtab)
+      }
+      assertNoDiffOrPrintExpected(obtained.mkString("\n"), expected)
+    })
+  }
+
+  def checkTrees(original: String, expected: String): Unit = {
+    checkDocument("trees - " + original, original, expected, { doc =>
+      val obtained = doc.synthetics.map { synthetic =>
+        Print.tree(Format.Compact, doc, synthetic.tree, printerSymtab)
+      }
+      assertNoDiffOrPrintExpected(obtained.mkString("\n"), expected)
+    })
+  }
+
+  checkType("java/io/ByteArrayOutputStream#buf.", "Array[Byte]")
+  checkType("scala/Predef.ArrowAssoc#`->`().", "Tuple2[A, B]")
+
+  checkConstant(s.UnitConstant(), "()")
+  checkConstant(s.LongConstant(64), "64L")
+  checkConstant(s.CharConstant('a'.toInt), "'a'")
+  checkConstant(s.StringConstant("a"), "\"a\"")
+
+  checkSignature(
+    "scala/Predef.assert(+1).",
+    """(assertion: Boolean, message: => Any): Unit"""
+  )
+  checkSignature(
+    "scala/Predef.ArrowAssoc#`->`().",
+    "[B](y: B): Tuple2[A, B]"
   )
 
+  checkInfo(
+    "scala/Predef.assert(+1).",
+    """scala/Predef.assert(+1). => @inline @elidable final method assert(assertion: Boolean, message: => Any): Unit"""
+  )
   checkInfo(
     "scala/Any#",
     """scala/Any# => abstract class Any { +10 decls }"""
   )
-
   checkInfo(
     "java/util/Collections#singletonList().",
     """java/util/Collections#singletonList(). => static method singletonList[T](param0: T): List[T]"""
   )
 
+  checkSynthetics(
+    "List(1).map(_ + 2)",
+    """|[2:0..2:18): List(1).map(_ + 2) => *(canBuildFrom[Int])
+       |[2:0..2:11): List(1).map => *[Int, List[Int]]
+       |[2:0..2:4): List => *.apply[Int]
+       |""".stripMargin
+  )
+
+  checkTrees(
+    "List(1).map(_ + 2)",
+    """|orig(List(1).map(_ + 2))(canBuildFrom[Int])
+       |orig(List(1).map)[Int, List[Int]]
+       |orig(List).apply[Int]
+       |""".stripMargin
+  )
 }


### PR DESCRIPTION
These avoid the need for scalafix to poke further into internals.