### PR TITLE
Memoize DescriptorParser (#1875)

### DIFF
--- a/semanticdb/semanticdb/src/main/scala/scala/meta/internal/semanticdb/Scala.scala
+++ b/semanticdb/semanticdb/src/main/scala/scala/meta/internal/semanticdb/Scala.scala
@@ -282,9 +282,15 @@ object Scala {
   }
 
   private[meta] object DescriptorParser {
-    def apply(symbol: String): (Descriptor, String) = {
+    private final val _cache = new java.util.HashMap[String, (Descriptor, String)]()
+
+    private def compute(symbol: String): (Descriptor, String) = {
       val parser = new DescriptorParser(symbol)
       parser.entryPoint()
+    }
+
+    def apply(symbol: String): (Descriptor, String) = {
+      _cache.computeIfAbsent(symbol, compute)
     }
   }
 }


### PR DESCRIPTION
Not sure how to bench, so just did `sbt benchAll`:

`master`:
```
[info] Result "scala.meta.internal.bench.MetacpScalaLibrary.run":
[info]   N = 15
[info]   mean =   2245.071 ±(99.9%) 80.041 ms/op

[info] Result "scala.meta.internal.bench.ScalacBaseline.run":
[info]   N = 67
[info]   mean =    789.296 ±(99.9%) 30.497 ms/op

[info] Result "scala.meta.internal.bench.ScalacRangepos.run":
[info]   N = 63
[info]   mean =    813.046 ±(99.9%) 25.182 ms/op
```

With this PR:
```
[info] Result "scala.meta.internal.bench.MetacpScalaLibrary.run":
[info]   N = 15
[info]   mean =   2222.981 ±(99.9%) 53.298 ms/op

[info] Result "scala.meta.internal.bench.ScalacBaseline.run":
[info]   N = 65
[info]   mean =    798.708 ±(99.9%) 36.026 ms/op

[info] Result "scala.meta.internal.bench.ScalacRangepos.run":
[info]   N = 67
[info]   mean =    770.030 ±(99.9%) 18.157 ms/op
```

Don't know if these are adequate nor how this change affects memory usage if that's okay.

It seems that everything is within margin of error. However, I've observed a significant performance improvement for Rsc while outlining larger targets. 