### PR TITLE
DiagnosticOps: Fix invalid range when `-Yrangepos` is disabled

### DIFF
--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DiagnosticOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DiagnosticOps.scala
@@ -19,7 +19,7 @@ trait DiagnosticOps { self: SemanticdbOps =>
                 case Some(name) => name.pos
                 case None =>
                   if (unit.source.content(gpos.point) == '_') // Importee.Wildcard()
-                    gpos.withStart(gpos.point).withEnd(gpos.point + 1).toMeta
+                    m.Position.Range(gpos.source.toInput, gpos.point, gpos.point + 1)
                   else gpos.toMeta
               }
             } else gpos.toMeta


### PR DESCRIPTION
`withStart()` may result in an invalid range:

```
java.lang.AssertionError: assertion failed: bad position: [291:282]
      at scala.Predef$.assert(Predef.scala:235)
      at scala.reflect.internal.util.Position$.validate(Position.scala:34)
      at scala.reflect.internal.util.Position$.range(Position.scala:51)
      at scala.reflect.internal.util.InternalPositionImpl.copyRange(Position.scala:205)
      at scala.reflect.internal.util.InternalPositionImpl.withStart(Position.scala:124)
      at scala.reflect.internal.util.InternalPositionImpl.withStart$(Position.scala:124)
      at scala.reflect.internal.util.Position.withStart(Position.scala:12)
      at scala.meta.internal.semanticdb.scalac.DiagnosticOps$XtensionCompilationUnitDiagnostics.$anonfun$reportedDiagnostics$1(DiagnosticOps.scala:22)
[...]
```

This happens whenever the new start position is after the current
end position. Since a new start and end position are set, the issue
can be resolved by instantiating `Position.Range()` directly.