### PR TITLE
change the way we check for being in the source root

### DIFF
--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/InputOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/InputOps.scala
@@ -3,6 +3,7 @@ package scala.meta.internal.semanticdb.scalac
 import java.net.{URI, URLEncoder}
 import java.nio.CharBuffer
 import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.Paths
 import java.security.MessageDigest
 import scala.collection.mutable
 import scala.{meta => m}
@@ -31,7 +32,7 @@ trait InputOps { self: SemanticdbOps =>
 
     def isInSourceroot(sourceroot: AbsolutePath): Boolean = gsource.file match {
       case gfile: GPlainFile =>
-        gfile.file.toPath.startsWith(config.sourceroot.toNIO)
+        gfile.file.toPath.startsWith(config.sourceroot.toNIO) || !gfile.file.toPath.isAbsolute
       case _: VirtualFile =>
         true // Would anyone go to the trouble of building a VirtualFile that's outside of sourceroot?
       case _ =>


### PR DESCRIPTION
This is my naive approach to fixing #1966 

It looks like there has been a regression since [this commit](https://github.com/scalameta/scalameta/pull/1890/files#diff-278ea33c862c6577981ab8da76b8a81fR59). The problem is this check:

```scala
gfile.file.toPath.startsWith(config.sourceroot.toNIO)
````

When check to make sure this is true, however let's take the following URI as an example:

```text
file:///Users/ckipp/Documents/scala-workspace/test-project/example/src/Main.scala
````

If I used `metac` in the `test-project` directory and considered that to be root, then targeted `Main.scala` like this `metac example/src/Main.scala` I would get the following to values for the above check.

`gfile.file.toPath`                --> `example/src/Main.scala`
`config.sourceroot.toNIO` --> `/Users/ckipp/Documents/scala-workspace/test-project`

This results in the check to fail since the first does not start with the latter. This was sort of annoying and I couldn't find a great way to make this check, so this PR takes the two paths, turns them to strings, and then creates a URI from them. Then it does a check to ensure that the URI we just created matches the full URI of the gfile. If this is true, and we successfully created the URI, we can assume we were in the sourceroot.

Again, I'm not sure if this is the best approach, or if bites us in other scenarios, but please let me know!