### PR TITLE
properly forward error/warning count to and from wrapped scalac reporter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -92,7 +92,17 @@ lazy val semanticdbScalacCore = project
     mimaPreviousArtifacts := Set.empty,
     moduleName := "semanticdb-scalac-core",
     description := "Library to generate SemanticDB from Scalac 2.x internal data structures",
-    libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value
+    libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value,
+    unmanagedSourceDirectories in Compile ++= {
+      (unmanagedSourceDirectories in Compile).value.map { dir =>
+        val sv = scalaVersion.value
+        val is130 = sv == "2.13.0" // reporters changed in 2.13.1
+        CrossVersion.partialVersion(sv) match {
+          case Some((2, n)) if n < 13 || is130 => file(dir.getPath ++ "-2.13.0-")
+          case _ => file(dir.getPath ++ "-2.13.1+")
+        }
+      }
+    },
   )
   .dependsOn(scalametaJVM)
 

--- a/build.sbt
+++ b/build.sbt
@@ -102,7 +102,7 @@ lazy val semanticdbScalacCore = project
           case _ => file(dir.getPath ++ "-2.13.1+")
         }
       }
-    },
+    }
   )
   .dependsOn(scalametaJVM)
 

--- a/semanticdb/scalac/library/src/main/scala-2.13.0-/scala/meta/internal/semanticdb/scalac/SemanticdbReporter.scala
+++ b/semanticdb/scalac/library/src/main/scala-2.13.0-/scala/meta/internal/semanticdb/scalac/SemanticdbReporter.scala
@@ -1,8 +1,7 @@
 package scala.meta.internal.semanticdb.scalac
 
 import scala.reflect.internal.util.Position
-import scala.tools.nsc.reporters.Reporter
-import scala.tools.nsc.reporters.StoreReporter
+import scala.tools.nsc.reporters.{Reporter, StoreReporter}
 
 class SemanticdbReporter(underlying: Reporter) extends StoreReporter {
   override protected def info0(
@@ -18,5 +17,13 @@ class SemanticdbReporter(underlying: Reporter) extends StoreReporter {
       case 2 => underlying.error(pos, msg)
       case _ =>
     }
+    // underlying reporter may have filtered out the message
+    updateCounts()
+  }
+
+  private def updateCounts(): Unit = {
+    INFO.count = underlying.INFO.count
+    WARNING.count = underlying.WARNING.count
+    ERROR.count = underlying.ERROR.count
   }
 }

--- a/semanticdb/scalac/library/src/main/scala-2.13.1+/scala/meta/internal/semanticdb/scalac/SemanticdbReporter.scala
+++ b/semanticdb/scalac/library/src/main/scala-2.13.1+/scala/meta/internal/semanticdb/scalac/SemanticdbReporter.scala
@@ -1,0 +1,22 @@
+package scala.meta.internal.semanticdb.scalac
+
+import scala.reflect.internal.util.Position
+import scala.tools.nsc.reporters.{FilteringReporter, StoreReporter}
+
+class SemanticdbReporter(underlying: FilteringReporter) extends StoreReporter {
+  override def doReport(pos: Position, msg: String, severity: Severity): Unit = {
+    super.doReport(pos, msg, severity)
+    underlying.doReport(pos, msg, severity)
+  }
+
+  // overriding increment and filter is enough so make sure that error/warning
+  // counts are the same as in underlying reporter
+
+  override def increment(severity: Severity): Unit = {
+    super.increment(severity)
+    underlying.increment(severity)
+  }
+
+  override def filter(pos: Position, msg: String, severity: Severity): Int =
+    underlying.filter(pos, msg, severity)
+}


### PR DESCRIPTION
This commit fixes #1505 and also updates Scala 2.13.1+ implementation to
new reporters API introduced in Scala 2.13.1.

A simple test would be nice but I'm not sure where to put it (`scala-compiler` is required on classpath).