### PR TITLE
LanguageOps: Detect Typelevel compiler

### DIFF
--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/LanguageOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/LanguageOps.scala
@@ -8,8 +8,12 @@ trait LanguageOps { self: SemanticdbOps =>
   lazy val language: String = {
     val version = Properties.versionNumberString
     if (version.startsWith("2.10")) "Scala210"
-    else if (version.startsWith("2.11")) "Scala211"
-    else if (version.startsWith("2.12")) "Scala212"
-    else sys.error(s"unsupported Scala version $version")
+    else if (version.startsWith("2.11")) {
+      if (!version.endsWith("-bin-typelevel-4")) "Scala211"
+      else "Typelevel211"
+    } else if (version.startsWith("2.12")) {
+      if (!version.endsWith("-bin-typelevel-4")) "Scala212"
+      else "Typelevel212"
+    } else sys.error(s"unsupported Scala version $version")
   }
 }


### PR DESCRIPTION
This allows to use Typelevel-specific features like literal types.