### PR TITLE
Adding a check to needsBraces method for interpolators arg names that begin with '_'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ sandbox/
 .Trash-*
 *.iml
 .idea/
+.bloop/
+.metals/
+.vscode/
 *.ipr
 *.iws
 /out/

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -279,10 +279,13 @@ object TreeSyntax {
         }
       case t: Term.Interpolate     =>
         def needBraces(id: String, charAfter: Option[Char]): Boolean = {
-          val isOpId = isOperatorPart(id.head)
-          val charAfterIsOp = charAfter.exists(isOperatorPart)
-          val charAfterIsIdPart = charAfter.exists(chr => isNameStart(chr) || Character.isDigit(chr))
-          if (isOpId) charAfterIsOp else charAfterIsIdPart
+          val startsWithUnderscore = id.startsWith("_")
+          startsWithUnderscore || {
+            val isOpId = isOperatorPart(id.head)
+            val charAfterIsOp = charAfter.exists(isOperatorPart)
+            val charAfterIsIdPart = charAfter.exists(chr => isNameStart(chr) || Character.isDigit(chr))
+            if (isOpId) charAfterIsOp else charAfterIsIdPart
+          }
         }
 
         val parts = t.parts.map { case Lit(part: String) => part.replace("$", "$$") }

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -588,6 +588,13 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     assert(q"""s"$${foo} ***"""".syntax == """s"$foo ***"""")
   }
 
+  test("interpolator braces for term names beginning with '_'") {
+    def interpolate(before: String, after: String): Term.Interpolate = Term.Interpolate(prefix = Term.Name("s"), parts = List(Lit.String(before), Lit.String(after)), args = List(Term.Name("_foo")))
+    assert(interpolate("", "").syntax == """s"${_foo}"""")
+    assert(interpolate("bar", "baz").syntax == """s"bar${_foo}baz"""")
+    assert(interpolate("[", "]").syntax == """s"[${_foo}]"""")
+  }
+
   test("empty-arglist application") {
     val tree = term("foo.toString()")
     assert(tree.structure === "Term.Apply(Term.Select(Term.Name(\"foo\"), Term.Name(\"toString\")), Nil)")


### PR DESCRIPTION
Also I added some extra stuff to the gitignore as I was using Metals and it generated lots of untracked files. 

No one responded to confirm the original issue yet as it was only an hour or so ago, but the fix looked simple so thought I'd have a go - if I'm missing something or if this is part of a more general check that can be included let me know, happy to have a go at that too (but I think the `guessIsBackquoted` method in there covers most bases except this one)

Fixes #1895 