### PR TITLE
Lower header size for "semanticdb-based tools" in guide

### DIFF
--- a/semanticdb/semanticdb3/guide.md
+++ b/semanticdb/semanticdb3/guide.md
@@ -741,9 +741,9 @@ documents {
 but nowadays it's a bit too low-level. It is recommended to use `metap`
 instead of `protoc`.
 
-# SemanticDB-based tools
+## SemanticDB-based tools
 
-## Scalafix
+### Scalafix
 
 [Scalafix](https://github.com/scalacenter/scalafix) is a rewrite and linting
 tool for Scala developed at the Scala Center with the goal to help automate
@@ -765,7 +765,7 @@ Thanks to SemanticDB, Scalafix is:
     rewrites and lints in parallel. (Unlike compiler plugin-based linters
     that are limited by the single-threaded architecture of Scalac).
 
-## Metadoc
+### Metadoc
 
 [Metadoc](https://github.com/scalameta/metadoc) is an experiment with SemanticDB
 to build online code browser with IDE-like features. Check out
@@ -785,7 +785,7 @@ Thanks to SemanticDB, Metadoc is:
     which means that it can seamlessly work with any compiler / compiler version
     that supports [the SemanticDB compiler plugin](#scalac-compiler-plugin).
 
-## Metals
+### Metals
 
 [Metals](https://github.com/scalameta/metals) is an experiment to implement a
 [language server](https://github.com/Microsoft/language-server-protocol) for Scala

--- a/semanticdb/semanticdb3/semanticdb3.md
+++ b/semanticdb/semanticdb3/semanticdb3.md
@@ -2514,7 +2514,7 @@ message SymbolOccurrence {
 
 There is a Scala compiler plugin
 that generates [SymbolOccurrences](#symboloccurrence) for Scala code.
-The implementation [\[71\]][71] is used at Twitter scale, and it works well -
+The implementation is used at Twitter scale, and it works well -
 both in terms of handling sizeable codebases and understanding esoteric
 language constructs and idioms. However, but we do not yet have a specification
 that comprehensively describes how Scala language features map onto symbol
@@ -3739,7 +3739,6 @@ the Java language. We may improve on this in the future.
 [68]: https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html
 [69]: https://github.com/scalameta/scalameta/blob/master/semanticdb/metacp/src/main/scala/scala/meta/internal/javacp/Javacp.scala
 [70]: https://www.scala-lang.org/files/archive/spec/2.12/02-identifiers-names-and-scopes.html
-[71]: https://github.com/scalameta/scalameta/blob/master/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DocumentOps.scala
 [72]: https://docs.oracle.com/javase/specs/jls/se8/html/jls-10.html#jls-10.1
 [73]: https://docs.oracle.com/javase/specs/jls/se8/html/jls-4.html#jls-PrimitiveType
 [74]: https://docs.oracle.com/javase/specs/jls/se8/html/jls-4.html


### PR DESCRIPTION
This makes them appear nicely in the new website.