### PR TITLE
Scalameta parsers fix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -207,6 +207,9 @@ lazy val parsers = crossProject(JSPlatform, JVMPlatform /*, NativePlatform*/ )
       )
     })
   )
+  .jsSettings(
+    scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
+  )
   // .nativeSettings(nativeSettings)
   .dependsOn(trees)
 lazy val parsersJVM = parsers.jvm

--- a/scalameta/parsers/js/npm/package.json
+++ b/scalameta/parsers/js/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scalameta-parsers",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "main": "index.js",
   "files": [
     "index.js"

--- a/scalameta/parsers/js/npm/package.json
+++ b/scalameta/parsers/js/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scalameta-parsers",
-  "version": "2.0.1",
+  "version": "4.2.0",
   "main": "index.js",
   "files": [
     "index.js"


### PR DESCRIPTION
Somewhere along the way this broke, so `parseStat` and `parseSource` were being exported as global functions instead of as a module.

Unfortunately I botched the 4.2.0 release on npm, so I republished the correct version as 4.2.1 (Scalameta will have to catch up :P )

4.2.1 is working 🎉 https://runkit.com/embed/l27a3qm5mggp