### PR TITLE
Fix parsing package with leftbrace in newline

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/PackageSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/PackageSuite.scala
@@ -103,4 +103,40 @@ class PackageSuite extends ParseSuite {
     ) =
       source("package foo; package bar; package baz")
   }
+
+  test("package { in newline") {
+      println(source(
+        """|
+           |package foo  // foo package left brace in newline
+           |/* still okay */
+           |{
+           |  package bar /* also in newline */
+           |  // open
+           |  {
+           |    package baz
+           |    { }
+           |  }
+           |}
+           |""".stripMargin
+           ).structure)
+
+    val Source(
+      List(Pkg(Term.Name("foo"), List(Pkg(Term.Name("bar"), List(Pkg(Term.Name("baz"), List()))))))
+    ) =
+      source(
+        """|
+           |package foo  // foo package left brace in newline
+           |/* still okay */
+           |{
+           |  package bar /* also in newline */
+           |  // open
+           |  {
+           |    package baz
+           |    { }
+           |  }
+           |}
+           |""".stripMargin
+           )
+
+  }
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/PackageSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/PackageSuite.scala
@@ -105,21 +105,6 @@ class PackageSuite extends ParseSuite {
   }
 
   test("package { in newline") {
-      println(source(
-        """|
-           |package foo  // foo package left brace in newline
-           |/* still okay */
-           |{
-           |  package bar /* also in newline */
-           |  // open
-           |  {
-           |    package baz
-           |    { }
-           |  }
-           |}
-           |""".stripMargin
-           ).structure)
-
     val Source(
       List(Pkg(Term.Name("foo"), List(Pkg(Term.Name("bar"), List(Pkg(Term.Name("baz"), List()))))))
     ) =
@@ -136,7 +121,7 @@ class PackageSuite extends ParseSuite {
            |  }
            |}
            |""".stripMargin
-           )
+      )
 
   }
 }


### PR DESCRIPTION
Fixes issue `sbt/A.scala#L2`
Fixes issue `breeze/package.scala#L43`
(they are both the same issues)
https://github.com/scalameta/scalameta/issues/312#issuecomment-267081928