### PR TITLE
Support methods with default args invoked via unstable identifi…

### DIFF
--- a/semanticdb/scalac/library/src/main/scala-2.11/scala/meta/internal/semanticdb/scalac/VersionSpecificOps.scala
+++ b/semanticdb/scalac/library/src/main/scala-2.11/scala/meta/internal/semanticdb/scalac/VersionSpecificOps.scala
@@ -12,13 +12,17 @@ trait VersionSpecificOps { self: SemanticdbOps =>
     */
   object NamedApplyBlock {
     def unapply(block: g.Block): Option[Option[g.analyzer.NamedApplyInfo]] =
-      if (block.stats.forall(stat =>
-            stat.symbol != null &&
-              stat.symbol.isArtifact &&
-              (stat match {
-                case g.ValDef(_, name, _, _) if name.startsWith(g.termNames.NAMEDARG_PREFIX) => true
-                case _ => false
-              }))) {
+      if (block.stats.forall(
+            stat =>
+              stat.symbol != null &&
+                stat.symbol.isArtifact &&
+                (stat match {
+                  case g.ValDef(_, name, _, _)
+                      if name.startsWith(g.termNames.NAMEDARG_PREFIX) ||
+                        name.startsWith(g.termNames.QUAL_PREFIX) =>
+                    true
+                  case _ => false
+                }))) {
         Some(None)
       } else {
         None

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/TargetedSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/TargetedSuite.scala
@@ -7,7 +7,7 @@ package semanticdb
 // - On test failure, the obtained output is printed to the console for
 //   easy copy-paste to replace the current expected output.
 // - Try to follow the alphabetical order of the enclosing package, at the time
-//   of this writing the latest package is `j`, so the next package should be `k`.
+//   of this writing the latest package is `j`, so the next package should be `l`.
 // - glhf, and if you have any questions don't hesitate to ask in the gitter channel :)
 class TargetedSuite extends SemanticdbSuite {
 
@@ -176,6 +176,22 @@ class TargetedSuite extends SemanticdbSuite {
     (doc, msg, bodyText) => {
       assert(msg == "j/ao.Msg.")
       assert(bodyText == "j/ao.bodyText.")
+    }
+  )
+
+  targeted(
+    """package k
+      |class target {
+      |  def foo(a: Int, b: Int = 1, c: Int = 2): Int = ???
+      |}
+      |object consumer {
+      |  def unstableQual = new target
+      |  unstableQual.<<foo>>(1, <<c>> = 1)
+      |}
+    """.stripMargin,
+    (doc, foo, c) => {
+      assert(foo == "k/target#foo().")
+      assert(c == "k/target#foo().(c)")
     }
   )
 }


### PR DESCRIPTION
I overlooked this case in my prior PR.

What I'm observing is that given input:
```
package k
class target {
  def foo(a: A, b: Int = 1, c: Int = 2): Int = ???
}
object consumer {
  def unstableQual = new target
  unstableQual.<<foo>>(1, <<c>> = 1)
}
```

scalac is not generating any Tree w/ position corresponding to the invocation of`<<foo>>`, rather there is only one corresponding to `<<.foo>>` (note leading period).

This Tree has its Position set by this logic: https://github.com/scala/scala/blob/7c354fc56df7c72ee829417264c2a2f97e65f274/src/compiler/scala/tools/nsc/typechecker/NamesDefaults.scala#L198-L200

I can't immediately spot why it would produce an off-by-one issue like this.

Some debug output corresponding to this test case:
```
Syntactic Positions:
indexName [8, 9] => k
indexName [16, 22] => target
indexName [31, 34] => foo
indexName [35, 36] => a
indexName [38, 41] => Int
indexName [43, 44] => b
indexName [46, 49] => Int
indexName [55, 56] => c
indexName [58, 61] => Int
indexName [68, 71] => Int
indexName [74, 77] => ???
indexName [87, 95] => consumer
indexName [104, 116] => unstableQual
indexName [123, 129] => target
indexName [132, 144] => unstableQual
indexName [145, 148] => foo
indexName [152, 153] => c

scalac output:
<132:158>Block(
  List(
    <132:144>ValDef(Modifiers(ARTIFACT), TermName("qual$1"), [132]TypeTree(), [132:144]Select([132]This(TypeName("consumer")), TermName("unstableQual"))), 
    [149:150]ValDef(Modifiers(ARTIFACT), TermName("x$1"), [149]TypeTree(), [149:150]Literal(Constant(1))),
    [156:157]ValDef(Modifiers(ARTIFACT), TermName("x$2"), [156]TypeTree(), [156:157]Literal(Constant(1))),
    [145]ValDef(Modifiers(ARTIFACT), TermName("x$3"), [145]TypeTree(), [145]Select([132]Ident(TermName("qual$1")), TermName("foo$default$2")))
  ),
  <132:158>Apply([144:148]Select([132]Ident(TermName("qual$1")), TermName("foo")), List([149]Ident(TermName("x$1")), [145]Ident(TermName("x$3")), [156]Ident(TermName("x$2"))))
)
```