### PR TITLE
WIP Adapt to proposed changes to Typer in 2.12.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -670,7 +670,8 @@ lazy val sharedSettings = Def.settings(
   scalaVersion := LanguageVersion,
   crossScalaVersions := LanguageVersions,
   organization := "org.scalameta",
-  addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.fullMapped(x => if (x.startsWith("2.12.7-bin")) "2.12.6" else x)),
+  addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.fullMapped(x =>
+    if (x.startsWith("2.12.7-bin")) "2.12.6" else x)),
   scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked"),
   scalacOptions.in(Compile, doc) ++= Seq("-skip-packages", ""),
   scalacOptions.in(Compile, doc) ++= Seq("-implicits", "-implicits-hide:."),
@@ -864,7 +865,8 @@ lazy val fullCrossVersionSettings = Seq(
     // not "scala_2.11.8" or "scala_2.12.1" that we need.
     // That's why we have to work around here.
     val base = sourceDirectory.in(Compile).value
-    val versionDir = if (scalaVersion.value.startsWith("2.12.7-bin")) "2.12.7" else scalaVersion.value
+    val versionDir =
+      if (scalaVersion.value.startsWith("2.12.7-bin")) "2.12.7" else scalaVersion.value
     base / ("scala-" + versionDir)
   }
 )

--- a/build.sbt
+++ b/build.sbt
@@ -670,7 +670,7 @@ lazy val sharedSettings = Def.settings(
   scalaVersion := LanguageVersion,
   crossScalaVersions := LanguageVersions,
   organization := "org.scalameta",
-  addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
+  addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.fullMapped(x => if (x.startsWith("2.12.7-bin")) "2.12.6" else x)),
   scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked"),
   scalacOptions.in(Compile, doc) ++= Seq("-skip-packages", ""),
   scalacOptions.in(Compile, doc) ++= Seq("-implicits", "-implicits-hide:."),
@@ -864,7 +864,8 @@ lazy val fullCrossVersionSettings = Seq(
     // not "scala_2.11.8" or "scala_2.12.1" that we need.
     // That's why we have to work around here.
     val base = sourceDirectory.in(Compile).value
-    base / ("scala-" + scalaVersion.value)
+    val versionDir = if (scalaVersion.value.startsWith("2.12.7-bin")) "2.12.7" else scalaVersion.value
+    base / ("scala-" + versionDir)
   }
 )
 

--- a/semanticdb/scalac/library/src/main/scala-2.12.7/scala/meta/internal/semanticdb/scalac/SemanticdbAnalyzer.scala
+++ b/semanticdb/scalac/library/src/main/scala-2.12.7/scala/meta/internal/semanticdb/scalac/SemanticdbAnalyzer.scala
@@ -1,0 +1,1178 @@
+// NOTE: has to be this package or otherwise we won't be able to access private[typechecker] methods
+package scala
+package tools.nsc
+package typechecker
+
+import scala.tools.nsc.typechecker.{Analyzer => NscAnalyzer}
+import scala.reflect.internal.Mode._
+import scala.reflect.internal.util._
+import scala.reflect.internal.Flags._
+import scala.meta.internal.semanticdb.scalac.ReflectionToolkit
+
+// NOTE: grep for "scalac deviation" to see what exactly has been changed
+// I had to copy/paste a lot of code from Namers and Typers, but only a small percentage is actually relevant
+
+trait SemanticdbAnalyzer extends NscAnalyzer with ReflectionToolkit {
+  import global._
+  import definitions._
+  import statistics._
+
+  override def newNamer(context: Context) = new SemanticdbNamer(context)
+  class SemanticdbNamer(context0: Context) extends Namer(context0) {
+    override def selfTypeCompleter(tree: Tree) = new SemanticdbSelfTypeCompleter(tree)
+    class SemanticdbSelfTypeCompleter(tree: Tree) extends SelfTypeCompleter(tree) {
+      override def completeImpl(sym: Symbol): Unit = {
+        val tree1 = typer.typedType(tree)
+        //+scalac deviation
+        tree.rememberSelfTypeOf(tree1.asInstanceOf[TypeTree].original)
+        //-scalac deviation
+        val selftpe = tree1.tpe
+        sym setInfo {
+          if (selftpe.typeSymbol isNonBottomSubClass sym.owner) selftpe
+          else intersectionType(List(sym.owner.tpe, selftpe))
+        }
+      }
+    }
+  }
+
+  override def newTyper(context: Context) = new SemanticdbTyper(context)
+  class SemanticdbTyper(context0: Context) extends Typer(context0) {
+    import infer._
+    import TyperErrorGen._
+    import typeDebug.ptTree
+    import runDefinitions._
+
+    override def canTranslateEmptyListToNil = false
+
+    override def typed1(tree: Tree, mode: Mode, pt: Type): Tree = {
+      def typedSingletonTypeTree(tree: SingletonTypeTree) = {
+        val refTyped = typedTypeSelectionQualifier(tree.ref)
+
+        if (refTyped.isErrorTyped) setError(tree)
+        else {
+          //+scalac deviation
+          tree setType refTyped.tpe.resultType.deconst rememberSingletonTypeTreeOf refTyped
+          //-scalac deviation
+          if (!treeInfo.admitsTypeSelection(refTyped)) UnstableTreeError(tree)
+          else tree
+        }
+      }
+
+      def tryTypedArgs(args: List[Tree], mode: Mode): Option[List[Tree]] = {
+        val c = context.makeSilent(reportAmbiguousErrors = false)
+        c.retyping = true
+        try {
+          val res = newTyper(c).typedArgs(args, mode)
+          if (c.reporter.hasErrors) None else Some(res)
+        } catch {
+          case ex: CyclicReference =>
+            throw ex
+          case te: TypeError =>
+            // @H some of typer errors can still leak,
+            // for instance in continuations
+            None
+        }
+      }
+
+      /* Try to apply function to arguments; if it does not work, try to convert Java raw to existentials, or try to
+       * insert an implicit conversion.
+       */
+      def tryTypedApply(fun: Tree, args: List[Tree]): Tree = {
+        val start = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.startTimer(failedApplyNanos) else null
+
+        def onError(typeErrors: Seq[AbsTypeError], warnings: Seq[(Position, String)]): Tree = {
+          if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopTimer(failedApplyNanos, start)
+
+          // If the problem is with raw types, convert to existentials and try again.
+          // See #4712 for a case where this situation arises,
+          if ((fun.symbol ne null) && fun.symbol.isJavaDefined) {
+            val newtpe = rawToExistential(fun.tpe)
+            if (fun.tpe ne newtpe) {
+              // println("late cooking: "+fun+":"+fun.tpe) // DEBUG
+              return tryTypedApply(fun setType newtpe, args)
+            }
+          }
+          def treesInResult(tree: Tree): List[Tree] = tree :: (tree match {
+            case Block(_, r)                        => treesInResult(r)
+            case Match(_, cases)                    => cases
+            case CaseDef(_, _, r)                   => treesInResult(r)
+            case Annotated(_, r)                    => treesInResult(r)
+            case If(_, t, e)                        => treesInResult(t) ++ treesInResult(e)
+            case Try(b, catches, _)                 => treesInResult(b) ++ catches
+            case MethodValue(r)                     => treesInResult(r)
+            case Select(qual, name)                 => treesInResult(qual)
+            case Apply(fun, args)                   => treesInResult(fun) ++ args.flatMap(treesInResult)
+            case TypeApply(fun, args)               => treesInResult(fun) ++ args.flatMap(treesInResult)
+            case _                                  => Nil
+          })
+          /* Only retry if the error hails from a result expression of `tree`
+           * (for instance, it makes no sense to retry on an error from a block statement)
+           * compare with `samePointAs` since many synthetic trees are made with
+           * offset positions even under -Yrangepos.
+           */
+          def errorInResult(tree: Tree) =
+            treesInResult(tree).exists(err => typeErrors.exists(_.errPos samePointAs err.pos))
+
+          val retry = (typeErrors.forall(_.errPos != null)) && (fun :: tree :: args exists errorInResult)
+          typingStack.printTyping({
+            val funStr = ptTree(fun) + " and " + (args map ptTree mkString ", ")
+            if (retry) "second try: " + funStr
+            else "no second try: " + funStr + " because error not in result: " + typeErrors.head.errPos+"!="+tree.pos
+          })
+          if (retry) {
+            val Select(qual, name) = fun
+            tryTypedArgs(args, forArgMode(fun, mode)) match {
+              case Some(args1) if !args1.exists(arg => arg.exists(_.isErroneous)) =>
+                val qual1 =
+                  if (!pt.isError) adaptToArguments(qual, name, args1, pt)
+                  else qual
+                if (qual1 ne qual) {
+                  val tree1 = Apply(Select(qual1, name) setPos fun.pos, args1) setPos tree.pos
+                  return context withinSecondTry typed1(tree1, mode, pt)
+                }
+              case _ => ()
+            }
+          }
+          typeErrors foreach context.issue
+          warnings foreach { case (p, m) => context.warning(p, m) }
+          setError(treeCopy.Apply(tree, fun, args))
+        }
+
+        silent(_.doTypedApply(tree, fun, args, mode, pt)) match {
+          case SilentResultValue(value) => value
+          case e: SilentTypeError => onError(e.errors, e.warnings)
+        }
+      }
+
+      def normalTypedApply(tree: Tree, fun: Tree, args: List[Tree]) = {
+        // (todo) replace `fun.symbol.isStable` by `treeInfo.isStableIdentifierPattern(fun)`
+        val stableApplication = (fun.symbol ne null) && fun.symbol.isMethod && fun.symbol.isStable
+        val funpt = if (mode.inPatternMode) pt else WildcardType
+        val appStart = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.startTimer(failedApplyNanos) else null
+        val opeqStart = if (StatisticsStatics.areSomeColdStatsEnabled) statistics.startTimer(failedOpEqNanos) else null
+
+        def isConversionCandidate(qual: Tree, name: Name): Boolean =
+          !mode.inPatternMode && nme.isOpAssignmentName(TermName(name.decode)) && !qual.exists(_.isErroneous)
+
+        def reportError(error: SilentTypeError): Tree = {
+          error.reportableErrors foreach context.issue
+          error.warnings foreach { case (p, m) => context.warning(p, m) }
+          args foreach (arg => typed(arg, mode, ErrorType))
+          setError(tree)
+        }
+        def advice1(convo: Tree, errors: List[AbsTypeError], err: SilentTypeError): List[AbsTypeError] =
+          errors.map { e =>
+            if (e.errPos == tree.pos) {
+              val header = f"${e.errMsg}%n  Expression does not convert to assignment because:%n    "
+              val expansion = f"%n    expansion: ${show(convo)}"
+              NormalTypeError(tree, err.errors.flatMap(_.errMsg.lines.toList).mkString(header, f"%n    ", expansion))
+            } else e
+          }
+        def advice2(errors: List[AbsTypeError]): List[AbsTypeError] =
+          errors.map { e =>
+            if (e.errPos == tree.pos) {
+              val msg = f"${e.errMsg}%n  Expression does not convert to assignment because receiver is not assignable."
+              NormalTypeError(tree, msg)
+            } else e
+          }
+        def onError(error: SilentTypeError): Tree = fun match {
+          case Select(qual, name) if isConversionCandidate(qual, name) =>
+            val qual1 = typedQualifier(qual)
+            if (treeInfo.isVariableOrGetter(qual1)) {
+              if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopTimer(failedOpEqNanos, opeqStart)
+              val erred = qual1.exists(_.isErroneous) || args.exists(_.isErroneous)
+              if (erred) reportError(error) else {
+                val convo = convertToAssignment(fun, qual1, name, args)
+                silent(op = _.typed1(convo, mode, pt)) match {
+                  case SilentResultValue(t) => t
+                  case err: SilentTypeError => reportError(
+                    SilentTypeError(advice1(convo, error.errors, err), error.warnings)
+                  )
+                }
+              }
+            } else {
+              if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopTimer(failedApplyNanos, appStart)
+              val Apply(Select(qual2, _), args2) = tree
+              val erred = qual2.exists(_.isErroneous) || args2.exists(_.isErroneous)
+              reportError {
+                if (erred) error else SilentTypeError(advice2(error.errors), error.warnings)
+              }
+            }
+          case _ =>
+            if (StatisticsStatics.areSomeColdStatsEnabled) statistics.stopTimer(failedApplyNanos, appStart)
+            reportError(error)
+        }
+        val silentResult = silent(
+          op                    = _.typed(fun, mode.forFunMode, funpt),
+          reportAmbiguousErrors = !mode.inExprMode && context.ambiguousErrors,
+          newtree               = if (mode.inExprMode) tree else context.tree
+        )
+        silentResult match {
+          case SilentResultValue(fun1) =>
+            val fun2 = if (stableApplication) stabilizeFun(fun1, mode, pt) else fun1
+            if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(typedApplyCount)
+            val noSecondTry = (
+                 isPastTyper
+              || context.inSecondTry
+              || (fun2.symbol ne null) && fun2.symbol.isConstructor
+              || isImplicitMethodType(fun2.tpe)
+            )
+            val isFirstTry = fun2 match {
+              case Select(_, _) => !noSecondTry && mode.inExprMode
+              case _            => false
+            }
+            if (isFirstTry)
+              tryTypedApply(fun2, args)
+            else
+              doTypedApply(tree, fun2, args, mode, pt)
+          case err: SilentTypeError => onError(err)
+        }
+      }
+
+      // convert new Array[T](len) to evidence[ClassTag[T]].newArray(len)
+      // convert new Array^N[T](len) for N > 1 to evidence[ClassTag[Array[...Array[T]...]]].newArray(len)
+      // where Array HK gets applied (N-1) times
+      object ArrayInstantiation {
+        def unapply(tree: Apply) = tree match {
+          case Apply(Select(New(tpt), name), arg :: Nil) if tpt.tpe != null && tpt.tpe.typeSymbol == ArrayClass =>
+            Some(tpt.tpe) collect {
+              case erasure.GenericArray(level, componentType) =>
+                val tagType = (1 until level).foldLeft(componentType)((res, _) => arrayType(res))
+
+                resolveClassTag(tree.pos, tagType) match {
+                  case EmptyTree => MissingClassTagError(tree, tagType)
+                  case tag       => atPos(tree.pos)(new ApplyToImplicitArgs(Select(tag, nme.newArray), arg :: Nil))
+                }
+            }
+          case _ => None
+        }
+      }
+
+      def typedApply(tree: Apply) = tree match {
+        case Apply(Block(stats, expr), args) =>
+          typed1(atPos(tree.pos)(Block(stats, Apply(expr, args) setPos tree.pos.makeTransparent)), mode, pt)
+        case Apply(fun, args) =>
+          normalTypedApply(tree, fun, args) match {
+            case tree1 @ ArrayInstantiation(tree2) =>
+              if (tree2.isErrorTyped) tree2
+              //+scalac deviation
+              else typed(tree2, mode, pt).rememberNewArrayOf(tree1)
+              //-scalac deviation
+            case Apply(Select(fun, nme.apply), _) if treeInfo.isSuperConstrCall(fun) =>
+              TooManyArgumentListsForConstructor(tree) //scala/bug#5696
+            case tree1 if mode.inPatternMode && tree1.tpe.paramSectionCount > 0 =>
+              // For a case class C with more than two parameter lists,
+              // C(_) is typed as C(_)() which is a method type like ()C.
+              // In a pattern, just use the final result type, C in this case.
+              // The enclosing context may be case c @ C(_) => or val c @ C(_) = v.
+              tree1 modifyType (_.finalResultType)
+              tree1
+            case tree1 =>
+              tree1
+          }
+      }
+
+      def convertToAssignment(fun: Tree, qual: Tree, name: Name, args: List[Tree]): Tree = {
+        val prefix = name.toTermName stripSuffix nme.EQL
+        def mkAssign(vble: Tree): Tree =
+          Assign(
+            vble,
+            Apply(
+              Select(vble.duplicate, prefix) setPos fun.pos.focus, args) setPos tree.pos.makeTransparent
+          ) setPos tree.pos
+
+        def mkUpdate(table: Tree, indices: List[Tree]) =
+          gen.evalOnceAll(table :: indices, context.owner, context.unit) {
+            case tab :: is =>
+              def mkCall(name: Name, extraArgs: Tree*) = (
+                Apply(
+                  Select(tab(), name) setPos table.pos,
+                  is.map(i => i()) ++ extraArgs
+                ) setPos tree.pos
+              )
+              mkCall(
+                nme.update,
+                Apply(Select(mkCall(nme.apply), prefix) setPos fun.pos, args) setPos tree.pos
+              )
+            case _ => EmptyTree
+          }
+
+        val assignment = qual match {
+          case Ident(_) =>
+            mkAssign(qual)
+
+          case Select(qualqual, vname) =>
+            gen.evalOnce(qualqual, context.owner, context.unit) { qq =>
+              val qq1 = qq()
+              mkAssign(Select(qq1, vname) setPos qual.pos)
+            }
+
+          case Apply(fn, indices) =>
+            fn match {
+              case treeInfo.Applied(Select(table, nme.apply), _, _) => mkUpdate(table, indices)
+              case _  => UnexpectedTreeAssignmentConversionError(qual)
+            }
+        }
+        assignment
+      }
+
+      def typedAnnotated(atd: Annotated): Tree = {
+        val ann = atd.annot
+        val arg1 = typed(atd.arg, mode, pt)
+        /* mode for typing the annotation itself */
+        val annotMode = (mode &~ TYPEmode) | EXPRmode
+
+        def resultingTypeTree(tpe: Type) = {
+          // we need symbol-ful originals for reification
+          // hence we go the extra mile to hand-craft this guy
+          val original = arg1 match {
+            case tt @ TypeTree() if tt.original != null => Annotated(ann, tt.original)
+            // this clause is needed to correctly compile stuff like "new C @D" or "@(inline @getter)"
+            case _ => Annotated(ann, arg1)
+          }
+          original setType ann.tpe
+          val result = TypeTree(tpe) setOriginal original setPos tree.pos.focus
+          //+scalac deviation
+          result rememberAnnotatedOf treeCopy.Annotated(atd, tpe.annotations.head.original, arg1)
+          //-scalac deviation
+        }
+
+        if (arg1.isType) {
+          // make sure the annotation is only typechecked once
+          if (ann.tpe == null) {
+            val ainfo = typedAnnotation(ann, annotMode)
+            val atype = arg1.tpe.withAnnotation(ainfo)
+
+            if (ainfo.isErroneous)
+              // Erroneous annotations were already reported in typedAnnotation
+              arg1  // simply drop erroneous annotations
+            else {
+              ann setType atype
+              resultingTypeTree(atype)
+            }
+          } else {
+            // the annotation was typechecked before
+            resultingTypeTree(ann.tpe)
+          }
+        }
+        else {
+          if (ann.tpe == null) {
+            val annotInfo = typedAnnotation(ann, annotMode)
+            ann setType arg1.tpe.withAnnotation(annotInfo)
+          }
+          val atype = ann.tpe
+          // For `f(): @inline/noinline` callsites, add the InlineAnnotatedAttachment. TypeApplys
+          // are eliminated by erasure, so add it to the underlying function in this case.
+          def setInlineAttachment(t: Tree, att: InlineAnnotatedAttachment): Unit = t match {
+            case TypeApply(fun, _) => setInlineAttachment(fun, att)
+            case _ => t.updateAttachment(att)
+          }
+          if (atype.hasAnnotation(definitions.ScalaNoInlineClass)) setInlineAttachment(arg1, NoInlineCallsiteAttachment)
+          else if (atype.hasAnnotation(definitions.ScalaInlineClass)) setInlineAttachment(arg1, InlineCallsiteAttachment)
+          Typed(arg1, resultingTypeTree(atype)) setPos tree.pos setType atype
+        }
+      }
+
+      // Lookup in the given class using the root mirror.
+      def lookupInOwner(owner: Symbol, name: Name): Symbol =
+        if (mode.inQualMode) rootMirror.missingHook(owner, name) else NoSymbol
+
+      // Lookup in the given qualifier.  Used in last-ditch efforts by typedIdent and typedSelect.
+      def lookupInRoot(name: Name): Symbol  = lookupInOwner(rootMirror.RootClass, name)
+      def lookupInEmpty(name: Name): Symbol = rootMirror.EmptyPackageClass.info member name
+
+      def lookupInQualifier(qual: Tree, name: Name): Symbol = (
+        if (name == nme.ERROR || qual.tpe.widen.isErroneous)
+          NoSymbol
+        else lookupInOwner(qual.tpe.typeSymbol, name) orElse {
+          NotAMemberError(tree, qual, name)
+          NoSymbol
+        }
+      )
+
+      def inCompanionForJavaStatic(pre: Type, cls: Symbol, name: Name): Symbol =
+        if (!(context.unit.isJava && cls.isClass && !cls.isModuleClass)) NoSymbol else {
+          val companion = companionSymbolOf(cls, context)
+          if (!companion.exists) NoSymbol
+          else member(gen.mkAttributedRef(pre, companion), name) // assert(res.isStatic, s"inCompanionJavaStatic($pre, $cls, $name) = $res ${res.debugFlagString}")
+        }
+
+      /* Attribute a selection where `tree` is `qual.name`.
+       * `qual` is already attributed.
+       */
+      def typedSelect(tree: Tree, qual: Tree, name: Name): Tree = {
+        // note: on error, we discard the work we did in type checking tree.qualifier into qual
+        // (tree is either Select or SelectFromTypeTree, and qual may be different from tree.qualifier because it has been type checked)
+        val qualTp = qual.tpe
+        if ((qualTp eq null) || qualTp.isError) setError(tree)
+        else if (name.isTypeName && qualTp.isVolatile)  // (todo) use same error message for volatileType#T and volatilePath.T?
+          if (tree.isInstanceOf[SelectFromTypeTree]) TypeSelectionFromVolatileTypeError(tree, qual)
+          else UnstableTreeError(qual)
+        else {
+          def asDynamicCall = dyna.mkInvoke(context, tree, qual, name) map { t =>
+            dyna.wrapErrors(t, (_.typed1(t, mode, pt)))
+          }
+
+          val sym = tree.symbol orElse member(qual, name) orElse inCompanionForJavaStatic(qual.tpe.prefix, qual.symbol, name)
+          if ((sym eq NoSymbol) && name != nme.CONSTRUCTOR && mode.inAny(EXPRmode | PATTERNmode)) {
+            // symbol not found? --> try to convert implicitly to a type that does have the required
+            // member.  Added `| PATTERNmode` to allow enrichment in patterns (so we can add e.g., an
+            // xml member to StringContext, which in turn has an unapply[Seq] method)
+
+            val qual1 = adaptToMemberWithArgs(tree, qual, name, mode)
+            if ((qual1 ne qual) && !qual1.isErrorTyped)
+              return typed(treeCopy.Select(tree, qual1, name), mode, pt)
+          }
+
+          // This special-case complements the logic in `adaptMember` in erasure, it handles selections
+          // from `Super`. In `adaptMember`, if the erased type of a qualifier doesn't conform to the
+          // owner of the selected member, a cast is inserted, e.g., (foo: Option[String]).get.trim).
+          // Similarly, for `super.m`, typing `super` during erasure assigns the superclass. If `m`
+          // is defined in a trait, this is incorrect, we need to assign a type to `super` that conforms
+          // to the owner of `m`. Adding a cast (as in `adaptMember`) would not work, `super.asInstanceOf`
+          // is not a valid tree.
+          if (phase.erasedTypes && qual.isInstanceOf[Super]) {
+            //  See the comment in `preErase` why we use the attachment (scala/bug#7936)
+            val qualSym = tree.getAndRemoveAttachment[QualTypeSymAttachment] match {
+              case Some(a) => a.sym
+              case None => sym.owner
+            }
+            qual.setType(qualSym.tpe)
+          }
+
+          if (!reallyExists(sym)) {
+            def handleMissing: Tree = {
+              def errorTree = missingSelectErrorTree(tree, qual, name)
+              def asTypeSelection = (
+                  if (context.unit.isJava && name.isTypeName) {
+                    // scala/bug#3120 Java uses the same syntax, A.B, to express selection from the
+                    // value A and from the type A. We have to try both.
+                    atPos(tree.pos)(gen.convertToSelectFromType(qual, name)) match {
+                      case EmptyTree => None
+                      case tree1     => Some(typed1(tree1, mode, pt))
+                    }
+                  }
+                  else None
+                  )
+              debuglog(s"""
+                          |qual=$qual:${qual.tpe}
+                          |symbol=${qual.tpe.termSymbol.defString}
+                          |scope-id=${qual.tpe.termSymbol.info.decls.hashCode}
+                          |members=${qual.tpe.members mkString ", "}
+                          |name=$name
+                          |found=$sym
+                          |owner=${context.enclClass.owner}
+                """.stripMargin)
+
+              // 1) Try converting a term selection on a java class into a type selection.
+              // 2) Try expanding according to Dynamic rules.
+              // 3) Try looking up the name in the qualifier.
+              asTypeSelection orElse asDynamicCall getOrElse (lookupInQualifier(qual, name) match {
+                case NoSymbol => setError(errorTree)
+                case found    => typed1(tree setSymbol found, mode, pt)
+              })
+            }
+            handleMissing
+          }
+          else {
+            val tree1 = tree match {
+              case Select(_, _) => treeCopy.Select(tree, qual, name)
+              case SelectFromTypeTree(_, _) => treeCopy.SelectFromTypeTree(tree, qual, name)
+            }
+            val (result, accessibleError) = silent(t => {
+              //+ scalac deviation
+              val semanticdbTyper = t.asInstanceOf[SemanticdbTyper]
+              //- scalac deviation
+              semanticdbTyper.makeAccessible(tree1, sym, qual.tpe, qual)
+            }) match {
+              case SilentTypeError(err: AccessTypeError) =>
+                (tree1, Some(err))
+              case SilentTypeError(err) =>
+                SelectWithUnderlyingError(tree, err)
+                return tree
+              case SilentResultValue((qual, pre)) =>
+                (stabilize(qual, pre, mode, pt), None)
+            }
+
+            result match {
+              // could checkAccessible (called by makeAccessible) potentially have skipped checking a type application in qual?
+              case SelectFromTypeTree(qual@TypeTree(), name) if qual.tpe.typeArgs.nonEmpty => // (todo) somehow the new qual is not checked in refchecks
+                treeCopy.SelectFromTypeTree(
+                  result,
+                  (TypeTreeWithDeferredRefCheck(){ () => val tp = qual.tpe; val sym = tp.typeSymbolDirect
+                    // will execute during refchecks -- (todo) make private checkTypeRef in refchecks public and call that one?
+                    checkBounds(qual, tp.prefix, sym.owner, sym.typeParams, tp.typeArgs, "")
+                    qual // you only get to see the wrapped tree after running this check :-p
+                  }) setType qual.tpe setPos qual.pos,
+                  name)
+              case _ if accessibleError.isDefined =>
+                // don't adapt constructor, scala/bug#6074
+                val qual1 = if (name == nme.CONSTRUCTOR) qual
+                else adaptToMemberWithArgs(tree, qual, name, mode, reportAmbiguous = false, saveErrors = false)
+                if (!qual1.isErrorTyped && (qual1 ne qual))
+                  typed(Select(qual1, name) setPos tree.pos, mode, pt)
+                else
+                // before failing due to access, try a dynamic call.
+                  asDynamicCall getOrElse {
+                    context.issue(accessibleError.get)
+                    setError(tree)
+                  }
+              case _ =>
+                result
+            }
+          }
+        }
+      }
+
+      //+scalac deviation
+      // the qualifier type of a supercall constructor is its first parent class
+      def typedSelectOrSuperQualifier(qual: Tree) =
+        context withinSuperInit typed(qual, PolyQualifierModes)
+      //-scalac deviation
+
+      def typedTypeSelectionQualifier(tree: Tree, pt: Type = AnyRefTpe) =
+        context.withImplicitsDisabled { typed(tree, MonoQualifierModes | mode.onlyTypePat, pt) }
+
+      def typedSelectOrSuperCall(tree: Select) = tree match {
+        case Select(qual @ Super(_, _), nme.CONSTRUCTOR) =>
+          // the qualifier type of a supercall constructor is its first parent class
+          typedSelect(tree, typedSelectOrSuperQualifier(qual), nme.CONSTRUCTOR)
+        case Select(qual, name) =>
+          if (name.isTypeName)
+            typedSelect(tree, typedTypeSelectionQualifier(tree.qualifier, WildcardType), name)
+          else {
+            if (StatisticsStatics.areSomeColdStatsEnabled) statistics.incCounter(typedSelectCount)
+            val qualTyped = checkDead(typedQualifier(qual, mode))
+            val tree1 = typedSelect(tree, qualTyped, name)
+
+            if (tree.isInstanceOf[PostfixSelect])
+              checkFeature(tree.pos, PostfixOpsFeature, name.decode)
+            val sym = tree1.symbol
+            if (sym != null && sym.isOnlyRefinementMember && !sym.isMacro)
+              checkFeature(tree1.pos, ReflectiveCallsFeature, sym.toString)
+
+            qualTyped.symbol match {
+              //+scalac deviation
+              case s: Symbol if s.isRootPackage => treeCopy.Ident(tree1, name).rememberSelectOf(tree1)
+              //-scalac deviation
+              case _ => tree1
+            }
+          }
+      }
+
+      tree match {
+        case tree: SingletonTypeTree => typedSingletonTypeTree(tree)
+        case tree: Apply => typedApply(tree)
+        case tree: Annotated => typedAnnotated(tree)
+        case tree: Select => typedSelectOrSuperCall(tree)
+        case _ => super.typed1(tree, mode, pt)
+      }
+    }
+
+    /** Make symbol accessible. This means:
+     *  If symbol refers to package object, insert `.package` as second to last selector.
+     *  (exception for some symbols in scala package which are dealiased immediately)
+     *  Call checkAccessible, which sets tree's attributes.
+     *  Also note that checkAccessible looks up sym on pre without checking that pre is well-formed
+     *  (illegal type applications in pre will be skipped -- that's why typedSelect wraps the resulting tree in a TreeWithDeferredChecks)
+     *  @return modified tree and new prefix type
+     */
+    private def makeAccessible(tree: Tree, sym: Symbol, pre: Type, site: Tree): (Tree, Type) =
+      if (context.isInPackageObject(sym, pre.typeSymbol)) {
+        if (pre.typeSymbol == ScalaPackageClass && sym.isTerm) {
+          // short cut some aliases. It seems pattern matching needs this
+          // to notice exhaustiveness and to generate good code when
+          // List extractors are mixed with :: patterns. See Test5 in lists.scala.
+          //
+          // TODO SI-6609 Eliminate this special case once the old pattern matcher is removed.
+          def dealias(sym: Symbol) = {
+            //+scalac deviation
+            val tree1 = atPos(tree.pos.makeTransparent) {gen.mkAttributedRef(sym)} setPos tree.pos
+            tree1.rememberSelectOf(tree)
+            (tree1, sym.owner.thisType)
+            //-scalac deviation
+          }
+          sym.name match {
+            case nme.List => return dealias(ListModule)
+            case nme.Seq  => return dealias(SeqModule)
+            case nme.Nil  => return dealias(NilModule)
+            case _ =>
+          }
+        }
+        val qual = typedQualifier { atPos(tree.pos.makeTransparent) {
+          tree match {
+            case Ident(_) =>
+              val packageObject =
+                if (!sym.isOverloaded && sym.owner.isModuleClass) sym.owner.sourceModule // historical optimization, perhaps no longer needed
+                else pre.typeSymbol.packageObject
+              Ident(packageObject)
+            case Select(qual, _) => Select(qual, nme.PACKAGEkw)
+            case SelectFromTypeTree(qual, _) => Select(qual, nme.PACKAGEkw)
+          }
+        }}
+        val tree1 = atPos(tree.pos) {
+          tree match {
+            case Ident(name) => Select(qual, name)
+            case Select(_, name) => Select(qual, name)
+            case SelectFromTypeTree(_, name) => SelectFromTypeTree(qual, name)
+          }
+        }
+        (checkAccessible(tree1, sym, qual.tpe, qual), qual.tpe)
+      } else {
+        (checkAccessible(tree, sym, pre, site), pre)
+      }
+
+    override protected def typedTypeApply(tree: Tree, mode: Mode, fun: Tree, args: List[Tree]): Tree = fun.tpe match {
+      case OverloadedType(pre, alts) =>
+        inferPolyAlternatives(fun, mapList(args)(treeTpe))
+
+        // SI-8267 `memberType` can introduce existentials *around* a PolyType/MethodType, see AsSeenFromMap#captureThis.
+        //         If we had selected a non-overloaded symbol, `memberType` would have been called in `makeAccessible`
+        //         and the resulting existential type would have been skolemized in `adapt` *before* we typechecked
+        //         the enclosing type-/ value- application.
+        //
+        //         However, if the selection is overloaded, we defer calling `memberType` until we can select a single
+        //         alternative here. It is therefore necessary to skolemize the existential here.
+        //
+        val fun1 = adaptAfterOverloadResolution(fun, mode.forFunMode | TAPPmode)
+
+        val tparams = fun1.symbol.typeParams //@M (todo) fun.symbol.info.typeParams ? (as in typedAppliedTypeTree)
+        val args1 = if (sameLength(args, tparams)) {
+          //@M: in case TypeApply we can't check the kind-arities of the type arguments,
+          // as we don't know which alternative to choose... here we do
+          map2Conserve(args, tparams) {
+            //@M! the polytype denotes the expected kind
+            (arg, tparam) => typedHigherKindedType(arg, mode, Kind.FromParams(tparam.typeParams))
+          }
+        } else // @M: there's probably something wrong when args.length != tparams.length... (triggered by bug #320)
+         // Martin, I'm using fake trees, because, if you use args or arg.map(typedType),
+         // inferPolyAlternatives loops...  -- I have no idea why :-(
+         // ...actually this was looping anyway, see bug #278.
+          return TypedApplyWrongNumberOfTpeParametersError(fun, fun)
+
+        typedTypeApply(tree, mode, fun1, args1)
+      case SingleType(_, _) =>
+        typedTypeApply(tree, mode, fun setType fun.tpe.widen, args)
+      case PolyType(tparams, restpe) if tparams.nonEmpty =>
+        if (sameLength(tparams, args)) {
+          val targs = mapList(args)(treeTpe)
+          checkBounds(tree, NoPrefix, NoSymbol, tparams, targs, "")
+          if (isPredefClassOf(fun.symbol)) {
+            //+scalac deviation
+            val result = typedClassOf(tree, args.head, noGen = true)
+            val original = atPos(tree.pos)(TypeApply(fun, args))
+            result.rememberClassOf(original)
+            //-scalac deviation
+          } else {
+            if (!isPastTyper && fun.symbol == Any_isInstanceOf && targs.nonEmpty) {
+              val scrutineeType = fun match {
+                case Select(qual, _) => qual.tpe
+                case _               => AnyTpe
+              }
+              checkCheckable(tree, targs.head, scrutineeType, inPattern = false)
+            }
+            val resultpe = restpe.instantiateTypeParams(tparams, targs)
+            //@M substitution in instantiateParams needs to be careful!
+            //@M example: class Foo[a] { def foo[m[x]]: m[a] = error("") } (new Foo[Int]).foo[List] : List[Int]
+            //@M    --> first, m[a] gets changed to m[Int], then m gets substituted for List,
+            //          this must preserve m's type argument, so that we end up with List[Int], and not List[a]
+            //@M related bug: #1438
+            //println("instantiating type params "+restpe+" "+tparams+" "+targs+" = "+resultpe)
+            treeCopy.TypeApply(tree, fun, args) setType resultpe
+          }
+        }
+        else {
+          TypedApplyWrongNumberOfTpeParametersError(tree, fun)
+        }
+      case ErrorType =>
+        setError(treeCopy.TypeApply(tree, fun, args))
+      case _ =>
+        fun match {
+          // drop the application for an applyDynamic or selectDynamic call since it has been pushed down
+          case treeInfo.DynamicApplication(_, _) => fun
+          case _ => TypedApplyDoesNotTakeTpeParametersError(tree, fun)
+        }
+    }
+
+    override protected def typedExistentialTypeTree(tree: ExistentialTypeTree, mode: Mode): Tree = {
+      for (wc <- tree.whereClauses)
+        if (wc.symbol == NoSymbol) { namer enterSym wc; wc.symbol setFlag EXISTENTIAL }
+        else context.scope enter wc.symbol
+      val whereClauses1 = typedStats(tree.whereClauses, context.owner)
+      for (vd @ ValDef(_, _, _, _) <- whereClauses1)
+        if (vd.symbol.tpe.isVolatile)
+          AbstractionFromVolatileTypeError(vd)
+      val tpt1 = typedType(tree.tpt, mode)
+      existentialTransform(whereClauses1 map (_.symbol), tpt1.tpe)((tparams, tp) => {
+        val original = tpt1 match {
+          case tpt : TypeTree => atPos(tree.pos)(ExistentialTypeTree(tpt.original, tree.whereClauses))
+          case _ => {
+            debuglog(s"cannot reconstruct the original for $tree, because $tpt1 is not a TypeTree")
+            tree
+          }
+        }
+        val result = TypeTree(newExistentialType(tparams, tp)) setOriginal original
+        //+scalac deviation
+        result.rememberExistentialTypeTreeOf(treeCopy.ExistentialTypeTree(tree, tpt1, whereClauses1.asInstanceOf[List[MemberDef]]))
+        //-scalac deviation
+      }
+      )
+    }
+
+    /** Perform the following adaptations of expression, pattern or type `tree` wrt to
+     *  given mode `mode` and given prototype `pt`:
+     *  (-1) For expressions with annotated types, let AnnotationCheckers decide what to do
+     *  (0) Convert expressions with constant types to literals (unless in interactive/scaladoc mode)
+     *  (1) Resolve overloading, unless mode contains FUNmode
+     *  (2) Apply parameterless functions
+     *  (3) Apply polymorphic types to fresh instances of their type parameters and
+     *      store these instances in context.undetparams,
+     *      unless followed by explicit type application.
+     *  (4) Do the following to unapplied methods used as values:
+     *  (4.1) If the method has only implicit parameters pass implicit arguments
+     *  (4.2) otherwise, if `pt` is a function type and method is not a constructor,
+     *        convert to function by eta-expansion,
+     *  (4.3) otherwise, if the method is nullary with a result type compatible to `pt`
+     *        and it is not a constructor, apply it to ()
+     *  otherwise issue an error
+     *  (5) Convert constructors in a pattern as follows:
+     *  (5.1) If constructor refers to a case class factory, set tree's type to the unique
+     *        instance of its primary constructor that is a subtype of the expected type.
+     *  (5.2) If constructor refers to an extractor, convert to application of
+     *        unapply or unapplySeq method.
+     *
+     *  (6) Convert all other types to TypeTree nodes.
+     *  (7) When in TYPEmode but not FUNmode or HKmode, check that types are fully parameterized
+     *      (7.1) In HKmode, higher-kinded types are allowed, but they must have the expected kind-arity
+     *  (8) When in both EXPRmode and FUNmode, add apply method calls to values of object type.
+     *  (9) If there are undetermined type variables and not POLYmode, infer expression instance
+     *  Then, if tree's type is not a subtype of expected type, try the following adaptations:
+     *  (10) If the expected type is Byte, Short or Char, and the expression
+     *      is an integer fitting in the range of that type, convert it to that type.
+     *  (11) Widen numeric literals to their expected type, if necessary
+     *  (12) When in mode EXPRmode, convert E to { E; () } if expected type is scala.Unit.
+     *  (13) When in mode EXPRmode, apply AnnotationChecker conversion if expected type is annotated.
+     *  (14) When in mode EXPRmode, do SAM conversion
+     *  (15) When in mode EXPRmode, apply a view
+     *  If all this fails, error
+     *
+     *  Note: the `original` tree parameter is for re-typing implicit method invocations (see below)
+     *  and should not be used otherwise. (todo) can it be replaced with a tree attachment?
+     */
+    override protected def adapt(tree: Tree, mode: Mode, pt: Type, original: Tree = EmptyTree): Tree = {
+      def hasUndets           = context.undetparams.nonEmpty
+      def hasUndetsInMonoMode = hasUndets && !mode.inPolyMode
+
+      def adaptToImplicitMethod(mt: MethodType): Tree = {
+        if (hasUndets) { // (9) -- should revisit dropped condition `hasUndetsInMonoMode`
+          // dropped so that type args of implicit method are inferred even if polymorphic expressions are allowed
+          // needed for implicits in 2.8 collection library -- maybe once #3346 is fixed, we can reinstate the condition?
+            context.undetparams = inferExprInstance(tree, context.extractUndetparams(), pt,
+              // approximate types that depend on arguments since dependency on implicit argument is like dependency on type parameter
+              mt.approximate,
+              keepNothings = false,
+              useWeaklyCompatible = true) // #3808
+        }
+
+        // avoid throwing spurious DivergentImplicit errors
+        if (context.reporter.hasErrors)
+          setError(tree)
+        else
+          withCondConstrTyper(treeInfo.isSelfOrSuperConstrCall(tree))(typer1 =>
+            if (original != EmptyTree && pt != WildcardType) {
+              typer1 silent { tpr =>
+                val withImplicitArgs = tpr.applyImplicitArgs(tree)
+                if (tpr.context.reporter.hasErrors) tree // silent will wrap it in SilentTypeError anyway
+                else tpr.typed(withImplicitArgs, mode, pt)
+              } orElse { _ =>
+                // Re-try typing (applying to implicit args) without expected type. Add in 53d98e7d42 to
+                // for better error message (scala/bug#2180, http://www.scala-lang.org/old/node/3453.html)
+                val resetTree = resetAttrs(original)
+                resetTree match {
+                  case treeInfo.Applied(fun, targs, args) =>
+                    if (fun.symbol != null && fun.symbol.isError)
+                      // SI-9041 Without this, we leak error symbols past the typer!
+                      // because the fallback typechecking notices the error-symbol,
+                      // refuses to re-attempt typechecking, and presumes that someone
+                      // else was responsible for issuing the related type error!
+                      fun.setSymbol(NoSymbol)
+                  case _ =>
+                }
+                debuglog(s"fallback on implicits: ${tree}/$resetTree")
+                // scala/bug#10066 Need to patch the enclosing tree in the context to make translation of Dynamic
+                // work during fallback typechecking below.
+                val resetContext: Context = {
+                  object substResetForOriginal extends Transformer {
+                    override def transform(tree: Tree): Tree = {
+                      if (tree eq original) resetTree
+                      else super.transform(tree)
+                    }
+                  }
+                  context.make(substResetForOriginal.transform(context.tree))
+                }
+                typerWithLocalContext(resetContext) { typer1 =>
+                  val tree1 = typer1.typed(resetTree, mode)
+                  // Q: `typed` already calls `pluginsTyped` and `adapt`. the only difference here is that
+                  // we pass `EmptyTree` as the `original`. intended? added in 2009 (53d98e7d42) by martin.
+                  tree1 setType pluginsTyped(tree1.tpe, typer1, tree1, mode, pt)
+                  //+scalac deviation
+                  if (tree1.isEmpty) tree1 else typer1.asInstanceOf[SemanticdbTyper].adapt(tree1, mode, pt)
+                  //-scalac deviation
+                }
+              }
+            }
+            else
+              typer1.typed(typer1.applyImplicitArgs(tree), mode, pt)
+          )
+      }
+
+      def instantiateToMethodType(mt: MethodType): Tree = {
+        val meth = tree match {
+          // a partial named application is a block (see comment in EtaExpansion)
+          case Block(_, tree1) => tree1.symbol
+          case _               => tree.symbol
+        }
+
+        def cantAdapt =
+          if (context.implicitsEnabled) MissingArgsForMethodTpeError(tree, meth)
+          else UnstableTreeError(tree)
+
+        def emptyApplication: Tree = adapt(typed(Apply(tree, Nil) setPos tree.pos), mode, pt, original)
+
+        // constructors do not eta-expand
+        if (meth.isConstructor) cantAdapt
+        // (4.2) eta-expand method value when function or sam type is expected
+        else if (isFunctionType(pt) || (!mt.params.isEmpty && samOf(pt).exists)) {
+          // SI-9536 `!mt.params.isEmpty &&`: for backwards compatiblity with 2.11,
+          // we don't adapt a zero-arg method value to a SAM
+          // In 2.13, we won't do any eta-expansion for zero-arg methods, but we should deprecate first
+
+          debuglog(s"eta-expanding $tree: ${tree.tpe} to $pt")
+          checkParamsConvertible(tree, tree.tpe)
+
+          // method values (`m _`) are always eta-expanded (this syntax will disappear once we eta-expand regardless of expected type, at least for arity > 0)
+          // a "naked" method reference (`m`) may or not be eta expanded -- currently, this depends on the expected type and the arity (the conditions for this are in flux)
+          def isMethodValue = tree.getAndRemoveAttachment[MethodValueAttachment.type].isDefined
+          val nakedZeroAryMethod = mt.params.isEmpty && !isMethodValue
+
+          // scala/bug#7187 eta-expansion of zero-arg method value is deprecated
+          // 2.13 will switch order of (4.3) and (4.2), always inserting () before attempting eta expansion
+          // (This effectively disables implicit eta-expansion of 0-ary methods.)
+          // See mind-bending stuff like scala/bug#9178
+          if (nakedZeroAryMethod && settings.isScala213) emptyApplication
+          else {
+            // eventually, we will deprecate insertion of `()` (except for java-defined methods) -- this is already the case in dotty
+            // Once that's done, we can more aggressively eta-expand method references, even if they are 0-arity
+            // 2.13 will already eta-expand non-zero-arity methods regardless of expected type (whereas 2.12 requires a function-equivalent type)
+            if (nakedZeroAryMethod && settings.isScala212) {
+              currentRun.reporting.deprecationWarning(tree.pos, NoSymbol,
+                                                       s"Eta-expansion of zero-argument methods is deprecated. To avoid this warning, write ${Function(Nil, Apply(tree, Nil))}.", "2.12.0")
+            }
+
+
+            val tree0 = etaExpand(context.unit, tree, this)
+
+            // #2624: need to infer type arguments for eta expansion of a polymorphic method
+            // context.undetparams contains clones of meth.typeParams (fresh ones were generated in etaExpand)
+            // need to run typer on tree0, since etaExpansion sets the tpe's of its subtrees to null
+            // can't type with the expected type, as we can't recreate the setup in (3) without calling typed
+            // (note that (3) does not call typed to do the polymorphic type instantiation --
+            //  it is called after the tree has been typed with a polymorphic expected result type)
+            if (hasUndets)
+              instantiate(typed(tree0, mode), mode, pt)
+            else
+              typed(tree0, mode, pt)
+          }
+        }
+        // (4.3) apply to empty argument list
+        else if (mt.params.isEmpty) emptyApplication
+        else cantAdapt
+      }
+
+      def adaptType(): Tree = {
+        // @M When not typing a type constructor (!context.inTypeConstructorAllowed)
+        // or raw type, types must be of kind *,
+        // and thus parameterized types must be applied to their type arguments
+        // @M (todo) why do kind-* tree's have symbols, while higher-kinded ones don't?
+        def properTypeRequired = (
+             tree.hasSymbolField
+          && !context.inTypeConstructorAllowed
+          && !context.unit.isJava
+        )
+        // @M: don't check tree.tpe.symbol.typeParams. check tree.tpe.typeParams!!!
+        // (e.g., m[Int] --> tree.tpe.symbol.typeParams.length == 1, tree.tpe.typeParams.length == 0!)
+        // @M: removed check for tree.hasSymbolField and replace tree.symbol by tree.tpe.symbol
+        // (TypeTree's must also be checked here, and they don't directly have a symbol)
+        def kindArityMismatch = (
+             context.inTypeConstructorAllowed
+          && !sameLength(tree.tpe.typeParams, pt.typeParams)
+        )
+        // Note that we treat Any and Nothing as kind-polymorphic.
+        // We can't perform this check when typing type arguments to an overloaded method before the overload is resolved
+        // (or in the case of an error type) -- this is indicated by pt == WildcardType (see case TypeApply in typed1).
+        def kindArityMismatchOk = tree.tpe.typeSymbol match {
+          case NothingClass | AnyClass => true
+          case _                       => pt == WildcardType
+        }
+
+        // todo. It would make sense when mode.inFunMode to instead use
+        //    tree setType tree.tpe.normalize
+        // when typechecking, say, TypeApply(Ident(`some abstract type symbol`), List(...))
+        // because otherwise Ident will have its tpe set to a TypeRef, not to a PolyType, and `typedTypeApply` will fail
+        // but this needs additional investigation, because it crashes t5228, gadts1 and maybe something else
+        if (mode.inFunMode)
+          tree
+        else if (properTypeRequired && tree.symbol.typeParams.nonEmpty)  // (7)
+          MissingTypeParametersError(tree)
+        else if (kindArityMismatch && !kindArityMismatchOk)  // (7.1) @M: check kind-arity
+          KindArityMismatchError(tree, pt)
+        else tree match { // (6)
+          case TypeTree() => tree
+          case _          => TypeTree(tree.tpe) setOriginal tree
+        }
+      }
+
+      def insertApply(): Tree = {
+        assert(!context.inTypeConstructorAllowed, mode) //@M
+        val adapted = adaptToName(tree, nme.apply)
+        val qual = gen.stabilize(adapted)
+        typedPos(tree.pos, mode, pt) {
+          Select(qual setPos tree.pos.makeTransparent, nme.apply)
+        }
+      }
+      def adaptConstant(value: Constant): Tree = {
+        val sym = tree.symbol
+        if (sym != null && sym.isDeprecated)
+          context.deprecationWarning(tree.pos, sym)
+
+        tree match {
+          case Literal(`value`) => tree
+          case _ =>
+            // If the original tree is not a literal, make it available to plugins in an attachment
+            val result = treeCopy.Literal(tree, value).updateAttachment(OriginalTreeAttachment(tree))
+            //+scalac deviation
+            result.rememberConstfoldOf(tree)
+            //-scalac deviation
+        }
+      }
+
+      // Ignore type errors raised in later phases that are due to mismatching types with existential skolems
+      // We have lift crashing in 2.9 with an adapt failure in the pattern matcher.
+      // Here's my hypothesis why this happens. The pattern matcher defines a variable of type
+      //
+      //   val x: T = expr
+      //
+      // where T is the type of expr, but T contains existential skolems ts.
+      // In that case, this value definition does not typecheck.
+      // The value definition
+      //
+      //   val x: T forSome { ts } = expr
+      //
+      // would typecheck. Or one can simply leave out the type of the `val`:
+      //
+      //   val x = expr
+      //
+      // SI-6029 shows another case where we also fail (in uncurry), but this time the expected
+      // type is an existential type.
+      //
+      // The reason for both failures have to do with the way we (don't) transform
+      // skolem types along with the trees that contain them. We'd need a
+      // radically different approach to do it. But before investing a lot of time to
+      // to do this (I have already sunk 3 full days with in the end futile attempts
+      // to consistently transform skolems and fix 6029), I'd like to
+      // investigate ways to avoid skolems completely.
+      //
+      // upd. The same problem happens when we try to typecheck the result of macro expansion against its expected type
+      // (which is the return type of the macro definition instantiated in the context of expandee):
+      //
+      //   Test.scala:2: error: type mismatch;
+      //     found   : $u.Expr[Class[_ <: Object]]
+      //     required: reflect.runtime.universe.Expr[Class[?0(in value <local Test>)]] where type ?0(in value <local Test>) <: Object
+      //     scala.reflect.runtime.universe.reify(new Object().getClass)
+      //                                         ^
+      // Therefore following Martin's advice I use this logic to recover from skolem errors after macro expansions
+      // (by adding the ` || tree.attachments.get[MacroExpansionAttachment].isDefined` clause to the conditional above).
+      //
+      def adaptMismatchedSkolems() = {
+        def canIgnoreMismatch = (
+             !context.reportErrors && isPastTyper
+          || tree.hasAttachment[MacroExpansionAttachment]
+        )
+        def bound = pt match {
+          case ExistentialType(qs, _) => qs
+          case _                      => Nil
+        }
+        def msg = sm"""
+          |Recovering from existential or skolem type error in
+          |  $tree
+          |with type: ${tree.tpe}
+          |       pt: $pt
+          |  context: ${context.tree}
+          |  adapted
+          """.trim
+
+        val boundOrSkolems = if (canIgnoreMismatch) bound ++ pt.skolemsExceptMethodTypeParams else Nil
+        boundOrSkolems match {
+          case Nil => AdaptTypeError(tree, tree.tpe, pt) ; setError(tree)
+          case _   => logResult(msg)(adapt(tree, mode, deriveTypeWithWildcards(boundOrSkolems)(pt)))
+        }
+      }
+
+      def adaptExprNotFunMode(): Tree = {
+        def lastTry(err: AbsTypeError = null): Tree = {
+          debuglog("error tree = " + tree)
+          if (settings.debug && settings.explaintypes) explainTypes(tree.tpe, pt)
+          if (err ne null) context.issue(err)
+          if (tree.tpe.isErroneous || pt.isErroneous) setError(tree)
+          else adaptMismatchedSkolems()
+        }
+
+        // (todo) should we even get to fallbackAfterVanillaAdapt for an ill-typed tree?
+        if (mode.typingExprNotFun && !tree.tpe.isErroneous) {
+          @inline def tpdPos(transformed: Tree) = typedPos(tree.pos, mode, pt)(transformed)
+          @inline def tpd(transformed: Tree)    = typed(transformed, mode, pt)
+
+          @inline def warnValueDiscard(): Unit = if (!isPastTyper && settings.warnValueDiscard) {
+            def isThisTypeResult = (tree, tree.tpe) match {
+              case (Apply(Select(receiver, _), _), SingleType(_, sym)) => sym == receiver.symbol
+              case _ => false
+            }
+            if (!isThisTypeResult) context.warning(tree.pos, "discarded non-Unit value")
+          }
+          @inline def warnNumericWiden(): Unit =
+            if (!isPastTyper && settings.warnNumericWiden) context.warning(tree.pos, "implicit numeric widening")
+
+          // The <: Any requirement inhibits attempts to adapt continuation types to non-continuation types.
+          val anyTyped = tree.tpe <:< AnyTpe
+
+          pt.dealias match {
+            case TypeRef(_, UnitClass, _) if anyTyped => // (12)
+              warnValueDiscard() ; tpdPos(gen.mkUnitBlock(tree))
+            case TypeRef(_, numValueCls, _) if anyTyped && isNumericValueClass(numValueCls) && isNumericSubType(tree.tpe, pt) => // (10) (11)
+              warnNumericWiden() ; tpdPos(Select(tree, s"to${numValueCls.name}"))
+            case dealiased if dealiased.annotations.nonEmpty && canAdaptAnnotations(tree, this, mode, pt) => // (13)
+              tpd(adaptAnnotations(tree, this, mode, pt))
+            case _ =>
+              if (hasUndets) instantiate(tree, mode, pt)
+              else {
+                // (14) sam conversion
+                // (todo) figure out how to avoid partially duplicating typedFunction (samMatchingFunction)
+                // Could we infer the SAM type, assign it to the tree and add the attachment,
+                // all in one fell swoop at the end of typedFunction?
+                val didInferSamType = inferSamType(tree, pt, mode)
+
+                if (didInferSamType) tree
+                else {  // (15) implicit view application
+                  val coercion =
+                    if (context.implicitsEnabled) inferView(tree, tree.tpe, pt)
+                    else EmptyTree
+                  if (coercion ne EmptyTree) {
+                    def msg = s"inferred view from ${tree.tpe} to $pt via $coercion: ${coercion.tpe}"
+                    if (settings.logImplicitConv) context.echo(tree.pos, msg)
+                    else debuglog(msg)
+
+                    val viewApplied = new ApplyImplicitView(coercion, List(tree)) setPos tree.pos
+                    val silentContext = context.makeImplicit(context.ambiguousErrors)
+                    val typedView = newTyper(silentContext).typed(viewApplied, mode, pt)
+
+                    silentContext.reporter.firstError match {
+                      case None => typedView
+                      case Some(err) => lastTry(err)
+                    }
+                  } else lastTry()
+                }
+              }
+          }
+        } else lastTry()
+      }
+
+
+      def vanillaAdapt(tree: Tree) = {
+        def applyPossible = {
+          def applyMeth = member(adaptToName(tree, nme.apply), nme.apply)
+          def hasPolymorphicApply = applyMeth.alternatives exists (_.tpe.typeParams.nonEmpty)
+          def hasMonomorphicApply = applyMeth.alternatives exists (_.tpe.paramSectionCount > 0)
+
+          dyna.acceptsApplyDynamic(tree.tpe) || (
+            if (mode.inTappMode)
+              tree.tpe.typeParams.isEmpty && hasPolymorphicApply
+            else
+              hasMonomorphicApply
+          )
+        }
+        def shouldInsertApply(tree: Tree) = mode.typingExprFun && {
+          tree.tpe match {
+            case _: MethodType | _: OverloadedType | _: PolyType => false
+            case _                                               => applyPossible
+          }
+        }
+        if (tree.isType)
+          adaptType()
+        else if (mode.typingExprNotFun && treeInfo.isMacroApplication(tree) && !isMacroExpansionSuppressed(tree))
+          macroExpand(this, tree, mode, pt)
+        else if (mode.typingConstructorPattern)
+          typedConstructorPattern(tree, pt)
+        else if (shouldInsertApply(tree))
+          insertApply()
+        else if (hasUndetsInMonoMode) { // (9)
+          assert(!context.inTypeConstructorAllowed, context) //@M
+          instantiatePossiblyExpectingUnit(tree, mode, pt)
+        }
+        else if (tree.tpe <:< pt)
+          tree
+        else if (mode.inPatternMode && { inferModulePattern(tree, pt); isPopulated(tree.tpe, approximateAbstracts(pt)) })
+          tree
+        else {
+          val constFolded = constfold(tree, pt)
+          if (constFolded.tpe <:< pt) adapt(constFolded, mode, pt, original) // set stage for (0)
+          else adaptExprNotFunMode() // (10) -- (15)
+        }
+      }
+
+      // begin adapt
+      if (isMacroImplRef(tree)) {
+        if (treeInfo.isMacroApplication(tree)) adapt(unmarkMacroImplRef(tree), mode, pt, original)
+        else tree
+      } else tree.tpe match {
+        case atp @ AnnotatedType(_, _) if canAdaptAnnotations(tree, this, mode, pt) => // (-1)
+          adaptAnnotations(tree, this, mode, pt)
+        case ct @ ConstantType(value) if mode.inNone(TYPEmode | FUNmode) && (ct <:< pt) && canAdaptConstantTypeToLiteral => // (0)
+          adaptConstant(value)
+        case OverloadedType(pre, alts) if !mode.inFunMode => // (1)
+          inferExprAlternative(tree, pt)
+          adaptAfterOverloadResolution(tree, mode, pt, original)
+        case NullaryMethodType(restpe) => // (2)
+          adapt(tree setType restpe, mode, pt, original)
+        case TypeRef(_, ByNameParamClass, arg :: Nil) if mode.inExprMode => // (2)
+          adapt(tree setType arg, mode, pt, original)
+        case tp if mode.typingExprNotLhs && isExistentialType(tp) &&
+             // (todo) this is a private method, unfortunately: !isSyntheticAccessor(context.owner) =>
+             !(context.owner.isAccessor && (!context.owner.isLazy || isPastTyper)) =>
+          adapt(tree setType tp.dealias.skolemizeExistential(context.owner, tree), mode, pt, original)
+        case PolyType(tparams, restpe) if mode.inNone(TAPPmode | PATTERNmode) && !context.inTypeConstructorAllowed => // (3)
+          // assert((mode & HKmode) == 0) //@M a PolyType in HKmode represents an anonymous type function,
+          // we're in HKmode since a higher-kinded type is expected --> hence, don't implicitly apply it to type params!
+          // ticket #2197 triggered turning the assert into a guard
+          // I guess this assert wasn't violated before because type aliases weren't expanded as eagerly
+          //  (the only way to get a PolyType for an anonymous type function is by normalisation, which applies eta-expansion)
+          // -- are we sure we want to expand aliases this early?
+          // -- what caused this change in behaviour??
+          val tparams1 = cloneSymbols(tparams)
+          val tree1 = (
+            if (tree.isType) tree
+            else TypeApply(tree, tparams1 map (tparam => TypeTree(tparam.tpeHK) setPos tree.pos.focus)) setPos tree.pos
+          )
+          context.undetparams ++= tparams1
+          notifyUndetparamsAdded(tparams1)
+          adapt(tree1 setType restpe.substSym(tparams, tparams1), mode, pt, original)
+
+        case mt: MethodType if mode.typingExprNotFunNotLhs && mt.isImplicit => // (4.1)
+          adaptToImplicitMethod(mt)
+        case mt: MethodType if mode.typingExprNotFunNotLhs && !hasUndetsInMonoMode && !treeInfo.isMacroApplicationOrBlock(tree) =>
+          instantiateToMethodType(mt)
+        case _ =>
+          vanillaAdapt(tree)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Working towards support of:

https://github.com/scala/scala/pull/7147

Locally:

```
$ cd /code/scala && git log -1 && git diff head
commit da58d8e4f13c75f9ac757ef6f78d40b9cd885c15 (HEAD -> perf-backport/omnibus-first-pr, retronym/perf-backport/omnibus-first-pr, origin/pr/7147)
Merge: 0a8e00cb18 8e4a40a688
Author: Jason Zaugg <jzaugg@gmail.com>
Date:   Fri Sep 14 16:20:05 2018 +1000

    Merge remote-tracking branch 'origin/2.12.x' into perf-backport/omnibus-first-pr
diff --git a/src/compiler/scala/tools/nsc/Global.scala b/src/compiler/scala/tools/nsc/Global.scala
index 42b8157508..d43564e44e 100644
--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -1142,7 +1142,7 @@ class Global(var currentSettings: Settings, reporter0: Reporter)
     val compiledFiles   = new mutable.HashSet[String]

     /** A map from compiled top-level symbols to their source files */
-    val symSource = new mutable.AnyRefMap[Symbol, AbstractFile]
+    val symSource = new mutable.HashMap[Symbol, AbstractFile]

     /** A map from compiled top-level symbols to their picklers */
     val symData = new mutable.AnyRefMap[Symbol, PickleBuffer]

$ sbt clean setupPublishCore dist/mkPack
```

```
$ cd /code/scalameta

$ sbt clean "++ 2.12.6=/code/scala/build/pack" testsJVM/test
[info] Loading global plugins from /Users/jz/.sbt/0.13/plugins
[info] Loading project definition from /Users/jz/code/scalameta/project/project
[info] Loading project definition from /Users/jz/code/scalameta/project
[info] Resolving key references (50441 settings) ...
[info] Welcome to scalameta 4.0.0-RC1-4-4a0d996c
[info] Set current project to scalametaRoot (in build file:/Users/jz/code/scalameta/)
[success] Total time: 0 s, completed 18/09/2018 2:34:50 PM
[info] Setting Scala home to /code/scala/build/pack with actual version 2.12.7-20180914-062005-da58d8e
[info] 	and using 2.12.6 for resolving dependencies.
[info] Reapplying settings...
[info] Welcome to scalameta 4.0.0-RC1-4-4a0d996c
[info] Set current project to scalametaRoot (in build file:/Users/jz/code/scalameta/)
[info] Compiling 2 protobuf files to /Users/jz/code/scalameta/semanticdb/semanticdb/.jvm/target/scala-2.12/src_managed/main
[info] Compiling schema /Users/jz/code/scalameta/semanticdb/semanticdb/semanticdb.proto
[info] Compiling schema /Users/jz/code/scalameta/semanticdb/semanticdb/semanticidx.proto
protoc-jar: protoc version: 3.5.1, detected platform: osx-x86_64 (mac os x/x86_64)
protoc-jar: embedded: bin/3.5.1/protoc-3.5.1-osx-x86_64.exe
protoc-jar: executing: [/var/folders/b7/xcc2k0ln6ldcv247ffpy2d1w0000gp/T/protocjar5116797196086050102/bin/protoc.exe, --plugin=protoc-gen-scala=/var/folders/b7/xcc2k0ln6ldcv247ffpy2d1w0000gp/T/protocbridge6314743011019068371, --scala_out=flat_package,grpc:/Users/jz/code/scalameta/semanticdb/semanticdb/.jvm/target/scala-2.12/src_managed/main, -I/Users/jz/code/scalameta/semanticdb/semanticdb, -I/Users/jz/code/scalameta/semanticdb/semanticdb/.jvm/target/protobuf_external, -I/Users/jz/code/scalameta/semanticdb/semanticdb, -I/Users/jz/code/scalameta/semanticdb/semanticdb/.jvm/target/protobuf_external, /Users/jz/code/scalameta/semanticdb/semanticdb/semanticdb.proto, /Users/jz/code/scalameta/semanticdb/semanticdb/semanticidx.proto]
[info] Compiling 4 Scala sources to /Users/jz/code/scalameta/semanticdb/cli/.jvm/target/scala-2.12/classes...
[info] Compiling 1 Scala source to /Users/jz/code/scalameta/semanticdb/integration-macros/target/scala-2.12/classes...
[info] Compiling protobuf
[info] Protoc target directory: /Users/jz/code/scalameta/semanticdb/semanticdb/.jvm/target/scala-2.12/src_managed/main
[info] Compiling 26 Scala sources to /Users/jz/code/scalameta/semanticdb/semanticdb/.jvm/target/scala-2.12/classes...
[info] Compiling 55 Scala sources to /Users/jz/code/scalameta/scalameta/common/jvm/target/scala-2.12/classes...
[info] Compiling 3 Scala sources to /Users/jz/code/scalameta/scalameta/dialects/jvm/target/scala-2.12/classes...
[info] Compiling 13 Scala sources to /Users/jz/code/scalameta/scalameta/io/jvm/target/scala-2.12/classes...
[info] Compiling 4 Scala sources to /Users/jz/code/scalameta/semanticdb/metai/target/scala-2.12/classes...
[info] Compiling 6 Scala sources to /Users/jz/code/scalameta/scalameta/inputs/jvm/target/scala-2.12/classes...
[info] Compiling 6 Scala sources to /Users/jz/code/scalameta/semanticdb/javac/target/scala-2.12/classes...
[info] Compiling 37 Scala sources to /Users/jz/code/scalameta/semanticdb/metacp/target/scala-2.12/classes...
[info] Compiling 13 Scala sources to /Users/jz/code/scalameta/scalameta/tokens/jvm/target/scala-2.12/classes...
[info] Compiling 13 Scala sources to /Users/jz/code/scalameta/semanticdb/metap/.jvm/target/scala-2.12/classes...
[info] Packaging /Users/jz/code/scalameta/semanticdb/javac/target/scala-2.12/semanticdb-javac_2.12-4.0.0-RC1-4-4a0d996c.jar ...
[info] Done packaging.
[info] Compiling 4 Scala sources to /Users/jz/code/scalameta/semanticdb/symtab/target/scala-2.12/classes...
[info] Compiling 14 Scala sources to /Users/jz/code/scalameta/scalameta/tokenizers/jvm/target/scala-2.12/classes...
[info] Compiling 14 Scala sources to /Users/jz/code/scalameta/scalameta/trees/jvm/target/scala-2.12/classes...
[info] Compiling 4 Scala sources to /Users/jz/code/scalameta/scalameta/transversers/jvm/target/scala-2.12/classes...
[info] Compiling 9 Scala sources to /Users/jz/code/scalameta/scalameta/parsers/jvm/target/scala-2.12/classes...
[info] Compiling 6 Scala sources to /Users/jz/code/scalameta/scalameta/quasiquotes/jvm/target/scala-2.12/classes...
[info] Compiling 1 Scala source to /Users/jz/code/scalameta/scalameta/scalameta/jvm/target/scala-2.12/classes...
[info] Compiling 24 Scala sources to /Users/jz/code/scalameta/semanticdb/scalac/library/target/scala-2.12/classes...
[info] Compiling 29 Scala sources to /Users/jz/code/scalameta/scalameta/contrib/jvm/target/scala-2.12/classes...
[info] Compiling 10 Scala sources to /Users/jz/code/scalameta/scalameta/testkit/target/scala-2.12/classes...
[info] Compiling 1 Scala source to /Users/jz/code/scalameta/scalameta/interactive/target/scala-2.12/classes...
[info] Packaging /Users/jz/code/scalameta/semanticdb/scalac/plugin/target/scala-2.12/semanticdb-scalac_2.12.6-4.0.0-RC1-4-4a0d996c.jar ...
[info] Done packaging.
[info] Compiling 3 Scala sources to /Users/jz/code/scalameta/semanticdb/metac/target/scala-2.12/classes...
[info] Compiling 26 Scala sources and 25 Java sources to /Users/jz/code/scalameta/semanticdb/integration/target/scala-2.12/classes...
java.lang.AbstractMethodError: Method scala/meta/internal/semanticdb/scalac/SemanticdbPlugin.scala$tools$nsc$typechecker$Contexts$_setter_$scala$tools$nsc$typechecker$Contexts$$SomeNil_$eq(Lscala/Some;)V is abstract
	at scala.meta.internal.semanticdb.scalac.SemanticdbPlugin.scala$tools$nsc$typechecker$Contexts$_setter_$scala$tools$nsc$typechecker$Contexts$$SomeNil_$eq(SemanticdbPlugin.scala)
	at scala.tools.nsc.typechecker.Contexts.$init$(Contexts.scala:1570)
	at scala.meta.internal.semanticdb.scalac.SemanticdbPlugin.<init>(SemanticdbPlugin.scala:10)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
```

That indicates that `SemanticdbPlugin` wasn't actually compiled against the new `Analyzer`, otherwise it ought to have the trait setter to initialized: [`SomeNil`](https://github.com/retronym/scala/blob/a857be2e121607ae9609c8c6f5578f709d98e498/src/compiler/scala/tools/nsc/typechecker/Contexts.scala#L1570)