### PR TITLE
Faster tree traversal

### DIFF
--- a/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/TreeOps.scala
+++ b/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/TreeOps.scala
@@ -6,6 +6,7 @@ import scala.language.higherKinds
 
 import scala.meta.contrib.equality.Equal
 import scala.meta.contrib.equality.TreeEquality
+import scala.meta.transversers.SimpleTraverser
 
 object TreeOps {
 
@@ -24,7 +25,7 @@ object TreeOps {
 
   def collectFirst[B](tree: Tree)(pf: PartialFunction[Tree, B]): Option[B] = {
     var result = Option.empty[B]
-    object traverser extends Traverser {
+    object traverser extends SimpleTraverser {
       override def apply(t: Tree): Unit = {
         if (result.isEmpty && pf.isDefinedAt(t)) {
           result = Some(pf(t))
@@ -42,7 +43,7 @@ object TreeOps {
 
   def descendants(tree: Tree): List[Tree] = {
     val builder = List.newBuilder[Tree]
-    object traverser extends Traverser {
+    object traverser extends SimpleTraverser {
       override def apply(t: Tree): Unit = {
         if (t ne tree) builder += t
         super.apply(t)

--- a/scalameta/testkit/src/test/scala/scala/meta/tests/transversers/TraverserOrder.scala
+++ b/scalameta/testkit/src/test/scala/scala/meta/tests/transversers/TraverserOrder.scala
@@ -1,0 +1,46 @@
+package scala.meta.tests
+package transversers
+
+import org.scalatest.FunSuite
+
+import scala.collection.mutable
+import scala.meta.Tree
+import scala.meta.testkit.SyntaxAnalysis
+import scala.meta.tests.contrib.ContribSuite
+import scala.meta.transversers.{SimpleTraverser, Traverser}
+
+class TraverserOrder extends FunSuite {
+  test("traversal order is preserved") {
+    val errors = SyntaxAnalysis.onParsed[Tree](ContribSuite.corpus) { ast =>
+      val trees1 = asList_Traverser(ast)
+      val trees2 = asList_SimpleTraverser(ast)
+
+      if (trees1.size != trees2.size) List(ast)
+      else {
+        val firstDiff =
+          trees1.zip(trees2)
+            .collectFirst { case (a, b) if a != b => a }
+        firstDiff.toList
+      }
+    }
+    assert(errors.isEmpty)
+  }
+
+  private def asList_Traverser(tree: Tree): List[Tree] = {
+    val buf = mutable.ListBuffer[Tree]()
+    object traverser extends Traverser {
+      override def apply(tree: Tree): Unit = { buf += tree; super.apply(tree) }
+    }
+    traverser(tree)
+    buf.toList
+  }
+
+  private def asList_SimpleTraverser(tree: Tree): List[Tree] = {
+    val buf = mutable.ListBuffer[Tree]()
+    object traverser extends SimpleTraverser {
+      override def apply(tree: Tree): Unit = { buf += tree; super.apply(tree) }
+    }
+    traverser(tree)
+    buf.toList
+  }
+}

--- a/scalameta/transversers/shared/src/main/scala/scala/meta/transversers/Api.scala
+++ b/scalameta/transversers/shared/src/main/scala/scala/meta/transversers/Api.scala
@@ -15,7 +15,7 @@ private[meta] trait Api {
 
     def traverse(fn: PartialFunction[Tree, Unit]): Unit = {
       val liftedFn = fn.lift
-      object traverser extends Traverser {
+      object traverser extends SimpleTraverser {
         override def apply(tree: Tree): Unit = {
           liftedFn(tree)
           super.apply(tree)
@@ -27,7 +27,7 @@ private[meta] trait Api {
     def collect[T](fn: PartialFunction[Tree, T]): List[T] = {
       val liftedFn = fn.lift
       val buf = scala.collection.mutable.ListBuffer[T]()
-      object traverser extends Traverser {
+      object traverser extends SimpleTraverser {
         override def apply(tree: Tree): Unit = {
           liftedFn(tree).foreach(buf += _)
           super.apply(tree)

--- a/scalameta/transversers/shared/src/main/scala/scala/meta/transversers/SimpleTraverser.scala
+++ b/scalameta/transversers/shared/src/main/scala/scala/meta/transversers/SimpleTraverser.scala
@@ -1,0 +1,6 @@
+package scala.meta
+package transversers
+
+private[meta] class SimpleTraverser {
+  def apply(tree: Tree): Unit = tree.children.foreach(apply)
+}

--- a/tests/shared/src/test/scala/scala/meta/tests/contrib/TreeOpsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/contrib/TreeOpsSuite.scala
@@ -49,4 +49,18 @@ class TreeOpsSuite extends FunSuite {
     assert(q"val x = { 2 + 3 }".exists(_.syntax == "3"))
   }
 
+  test("contains") {
+    a.foreach(t => assert(a.contains(t)))
+    val b: Defn.Object = q"object Foo { def bar: Any = ??? }"
+    b.foreach(t => assert(!a.contains(t)))
+  }
+
+  test("collectFirst") {
+    assert(a.collectFirst { case t: Tree => t } == Some(a))
+    assert(a.collectFirst { case t: Defn.Val => t }.nonEmpty)
+    assert(a.collectFirst { case t: Lit => t }.nonEmpty)
+    assert(a.collectFirst { case t: Type => t }.nonEmpty)
+    assert(a.collectFirst { case t: Defn.Trait => t }.isEmpty)
+    assert(a.collectFirst { case t: Defn.Def => t }.isEmpty)
+  }
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/transversers/SimpleTraverserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/transversers/SimpleTraverserSuite.scala
@@ -1,11 +1,12 @@
-package scala.meta.tests
-package transversers
+package scala.meta.tests.transversers
 
 import org.scalatest._
-import scala.compat.Platform.EOL
-import scala.meta._
 
-class TransverserSuite extends FunSuite {
+import scala.meta._
+import scala.meta.transversers.SimpleTraverser
+
+class SimpleTraverserSuite extends FunSuite {
+
   test("Traverser Ok") {
     val tree0 = q"""
       def foo(x: x)(x: Int) = x + x
@@ -14,7 +15,7 @@ class TransverserSuite extends FunSuite {
       }
     """
     val log = scala.collection.mutable.ListBuffer[String]()
-    object traverser extends Traverser {
+    object traverser extends SimpleTraverser {
       override def apply(tree: Tree): Unit = {
         log += tree.toString.trim.replace("\n", " ")
         super.apply(tree)
@@ -52,53 +53,6 @@ class TransverserSuite extends FunSuite {
       |x
       |???
     """.trim.stripMargin)
-  }
-
-  test("Transformer Ok") {
-    val tree0 = q"""
-      def foo(x: x)(x: Int) = x + x
-      class C(x: x) {
-        def bar(x: x) = ???
-      }
-    """
-    val log = scala.collection.mutable.ListBuffer[String]()
-    object transformer extends Transformer {
-      override def apply(tree: Tree): Tree = tree match {
-        case Term.Name("x") => Term.Name("y")
-        case Type.Name("x") => Type.Name("y")
-        case _ => super.apply(tree)
-      }
-    }
-    val tree1 = transformer(tree0)
-    assert(tree1.toString === """
-      |{
-      |  def foo(y: y)(y: Int) = y + y
-      |  class C(y: y) { def bar(y: y) = ??? }
-      |}
-    """.trim.stripMargin.split('\n').mkString(EOL))
-  }
-
-  test("Transformer Fail") {
-    val tree0 = q"""
-      def foo(x: x)(x: Int) = x + x
-      class C(x: x) {
-        def bar(x: x) = ???
-      }
-    """
-    val log = scala.collection.mutable.ListBuffer[String]()
-    object transformer extends Transformer {
-      override def apply(tree: Tree): Tree = {
-        if (tree.toString == "x") q"y"
-        else super.apply(tree)
-      }
-    }
-    intercept[UnsupportedOperationException]{ transformer(tree0) }
-  }
-
-  test("Tree.transform") {
-    val tree0 = q"x + y"
-    val tree1 = tree0.transform { case Term.Name(s) => Term.Name(s + s) }
-    assert(tree1.toString == "xx ++ yy")
   }
 
   test("Tree.traverse") {

--- a/tests/shared/src/test/scala/scala/meta/tests/transversers/TransformerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/transversers/TransformerSuite.scala
@@ -1,0 +1,56 @@
+package scala.meta.tests.transversers
+
+import org.scalatest._
+
+import scala.compat.Platform.EOL
+import scala.meta._
+
+class TransformerSuite extends FunSuite {
+
+  test("Transformer Ok") {
+    val tree0 = q"""
+      def foo(x: x)(x: Int) = x + x
+      class C(x: x) {
+        def bar(x: x) = ???
+      }
+    """
+    val log = scala.collection.mutable.ListBuffer[String]()
+    object transformer extends Transformer {
+      override def apply(tree: Tree): Tree = tree match {
+        case Term.Name("x") => Term.Name("y")
+        case Type.Name("x") => Type.Name("y")
+        case _ => super.apply(tree)
+      }
+    }
+    val tree1 = transformer(tree0)
+    assert(tree1.toString === """
+      |{
+      |  def foo(y: y)(y: Int) = y + y
+      |  class C(y: y) { def bar(y: y) = ??? }
+      |}
+    """.trim.stripMargin.split('\n').mkString(EOL))
+  }
+
+  test("Transformer Fail") {
+    val tree0 = q"""
+      def foo(x: x)(x: Int) = x + x
+      class C(x: x) {
+        def bar(x: x) = ???
+      }
+    """
+    val log = scala.collection.mutable.ListBuffer[String]()
+    object transformer extends Transformer {
+      override def apply(tree: Tree): Tree = {
+        if (tree.toString == "x") q"y"
+        else super.apply(tree)
+      }
+    }
+    intercept[UnsupportedOperationException]{ transformer(tree0) }
+  }
+
+  test("Tree.transform") {
+    val tree0 = q"x + y"
+    val tree1 = tree0.transform { case Term.Name(s) => Term.Name(s + s) }
+    assert(tree1.toString == "xx ++ yy")
+  }
+}

--- a/tests/shared/src/test/scala/scala/meta/tests/transversers/TraverserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/transversers/TraverserSuite.scala
@@ -1,0 +1,56 @@
+package scala.meta.tests
+package transversers
+
+import org.scalatest._
+import scala.meta._
+
+class TraverserSuite extends FunSuite {
+
+  test("Traverser Ok") {
+    val tree0 = q"""
+      def foo(x: x)(x: Int) = x + x
+      class C(x: x) {
+        def bar(x: x) = ???
+      }
+    """
+    val log = scala.collection.mutable.ListBuffer[String]()
+    object traverser extends Traverser {
+      override def apply(tree: Tree): Unit = {
+        log += tree.toString.trim.replace("\n", " ")
+        super.apply(tree)
+      }
+    }
+    traverser(tree0)
+    assert(log.mkString("\n").replace("\r", "") === """
+      |{   def foo(x: x)(x: Int) = x + x   class C(x: x) { def bar(x: x) = ??? } }
+      |def foo(x: x)(x: Int) = x + x
+      |foo
+      |x: x
+      |x
+      |x
+      |x: Int
+      |x
+      |Int
+      |x + x
+      |x
+      |+
+      |x
+      |class C(x: x) { def bar(x: x) = ??? }
+      |C
+      |def this(x: x)
+      |_
+      |x: x
+      |x
+      |x
+      |{ def bar(x: x) = ??? }
+      |_
+      |_
+      |def bar(x: x) = ???
+      |bar
+      |x: x
+      |x
+      |x
+      |???
+    """.trim.stripMargin)
+  }
+}


### PR DESCRIPTION
While profiling Scalafix I found out that the main hotspot is `scala.meta.Traverser`. It accounts for ~60% of the running time (see details here: https://github.com/scalacenter/scalafix/issues/894). It turns out that the code generated by the `scala.meta.internal.transversers.TraverserMacros` macro annotation contains a large amount of pattern matching making traversal terribly slow.

This PR introduces a new traverser which relies on `Tree.children`. JMH benchmarks show that it makes tree traversal ~20-70 times faster than the existing one:

>As input for the benchmark, I picked some random *.scala files with 3 (XS), 50 (S), 500 (M), 1000 (L) and 5800 (XL) lines of code and measured the cost of traversing the entire tree. FYR, the source code can be found here https://github.com/marcelocenerine/scalameta-benchmark. 

```
[info] Benchmark                            (size)  Mode  Cnt      Score     Error  Units
[info] TraverserBenchmark.simple_traverser      XS  avgt   10      0.389 ±   0.021  us/op
[info] TraverserBenchmark.simple_traverser       S  avgt   10      8.444 ±   0.134  us/op
[info] TraverserBenchmark.simple_traverser       M  avgt   10    248.154 ±  38.820  us/op
[info] TraverserBenchmark.simple_traverser       L  avgt   10    320.614 ±   2.501  us/op
[info] TraverserBenchmark.simple_traverser      XL  avgt   10   1958.657 ±  22.550  us/op
[info] TraverserBenchmark.traverser             XS  avgt   10     26.749 ±   0.320  us/op
[info] TraverserBenchmark.traverser              S  avgt   10    361.805 ±  28.225  us/op
[info] TraverserBenchmark.traverser              M  avgt   10   5192.518 ± 114.954  us/op
[info] TraverserBenchmark.traverser              L  avgt   10   6553.171 ± 125.726  us/op
[info] TraverserBenchmark.traverser             XL  avgt   10  36190.514 ± 585.949  us/op
```

Methods in `scala.meta.contrib.TreeOps` and `scala.meta.transversers.Api` were updated to use the new traverser. Other utilities under `.internal.` remains as is (same for the alias in `scala.meta.transversers.Aliases`). `scala.meta.transversers.Transformer` (and everything that relies on it) also remains as is.

`scala.meta.internal.transversers.TraverserMacros` (and the supertype `scala.meta.internal.transversers.TransverserMacros`) contains some additional logic to ignore non-relevant fields as well as to sort fiels by priority. For the sake of simplicity, those were not implemented in the new `SimpleTraverser`. Despite that, the traversal order appears to have been preserved (tested on the following repos: spark, akka, scala, kafka, scalafix and scalameta). If there is any edge case that requires that special logic, please let me know.

/cc @olafurpg 