### PR TITLE
Fix symbols of nullary method eta-expansions

### DIFF
--- a/semanticdb/integration/src/main/scala/example/EtaExpansion.scala
+++ b/semanticdb/integration/src/main/scala/example/EtaExpansion.scala
@@ -3,4 +3,10 @@ package example
 class EtaExpansion {
   Some(1).map(identity)
   List(1).foldLeft("")(_ + _)
+
+  def prop = ""
+  def meth() = ""
+
+  prop _
+  meth _
 }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
@@ -632,7 +632,7 @@ trait TextDocumentOps { self: SemanticdbOps =>
                 traverse(original)
               case SelectOf(original) =>
                 traverse(original)
-              case g.Function(params, body) if params.exists { param =>
+              case g.Function(params, body) if params.forall { param =>
                     param.symbol.isSynthetic ||
                     param.name.decoded.startsWith("x$")
                   } =>

--- a/tests/jvm/src/test/resources/example/EtaExpansion.scala
+++ b/tests/jvm/src/test/resources/example/EtaExpansion.scala
@@ -3,4 +3,10 @@ package example
 class EtaExpansion/*<=example.EtaExpansion#*/ {
   Some/*=>scala.Some.*/(1).map/*=>scala.Option#map().*/(identity/*=>scala.Predef.identity().*/)
   List/*=>scala.collection.immutable.List.*/(1).foldLeft/*=>scala.collection.LinearSeqOptimized#foldLeft().*/("")(_ +/*=>java.lang.String#`+`().*/ _)
+
+  def prop/*<=example.EtaExpansion#prop().*/ = ""
+  def meth/*<=example.EtaExpansion#meth().*/() = ""
+
+  prop/*=>local1*/ _
+  meth/*=>local2*/ _
 }

--- a/tests/jvm/src/test/resources/example/EtaExpansion.scala
+++ b/tests/jvm/src/test/resources/example/EtaExpansion.scala
@@ -7,6 +7,6 @@ class EtaExpansion/*<=example.EtaExpansion#*/ {
   def prop/*<=example.EtaExpansion#prop().*/ = ""
   def meth/*<=example.EtaExpansion#meth().*/() = ""
 
-  prop/*=>local1*/ _
-  meth/*=>local2*/ _
+  prop/*=>example.EtaExpansion#prop().*/ _
+  meth/*=>example.EtaExpansion#meth().*/ _
 }

--- a/tests/jvm/src/test/resources/metac.expect
+++ b/tests/jvm/src/test/resources/metac.expect
@@ -1108,8 +1108,8 @@ Occurrences:
 [4:25..4:26): + => java/lang/String#`+`().
 [6:6..6:10): prop <= example/EtaExpansion#prop().
 [7:6..7:10): meth <= example/EtaExpansion#meth().
-[9:2..9:6): prop => local1
-[10:2..10:6): meth => local2
+[9:2..9:6): prop => example/EtaExpansion#prop().
+[10:2..10:6): meth => example/EtaExpansion#meth().
 
 Synthetics:
 [3:2..3:6): Some => *.apply[Int]

--- a/tests/jvm/src/test/resources/metac.expect
+++ b/tests/jvm/src/test/resources/metac.expect
@@ -1081,14 +1081,18 @@ Schema => SemanticDB v4
 Uri => semanticdb/integration/src/main/scala/example/EtaExpansion.scala
 Text => non-empty
 Language => Scala
-Symbols => 3 entries
-Occurrences => 9 entries
+Symbols => 5 entries
+Occurrences => 13 entries
 Synthetics => 5 entries
 
 Symbols:
-example/EtaExpansion# => class EtaExpansion extends AnyRef { +1 decls }
+example/EtaExpansion# => class EtaExpansion extends AnyRef { +3 decls }
   AnyRef => scala/AnyRef#
 example/EtaExpansion#`<init>`(). => primary ctor <init>()
+example/EtaExpansion#meth(). => method meth(): String
+  String => java/lang/String#
+example/EtaExpansion#prop(). => method prop: String
+  String => java/lang/String#
 local0 => param x: Int
   Int => scala/Int#
 
@@ -1102,6 +1106,10 @@ Occurrences:
 [4:2..4:6): List => scala/collection/immutable/List.
 [4:10..4:18): foldLeft => scala/collection/LinearSeqOptimized#foldLeft().
 [4:25..4:26): + => java/lang/String#`+`().
+[6:6..6:10): prop <= example/EtaExpansion#prop().
+[7:6..7:10): meth <= example/EtaExpansion#meth().
+[9:2..9:6): prop => local1
+[10:2..10:6): meth => local2
 
 Synthetics:
 [3:2..3:6): Some => *.apply[Int]

--- a/tests/jvm/src/test/resources/metacp.expect
+++ b/tests/jvm/src/test/resources/metacp.expect
@@ -1705,12 +1705,16 @@ Schema => SemanticDB v4
 Uri => example/EtaExpansion.class
 Text => empty
 Language => Scala
-Symbols => 2 entries
+Symbols => 4 entries
 
 Symbols:
-example/EtaExpansion# => class EtaExpansion extends AnyRef { +1 decls }
+example/EtaExpansion# => class EtaExpansion extends AnyRef { +3 decls }
   AnyRef => scala/AnyRef#
 example/EtaExpansion#`<init>`(). => primary ctor <init>()
+example/EtaExpansion#meth(). => method meth(): String
+  String => java/lang/String#
+example/EtaExpansion#prop(). => method prop: String
+  String => java/lang/String#
 
 example/Example.class
 ---------------------


### PR DESCRIPTION
When the Scala parser encounters an underscore while parsing expressions it
discards that token's position and creates a `MethodValue` of the target
method:

    case USCORE =>
      atPos(t.pos.start, in.skipToken()) { MethodValue(stripParens(t)) }

Then the Scala typechecker creates a `Function0` out of that, defining its
position as the position of the underlying method value:

    val pos = methodValue.pos
    // must create it here to change owner (normally done by typed's typedFunction)
    val funSym = context.owner.newAnonymousFunctionValue(pos)
    new ChangeOwnerTraverser(context.owner, funSym) traverse methodValue

    val result = typed(Function(List(), methodValue) setSymbol funSym setPos pos, mode, pt)

The result is that `XtensionCompilationUnitDocument#toTextDocument`, which
uses positions, incorrectly matches the `Function0` (Global) tree
(e.g. `(() => this.prop)`) to the underlying method expression (`prop`) 
Scalameta tree, and then converts that anonymous class (Global) symbol into
a local Semanticdb symbol.

So, instead of that, we skip the outer function when it has no params
(by flipping from `exists` to `forall`) so now the Scalameta tree `prop` is
correctly associated to the method's symbol.