### PR TITLE
Guard against null in `URI.getPath`.

### DIFF
--- a/scalameta/io/shared/src/main/scala/scala/meta/io/AbsolutePath.scala
+++ b/scalameta/io/shared/src/main/scala/scala/meta/io/AbsolutePath.scala
@@ -18,7 +18,7 @@ sealed abstract case class AbsolutePath(toNIO: nio.Path) {
   def toURI: URI = toURI(Files.isDirectory(toNIO))
   def toURI(isDirectory: Boolean): URI = {
     val uri = toNIO.toUri
-    if (isDirectory && !uri.getPath.endsWith("/")) {
+    if (isDirectory && uri.getPath != null && !uri.getPath.endsWith("/")) {
       // If toNIO exists, toUri will return a trailing slash, otherwise it won't (at least on JDK 8).
       // This is important because URI.resolve(String) will drop the last segment of the URI's path if
       // there is not a trailing slash:

--- a/tests/shared/src/test/scala/scala/meta/tests/io/NIOPathTest.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/io/NIOPathTest.scala
@@ -4,8 +4,10 @@ package io
 import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
+import scala.meta.io._
 import scala.meta.internal.io._
 import org.scalatest.FunSuite
+import java.nio.file.Files
 
 class NIOPathTest extends FunSuite {
 
@@ -79,13 +81,25 @@ class NIOPathTest extends FunSuite {
   test(".relativize(Path)") {
     assert(abs.relativize(abs.resolve("qux")) == Paths.get("qux"))
   }
-  test(".toUri") {
+  test("file.toUri") {
     assert(file.toUri.getPath.endsWith("build.sbt"))
     // NOTE: Paths API seems to work inconsistently under Scala Native.
     // [info] - .toUri *** FAILED ***
     // [info]   "/Users/eburmako/Projects/scalameta/project" did not end with "project/" (NIOPathTest.scala:84)
     // assert(project.toUri.getPath.endsWith("project/"))
   }
+
+  test("jar.toUri") {
+    if (scala.meta.internal.platform.isJVM) {
+      val jar = Files.createTempDirectory("scalameta").resolve("foo.jar")
+      FileIO.withJarFileSystem(AbsolutePath(jar), true, true) { root =>
+        val hello = root.resolve("hello")
+        Files.createDirectories(hello.toNIO)
+        assert(hello.toURI.toString.endsWith("hello"))
+      }
+    }
+  }
+
   test(".toAbsolutePath") {
     assert(file.toAbsolutePath.endsWith(file))
     // NOTE: Paths API seems to work inconsistently under Scala Native.


### PR DESCRIPTION
Previously, calling `AbsolutePath.toURI` could throw a null pointer
exception for directories inside jars. Now, we guard against null
so calling `.toURI` succeeds.

This fixes a regression from #1890. Could you take a look @jameskoch?
