### PR TITLE
Scala.js source maps are now pointing to github

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ enablePlugins(ScalaUnidocPlugin)
 addCommandAlias("benchAll", benchAll.command)
 addCommandAlias("benchLSP", benchLSP.command)
 addCommandAlias("benchQuick", benchQuick.command)
-val munitVersion = "0.4.1"
+val munitVersion = "0.4.3"
 commands += Command.command("ci-windows") { s =>
   s"testsJVM/all:testOnly -- --exclude-tags=SkipWindows" ::
     s

--- a/build.sbt
+++ b/build.sbt
@@ -78,11 +78,14 @@ unidocProjectFilter.in(ScalaUnidoc, unidoc) := inAnyProject
 console := console.in(scalametaJVM, Compile).value
 
 val commonJsSettings = Seq(
-  scalacOptions ++= (if(isSnapshot.value) Seq.empty else {
-    val localDir = (baseDirectory in ThisBuild).value.toURI.toString
-    val githubDir = "https://raw.githubusercontent.com/scalameta/scalameta"
-    Seq(s"-P:scalajs:mapSourceURI:$localDir->$githubDir/v${version.value}/")
-  }),
+  scalacOptions ++= {
+    if (isSnapshot.value) Seq.empty
+    else {
+      val localDir = (baseDirectory in ThisBuild).value.toURI.toString
+      val githubDir = "https://raw.githubusercontent.com/scalameta/scalameta"
+      Seq(s"-P:scalajs:mapSourceURI:$localDir->$githubDir/v${version.value}/")
+    }
+  }
 )
 
 /** ======================== SEMANTICDB ======================== **/

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -28,4 +28,4 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.32")
 
 addSbtPlugin("org.scala-debugger" % "sbt-jdi-tools" % "1.1.1")
 
-addSbtPlugin("org.scalameta" % "sbt-munit" % "0.4.1")
+addSbtPlugin("org.scalameta" % "sbt-munit" % "0.4.3")


### PR DESCRIPTION
By default, source maps generated by Scala.js compiler point to local files.
This PR changes this so that for non-snapshot versions, source maps point to github raw content.