### PR TITLE
Get rid of global token cache, fixes #1068

### DIFF
--- a/scalameta/inputs/shared/src/main/scala/scala/meta/internal/inputs/InternalInput.scala
+++ b/scalameta/inputs/shared/src/main/scala/scala/meta/internal/inputs/InternalInput.scala
@@ -6,11 +6,13 @@ import scala.collection.concurrent.TrieMap
 import scala.meta.inputs._
 import scala.meta.Dialect
 import scala.meta.tokens.Tokens
+import scala.meta.internal.tokenizers.Compat
 
 trait InternalInput {
   self: Input =>
 
-  private [meta] lazy val tokenCache: TrieMap[Dialect, Tokens] = TrieMap.empty
+  private [meta] lazy val tokenCache: mutable.Map[Dialect, Tokens] =
+    Compat.newMutableMap[Dialect, Tokens]
 
   // NOTE: It's regrettable that we need to taint the pure abstraction of Input.
   // However, as #334 shows, we just can't redo offset -> line conversions over and over again.

--- a/scalameta/inputs/shared/src/main/scala/scala/meta/internal/inputs/InternalInput.scala
+++ b/scalameta/inputs/shared/src/main/scala/scala/meta/internal/inputs/InternalInput.scala
@@ -2,10 +2,15 @@ package scala.meta.internal
 package inputs
 
 import scala.collection.mutable
+import scala.collection.concurrent.TrieMap
 import scala.meta.inputs._
+import scala.meta.Dialect
+import scala.meta.tokens.Tokens
 
 trait InternalInput {
   self: Input =>
+
+  private [meta] lazy val tokenCache: TrieMap[Dialect, Tokens] = TrieMap.empty
 
   // NOTE: It's regrettable that we need to taint the pure abstraction of Input.
   // However, as #334 shows, we just can't redo offset -> line conversions over and over again.

--- a/scalameta/tokenizers/js/src/main/scala/scala/meta/internal/tokenizers/Compat.scala
+++ b/scalameta/tokenizers/js/src/main/scala/scala/meta/internal/tokenizers/Compat.scala
@@ -1,0 +1,7 @@
+package scala.meta.internal.tokenizers
+
+import scala.collection.mutable
+
+object Compat {
+  def newMutableMap[A, B] = mutable.Map.empty[A, B]
+}

--- a/scalameta/tokenizers/js/src/main/scala/scala/meta/internal/tokenizers/PlatformTokenizerCache.scala
+++ b/scalameta/tokenizers/js/src/main/scala/scala/meta/internal/tokenizers/PlatformTokenizerCache.scala
@@ -8,6 +8,7 @@ import scala.meta.tokens._
 
 import java.{util => ju}
 
+@deprecated("No longer used", "4.3.0")
 object PlatformTokenizerCache {
   // On the JVM, this is a weak hashmap.
   val megaCache = new ju.HashMap[Dialect, mutable.Map[Input, Tokens]]()

--- a/scalameta/tokenizers/jvm/src/main/scala/scala/meta/internal/tokenizers/Compat.scala
+++ b/scalameta/tokenizers/jvm/src/main/scala/scala/meta/internal/tokenizers/Compat.scala
@@ -1,0 +1,7 @@
+package scala.meta.internal.tokenizers
+
+import scala.collection.concurrent.TrieMap
+
+object Compat {
+  def newMutableMap[A, B] = TrieMap.empty[A, B]
+}

--- a/scalameta/tokenizers/jvm/src/main/scala/scala/meta/internal/tokenizers/PlatformTokenizerCache.scala
+++ b/scalameta/tokenizers/jvm/src/main/scala/scala/meta/internal/tokenizers/PlatformTokenizerCache.scala
@@ -9,6 +9,7 @@ import scala.meta.tokens._
 import java.{util => ju}
 import java.util.{concurrent => juc}
 
+@deprecated("No longer used", "4.3.0")
 object PlatformTokenizerCache {
   // NOTE: Manipulated by tokenization code in the ScalametaTokenizer class.
   // Caching just in toTokenize wouldn't be enough, because someone could call the tokenizer directly.

--- a/scalameta/tokenizers/native/src/main/scala/scala/meta/internal/tokenizers/Compat.scala
+++ b/scalameta/tokenizers/native/src/main/scala/scala/meta/internal/tokenizers/Compat.scala
@@ -1,0 +1,7 @@
+package scala.meta.internal.tokenizers
+
+import scala.collection.mutable
+
+object Compat {
+  def newMutableMap[A, B] = mutable.Map.empty[A, B]
+}

--- a/scalameta/tokenizers/native/src/main/scala/scala/meta/internal/tokenizers/PlatformTokenizerCache.scala
+++ b/scalameta/tokenizers/native/src/main/scala/scala/meta/internal/tokenizers/PlatformTokenizerCache.scala
@@ -8,6 +8,7 @@ import scala.meta.tokens._
 
 import java.{util => ju}
 
+@deprecated("No longer used", "4.3.0")
 object PlatformTokenizerCache {
   // On the JVM, this is a weak hashmap.
   val megaCache = new ju.HashMap[Dialect, mutable.Map[Input, Tokens]]()


### PR DESCRIPTION
Previously, Scalameta kept a global cache for the tokens of all inputs.
Now, the global cache has been replaced with a cache that's local to the
input itself.

The new solution was not possible before #1863 since the `Input` type
was kept in a separate module from `Tokens`. Now the two types live in
the same module so it's possible to make the token cache local to
inputs.

I verified that this change does not regress the performance of
Scalafmt.