### PR TITLE
Fix multiple Term.Select parentheses (prettyprinting syntax)

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -308,20 +308,17 @@ object TreeSyntax {
               case _: Term.Placeholder => true
               case Term.Select(lhs, _) => lhsIsPlaceHolder(lhs)
               case Term.Apply(lhs, _) => lhsIsPlaceHolder(lhs)
+              case Term.ApplyInfix(lhs, _, _, _) => lhsIsPlaceHolder(lhs)
               case _ => false
             }
 
             def needsParens: Boolean = arg match {
-              case Term.Select(_: Term.Placeholder, _) => // `a op (_.b)`
-                true
-              case Term.Apply(lhs, _) if lhsIsPlaceHolder(lhs) => // `a op (_.b(c))`
+              case placeholder if lhsIsPlaceHolder(placeholder) => // `a op (_.b)`
                 true
               case apply: Term.Apply => apply.args.exists { // `a op (apply(b, _))`
                 case _: Term.Placeholder => true
                 case _ => false
               }
-              case Term.ApplyInfix(lhs, _, _, _) if lhsIsPlaceHolder(lhs) =>  // `a op (_ b c)`
-                true
               case _: Lit | _: Term.Ref | _: Term.Function | _: Term.If | _: Term.Match | _: Term.ApplyInfix =>
                 false
               case _ =>

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -711,6 +711,9 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     checkTree(q"list map (_.bar)", "list map (_.bar)")
     checkTree(q"list map (Foo.bar)", "list map Foo.bar")
   }
+  test("1826 ApplyInfix parentheses on multiple Select") {
+    checkTree(q"list map (_.foo.bar)", "list map (_.foo.bar)")
+  }
   test("#1826 ApplyInfix parentheses on tuple") {
     checkTree(q"list map ((_, foo))", "list map ((_, foo))")
   }


### PR DESCRIPTION
`Term.Select` placeholders would only be checked one level deep instead of recursively (`_.foo.bar.baz`). This PR fixes that and simplifies the needsParens function a little bit