### PR TITLE
Exclude `sun._` and `com.sun._` from semanticdb-scalac jar

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -706,6 +706,13 @@ lazy val mergeSettings = Def.settings(
     IO.copy(List(fatJar -> slimJar), overwrite = true)
     (art, slimJar)
   },
+  assemblyMergeStrategy.in(assembly) := {
+    case PathList("com", "sun", _*) => MergeStrategy.discard
+    case PathList("sun", _*) => MergeStrategy.discard
+    case x =>
+      val oldStrategy = (assemblyMergeStrategy in assembly).value
+      oldStrategy(x)
+  },
   mimaCurrentClassfiles := {
     Keys.`package`.in(Compile).value
   }


### PR DESCRIPTION
This slims the fatjar from 20mb down to 12mb. I don't know why these
artifacts started being included in the fatjar but I suspect it's caused
by the custom javaHome settings.

Before:

```
$ du -h semanticdb-scalac.jar
20M
```

After
```
$ du -h semanticdb-scalac.jar
12M
```