### PR TITLE
Shade fastparse v1 under scala.meta.internal.fastparse

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -360,7 +360,7 @@ lazy val tokenizers = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     description := "Scalameta APIs for tokenization and their baseline implementation",
     // NOTE(olafur): use shaded version of fastparse because the latest version v2.0.0
     // has binary incompatibilites with the v1.0.0 version used by Scalameta.
-    libraryDependencies += "com.geirsson" %%% "fastparse" % "1.0.0",
+    libraryDependencies += "org.scalameta" %%% "fastparse" % "1.0.0",
     enableMacros
   )
   .nativeSettings(nativeSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -358,7 +358,9 @@ lazy val tokenizers = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(
     publishableSettings,
     description := "Scalameta APIs for tokenization and their baseline implementation",
-    libraryDependencies += "com.lihaoyi" %%% "fastparse" % "1.0.0",
+    // NOTE(olafur): use shaded version of fastparse because the latest version v2.0.0
+    // has binary incompatibilites with the v1.0.0 version used by Scalameta.
+    libraryDependencies += "com.geirsson" %%% "fastparse" % "1.0.0",
     enableMacros
   )
   .nativeSettings(nativeSettings)

--- a/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/DocToken.scala
+++ b/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/DocToken.scala
@@ -1,7 +1,7 @@
 package scala.meta.contrib
 
-import fastparse.all._
-import fastparse.core.Parsed
+import scala.meta.internal.fastparse.all._
+import scala.meta.internal.fastparse.core.Parsed
 
 /**
   * Represents a scaladoc line.

--- a/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/ScaladocParser.scala
+++ b/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/ScaladocParser.scala
@@ -1,7 +1,7 @@
 package scala.meta.contrib
 
-import fastparse.all._
-import fastparse.core.Parsed
+import scala.meta.internal.fastparse.all._
+import scala.meta.internal.fastparse.core.Parsed
 
 import scala.meta.contrib.DocToken._
 import scala.meta.tokens.Token.Comment

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
@@ -973,7 +973,7 @@ class LegacyScanner(input: Input, dialect: Dialect) {
 
   def getXml(): Unit = {
     // 1. Collect positions of scala expressions inside this xml literal.
-    import fastparse.core.Parsed
+    import scala.meta.internal.fastparse.core.Parsed
     val start = offset
     val embeddedScalaExprPositions = new ScalaExprPositionParser(dialect)
     val xmlParser = new XmlParser(embeddedScalaExprPositions)

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/XmlParser.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/XmlParser.scala
@@ -4,7 +4,8 @@ import scala.annotation.switch
 import scala.meta.Dialect
 import scala.meta.inputs.Input
 
-import fastparse.all._
+import scala.meta.internal.fastparse
+import scala.meta.internal.fastparse.all._
 
 /**
   * Copy-pasta from this lihaoyi comment:


### PR DESCRIPTION
To avoid binary conflicts with fastparse v2. This commit doesn't fully
solve our problem since scalapb still brings in fastparse, we may have
to shade scalapb in a separate PR.

Fix #1800 