### PR TITLE
Fixes mishandling of URI -> nio.file.Path conversions and splicing.

### DIFF
--- a/scalameta/io/shared/src/main/scala/scala/meta/io/AbsolutePath.scala
+++ b/scalameta/io/shared/src/main/scala/scala/meta/io/AbsolutePath.scala
@@ -3,6 +3,7 @@ package scala.meta.io
 import java.io._
 import java.nio.{file => nio}
 import java.net._
+import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import scalapb.GeneratedMessage
@@ -14,6 +15,7 @@ import scala.meta.internal.io.PathIO
 sealed abstract case class AbsolutePath(toNIO: nio.Path) {
   require(toNIO.isAbsolute, s"$toNIO is not absolute!")
   def toFile: File = toNIO.toFile
+  def toURI: URI = toURI(Files.isDirectory(toNIO))
   def toURI(isDirectory: Boolean): URI = {
     val uri = toNIO.toUri
     if (isDirectory && !uri.getPath.endsWith("/")) {

--- a/scalameta/io/shared/src/main/scala/scala/meta/io/AbsolutePath.scala
+++ b/scalameta/io/shared/src/main/scala/scala/meta/io/AbsolutePath.scala
@@ -14,7 +14,21 @@ import scala.meta.internal.io.PathIO
 sealed abstract case class AbsolutePath(toNIO: nio.Path) {
   require(toNIO.isAbsolute, s"$toNIO is not absolute!")
   def toFile: File = toNIO.toFile
-  def toURI: URI = toNIO.toUri
+  def toURI(isDirectory: Boolean): URI = {
+    val uri = toNIO.toUri
+    if (isDirectory && !uri.getPath.endsWith("/")) {
+      // If toNIO exists, toUri will return a trailing slash, otherwise it won't (at least on JDK 8).
+      // This is important because URI.resolve(String) will drop the last segment of the URI's path if
+      // there is not a trailing slash:
+      //    scala> Paths.get("/tmp/test/doesNotExist").toUri.resolve("bar")
+      //    res1: java.net.URI = file:/tmp/test/bar
+      //    scala> Paths.get("/tmp/test/doesExist").toUri.resolve("bar")
+      //    res2: java.net.URI = file:/tmp/test/doesExist/bar
+      URI.create(uri.toString + "/")
+    } else {
+      uri
+    }
+  }
 
   def syntax: String = toString
   def structure: String = s"""AbsolutePath("$syntax")"""
@@ -48,4 +62,8 @@ object AbsolutePath {
     } else {
       cwd.resolve(path.toString)
     }
+  def fromAbsoluteUri(uri: URI)(implicit cwd: AbsolutePath): AbsolutePath = {
+    require(uri.isAbsolute, "This method only works on absolute URIs at present.") // Limitation of Paths.get(URI)
+    apply(Paths.get(uri))(cwd)
+  }
 }

--- a/semanticdb/integration/src/main/scala/example/filename with spaces.scala
+++ b/semanticdb/integration/src/main/scala/example/filename with spaces.scala
@@ -1,0 +1,3 @@
+package example
+
+class FilenameWithSpaces

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/InputOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/InputOps.scala
@@ -17,7 +17,7 @@ trait InputOps { self: SemanticdbOps =>
   implicit class XtensionGSourceFileInput(gsource: GSourceFile) {
     def toUri: String = toInput match {
       case input: m.Input.File =>
-        config.sourceroot.toURI.relativize(input.path.toURI).toString
+        config.sourceroot.toURI(isDirectory = true).relativize(input.path.toURI(isDirectory = false)).toString
       case input: m.Input.VirtualFile =>
         input.path
       case _ =>
@@ -46,7 +46,7 @@ trait InputOps { self: SemanticdbOps =>
           case gfile: GPlainFile =>
             if (config.text.isOn) {
               val path = m.AbsolutePath(gfile.file)
-              val label = config.sourceroot.toURI.relativize(path.toURI).toString
+              val label = config.sourceroot.toURI(isDirectory = true).relativize(path.toURI(isDirectory = false)).toString
               // NOTE: Can't use gsource.content because it's preprocessed by scalac.
               val contents = FileIO.slurp(path, UTF_8)
               m.Input.VirtualFile(label, contents)

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/InputOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/InputOps.scala
@@ -31,7 +31,7 @@ trait InputOps { self: SemanticdbOps =>
 
     def isInSourceroot(sourceroot: AbsolutePath): Boolean = gsource.file match {
       case gfile: GPlainFile =>
-        !config.sourceroot.toNIO.relativize(gfile.file.toPath).toString.contains("..")
+        gfile.file.toPath.startsWith(config.sourceroot.toNIO)
       case _: VirtualFile =>
         true // Would anyone go to the trouble of building a VirtualFile that's outside of sourceroot?
       case _ =>

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/InputOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/InputOps.scala
@@ -1,12 +1,13 @@
 package scala.meta.internal.semanticdb.scalac
 
-import java.net.URLEncoder
+import java.net.{URI, URLEncoder}
 import java.nio.CharBuffer
 import java.nio.charset.StandardCharsets.UTF_8
 import java.security.MessageDigest
 import scala.collection.mutable
 import scala.{meta => m}
 import scala.meta.internal.io._
+import scala.meta.io.AbsolutePath
 import scala.reflect.internal.util.{Position => GPosition, SourceFile => GSourceFile}
 import scala.reflect.io.VirtualFile
 import scala.reflect.io.{PlainFile => GPlainFile}
@@ -15,9 +16,31 @@ trait InputOps { self: SemanticdbOps =>
 
   lazy val gSourceFileInputCache = mutable.Map[GSourceFile, m.Input]()
   implicit class XtensionGSourceFileInput(gsource: GSourceFile) {
+    private def uriRelativeToSourceRoot(file: AbsolutePath): URI = {
+      val fileUri = file.toURI(isDirectory = false)
+      val result = config.sourceroot.toURI(isDirectory = true).relativize(fileUri)
+      if (result == fileUri) {
+        // java.net.URI.relativize returns `fileUri` unchanged when it is not contained within our sourceroot.
+        // We could attempt to return a ".." URI, but java.net doesn't provide facilities for that. While nio's Path
+        // does contain facilities for that, such relative paths cannot then be used to produce a percent-encoded,
+        // relative URI. It doesn't seem worth fighting this battle at the moment, so:
+        sys.error(s"'$file' is not located within sourceroot '${config.sourceroot}'.")
+      }
+      result
+    }
+
+    def isInSourceroot(sourceroot: AbsolutePath): Boolean = gsource.file match {
+      case gfile: GPlainFile =>
+        !config.sourceroot.toNIO.relativize(gfile.file.toPath).toString.contains("..")
+      case _: VirtualFile =>
+        true // Would anyone go to the trouble of building a VirtualFile that's outside of sourceroot?
+      case _ =>
+        false
+    }
+
     def toUri: String = toInput match {
       case input: m.Input.File =>
-        config.sourceroot.toURI(isDirectory = true).relativize(input.path.toURI(isDirectory = false)).toString
+        uriRelativeToSourceRoot(input.path).toString
       case input: m.Input.VirtualFile =>
         input.path
       case _ =>
@@ -46,7 +69,7 @@ trait InputOps { self: SemanticdbOps =>
           case gfile: GPlainFile =>
             if (config.text.isOn) {
               val path = m.AbsolutePath(gfile.file)
-              val label = config.sourceroot.toURI(isDirectory = true).relativize(path.toURI(isDirectory = false)).toString
+              val label = uriRelativeToSourceRoot(path).toString
               // NOTE: Can't use gsource.content because it's preprocessed by scalac.
               val contents = FileIO.slurp(path, UTF_8)
               m.Input.VirtualFile(label, contents)

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SemanticdbPaths.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SemanticdbPaths.scala
@@ -49,7 +49,9 @@ object SemanticdbPaths {
   def toSemanticdb(doc: s.TextDocument, targetroot: AbsolutePath): AbsolutePath = {
     val targetrootWithSemanticdbPrefix = targetroot.resolve(semanticdbPrefix)
     // Doing this operation in URI space is important if doc.uri contains encoded chars:
-    val uri = targetrootWithSemanticdbPrefix.toURI(isDirectory = true).resolve(doc.uri + "." + semanticdbExtension)
+    val uri = targetrootWithSemanticdbPrefix
+      .toURI(isDirectory = true)
+      .resolve(doc.uri + "." + semanticdbExtension)
     AbsolutePath.fromAbsoluteUri(uri)
   }
 }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SemanticdbPaths.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SemanticdbPaths.scala
@@ -47,6 +47,9 @@ object SemanticdbPaths {
   }
 
   def toSemanticdb(doc: s.TextDocument, targetroot: AbsolutePath): AbsolutePath = {
-    targetroot.resolve(semanticdbPrefix).resolve(doc.uri + "." + semanticdbExtension)
+    val targetrootWithSemanticdbPrefix = targetroot.resolve(semanticdbPrefix)
+    // Doing this operation in URI space is important if doc.uri contains encoded chars:
+    val uri = targetrootWithSemanticdbPrefix.toURI(isDirectory = true).resolve(doc.uri + "." + semanticdbExtension)
+    AbsolutePath.fromAbsoluteUri(uri)
   }
 }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SemanticdbPipeline.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SemanticdbPipeline.scala
@@ -56,7 +56,7 @@ trait SemanticdbPipeline extends SemanticdbOps { self: SemanticdbPlugin =>
 
       def saveSemanticdbForCompilationUnit(unit: g.CompilationUnit): Unit = {
         try {
-          if (unit.isIgnored) return
+          if (unit.isIgnored || !unit.source.isInSourceroot(config.sourceroot)) return
           val sdoc = unit.toTextDocument
           sdoc.save(config.targetroot)
           PlatformTokenizerCache.megaCache.clear()
@@ -100,7 +100,7 @@ trait SemanticdbPipeline extends SemanticdbOps { self: SemanticdbPlugin =>
         try {
           if (config.diagnostics.isOn) {
             val diagnostics = unit.reportedDiagnostics(Map.empty)
-            if (diagnostics.nonEmpty) {
+            if (diagnostics.nonEmpty && unit.source.isInSourceroot(config.sourceroot)) {
               val sdoc = s.TextDocument(
                 schema = s.Schema.SEMANTICDB4,
                 uri = unit.source.toUri,
@@ -137,7 +137,7 @@ trait SemanticdbPipeline extends SemanticdbOps { self: SemanticdbPlugin =>
       var where = config.targetroot.toString
       where = where.stripSuffix("/").stripSuffix("/.")
       where = where + "/META-INF/semanticdb"
-      s"Created $howMany semanticdb $what in $where"
+      s"Processed $howMany sources into semanticdb $what in $where"
     }
     def performanceOverheadMessage = {
       val computeMs = (timestampComputeFinished - timestampComputeStarted) / 1000000

--- a/tests/jvm/src/test/resources/example/filename with spaces.scala
+++ b/tests/jvm/src/test/resources/example/filename with spaces.scala
@@ -1,0 +1,3 @@
+package example
+
+class FilenameWithSpaces/*<=example.FilenameWithSpaces#*/

--- a/tests/jvm/src/test/resources/metac.expect
+++ b/tests/jvm/src/test/resources/metac.expect
@@ -1071,6 +1071,27 @@ Diagnostics => 1 entries
 Diagnostics:
 [5:6..5:41) [warning] class Stack in package mutable is deprecated (since 2.12.0): Stack is an inelegant and potentially poorly-performing wrapper around List. Use a List assigned to a var instead.
 
+semanticdb/integration/src/main/scala/example/filename%20with%20spaces.scala
+----------------------------------------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => semanticdb/integration/src/main/scala/example/filename%20with%20spaces.scala
+Text => non-empty
+Language => Scala
+Symbols => 2 entries
+Occurrences => 3 entries
+
+Symbols:
+example/FilenameWithSpaces# => class FilenameWithSpaces extends AnyRef { +1 decls }
+  AnyRef => scala/AnyRef#
+example/FilenameWithSpaces#`<init>`(). => primary ctor <init>()
+
+Occurrences:
+[0:8..0:15): example <= example/
+[2:6..2:24): FilenameWithSpaces <= example/FilenameWithSpaces#
+[2:24..2:24):  <= example/FilenameWithSpaces#`<init>`().
+
 semanticdb/integration/src/main/scala/example/Flags.scala
 ---------------------------------------------------------
 

--- a/tests/jvm/src/test/resources/metacp.expect
+++ b/tests/jvm/src/test/resources/metacp.expect
@@ -1677,6 +1677,21 @@ example/Example.x. => val method x: ClassTag[Int]
   ClassTag => scala/reflect/ClassTag#
   Int => scala/Int#
 
+example/FilenameWithSpaces.class
+--------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => example/FilenameWithSpaces.class
+Text => empty
+Language => Scala
+Symbols => 2 entries
+
+Symbols:
+example/FilenameWithSpaces# => class FilenameWithSpaces extends AnyRef { +1 decls }
+  AnyRef => scala/AnyRef#
+example/FilenameWithSpaces#`<init>`(). => primary ctor <init>()
+
 example/ForComprehension.class
 ------------------------------
 

--- a/tests/jvm/src/test/scala-2.12/scala/meta/tests/cli/CliSuite.scala
+++ b/tests/jvm/src/test/scala-2.12/scala/meta/tests/cli/CliSuite.scala
@@ -93,31 +93,17 @@ class CliSuite extends FunSuite with DiffAssertions {
   }
 
   test("metac only outputs semanticdb for files in sourceroot") {
-    val projectroot = Files.createTempDirectory("projectroot_")
-
+    val projectroot = StringFS.fromString(
+      """|/sourceroot_/Left.scala
+         |object Left { def right = 42 }
+         |/not_sourceroot_/Right.scala
+         |object Right { def left = 41 }
+         |""".stripMargin
+    ).toNIO
     val sourceroot = projectroot.resolve("sourceroot_")
-    Files.createDirectories(sourceroot)
-
     val notSourceroot = projectroot.resolve("not_sourceroot_")
-    Files.createDirectories(notSourceroot)
-
     val inSourcerootScala = sourceroot.resolve("Left.scala")
-    Files.write(
-      inSourcerootScala,
-      """
-        object Left {
-          def right = Right
-        }
-      """.getBytes(UTF_8))
-
     val notInSourcerootScala = notSourceroot.resolve("Right.scala")
-    Files.write(
-      notInSourcerootScala,
-      """
-        object Right {
-          def left = Left
-        }
-      """.getBytes(UTF_8))
 
     val target = Files.createTempDirectory("target_")
     val inSourcerootSemanticdb = target.resolve("META-INF/semanticdb/Left.scala.semanticdb")


### PR DESCRIPTION
Previously this caused an input file "filename with spaces.scala" to briefly generate
"filename%20%with%20spaces.scala.semanticdb" only to have it subsequently deleted by
RemoveOrphanSemanticdbFiles (which attempts to remove stale semanticdb outputs).

Fixes #1888 