### PR TITLE
Fix for #1826 ApplyInfix parentheses syntax

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -299,8 +299,8 @@ object TreeSyntax {
                     case _ => false
                   } =>
                   true
-                // Include parentheses for `a op (bar: _*)`
-                case repeated: Term.Repeated =>
+                // Include parentheses for `a op (b: _*)`, tuple `a op ((b, c))`, `a op (_.bar), a op (_.opTwo(b))`, `a op (_ opTwo b)`
+                case _: Term.Repeated | _: Term.Tuple |  Term.Select(_: Term.Placeholder, _) | Term.Apply(Term.Select(_: Term.Placeholder, _), _) | Term.ApplyInfix(_: Term.Placeholder, _, _, _) =>
                   true
                 case _ =>
                   false

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -301,14 +301,22 @@ object TreeSyntax {
                     case _: Term.Placeholder => true
                     case _ => false
                   }
-                case Term.ApplyInfix(lhs, _, _, _) if !lhs.isInstanceOf[Term.Placeholder] => // Not `a op (_ b c)`
-                  false
-                case _: Lit | _: Term.Ref | _: Term.Function | _: Term.If | _: Term.Match =>
+                case Term.ApplyInfix(_: Term.Placeholder, _, _, _) =>  // `a op (_ b c)`
+                  true
+                case _: Lit | _: Term.Ref | _: Term.Function | _: Term.If | _: Term.Match | _: Term.ApplyInfix =>
                   false
                 case _ =>
                   true
               }
-              if (needsParens) s("(", p(InfixExpr(t.op.value), arg, right = true), ")")
+              val checkPrecedence = arg match {
+                case Term.ApplyInfix(_: Term.Placeholder, _, _, _) =>
+                  false
+                case _ =>
+                  true
+              }
+              if (needsParens) 
+                if (checkPrecedence) s("(", p(InfixExpr(t.op.value), arg, right = true), ")")
+                else s("(", arg, ")")
               else s(p(InfixExpr(t.op.value), arg, right = true))
               case args => s(args)
           }

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -293,17 +293,17 @@ object TreeSyntax {
               s("(())")
             case (arg: Term) :: Nil =>
               val needsParens = arg match {
-                case apply: Term.Apply if apply.args.exists { // `a op (apply(b, _))`
-                    case _: Term.Placeholder => true
-                    case _ => false
-                  } => true
                 case Term.Select(_: Term.Placeholder, _) => // `a op (_.b)`
                   true
                 case Term.Apply(Term.Select(lhs: Term.Placeholder, _), _) => // `a op (_.b(c))`
                   true
+                case apply: Term.Apply => apply.args.exists { // `a op (apply(b, _))`
+                    case _: Term.Placeholder => true
+                    case _ => false
+                  }
                 case Term.ApplyInfix(lhs, _, _, _) if !lhs.isInstanceOf[Term.Placeholder] => // Not `a op (_ b c)`
                   false
-                case _: Lit | _: Term.Ref | _: Term.Function | _: Term.Apply | _: Term.If | _: Term.Match =>
+                case _: Lit | _: Term.Ref | _: Term.Function | _: Term.If | _: Term.Match =>
                   false
                 case _ =>
                   true

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -701,14 +701,28 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     assert(q"list map (add(_, 1))".syntax == "list map (add(_, 1))")
     assert(q"list map (bar:_*)".syntax == "list map (bar: _*)")
   }
-
-  test("#1826 ApplyInfix parentheses on Tuple and Select") {
+  test("#1826 ApplyInfix parentheses on Select") {
     assert(q"list map (_.bar)".syntax == "list map (_.bar)")
     assert(q"list map (Foo.bar)".syntax == "list map Foo.bar")
+  }
+  test("#1826 ApplyInfix parentheses on tuple") {
     assert(q"list map ((_, foo))".syntax == "list map ((_, foo))")
-    assert(q"list map (_ -> foo)".syntax == "list map (_ -> foo)")
+  }
+  test("#1826 ApplyInfix parentheses on Apply") {
     assert(q"list map (_.->(foo))".syntax == "list map (_.->(foo))")
+    assert(q"list map a.->(foo)".syntax == "list map a.->(foo)")
+    assert(q"list map (_.diff(foo))".syntax == "list map (_.diff(foo))")
+    assert(q"list map a.diff(foo)".syntax == "list map a.diff(foo)")
+  }
+  test("#1826 ApplyInfix parentheses on Function") {
     assert(q"list map (_ => foo)".syntax == "list map (_ => foo)")
+  }
+  test("#1826 ApplyInfix parentheses on ApplyInfix function") {
     assert(q"list map (_ diff foo)".syntax == "list map (_ diff foo)")
+    assert(q"list map (a diff foo)".syntax == "list map a diff foo")
+  }
+  test("#1826 ApplyInfix parentheses on ApplyInfix operator") {
+    assert(q"list map (_ -> foo)".syntax == "list map (_ -> foo)")
+    assert(q"list map (a -> foo)".syntax == "list map a -> foo")
   }
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -701,4 +701,13 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     assert(q"list map (add(_, 1))".syntax == "list map (add(_, 1))")
     assert(q"list map (bar:_*)".syntax == "list map (bar: _*)")
   }
+
+  test("#1826 ApplyInfix parentheses on Tuple and Select") {
+    assert(q"list map (_.bar)".syntax == "list map (_.bar)")
+    assert(q"list map (_ diff foo)".syntax == "list map (_ diff foo)")
+    assert(q"list map ((_, foo))".syntax == "list map ((_, foo))")
+    assert(q"list map (_ -> foo)".syntax == "list map (_ -> foo)")
+    assert(q"list map (_.->(foo))".syntax == "list map (_.->(foo))")
+    assert(q"list map (_ => foo)".syntax == "list map (_ => foo)")
+  }
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -719,10 +719,12 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
   }
   test("#1826 ApplyInfix parentheses on ApplyInfix function") {
     checkTree(q"list map (_ diff foo)", "list map (_ diff foo)")
-    checkTree(q"list map (a diff foo)", "list map a diff foo")
+    // 'diff' has same precedence as 'map', so parentheses should be added
+    checkTree(q"list map (a diff foo)", "list map (a diff foo)")
   }
   test("#1826 ApplyInfix parentheses on ApplyInfix operator") {
     checkTree(q"list map (_ -> foo)", "list map (_ -> foo)")
+    // '->' has greater precendence than 'map', so parentheses are not needed
     checkTree(q"list map (a -> foo)", "list map a -> foo")
   }
   test("1826 ApplyInfix parentheses on Term.Match") {

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -704,10 +704,11 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
 
   test("#1826 ApplyInfix parentheses on Tuple and Select") {
     assert(q"list map (_.bar)".syntax == "list map (_.bar)")
-    assert(q"list map (_ diff foo)".syntax == "list map (_ diff foo)")
+    assert(q"list map (Foo.bar)".syntax == "list map Foo.bar")
     assert(q"list map ((_, foo))".syntax == "list map ((_, foo))")
     assert(q"list map (_ -> foo)".syntax == "list map (_ -> foo)")
     assert(q"list map (_.->(foo))".syntax == "list map (_.->(foo))")
     assert(q"list map (_ => foo)".syntax == "list map (_ => foo)")
+    assert(q"list map (_ diff foo)".syntax == "list map (_ diff foo)")
   }
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -696,33 +696,41 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
   }
 
   test("#1817 ApplyInfix parentheses") {
-    assert(q"list map (println)".syntax == "list map println")
-    assert(q"list map (add(1))".syntax == "list map add(1)")
-    assert(q"list map (add(_, 1))".syntax == "list map (add(_, 1))")
-    assert(q"list map (bar:_*)".syntax == "list map (bar: _*)")
+    checkTree(q"list map (println)", "list map println")
+    checkTree(q"list map (add(1))", "list map add(1)")
+    checkTree(q"list map (add(_, 1))", "list map (add(_, 1))")
+    checkTree(q"list map (bar:_*)", "list map (bar: _*)")
   }
   test("#1826 ApplyInfix parentheses on Select") {
-    assert(q"list map (_.bar)".syntax == "list map (_.bar)")
-    assert(q"list map (Foo.bar)".syntax == "list map Foo.bar")
+    checkTree(q"list map (_.bar)", "list map (_.bar)")
+    checkTree(q"list map (Foo.bar)", "list map Foo.bar")
   }
   test("#1826 ApplyInfix parentheses on tuple") {
-    assert(q"list map ((_, foo))".syntax == "list map ((_, foo))")
+    checkTree(q"list map ((_, foo))", "list map ((_, foo))")
   }
   test("#1826 ApplyInfix parentheses on Apply") {
-    assert(q"list map (_.->(foo))".syntax == "list map (_.->(foo))")
-    assert(q"list map a.->(foo)".syntax == "list map a.->(foo)")
-    assert(q"list map (_.diff(foo))".syntax == "list map (_.diff(foo))")
-    assert(q"list map a.diff(foo)".syntax == "list map a.diff(foo)")
+    checkTree(q"list map (_.->(foo))", "list map (_.->(foo))")
+    checkTree(q"list map a.->(foo)", "list map a.->(foo)")
+    checkTree(q"list map (_.diff(foo))", "list map (_.diff(foo))")
+    checkTree(q"list map a.diff(foo)", "list map a.diff(foo)")
   }
   test("#1826 ApplyInfix parentheses on Function") {
-    assert(q"list map (_ => foo)".syntax == "list map (_ => foo)")
+    checkTree(q"list map (_ => foo)", "list map (_ => foo)")
   }
   test("#1826 ApplyInfix parentheses on ApplyInfix function") {
-    assert(q"list map (_ diff foo)".syntax == "list map (_ diff foo)")
-    assert(q"list map (a diff foo)".syntax == "list map a diff foo")
+    checkTree(q"list map (_ diff foo)", "list map (_ diff foo)")
+    checkTree(q"list map (a diff foo)", "list map a diff foo")
   }
   test("#1826 ApplyInfix parentheses on ApplyInfix operator") {
-    assert(q"list map (_ -> foo)".syntax == "list map (_ -> foo)")
-    assert(q"list map (a -> foo)".syntax == "list map a -> foo")
+    checkTree(q"list map (_ -> foo)", "list map (_ -> foo)")
+    checkTree(q"list map (a -> foo)", "list map a -> foo")
+  }
+  test("1826 ApplyInfix parentheses on Term.Match") {
+    checkTree(q"list map (_ match { case 1 => 2})", s"list map (_ match {${EOL}  case 1 => 2${EOL}})")
+  }
+
+  def checkTree(original: Tree, expected: String): Unit = {
+    assert(original.syntax == expected)
+    assert(original.structure == (expected.parse[Stat]).get.structure)
   }
 }


### PR DESCRIPTION
Fixes #1826 syntax printer bugs.

~One case still fails: `list map (_ diff foo)`. It adds an extra set of parentheses around the argument. I am unsure why that fails but another case `list map (_ -> foo)` does work, as they seem to have the same AST.~