### PR TITLE
Fix span methods on Tokens

### DIFF
--- a/scalameta/tokens/shared/src/main/scala/scala/meta/tokens/Tokens.scala
+++ b/scalameta/tokens/shared/src/main/scala/scala/meta/tokens/Tokens.scala
@@ -59,9 +59,17 @@ extends immutable.IndexedSeq[Token] with IndexedSeqOptimized[Token] {
 
   override def splitAt(n: Int): (Tokens, Tokens) = (take(n), drop(n))
 
-  override def span(p: Token => Boolean): (Tokens, Tokens) = splitAt(indexWhere(!p.apply(_)))
+  override def span(p: Token => Boolean): (Tokens, Tokens) = {
+    val index = indexWhere(!p.apply(_))
 
-  def spanRight(p: Token => Boolean): (Tokens, Tokens) = splitAt(length - reverseIterator.indexWhere(!p.apply(_)))
+    splitAt(if (index < 0) length else index)
+  }
+
+  def spanRight(p: Token => Boolean): (Tokens, Tokens) = {
+    val index = reverseIterator.indexWhere(!p.apply(_))
+
+    splitAt(length - (if (index < 0) length else index))
+  }
 }
 
 object Tokens {

--- a/tests/shared/src/test/scala/scala/meta/tests/tokens/TokensSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokens/TokensSuite.scala
@@ -131,4 +131,20 @@ class TokensApiSuite extends FunSuite {
     assert(slice(0) === tokens(11))
     assert(slice(1) === tokens(12))
   }
+
+  test("Tokens.span - predicate is always true") {
+    val tokens = tokenize("val foo = 0")
+    val (before, after) = tokens.span(_ => true)
+
+    assert(before == tokens)
+    assert(after.isEmpty)
+  }
+
+  test("Tokens.spanRight - predicate is always true") {
+    val tokens = tokenize("val foo = 0")
+    val (before, after) = tokens.spanRight(_ => true)
+
+    assert(after == tokens)
+    assert(before.isEmpty)
+  }
 }


### PR DESCRIPTION
If the predicate passed to `span` is true for all of the elements in a collection, the first element of the result should be the original collection and the second should be empty (and the reverse for `spanRight`).

The current implementation is broken because it doesn't handle the case where `indexWhere` returns -1. I've included some failing tests that show the issue, and a fix. I took a quick look around for similar bugs but didn't see anything.