### PR TITLE
Fix *-parameter check for method definition

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2997,6 +2997,17 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
       )
     val tparams = typeParamClauseOpt(ownerIsType = false, ctxBoundsAllowed = true)
     val paramss = paramClauses(ownerIsType = false).require[List[List[Term.Param]]]
+
+    def onlyLastParameterCanBeRepeated(params: List[Term.Param]): Unit = {
+      params.reverse.tail.foreach(p =>
+        if (p.decltpe.exists(_.isInstanceOf[Type.Repeated])) {
+          syntaxError("*-parameter must come last", p)
+        }
+      )
+    }
+
+    paramss.foreach(onlyLastParameterCanBeRepeated)
+
     newLineOptWhenFollowedBy[LeftBrace]
     val restype = fromWithinReturnType(typedOpt())
     if (token.is[StatSep] || token.is[RightBrace]) {

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -3002,7 +3002,7 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
       params.iterator
         .take(params.length - 1)
         .filter(p => !p.is[Term.Param.Quasi] && p.decltpe.exists(_.is[Type.Repeated]))
-        .foreach(syntaxError("*-parameter must come last", _))
+        .foreach(p => syntaxError("*-parameter must come last", p))
     }
 
     paramss.foreach(onlyLastParameterCanBeRepeated)

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2999,13 +2999,10 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
     val paramss = paramClauses(ownerIsType = false).require[List[List[Term.Param]]]
 
     def onlyLastParameterCanBeRepeated(params: List[Term.Param]): Unit = {
-      params
+      params.iterator
         .take(params.length - 1)
-        .foreach(p =>
-          if (p.decltpe.exists(_.isInstanceOf[Type.Repeated])) {
-            syntaxError("*-parameter must come last", p)
-          }
-        )
+        .filter(p => !p.is[Term.Param.Quasi] && p.decltpe.exists(_.is[Type.Repeated]))
+        .foreach(syntaxError("*-parameter must come last", _))
     }
 
     paramss.foreach(onlyLastParameterCanBeRepeated)

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2999,11 +2999,13 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
     val paramss = paramClauses(ownerIsType = false).require[List[List[Term.Param]]]
 
     def onlyLastParameterCanBeRepeated(params: List[Term.Param]): Unit = {
-      params.reverse.tail.foreach(p =>
-        if (p.decltpe.exists(_.isInstanceOf[Type.Repeated])) {
-          syntaxError("*-parameter must come last", p)
-        }
-      )
+      params
+        .take(params.length - 1)
+        .foreach(p =>
+          if (p.decltpe.exists(_.isInstanceOf[Type.Repeated])) {
+            syntaxError("*-parameter must come last", p)
+          }
+        )
     }
 
     paramss.foreach(onlyLastParameterCanBeRepeated)

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -294,7 +294,9 @@ object Defn {
       decltpe: Option[scala.meta.Type],
       body: Term
   ) extends Defn
-      with Member.Term
+    with Member.Term {
+      checkFields(paramss.forall(onlyLastParamCanBeRepeated))
+    }
   @ast class Macro(
       mods: List[Mod],
       name: Term.Name,

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -294,9 +294,9 @@ object Defn {
       decltpe: Option[scala.meta.Type],
       body: Term
   ) extends Defn
-    with Member.Term {
-      checkFields(paramss.forall(onlyLastParamCanBeRepeated))
-    }
+      with Member.Term {
+    checkFields(paramss.forall(onlyLastParamCanBeRepeated))
+  }
   @ast class Macro(
       mods: List[Mod],
       name: Term.Name,

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/package.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/package.scala
@@ -217,6 +217,6 @@ package object trees {
   }
 
   def onlyLastParamCanBeRepeated(params: List[Term.Param]): Boolean = {
-    params.reverse.tail.forall(!_.decltpe.exists(_.isInstanceOf[Type.Repeated]))
+    params.take(params.length - 1).forall(!_.decltpe.exists(_.isInstanceOf[Type.Repeated]))
   }
 }

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/package.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/package.scala
@@ -215,4 +215,8 @@ package object trees {
     if (rank == 0) clazz
     else arrayClass(ScalaRunTime.arrayClass(clazz), rank - 1)
   }
+
+  def onlyLastParamCanBeRepeated(params: List[Term.Param]): Boolean = {
+    params.reverse.tail.forall(!_.decltpe.exists(_.isInstanceOf[Type.Repeated]))
+  }
 }

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/package.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/package.scala
@@ -217,7 +217,7 @@ package object trees {
   }
 
   def onlyLastParamCanBeRepeated(params: List[Term.Param]): Boolean = {
-    params
+    params.iterator
       .take(params.length - 1)
       .forall(p => p.is[Term.Param.Quasi] || !p.decltpe.exists(_.is[Type.Repeated]))
   }

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/package.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/package.scala
@@ -217,6 +217,8 @@ package object trees {
   }
 
   def onlyLastParamCanBeRepeated(params: List[Term.Param]): Boolean = {
-    params.take(params.length - 1).forall(!_.decltpe.exists(_.isInstanceOf[Type.Repeated]))
+    params
+      .take(params.length - 1)
+      .forall(p => p.is[Term.Param.Quasi] || !p.decltpe.exists(_.is[Type.Repeated]))
   }
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/StarParameterSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/StarParameterSuite.scala
@@ -1,0 +1,117 @@
+package scala.meta.tests
+package parsers
+
+import scala.meta._, Defn.Class
+import scala.meta.dialects.Scala211
+
+class StarParameterSuite extends ParseSuite {
+
+  test("star parameter single argument") {
+    val obj = Defn.Def(Nil, Term.Name("obj"), Nil,
+            List(List(Term.Param(
+              Nil,
+              Term.Name("f"),
+              Some(Type.Repeated(Type.Name("Int"))),
+              None
+            ))),
+            Some(Type.Name("Boolean")),
+            Lit.Boolean(true)
+          )
+    check("def obj(f: Int*): Boolean = true", obj)
+  }
+
+  test("star parameter multiple arguments") {
+    val obj = Defn.Def(Nil, Term.Name("obj"), Nil,
+            List(List(
+            Term.Param(Nil, Term.Name("a"), Some(Type.Name("String")), None),
+            Term.Param(Nil, Term.Name("b"), Some(Type.Name("Boolean")), None),
+            Term.Param(
+              Nil,
+              Term.Name("f"),
+              Some(Type.Repeated(Type.Name("Int"))),
+              None
+            ))),
+            Some(Type.Name("Boolean")),
+            Lit.Boolean(true)
+          )
+    check("def obj(a: String, b: Boolean, f: Int*): Boolean = true", obj)
+  }
+
+  test("star parameter partially applied arguments") {
+    val obj = Defn.Def(Nil, Term.Name("obj"), Nil,
+            List(List(
+            Term.Param(Nil, Term.Name("fa"),
+              Some(Type.Repeated(Type.Name("Int"))),
+              None)),
+              List(
+            Term.Param(Nil, Term.Name("fb"),
+              Some(Type.Repeated(Type.Name("Int"))),
+              None
+            ))),
+            Some(Type.Name("Boolean")),
+            Lit.Boolean(true)
+          )
+    check("def obj(fa: Int*)(fb: Int*): Boolean = true", obj)
+  }
+
+  test("star parameter implicit argument") {
+    val obj = Defn.Def(Nil, Term.Name("obj"), Nil,
+            List(List(
+            Term.Param(Nil, Term.Name("fa"),
+              Some(Type.Repeated(Type.Name("Int"))),
+              None)),
+              List(
+            Term.Param(List(Mod.Implicit()), Term.Name("fb"),
+              Some(Type.Repeated(Type.Name("Int"))),
+              None
+            ))),
+            Some(Type.Name("Boolean")),
+            Lit.Boolean(true)
+          )
+    check("def obj(fa: Int*)(implicit fb: Int*): Boolean = true", obj)
+  }
+
+  test("error on return type star parameters") {
+    val definition = "def obj(f: Int*): Boolean* = true"
+
+    val error = intercept[parsers.ParseException] {
+      source(s"object Test { ${definition} }")
+    }
+    assert(error.getMessage.contains("error: = expected but identifier found"))
+  }
+
+  // TODO: This case should be correct in dotty(no error)!
+  test("error on star parameter by name") {
+    val definition = "def obj(f: => Int*): Boolean = true"
+
+    val error = intercept[parsers.ParseException] {
+      source(s"object Test { ${definition} }")
+    }
+    assert(error.getMessage.contains("error: ) expected but identifier found"))
+  }
+
+  test("error on multiple star parameters1") {
+    val definition = "def obj(fa: Int*, fb: String): Boolean = true"
+
+    val error = intercept[parsers.ParseException] {
+      source(s"object Test { ${definition} }")
+    }
+    assert(error.getMessage.contains("error: *-parameter must come last"))
+  }
+
+  test("error on multiple star parameters2") {
+    val definition = "def obj(fa: Int*, fb: Int*) = true"
+
+    val error = intercept[parsers.ParseException] {
+      source(s"object Test { ${definition} }")
+    }
+    assert(error.getMessage.contains("error: *-parameter must come last"))
+  }
+
+  private def check(definition: String, expected: scala.meta.Stat): Unit = {
+    val wrappedExpected: scala.meta.Source = Source(List(
+      Defn.Object(Nil, Term.Name("Test"), Template(Nil, Nil, Self(Name(""), None), List(expected)))
+    ))
+    assertEquals(source(s"object Test { ${definition} }"), wrappedExpected)
+  }
+}

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/StarParameterSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/StarParameterSuite.scala
@@ -7,67 +7,83 @@ import scala.meta.dialects.Scala211
 class StarParameterSuite extends ParseSuite {
 
   test("star parameter single argument") {
-    val obj = Defn.Def(Nil, Term.Name("obj"), Nil,
-            List(List(Term.Param(
-              Nil,
-              Term.Name("f"),
-              Some(Type.Repeated(Type.Name("Int"))),
-              None
-            ))),
-            Some(Type.Name("Boolean")),
-            Lit.Boolean(true)
+    val obj = Defn.Def(
+      Nil,
+      Term.Name("obj"),
+      Nil,
+      List(
+        List(
+          Term.Param(
+            Nil,
+            Term.Name("f"),
+            Some(Type.Repeated(Type.Name("Int"))),
+            None
           )
+        )
+      ),
+      Some(Type.Name("Boolean")),
+      Lit.Boolean(true)
+    )
     check("def obj(f: Int*): Boolean = true", obj)
   }
 
   test("star parameter multiple arguments") {
-    val obj = Defn.Def(Nil, Term.Name("obj"), Nil,
-            List(List(
-            Term.Param(Nil, Term.Name("a"), Some(Type.Name("String")), None),
-            Term.Param(Nil, Term.Name("b"), Some(Type.Name("Boolean")), None),
-            Term.Param(
-              Nil,
-              Term.Name("f"),
-              Some(Type.Repeated(Type.Name("Int"))),
-              None
-            ))),
-            Some(Type.Name("Boolean")),
-            Lit.Boolean(true)
+    val obj = Defn.Def(
+      Nil,
+      Term.Name("obj"),
+      Nil,
+      List(
+        List(
+          Term.Param(Nil, Term.Name("a"), Some(Type.Name("String")), None),
+          Term.Param(Nil, Term.Name("b"), Some(Type.Name("Boolean")), None),
+          Term.Param(
+            Nil,
+            Term.Name("f"),
+            Some(Type.Repeated(Type.Name("Int"))),
+            None
           )
+        )
+      ),
+      Some(Type.Name("Boolean")),
+      Lit.Boolean(true)
+    )
     check("def obj(a: String, b: Boolean, f: Int*): Boolean = true", obj)
   }
 
   test("star parameter partially applied arguments") {
-    val obj = Defn.Def(Nil, Term.Name("obj"), Nil,
-            List(List(
-            Term.Param(Nil, Term.Name("fa"),
-              Some(Type.Repeated(Type.Name("Int"))),
-              None)),
-              List(
-            Term.Param(Nil, Term.Name("fb"),
-              Some(Type.Repeated(Type.Name("Int"))),
-              None
-            ))),
-            Some(Type.Name("Boolean")),
-            Lit.Boolean(true)
-          )
+    val obj = Defn.Def(
+      Nil,
+      Term.Name("obj"),
+      Nil,
+      List(
+        List(Term.Param(Nil, Term.Name("fa"), Some(Type.Repeated(Type.Name("Int"))), None)),
+        List(Term.Param(Nil, Term.Name("fb"), Some(Type.Repeated(Type.Name("Int"))), None))
+      ),
+      Some(Type.Name("Boolean")),
+      Lit.Boolean(true)
+    )
     check("def obj(fa: Int*)(fb: Int*): Boolean = true", obj)
   }
 
   test("star parameter implicit argument") {
-    val obj = Defn.Def(Nil, Term.Name("obj"), Nil,
-            List(List(
-            Term.Param(Nil, Term.Name("fa"),
-              Some(Type.Repeated(Type.Name("Int"))),
-              None)),
-              List(
-            Term.Param(List(Mod.Implicit()), Term.Name("fb"),
-              Some(Type.Repeated(Type.Name("Int"))),
-              None
-            ))),
-            Some(Type.Name("Boolean")),
-            Lit.Boolean(true)
+    val obj = Defn.Def(
+      Nil,
+      Term.Name("obj"),
+      Nil,
+      List(
+        List(Term.Param(Nil, Term.Name("fa"), Some(Type.Repeated(Type.Name("Int"))), None)),
+        List(
+          Term.Param(
+            List(Mod.Implicit()),
+            Term.Name("fb"),
+            Some(Type.Repeated(Type.Name("Int"))),
+            None
           )
+        )
+      ),
+      Some(Type.Name("Boolean")),
+      Lit.Boolean(true)
+    )
     check("def obj(fa: Int*)(implicit fb: Int*): Boolean = true", obj)
   }
 
@@ -109,9 +125,12 @@ class StarParameterSuite extends ParseSuite {
   }
 
   private def check(definition: String, expected: scala.meta.Stat): Unit = {
-    val wrappedExpected: scala.meta.Source = Source(List(
-      Defn.Object(Nil, Term.Name("Test"), Template(Nil, Nil, Self(Name(""), None), List(expected)))
-    ))
+    val wrappedExpected: scala.meta.Source = Source(
+      List(
+        Defn
+          .Object(Nil, Term.Name("Test"), Template(Nil, Nil, Self(Name(""), None), List(expected)))
+      )
+    )
     assertEquals(source(s"object Test { ${definition} }"), wrappedExpected)
   }
 }


### PR DESCRIPTION
Fixes #2006

One check is added in `trees` hierarchy to ensure structure is consistent and if anyone uses trees somewhere else this bad state will throw exception.
Let's say "duplicated check" is done in ScalametaParser to provide proper feedback for the user(same as compiler would generate).
(that's why 2 similar checks, I don't know have vision how to have only one check)

Also I added 1 test that should throw error for scala 2 but should be valid for scala 3, do we have a way to determine in test specific scala version?