### PR TITLE
Fix compile error reporting when using smenaticdb plugin

### DIFF
--- a/semanticdb/scalac/library/src/main/scala-2.13.0-/scala/meta/internal/semanticdb/scalac/SemanticdbReporter.scala
+++ b/semanticdb/scalac/library/src/main/scala-2.13.0-/scala/meta/internal/semanticdb/scalac/SemanticdbReporter.scala
@@ -17,13 +17,11 @@ class SemanticdbReporter(underlying: Reporter) extends StoreReporter {
       case 2 => underlying.error(pos, msg)
       case _ =>
     }
-    // underlying reporter may have filtered out the message
-    updateCounts()
+
   }
 
-  private def updateCounts(): Unit = {
-    INFO.count = underlying.INFO.count
-    WARNING.count = underlying.WARNING.count
-    ERROR.count = underlying.ERROR.count
-  }
+  override def hasErrors: Boolean = underlying.hasErrors
+
+  override def hasWarnings: Boolean = underlying.hasWarnings
+
 }


### PR DESCRIPTION
The version before caused this issue in case of any errors:

```
ERROR Unexpected error when compiling root: 'assertion failed: 
  name
     while compiling: /home/tgodzik/Documents/workspaces/metals-sample/src/main/scala/Main.scala
        during phase: globalPhase=erasure, enteringPhase=posterasure
     library version: version 2.12.11
    compiler version: version 2.12.11
  reconstructed args: ...
  last tree to typer: TypeTree(class String)
       tree position: line 12 of /home/tgodzik/Documents/workspaces/metals-sample/src/main/scala/Main.scala
            tree tpe: String
              symbol: final class String in package lang
   symbol definition: final class String extends Serializable with Comparable with CharSequence (a ClassSymbol)
      symbol package: java.lang
       symbol owners: class String
           call site: method main in object Main in package example

== Source file context for tree position ==

     9 
    10     name match {
    11       case None    => println("Hello <unknown>")
    12       case Some(x) => println(s"Hello $x")
    13     }
    14     name.trim
    15   }'
```

cc @ghik 