### PR TITLE
Add support for Scala 2.13 numeric literal separators

### DIFF
--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -50,8 +50,8 @@ import scala.compat.Platform.EOL
   // Some quasiquotes only support single-line snippets.
   allowMultilinePrograms: Boolean,
 
-  // Are numeric literal separators, i.e. `1_000_000` legal or not?
-  allowNumericLiteralSeparators: Boolean,
+  // Are numeric literal underscore separators, i.e. `1_000_000` legal or not?
+  allowNumericLiteralUnderscoreSeparators: Boolean,
 
   // Are `|` (union types) supported by this dialect?
   allowOrTypes: Boolean,
@@ -130,7 +130,7 @@ package object dialects {
     allowLiteralTypes = false,
     allowMethodTypes = false,
     allowMultilinePrograms = true,
-    allowNumericLiteralSeparators = false,
+    allowNumericLiteralUnderscoreSeparators = false,
     allowOrTypes = false,
     allowPatUnquotes = false,
     allowSpliceUnderscores = false, // SI-7715, only fixed in 2.11.0-M5
@@ -171,7 +171,7 @@ package object dialects {
   implicit val Scala213 = Scala212.copy(
     allowImplicitByNameParameters = true,
     allowLiteralTypes = true,
-    allowNumericLiteralSeparators = true
+    allowNumericLiteralUnderscoreSeparators = true
   )
 
   implicit val Scala = Scala212 // alias for latest Scala dialect.

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -50,6 +50,9 @@ import scala.compat.Platform.EOL
   // Some quasiquotes only support single-line snippets.
   allowMultilinePrograms: Boolean,
 
+  // Are numeric literal separators, i.e. `1_000_000` legal or not?
+  allowNumericLiteralSeparators: Boolean,
+
   // Are `|` (union types) supported by this dialect?
   allowOrTypes: Boolean,
 
@@ -127,6 +130,7 @@ package object dialects {
     allowLiteralTypes = false,
     allowMethodTypes = false,
     allowMultilinePrograms = true,
+    allowNumericLiteralSeparators = false,
     allowOrTypes = false,
     allowPatUnquotes = false,
     allowSpliceUnderscores = false, // SI-7715, only fixed in 2.11.0-M5
@@ -166,7 +170,8 @@ package object dialects {
 
   implicit val Scala213 = Scala212.copy(
     allowImplicitByNameParameters = true,
-    allowLiteralTypes = true
+    allowLiteralTypes = true,
+    allowNumericLiteralSeparators = true
   )
 
   implicit val Scala = Scala212 // alias for latest Scala dialect.

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -50,9 +50,6 @@ import scala.compat.Platform.EOL
   // Some quasiquotes only support single-line snippets.
   allowMultilinePrograms: Boolean,
 
-  // Are numeric literal underscore separators, i.e. `1_000_000` legal or not?
-  allowNumericLiteralUnderscoreSeparators: Boolean,
-
   // Are `|` (union types) supported by this dialect?
   allowOrTypes: Boolean,
 
@@ -97,8 +94,26 @@ import scala.compat.Platform.EOL
   // Normally none is required, but scripts may have their own rules.
   toplevelSeparator: String
 ) {
+
   // Are unquotes ($x) and splices (..$xs, ...$xss) allowed?
   def allowUnquotes: Boolean = allowTermUnquotes || allowPatUnquotes
+
+  // Are numeric literal underscore separators, i.e. `1_000_000` legal or not?
+  def allowNumericLiteralUnderscoreSeparators: Boolean = internalAllowNumericLiteralUnderscoreSeparators
+  private var internalAllowNumericLiteralUnderscoreSeparators: Boolean = false
+  // IMPORTANT: Methods like `withAllowNumericLiteralUnderscoreSeparators()`
+  // must always come last in the method chain, it's not supported to change a
+  // dialect using a pattern like this:
+  // `.withAllowNumericLiteralUnderscoreSeparators(true).copy(...)`
+  def withAllowNumericLiteralUnderscoreSeparators(allowNumericLiteralUnderscoreSeparators: Boolean): Dialect = {
+    val result = copyWithInternalVars()
+    result.internalAllowNumericLiteralUnderscoreSeparators = allowNumericLiteralUnderscoreSeparators
+    result
+  }
+
+  // NOTE(olafur): new fields to the `Dialect` class must be added as private
+  // vars using the same pattern as `internalAllowNumericLiteralUnderscoreSeparators`
+  // in order to preservere binary compatibility with older Scalameta versions.
 
   // Dialects have reference equality semantics,
   // because sometimes dialects representing distinct Scala versions
@@ -106,6 +121,12 @@ import scala.compat.Platform.EOL
   override def canEqual(that: Any): Boolean = this eq that.asInstanceOf[AnyRef]
   override def equals(other: Any): Boolean = this eq other.asInstanceOf[AnyRef]
   override def hashCode: Int = System.identityHashCode(this)
+  // Create new reference that copies over internal var settings from this instance.
+  private def copyWithInternalVars(): Dialect = {
+    val result = copy()
+    result.internalAllowNumericLiteralUnderscoreSeparators = this.internalAllowNumericLiteralUnderscoreSeparators
+    result
+  }
 
   // Smart prettyprinting that knows about standard dialects.
   override def toString = {
@@ -130,7 +151,6 @@ package object dialects {
     allowLiteralTypes = false,
     allowMethodTypes = false,
     allowMultilinePrograms = true,
-    allowNumericLiteralUnderscoreSeparators = false,
     allowOrTypes = false,
     allowPatUnquotes = false,
     allowSpliceUnderscores = false, // SI-7715, only fixed in 2.11.0-M5
@@ -170,11 +190,10 @@ package object dialects {
 
   implicit val Scala213 = Scala212.copy(
     allowImplicitByNameParameters = true,
-    allowLiteralTypes = true,
-    allowNumericLiteralUnderscoreSeparators = true
-  )
+    allowLiteralTypes = true
+  ).withAllowNumericLiteralUnderscoreSeparators(true)
 
-  implicit val Scala = Scala212 // alias for latest Scala dialect.
+  implicit val Scala = Scala213 // alias for latest Scala dialect.
 
   implicit val Sbt0136 = Scala210.copy(
     allowToplevelTerms = true,

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
@@ -828,7 +828,7 @@ class LegacyScanner(input: Input, dialect: Dialect) {
 
   @inline private def isNumberSeparator(c: Char): Boolean = {
     val isSeparator = c == '_'
-    if (isSeparator && !dialect.allowNumericLiteralSeparators) 
+    if (isSeparator && !dialect.allowNumericLiteralUnderscoreSeparators)
       syntaxError("numeric separators are not allowed", at = offset)
     else isSeparator
   }

--- a/tests/shared/src/test/scala-2.12/meta/tests/dialects/DialectSuite.scala
+++ b/tests/shared/src/test/scala-2.12/meta/tests/dialects/DialectSuite.scala
@@ -8,4 +8,11 @@ class DialectSuite extends FunSuite {
   test("Dialect.current") {
     assert(Dialect.current == scala.meta.dialects.Scala212)
   }
+  test("internal mutation doesn't leak") {
+    import scala.meta.dialects.Scala212
+    val Scala212WithUnderscoreSeparator = Scala212.withAllowNumericLiteralUnderscoreSeparators(true)
+    assert(!Scala212.allowNumericLiteralUnderscoreSeparators)
+    assert(Scala212WithUnderscoreSeparator.allowNumericLiteralUnderscoreSeparators)
+    assert(Scala212WithUnderscoreSeparator != Scala212)
+  }
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
@@ -131,7 +131,7 @@ class PublicSuite extends FunSuite {
   }
 
   test("scala.meta.dialects.Scala.toString") {
-    assert(scala.meta.dialects.Scala.toString === "Scala212")
+    assert(scala.meta.dialects.Scala.toString === "Scala213")
   }
 
   test("scala.meta.dialects.Typelevel211.toString") {

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
@@ -908,4 +908,23 @@ class TokenizerSuite extends BaseTokenizerSuite {
 
     assert(dialects.Dotty("s\"$enum\"").tokenize.isInstanceOf[Tokenized.Error])
   }
+
+  test("numeric literal separator") {
+    dialects.Scala213("1_024").tokenize.get
+    dialects.Scala213("1_024L").tokenize.get
+    dialects.Scala213("3_14e-2").tokenize.get
+    dialects.Scala213("3_14E-2_1").tokenize.get
+
+    assert(dialects.Scala213("123_456_").tokenize.isInstanceOf[Tokenized.Error])
+    assert(dialects.Scala213("123_456_L").tokenize.isInstanceOf[Tokenized.Error])
+    assert(dialects.Scala213("3_14_E-2").tokenize.isInstanceOf[Tokenized.Error])
+    assert(dialects.Scala213("3_14E-_2").tokenize.isInstanceOf[Tokenized.Error])
+    assert(dialects.Scala213("3_14E-2_").tokenize.isInstanceOf[Tokenized.Error])
+    assert(dialects.Scala213("3.1_4_").tokenize.isInstanceOf[Tokenized.Error])
+    assert(dialects.Scala213("3.1_4_d").tokenize.isInstanceOf[Tokenized.Error])
+    assert(dialects.Scala213("3.1_4_dd").tokenize.isInstanceOf[Tokenized.Error])
+    assert(dialects.Scala213("3.1_4_dd").tokenize.isInstanceOf[Tokenized.Error])
+
+    assert(dialects.Scala212("1_024").tokenize.isInstanceOf[Tokenized.Error])
+  }
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
@@ -926,5 +926,9 @@ class TokenizerSuite extends BaseTokenizerSuite {
     assert(dialects.Scala213("3.1_4_dd").tokenize.isInstanceOf[Tokenized.Error])
 
     assert(dialects.Scala212("1_024").tokenize.isInstanceOf[Tokenized.Error])
+
+    val intConstant = dialects.Scala213(" 1_000_000 ").tokenize.get(2).asInstanceOf[Token.Constant.Int]
+    assert(intConstant.pos.text == "1_000_000") // assert token position includes underscores
+    assert(intConstant.value == BigInt(1000000))
   }
 }


### PR DESCRIPTION
This PR adds a new `allowNumericLiteralSeparators` option to
`Dialect`, which is only true in the `Scala213` dialect.

This is mostly a direct port of the respective scalac commit
(https://github.com/scala/scala/commit/c3591880d809985fd3de96462bf2742823b66234?w=1),
including the positive and negative tests.

--

## ☢️ Warning ☢️ 

![image](https://user-images.githubusercontent.com/691940/60296742-0b11c900-9927-11e9-948d-36432ae62864.png)

(but tests gave me the confidence to open this PR)