### PR TITLE
add occurrences for references from val initialisation blocks

### DIFF
--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.semanticdb.scalac
 
+import jdk.nashorn.internal.runtime.regexp.joni.Config
 import org.scalameta.internal.ScalaCompat._
 import scala.collection.mutable
 import scala.meta.internal.inputs._
@@ -370,6 +371,33 @@ trait TextDocumentOps { self: SemanticdbOps =>
                   // Skip the field definition in favor of the associated getter.
                   // This will make sure that val/var class parameters are consistently
                   // resolved to getter symbols both as definition and references.
+
+                  def flattenRec(tree: g.Tree): List[g.Tree] = tree match {
+                    case b: g.Block =>
+                      b.children.flatMap(flattenRec)
+                    case tree: g.Tree =>
+                      tree :: tree.children.flatMap(flattenRec)
+                  }
+
+                  if (gtree.rhs.isInstanceOf[g.Block]) {
+                    flattenRec(gtree.rhs)
+                      .collect {
+                        case v: g.ValDef if v.rhs.symbol != null =>
+                          v
+                      }
+                      .map(v => {
+                        if (v.symbol.isLocalToBlock)
+                          occurrences
+                            .find(t => t._2 == v.rhs.symbol.toSemantic)
+                            .map(t => (v.rhs.pos.toMeta, t._2))
+                            .getOrElse((v.rhs.pos.toMeta, v.rhs.symbol.toSemantic))
+                        else
+                          (v.rhs.pos.toMeta, v.rhs.symbol.toSemantic)
+                      })
+                      .foreach(v => {
+                        occurrences(v._1) = v._2
+                      })
+                  }
                 } else {
                   tryMstart(gstart)
                   tryMstart(gpoint)

--- a/tests/jvm/src/test/resources/example/NamedApplyBlock.scala
+++ b/tests/jvm/src/test/resources/example/NamedApplyBlock.scala
@@ -10,5 +10,5 @@ object NamedApplyBlockMethods/*<=example.NamedApplyBlockMethods.*/ {
 object NamedApplyBlockCaseClassConstruction/*<=example.NamedApplyBlockCaseClassConstruction.*/ {
   case class Msg/*<=example.NamedApplyBlockCaseClassConstruction.Msg#*/(body/*<=example.NamedApplyBlockCaseClassConstruction.Msg#body.*/: String/*=>scala.Predef.String#*/, head/*<=example.NamedApplyBlockCaseClassConstruction.Msg#head.*/: String/*=>scala.Predef.String#*/ = "default", tail/*<=example.NamedApplyBlockCaseClassConstruction.Msg#tail.*/: String/*=>scala.Predef.String#*/)
   val bodyText/*<=example.NamedApplyBlockCaseClassConstruction.bodyText.*/ = "body"
-  val msg/*<=example.NamedApplyBlockCaseClassConstruction.msg.*/ = Msg/*=>example.NamedApplyBlockCaseClassConstruction.Msg.*/(bodyText/*=>example.NamedApplyBlockCaseClassConstruction.bodyText.*/, tail/*=>example.NamedApplyBlockCaseClassConstruction.Msg.apply().(tail)*/ = "tail")
+  val msg/*<=example.NamedApplyBlockCaseClassConstruction.msg.*/ = /*=>example.NamedApplyBlockCaseClassConstruction.Msg.apply$default$2().*/Msg/*=>example.NamedApplyBlockCaseClassConstruction.Msg.*/(bodyText/*=>example.NamedApplyBlockCaseClassConstruction.bodyText.*/, tail/*=>example.NamedApplyBlockCaseClassConstruction.Msg.apply().(tail)*/ = "tail")
 }

--- a/tests/jvm/src/test/resources/metac.expect
+++ b/tests/jvm/src/test/resources/metac.expect
@@ -2636,7 +2636,7 @@ Uri => semanticdb/integration/src/main/scala/example/NamedApplyBlock.scala
 Text => non-empty
 Language => Scala
 Symbols => 64 entries
-Occurrences => 41 entries
+Occurrences => 42 entries
 Synthetics => 1 entries
 
 Symbols:
@@ -2846,6 +2846,7 @@ Occurrences:
 [10:63..10:69): String => scala/Predef.String#
 [11:6..11:14): bodyText <= example/NamedApplyBlockCaseClassConstruction.bodyText.
 [12:6..12:9): msg <= example/NamedApplyBlockCaseClassConstruction.msg.
+[12:12..12:12):  => example/NamedApplyBlockCaseClassConstruction.Msg.apply$default$2().
 [12:12..12:15): Msg => example/NamedApplyBlockCaseClassConstruction.Msg.
 [12:16..12:24): bodyText => example/NamedApplyBlockCaseClassConstruction.bodyText.
 [12:26..12:30): tail => example/NamedApplyBlockCaseClassConstruction.Msg.apply().(tail)


### PR DESCRIPTION
Previously semanticdb was generating incorrect occurrences for contents of val initialisation blocks. Now they are correct. Fixes #1878.