### PR TITLE
Goodbye, Scalameta!

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ If you'd like to find out how to use scalameta, see this [tutorial](http://scala
 ### Team
 The current maintainers (people who can merge pull requests) are:
 
-* Eugene Burmako - [`@xeno-by`](https://github.com/xeno-by)
 * David Dudson - [`@DavidDudson`](https://github.com/DavidDudson)
 * Ólafur Páll Geirsson - [`@olafurpg`](https://github.com/olafurpg)
 * Mikhail Mutcianko - [`@mutcianm`](https://github.com/mutcianm)


### PR DESCRIPTION
I'm very proud of what we've achieved in Scalameta.

What started as a research macro system for Scala, ended up as a foundation
for a family of new-style developer tools, with more than 10000 commits
and 200 contributors. Even more, one of our technologies - SemanticDB -
has become a metadata format for Rsc, a brand new Scala compiler.
I couldn't have wished for more!!

Olaf, the stage is yours.