### PR TITLE
fix: remove NotImplementedError in SymbolInformationOps

### DIFF
--- a/semanticdb/metacp/src/main/scala/scala/meta/internal/scalacp/SymbolInformationOps.scala
+++ b/semanticdb/metacp/src/main/scala/scala/meta/internal/scalacp/SymbolInformationOps.scala
@@ -73,7 +73,6 @@ trait SymbolInformationOps { self: Scalacp =>
         // NOTE: Scalap doesn't expose JAVA_ENUM.
         // if (sym.isJavaEnum) flip(p.ENUM)
         if (sym.isStatic) flip(p.STATIC)
-        ???
       } else {
         if (isAbstractClass || isAbstractMethod || isAbstractType) flip(p.ABSTRACT)
         if (sym.isFinal || sym.isModule) flip(p.FINAL)


### PR DESCRIPTION
Causes scalameta/scalafix to fail when synthetic is turned on. 