### PR TITLE
Fixed NoSuchElementException when parse Unit with infix operations

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -722,4 +722,29 @@ class TermSuite extends ParseSuite {
       Nil
     ) = term(" new C()[String]() ")
   }
+
+  test("#492 parse Unit in infix operations") {
+    val Term.ApplyInfix(
+      Term.Name("x"),
+      Term.Name("=="),
+      Nil,
+      List(Term.ApplyInfix(Lit.Unit(), Term.Name("::"), Nil, List(Term.Name("Nil"))))
+    ) = term("x == () :: Nil")
+  }
+
+  test("#492 parse hlist with Unit") {
+    val Term.ApplyInfix(
+      Lit.String("foo"),
+      Term.Name("::"),
+      Nil,
+      List(
+        Term.ApplyInfix(
+          Lit.Unit(),
+          Term.Name("::"),
+          Nil,
+          List(Term.ApplyInfix(Lit.Boolean(true), Term.Name("::"), Nil, List(Term.Name("HNil"))))
+        )
+      )
+    ) = term(""""foo" :: () :: true :: HNil""")
+  }
 }


### PR DESCRIPTION
Hello!

This is my first contribution here and I might be wrong with suite for tests, naming convention and other stuff.

Fixes #492 

And this is a source of https://github.com/scalameta/scalafmt/issues/1245