### PR TITLE
Scala 2.13 supports by-name implicits

### DIFF
--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -165,6 +165,7 @@ package object dialects {
   )
 
   implicit val Scala213 = Scala212.copy(
+    allowImplicitByNameParameters = true,
     allowLiteralTypes = true
   )
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/Scala213Suite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/Scala213Suite.scala
@@ -1,0 +1,10 @@
+package scala.meta.tests
+package parsers
+
+import scala.meta._
+import scala.meta.dialects.Scala213
+
+class Scala213Suite extends ParseSuite {
+  checkOK("def foo(implicit x: => Int) = 1")
+  checkOK("def foo(implicit y: Int, x: => Int) = 1")
+}


### PR DESCRIPTION
Resubmitting this PR (originally #1879) as requested by the CLA error message in CI. I'm sure I've signed these CLAs before but I did them both again.

I've just copied the relevant tests from the Dotty dialect test suite—I'm happy to expand them if people want.