### PR TITLE
Use @JSImport to load native "fs" and "path" modules

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -539,6 +539,9 @@ lazy val tests = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .jvmConfigure(
     _.dependsOn(testkit, interactive, metac, metacp, metai, symtab, semanticdbIntegration)
   )
+  .jsSettings(
+    scalaJSModuleKind := ModuleKind.CommonJSModule
+  )
   .nativeSettings(
     nativeSettings,
     // FIXME: https://github.com/scalatest/scalatest/issues/1112

--- a/scalameta/io/js/src/main/scala/java/io/File.scala
+++ b/scalameta/io/js/src/main/scala/java/io/File.scala
@@ -49,7 +49,7 @@ class File(path: String) {
 object File {
   def listRoots(): Array[File] = Array(
     new File(
-      if (JSIO.isNode) JSIO.path.parse(JSIO.path.resolve()).root
+      if (JSIO.isNode) JSPath.parse(JSPath.resolve()).root
       else "/"
     )
   )
@@ -58,10 +58,10 @@ object File {
     separator.charAt(0)
 
   def separator: String =
-    if (JSIO.isNode) JSIO.path.sep
+    if (JSIO.isNode) JSPath.sep
     else "/"
 
   def pathSeparator: String =
-    if (JSIO.isNode) JSIO.path.delimiter
+    if (JSIO.isNode) JSPath.delimiter
     else ":"
 }

--- a/scalameta/io/js/src/main/scala/scala/meta/internal/io/JSIO.scala
+++ b/scalameta/io/js/src/main/scala/scala/meta/internal/io/JSIO.scala
@@ -18,25 +18,13 @@ trait JSProcess extends js.Any {
   def cwd(): String = js.native
 }
 
-/** Facade for the native nodejs modules API
-  *
-  * @see https://nodejs.org/api/modules.html
-  */
-@js.native
-trait JSModules extends js.Any {
-  /** Load a module by ID or path.
-    *
-    * @see https://nodejs.org/api/modules.html#modules_require
-    */
-  def require[T](path: String): T = js.native
-}
-
 /** Facade for native nodejs module "fs".
   *
   * @see https://nodejs.org/api/fs.html
   */
 @js.native
-trait JSFs extends js.Any {
+@JSImport("fs", Namespace)
+object JSFs extends js.Any {
 
   /** Returns the file contents as Buffer using blocking apis.
     *
@@ -69,7 +57,8 @@ trait JSFs extends js.Any {
   * @see https://nodejs.org/api/fs.html#fs_class_fs_stats
   */
 @js.native
-trait JSStats extends js.Any {
+@JSImport("fs", Namespace)
+class JSStats extends js.Any {
   def isFile(): Boolean = js.native
   def isDirectory(): Boolean = js.native
 }
@@ -79,11 +68,12 @@ trait JSStats extends js.Any {
   * @see https://nodejs.org/api/path.html
   */
 @js.native
-trait JSPath extends js.Any {
+@JSImport("path", Namespace)
+object JSPath extends js.Any {
   def sep: String = js.native
   def delimiter: String = js.native
   def isAbsolute(path: String): Boolean = js.native
-  def parse(path: String): JSPath = js.native
+  def parse(path: String): JSPath.type = js.native
   def resolve(paths: String*): String = js.native
   def normalize(path: String): String = js.native
   def basename(path: String): String = js.native
@@ -96,9 +86,6 @@ trait JSPath extends js.Any {
 object JSIO {
   private[io] val process: JSProcess = js.Dynamic.global.process.asInstanceOf[JSProcess]
   def isNode = !js.isUndefined(process) && !js.isUndefined(process.cwd)
-  private[io] lazy val module: JSModules = js.Dynamic.global.asInstanceOf[JSModules]
-  lazy val fs: JSFs = module.require("fs")
-  lazy val path: JSPath = module.require("path")
 
   def inNode[T](f: => T): T =
     if (JSIO.isNode) f
@@ -111,12 +98,12 @@ object JSIO {
     else "/"
 
   def exists(path: String): Boolean =
-    if (isNode) fs.existsSync(path)
+    if (isNode) JSFs.existsSync(path)
     else false
 
   def isFile(path: String): Boolean =
-    exists(path) && fs.lstatSync(path).isFile()
+    exists(path) && JSFs.lstatSync(path).isFile()
 
   def isDirectory(path: String): Boolean =
-    exists(path) && fs.lstatSync(path).isDirectory()
+    exists(path) && JSFs.lstatSync(path).isDirectory()
 }

--- a/scalameta/io/js/src/main/scala/scala/meta/internal/io/NodeNIOPath.scala
+++ b/scalameta/io/js/src/main/scala/scala/meta/internal/io/NodeNIOPath.scala
@@ -22,7 +22,7 @@ case class NodeNIOPath(filename: String) extends Path {
   override def toFile: File =
     new File(filename)
   override def isAbsolute: Boolean =
-    if (JSIO.isNode) JSIO.path.isAbsolute(filename)
+    if (JSIO.isNode) JSPath.isAbsolute(filename)
     else filename.startsWith(File.separator)
   override def getName(index: Int): Path =
     NodeNIOPath(
@@ -31,12 +31,12 @@ case class NodeNIOPath(filename: String) extends Path {
         .lift(adjustIndex(index))
         .getOrElse(throw new IllegalArgumentException))
   override def getParent: Path =
-    NodeNIOPath(JSIO.path.dirname(filename))
+    NodeNIOPath(JSPath.dirname(filename))
   override def toAbsolutePath: Path =
     if (isAbsolute) this
     else NodeNIOPath.workingDirectory.resolve(this)
   override def relativize(other: Path): Path =
-    NodeNIOPath(JSIO.path.relative(filename, other.toString))
+    NodeNIOPath(JSPath.relative(filename, other.toString))
   override def getNameCount: Int = {
     val strippeddrive =
       if ((filename.length > 1) && (filename(1) == ':')) filename.substring(2) else filename
@@ -46,18 +46,18 @@ case class NodeNIOPath(filename: String) extends Path {
   }
   override def toUri: URI = toFile.toURI
   override def getFileName: Path =
-    NodeNIOPath(JSIO.path.basename(filename))
+    NodeNIOPath(JSPath.basename(filename))
   override def getRoot: Path =
     if (!isAbsolute) null
     else NodeNIOPath(File.separator)
   override def normalize(): Path =
-    if (JSIO.isNode) NodeNIOPath(JSIO.path.normalize(filename))
+    if (JSIO.isNode) NodeNIOPath(JSPath.normalize(filename))
     else this
   override def endsWith(other: Path): Boolean =
     endsWith(other.toString)
   override def endsWith(other: String): Boolean =
     paths(filename).endsWith(paths(other))
-  // JSIO.path.resolve(relpath, relpath) produces an absolute path from cwd.
+  // JSPath.resolve(relpath, relpath) produces an absolute path from cwd.
   // This method turns the generated absolute path back into a relative path.
   private def adjustResolvedPath(resolved: Path): Path =
     if (isAbsolute) resolved
@@ -65,11 +65,11 @@ case class NodeNIOPath(filename: String) extends Path {
   override def resolveSibling(other: Path): Path =
     resolveSibling(other.toString)
   override def resolveSibling(other: String): Path =
-    adjustResolvedPath(NodeNIOPath(JSIO.path.resolve(JSIO.path.dirname(filename), other)))
+    adjustResolvedPath(NodeNIOPath(JSPath.resolve(JSPath.dirname(filename), other)))
   override def resolve(other: Path): Path =
     resolve(other.toString)
   override def resolve(other: String): Path =
-    adjustResolvedPath(NodeNIOPath(JSIO.path.resolve(filename, other)))
+    adjustResolvedPath(NodeNIOPath(JSPath.resolve(filename, other)))
   override def startsWith(other: Path): Boolean =
     startsWith(other.toString)
   override def startsWith(other: String): Boolean =

--- a/scalameta/io/js/src/main/scala/scala/meta/internal/io/PlatformFileIO.scala
+++ b/scalameta/io/js/src/main/scala/scala/meta/internal/io/PlatformFileIO.scala
@@ -25,7 +25,7 @@ object PlatformFileIO {
     }
 
   def readAllBytes(path: AbsolutePath): Array[Byte] = JSIO.inNode {
-    val jsArray = JSIO.fs.readFileSync(path.toString)
+    val jsArray = JSFs.readFileSync(path.toString)
     val len = jsArray.length
     val result = new Array[Byte](len)
     var curr = 0
@@ -42,20 +42,20 @@ object PlatformFileIO {
   }
 
   def write(path: AbsolutePath, proto: GeneratedMessage): Unit = JSIO.inNode {
-    JSIO.fs.mkdirSync(path.toNIO.getParent.toString)
+    JSFs.mkdirSync(path.toNIO.getParent.toString)
     val os = new ByteArrayOutputStream
     proto.writeTo(os)
     val buffer = os.toByteArray.map(_.toInt).toJSArray
-    JSIO.fs.writeFileSync(path.toString, buffer)
+    JSFs.writeFileSync(path.toString, buffer)
   }
 
   def slurp(path: AbsolutePath, charset: Charset): String =
-    JSIO.inNode(JSIO.fs.readFileSync(path.toString, charset.toString))
+    JSIO.inNode(JSFs.readFileSync(path.toString, charset.toString))
 
   def listFiles(path: AbsolutePath): ListFiles = JSIO.inNode {
     if (path.isFile) new ListFiles(path, Nil)
     else {
-      val jsArray = JSIO.fs.readdirSync(path.toString)
+      val jsArray = JSFs.readdirSync(path.toString)
       val builder = List.newBuilder[RelativePath]
       builder.sizeHint(jsArray.length)
       var curr = 0


### PR DESCRIPTION
This effectively reverts https://github.com/scalameta/scalameta/commit/032dc56318bc81d3ecd4aa39040a15a74bf4fd8c#diff-e392e6315fa9beedb70580bda57714c0

According to [a discussion with Sébastien on Gitter](https://gitter.im/scala-js/scala-js?at=5c7fc7f1f895944c084d730b), accessing `require` from the Global scope is invalid. The reason it works is that tests are run into a sort-of node REPL, where the global scope has a `require` function. However, when running Scalameta as a script, `require` is `undefined`, causing a runtime failure.

It seems we have to use `@JSImport` to reference the native `path` and `fs` modules.

It used to be that way, but it was changed by @jonas at some point in 2017 (see the commit below), but I couldn't find any further context for that change.