### PR TITLE
Fix or remove dead links

### DIFF
--- a/notes/quasiquotes.md
+++ b/notes/quasiquotes.md
@@ -46,30 +46,30 @@ the end of the document.
 
 ## Types (meta.Type)
 
-|                   | Quasiquote                                                                                                                             |
-| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| Literal           | `t"<literal>"`                                                                                                                         |
-| Name              | `t"<name>"`                                                                                                                            |
-| Selection         | `t"$eref.$tname"`                                                                                                                      |
-| Projection        | `t"$tpe#$tname"`                                                                                                                       |
-| Singleton         | `t"$eref.type"`                                                                                                                        |
-| Application       | `t"$tpe[..$tpesnel]` (vote for #519 to support `q"$expr[...$tpess]"`)                                                                  |
-| Infix Application | `t"$tpe $tname $tpe"`                                                                                                                  |
-| With              | `t"$tpe with $tpe"` (only for [supported dialects](/scalameta/dialects/src/main/scala/scala/meta/dialects/package.scala))              |
-| And               | `t"$tpe & $tpe"` (only for [supported dialects](/scalameta/dialects/src/main/scala/scala/meta/dialects/package.scala))                 |
-| Or                | <code>t"$tpe &#124; $tpe"</code> (only for [supported dialects](/scalameta/dialects/src/main/scala/scala/meta/dialects/package.scala)) |
-| Function          | `t"(..$tpes) => $tpe"`                                                                                                                 |
-| Implicit Function | `t"implicit (..$tpes) => $tpe"`                                                                                                        |
-| Tuple             | `t"(..$tpesnel)"`                                                                                                                      |
-| Refine            | `t"$tpeopt { ..$stats }"`                                                                                                              |
-| Existential       | `t"$tpe forSome { ..$statsnel }"`                                                                                                      |
-| Annotate          | `t"$tpe ..@$annotsnel"`                                                                                                                |
-| Lambda            | `t[..$tparams] => $tpe`                                                                                                                |
-| Method            | `t(...$paramss): $tpe`                                                                                                                 |
-| Placeholder       | `t"_ >: $tpeopt <: $tpeopt"`                                                                                                           |
-| By Name           | `t"=> $tpe"`                                                                                                                           |
-| Repeated          | `t"$tpe*"`                                                                                                                             |
-| Var               | Not supported                                                                                                                          |
+|                   | Quasiquote                                                            |
+| ----------------- | --------------------------------------------------------------------- |
+| Literal           | `t"<literal>"`                                                        |
+| Name              | `t"<name>"`                                                           |
+| Selection         | `t"$eref.$tname"`                                                     |
+| Projection        | `t"$tpe#$tname"`                                                      |
+| Singleton         | `t"$eref.type"`                                                       |
+| Application       | `t"$tpe[..$tpesnel]` (vote for #519 to support `q"$expr[...$tpess]"`) |
+| Infix Application | `t"$tpe $tname $tpe"`                                                 |
+| With              | `t"$tpe with $tpe"` (only for supported dialects)                     |
+| And               | `t"$tpe & $tpe"` (only for supported dialects)                        |
+| Or                | <code>t"$tpe &#124; $tpe"</code> (only for supported dialects)        |
+| Function          | `t"(..$tpes) => $tpe"`                                                |
+| Implicit Function | `t"implicit (..$tpes) => $tpe"`                                       |
+| Tuple             | `t"(..$tpesnel)"`                                                     |
+| Refine            | `t"$tpeopt { ..$stats }"`                                             |
+| Existential       | `t"$tpe forSome { ..$statsnel }"`                                     |
+| Annotate          | `t"$tpe ..@$annotsnel"`                                               |
+| Lambda            | `t[..$tparams] => $tpe`                                               |
+| Method            | `t(...$paramss): $tpe`                                                |
+| Placeholder       | `t"_ >: $tpeopt <: $tpeopt"`                                          |
+| By Name           | `t"=> $tpe"`                                                          |
+| Repeated          | `t"$tpe*"`                                                            |
+| Var               | Not supported                                                         |
 
 ## Patterns (meta.Pat) and Cases (meta.Case)
 

--- a/semanticdb/semanticdb3/semanticdb3.md
+++ b/semanticdb/semanticdb3/semanticdb3.md
@@ -178,7 +178,7 @@ enum Language {
 ```
 
 `Language` represents a programming language that defines certain SemanticDB
-entities, e.g. [Document](#document) or [Symbol](#symbol). Currently,
+entities, e.g. [TextDocument](#textdocument) or [Symbol](#symbol). Currently,
 See [Languages](#languages) for the details of how features of supported
 programming languages map onto SemanticDB.
 
@@ -1026,7 +1026,7 @@ A `Tree` represents a typed abstract syntax tree.
 The trees are similar to Scalameta and Rsc trees, except for
 `OriginalTree`, which represents a quote of the original source file.
 We only support a small subset of Scala syntax necessary to model
-[Synthetics](#synthetics).
+[Synthetics](#synthetic).
 At the moment, we do not have plans to add more trees.
 
 ```protobuf


### PR DESCRIPTION
These dead links were detected by mdoc while I was working on the new scalameta docs

```
warning: quasiquotes.md:63:53: warning: Unknown link '/scalameta/dialects/src/main/scala/scala/meta/dialects/package.scala'. To fix this problem, either make the link relative or turn it into complete URL such as http://example.com/scalameta/dialects/src/main/scala/scala/meta/dialects/package.scala.
| With              | `t"$tpe with $tpe"` (only for [supported dialects](/scalameta/dialects/src/main/scala/scala/meta/dialects/package.scala))              |
                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
warning: quasiquotes.md:64:50: warning: Unknown link '/scalameta/dialects/src/main/scala/scala/meta/dialects/package.scala'. To fix this problem, either make the link relative or turn it into complete URL such as http://example.com/scalameta/dialects/src/main/scala/scala/meta/dialects/package.scala.
| And               | `t"$tpe & $tpe"` (only for [supported dialects](/scalameta/dialects/src/main/scala/scala/meta/dialects/package.scala))                 |
                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
warning: quasiquotes.md:65:66: warning: Unknown link '/scalameta/dialects/src/main/scala/scala/meta/dialects/package.scala'. To fix this problem, either make the link relative or turn it into complete URL such as http://example.com/scalameta/dialects/src/main/scala/scala/meta/dialects/package.scala.
| Or                | <code>t"$tpe &#124; $tpe"</code> (only for [supported dialects](/scalameta/dialects/src/main/scala/scala/meta/dialects/package.scala)) |
                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
warning: semanticdb.md:147:16: warning: Unknown link 'semanticdb.md#document', did you mean 'semanticdb.md#textdocument'?
entities, e.g. [Document](#document) or [Symbol](#symbol). Currently,
               ^^^^^^^^^^^^^^^^^^^^^
warning: semanticdb.md:995:1: warning: Unknown link 'semanticdb.md#synthetics', did you mean 'semanticdb.md#synthetic'?
[Synthetics](#synthetics).
^^^^^^^^^^^^^^^^^^^^^^^^^
```
Absolute links like `[foo](/absolute/path.html)` are difficult to render correctly on GitHub + GitHub pages + Maven Central archives so I recommend using  relative links instead.