### PR TITLE
Remove `javax.xml.bind` usage

### DIFF
--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/Hex.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/Hex.scala
@@ -1,0 +1,19 @@
+package scala.meta.internal.semanticdb.scalac
+
+object Hex {
+  // copied from scalameta/metals, see
+  // https://github.com/scalameta/metals/blob/8ba8ac9c29d4ab51424de9ad1c9a2e86d956a75d/mtags/src/main/scala/scala/meta/internal/mtags/MD5.scala#L16-L27
+
+  private val hexArray = "0123456789ABCDEF".toCharArray
+  private[scalac] def bytesToHex(bytes: Array[Byte]): String = {
+    val hexChars = new Array[Char](bytes.length * 2)
+    var j = 0
+    while (j < bytes.length) {
+      val v: Int = bytes(j) & 0xFF
+      hexChars(j * 2) = hexArray(v >>> 4)
+      hexChars(j * 2 + 1) = hexArray(v & 0x0F)
+      j += 1
+    }
+    new String(hexChars)
+  }
+}

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/InputOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/InputOps.scala
@@ -4,7 +4,6 @@ import java.net.URLEncoder
 import java.nio.CharBuffer
 import java.nio.charset.StandardCharsets.UTF_8
 import java.security.MessageDigest
-import javax.xml.bind.DatatypeConverter
 import scala.collection.mutable
 import scala.{meta => m}
 import scala.meta.internal.io._
@@ -38,7 +37,7 @@ trait InputOps { self: SemanticdbOps =>
         val md5 = MessageDigest.getInstance("MD5")
         val bytes = UTF_8.encode(CharBuffer.wrap(toInput.chars))
         md5.update(bytes)
-        DatatypeConverter.printHexBinary(md5.digest())
+        Hex.bytesToHex(md5.digest())
       }
     }
     def toInput: m.Input =


### PR DESCRIPTION
This package has been deprecated in Java 9 and was removed in Java 11.

This change lays ground for Java 11 support by not using the `DatatypeConverter`
of this package anymore and uses an internal function instead.

Fixes #1796.