### PR TITLE
Make SimpleTraverser public

### DIFF
--- a/scalameta/transversers/shared/src/main/scala/scala/meta/transversers/SimpleTraverser.scala
+++ b/scalameta/transversers/shared/src/main/scala/scala/meta/transversers/SimpleTraverser.scala
@@ -1,6 +1,6 @@
 package scala.meta
 package transversers
 
-private[meta] class SimpleTraverser {
+class SimpleTraverser {
   def apply(tree: Tree): Unit = tree.children.foreach(apply)
 }

--- a/tests/jvm/src/test/scala/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/api/SurfaceSuite.scala
@@ -132,6 +132,7 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.tokens.Token.Xml *
       |scala.meta.tokens.Tokens
       |scala.meta.transversers
+      |scala.meta.transversers.SimpleTraverser *
       |scala.meta.transversers.Transformer
       |scala.meta.transversers.Traverser
       |scala.meta.trees

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
@@ -412,6 +412,10 @@ class PublicSuite extends FunSuite {
     // n/a
   }
 
+  test("scala.meta.transversers.SimpleTraverser.toString") {
+    // n/a
+  }
+
   test("scala.meta.transversers.Transformer.toString") {
     // n/a
   }


### PR DESCRIPTION
There is no reasons users shouldn't be able to extend SimpleTraverser
to implement custom traversal strategies as we document here:
https://scalameta.org/docs/trees/guide.html#custom-traversals

cc/ @marcelocenerine 