### PR TITLE
Enable trailing commas in dotty

### DIFF
--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -212,7 +212,7 @@ package object dialects {
     allowLiteralTypes = true, // New feature in Dotty
     allowMethodTypes = false,
     allowOrTypes = true, // New feature in Dotty
-    allowTrailingCommas = false, // Not yet implemented in Dotty
+    allowTrailingCommas = true,
     allowTraitParameters = true, // New feature in Dotty
     allowTypeLambdas = true, // New feature in Dotty
     allowViewBounds = false, // View bounds have been removed in Dotty

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/DottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/DottySuite.scala
@@ -125,4 +125,11 @@ class DottySuite extends ParseSuite {
 
   checkOK("def foo(implicit x: => Int) = 1")
   checkOK("def foo(implicit y: Int, x: => Int) = 1")
+
+  test("trailing commas are allowed") {
+    templStat("""|case class A(
+                 |  x: X,
+                 |)""".stripMargin)
+  }
+
 }


### PR DESCRIPTION
Trailing commas have been added to Dotty in https://github.com/lampepfl/dotty/pull/3463