### PR TITLE
Introduce --stub-broken-signatures for Metacp

### DIFF
--- a/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/ClassfileInfos.scala
+++ b/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/ClassfileInfos.scala
@@ -2,12 +2,14 @@ package scala.meta.internal.metacp
 
 import java.nio.file.Files
 import scala.collection.JavaConverters._
+import scala.meta.cli._
 import scala.meta.internal.classpath.ClasspathIndex
 import scala.meta.internal.io.FileIO
 import scala.meta.internal.javacp.Javacp
 import scala.meta.internal.scalacp.Scalacp
 import scala.meta.internal.{semanticdb => s}
 import scala.meta.io.AbsolutePath
+import scala.meta.metacp._
 import scala.tools.asm.tree.ClassNode
 
 final case class ClassfileInfos(
@@ -35,11 +37,13 @@ final case class ClassfileInfos(
 object ClassfileInfos {
   def fromClassNode(
       node: ClassNode,
-      classpathIndex: ClasspathIndex
+      classpathIndex: ClasspathIndex,
+      settings: Settings,
+      reporter: Reporter
   ): Option[ClassfileInfos] = {
     node.scalaSig match {
       case Some(scalaSig) =>
-        Some(Scalacp.parse(scalaSig, classpathIndex))
+        Some(Scalacp.parse(scalaSig, classpathIndex, settings, reporter))
       case None =>
         val attrs = if (node.attrs != null) node.attrs.asScala else Nil
         if (attrs.exists(_.`type` == "Scala")) {

--- a/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/Main.scala
+++ b/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/Main.scala
@@ -187,7 +187,7 @@ class Main(settings: Settings, reporter: Reporter) {
             try {
               val abspath = AbsolutePath(path)
               val node = abspath.toClassNode
-              val result = ClassfileInfos.fromClassNode(node, classpathIndex)
+              val result = ClassfileInfos.fromClassNode(node, classpathIndex, settings, reporter)
               result.foreach { infos =>
                 infos.save(out)
               }

--- a/semanticdb/metacp/src/main/scala/scala/meta/internal/scalacp/Scalacp.scala
+++ b/semanticdb/metacp/src/main/scala/scala/meta/internal/scalacp/Scalacp.scala
@@ -3,10 +3,14 @@ package scala.meta.internal.scalacp
 import scala.meta.internal.classpath._
 import scala.meta.internal.metacp._
 import scala.meta.internal.{semanticdb => s}
+import scala.meta.cli._
+import scala.meta.metacp._
 import scala.tools.scalap.scalax.rules.scalasig._
 
 final class Scalacp private (
-    val symbolIndex: SymbolIndex
+    val symbolIndex: SymbolIndex,
+    val settings: Settings,
+    val reporter: Reporter
 ) extends AnnotationOps
     with SymbolInformationOps
     with SymbolOps
@@ -37,10 +41,12 @@ final class Scalacp private (
 object Scalacp {
   def parse(
       node: ScalaSigNode,
-      classpathIndex: ClasspathIndex
+      classpathIndex: ClasspathIndex,
+      settings: Settings,
+      reporter: Reporter
   ): ClassfileInfos = {
     val symbolIndex = SymbolIndex(classpathIndex)
-    val scalacp = new Scalacp(symbolIndex)
+    val scalacp = new Scalacp(symbolIndex, settings, reporter)
     scalacp.parse(node)
   }
 }

--- a/semanticdb/metacp/src/main/scala/scala/meta/internal/scalacp/SymbolInformationOps.scala
+++ b/semanticdb/metacp/src/main/scala/scala/meta/internal/scalacp/SymbolInformationOps.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.scalacp
 
 import scala.collection.mutable
+import scala.meta.internal.classpath._
 import scala.meta.internal.{semanticdb => s}
 import scala.meta.internal.semanticdb.{Language => l}
 import scala.meta.internal.semanticdb.Scala._
@@ -184,6 +185,15 @@ trait SymbolInformationOps { self: Scalacp =>
           }
         }
       } catch {
+        case ex: MissingSymbolException =>
+          if (settings.logBrokenSignatures) {
+            reporter.err.println(s"broken signature for ${sym.ssym}: ${ex.getMessage}")
+          }
+          if (settings.stubBrokenSignatures) {
+            s.NoSignature
+          } else {
+            throw ex
+          }
         case ScalaSigParserError("Unexpected failure") =>
           // FIXME: https://github.com/scalameta/scalameta/issues/1494
           s.NoSignature

--- a/semanticdb/metacp/src/main/scala/scala/meta/metacp/Settings.scala
+++ b/semanticdb/metacp/src/main/scala/scala/meta/metacp/Settings.scala
@@ -12,7 +12,9 @@ final class Settings private (
     val scalaLibrarySynthetics: Boolean,
     val par: Boolean,
     val verbose: Boolean,
-    val usejavacp: Boolean
+    val usejavacp: Boolean,
+    val stubBrokenSignatures: Boolean,
+    val logBrokenSignatures: Boolean
 ) {
   private def this() = {
     this(
@@ -22,7 +24,9 @@ final class Settings private (
       scalaLibrarySynthetics = false,
       par = false,
       verbose = false,
-      usejavacp = false
+      usejavacp = false,
+      stubBrokenSignatures = false,
+      logBrokenSignatures = false
     )
   }
 
@@ -59,6 +63,14 @@ final class Settings private (
     copy(usejavacp = usejavacp)
   }
 
+  def withStubBrokenSignatures(stubBrokenSignatures: Boolean): Settings = {
+    copy(stubBrokenSignatures = stubBrokenSignatures)
+  }
+
+  def withLogBrokenSignatures(logBrokenSignatures: Boolean): Settings = {
+    copy(logBrokenSignatures = logBrokenSignatures)
+  }
+
   private def copy(
       out: AbsolutePath = out,
       classpath: Classpath = classpath,
@@ -66,7 +78,9 @@ final class Settings private (
       scalaLibrarySynthetics: Boolean = scalaLibrarySynthetics,
       par: Boolean = par,
       verbose: Boolean = verbose,
-      usejavacp: Boolean = usejavacp
+      usejavacp: Boolean = usejavacp,
+      stubBrokenSignatures: Boolean = stubBrokenSignatures,
+      logBrokenSignatures: Boolean = logBrokenSignatures
   ): Settings = {
     new Settings(
       out = out,
@@ -75,7 +89,9 @@ final class Settings private (
       scalaLibrarySynthetics = scalaLibrarySynthetics,
       par = par,
       verbose = verbose,
-      usejavacp = usejavacp
+      usejavacp = usejavacp,
+      stubBrokenSignatures = stubBrokenSignatures,
+      logBrokenSignatures = logBrokenSignatures
     )
   }
 }
@@ -103,6 +119,10 @@ object Settings {
           loop(settings.copy(verbose = true), true, rest)
         case "--usejavacp" +: rest if allowOptions =>
           loop(settings.copy(usejavacp = true), true, rest)
+        case "--stub-broken-signatures" +: rest if allowOptions =>
+          loop(settings.copy(stubBrokenSignatures = true), true, rest)
+        case "--log-broken-signatures" +: rest if allowOptions =>
+          loop(settings.copy(logBrokenSignatures = true), true, rest)
         case flag +: _ if allowOptions && flag.startsWith("-") =>
           reporter.err.println(s"unsupported flag $flag")
           None

--- a/semanticdb/semanticdb3/guide.md
+++ b/semanticdb/semanticdb3/guide.md
@@ -490,6 +490,54 @@ metacp [options] <classpath>
       <code>--no-par</code>
     </td>
   </tr>
+  <tr>
+    <td><code>--verbose</code></td>
+    <td></td>
+    <td>
+      Toggles periodic progress printouts that help gauge Metacp's progress
+      for long-running invocations.
+    </td>
+    <td>
+      <code></code>
+    </td>
+  </tr>
+  <tr>
+    <td><code>--usejavacp</code></td>
+    <td></td>
+    <td>
+      Attempts to autodetect the locations of JDK libraries and the Scala library
+      based on the Metacp's classloader, so that these libraries don't have to be
+      specified in <code>--dependency-classpath</code>.
+    </td>
+    <td>
+      <code></code>
+    </td>
+  </tr>
+  <tr>
+    <td><code>--stub-broken-signatures</code></td>
+    <td></td>
+    <td>
+      Catches exceptions that arise during generation of `Signature` payloads
+      and stubs these payloads with `NoSignature` values instead of failing Metacp
+      invocations. May be useful for dealing with missing symbol errors arising
+      from missing optional dependencies.
+    </td>
+    <td>
+      <code></code>
+    </td>
+  </tr>
+  <tr>
+    <td><code>--log-broken-signatures</code></td>
+    <td></td>
+    <td>
+      Logs exceptions that arise during generation of `Signature` payloads.
+      May be useful in combination with <code>--stub-broken-signatures</code>
+      to have a sense of what exactly is being stubbed.
+    </td>
+    <td>
+      <code></code>
+    </td>
+  </tr>
 </table>
 
 Metacp understands classfiles produced by both the Scala and Java compiler.


### PR DESCRIPTION
Many JVM-related tools like Javac, Scalac (and the Hotspot JVM itself)
perform lazy linking, which means that missing dependencies aren't
a problem unless they are explicitly used.

At the moment, Metacp is uncharacteristically strict about this.
Since it performs eager conversion to SemanticDB, any missing dependencies
result in an immediate error.

While GlobalSymbolTable solves this problem by being lazy, there are
still some use cases (one of them being Rsc) that rely on eager
conversion. That doesn't work too well in a number of scenarios
including shading and `<dependency><optional>true</optional></dependency>`.

This commit provides a workaround for this problem by introducing the
ability to silence missing symbol errors and emit empty signatures instead.