### PR TITLE
Fix documentation for arguments for metap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ lib_managed/
 src_managed/
 project/boot/
 project/plugins/project/
+project/metals.sbt
 .scala_dependencies
 .worksheet
 *.actual

--- a/docs/semanticdb/guide.md
+++ b/docs/semanticdb/guide.md
@@ -492,17 +492,17 @@ metap [options] <classpath>
     <td></td>
   </tr>
   <tr>
-    <td><code>--compact</code>,<br/><code>--detailed</code>,<br/><code>--proto</code></td>
+    <td><code>-compact</code>,<br/><code>-detailed</code>,<br/><code>-proto</code></td>
     <td></td>
     <td>
-      Specifies prettyprinting format, which can be either <code>--compact</code>
+      Specifies prettyprinting format, which can be either <code>-compact</code>
       (prints the most important parts of the payload in a condensed fashion),
-      <code>--detailed</code> (more detailed than --compact, but still pretty
-      condensed), or <code>--proto</code> (prints the same output as
+      <code>-detailed</code> (more detailed than -compact, but still pretty
+      condensed), or <code>-proto</code> (prints the same output as
       <code>protoc</code> would print, <a href="#protoc">see below</a>).
     </td>
     <td>
-      <code>--compact</code>
+      <code>-compact</code>
     </td>
   </tr>
 </table>

--- a/semanticdb/semanticdb3/guide.md
+++ b/semanticdb/semanticdb3/guide.md
@@ -481,17 +481,17 @@ metap [options] <classpath>
     <td></td>
   </tr>
   <tr>
-    <td><code>--compact</code>,<br/><code>--detailed</code>,<br/><code>--proto</code></td>
+    <td><code>-compact</code>,<br/><code>-detailed</code>,<br/><code>-proto</code></td>
     <td></td>
     <td>
-      Specifies prettyprinting format, which can be either <code>--compact</code>
+      Specifies prettyprinting format, which can be either <code>-compact</code>
       (prints the most important parts of the payload in a condensed fashion),
-      <code>--detailed</code> (more detailed than --compact, but still pretty
-      condensed), or <code>--proto</code> (prints the same output as
+      <code>-detailed</code> (more detailed than -compact, but still pretty
+      condensed), or <code>-proto</code> (prints the same output as
       <code>protoc</code> would print, <a href="#protoc">see below</a>).
     </td>
     <td>
-      <code>--compact</code>
+      <code>-compact</code>
     </td>
   </tr>
 </table>


### PR DESCRIPTION
This is a code parsing params, it is expected to provide them with single '-' but in website documentation there is '--' which throws unknown parameters error

```scala
        case "-compact" +: rest if allowOptions =>
          loop(settings.copy(format = Format.Compact), allowOptions = true, rest)
        case ("-detailed" | "-pretty") +: rest if allowOptions =>
          loop(settings.copy(format = Format.Detailed), allowOptions = true, rest)
        case "-proto" +: rest if allowOptions =>
          loop(settings.copy(format = Format.Proto), allowOptions = true, rest)
```

Also added to .gitignore 'metals.sbt' (it should not be commited similary to as it is in metals, right?)