### PR TITLE
Add Scala.js 1.0 support (and Drop Scala.js 0.6 support)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
           - "++2.13.1 testsJVM/test"
           - "++2.13.2 testsJVM/test"
           - "download-scala-library ++2.12.11 testsJVM/slow:test"
-          - "++2.11.12 testsJS/test"
           - "++2.12.10 testsJS/test"
           - "++2.13.1 testsJS/test"
           - "mima"

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,6 @@ import sbtcrossproject.CrossPlugin.autoImport.crossProject
 import org.scalameta.build._
 import org.scalameta.build.Versions._
 import complete.DefaultParsers._
-import scalapb.compiler.Version.scalapbVersion
 import munit.sbtmunit.BuildInfo.munitVersion
 
 lazy val LanguageVersions = Seq(LatestScala213, LatestScala212, LatestScala211)
@@ -547,12 +546,35 @@ lazy val mergeSettings = Def.settings(
 lazy val protobufSettings = Def.settings(
   sharedSettings,
   PB.targets.in(Compile) := Seq(
-    scalapb.gen(
-      flatPackage = true // Don't append filename to package
-    ) -> sourceManaged.in(Compile).value
+    protocbridge.Target(
+      generator = PB.gens.plugin("scala"),
+      outputPath = (sourceManaged in Compile).value,
+      options = scalapb.gen(
+        flatPackage = true // Don't append filename to package
+      )._2
+    )
   ),
   PB.protoSources.in(Compile) := Seq(file("semanticdb/semanticdb")),
-  libraryDependencies += "com.thesamet.scalapb" %%% "scalapb-runtime" % scalapbVersion
+  PB.additionalDependencies := Nil,
+  libraryDependencies ++= {
+    val scalapbVersion =
+      if (scalaBinaryVersion.value == "2.11") {
+        "0.9.7"
+      } else {
+        scalapb.compiler.Version.scalapbVersion
+      }
+    Seq(
+      "com.thesamet.scalapb" %%% "scalapb-runtime" % scalapbVersion,
+      "com.thesamet.scalapb" %%% "scalapb-runtime" % scalapbVersion % "protobuf",
+      "com.thesamet.scalapb" % "protoc-gen-scala" % scalapbVersion % "protobuf" artifacts(
+        if (scala.util.Properties.isWin) {
+          Artifact("protoc-gen-scala", PB.ProtocPlugin, "bat", "windows")
+        } else {
+          Artifact("protoc-gen-scala", PB.ProtocPlugin, "sh", "unix")
+        }
+      )
+    )
+  }
 )
 
 lazy val adhocRepoUri = sys.props("scalameta.repository.uri")

--- a/build.sbt
+++ b/build.sbt
@@ -549,9 +549,11 @@ lazy val protobufSettings = Def.settings(
     protocbridge.Target(
       generator = PB.gens.plugin("scala"),
       outputPath = (sourceManaged in Compile).value,
-      options = scalapb.gen(
-        flatPackage = true // Don't append filename to package
-      )._2
+      options = scalapb
+        .gen(
+          flatPackage = true // Don't append filename to package
+        )
+        ._2
     )
   ),
   PB.protoSources.in(Compile) := Seq(file("semanticdb/semanticdb")),
@@ -566,7 +568,7 @@ lazy val protobufSettings = Def.settings(
     Seq(
       "com.thesamet.scalapb" %%% "scalapb-runtime" % scalapbVersion,
       "com.thesamet.scalapb" %%% "scalapb-runtime" % scalapbVersion % "protobuf",
-      "com.thesamet.scalapb" % "protoc-gen-scala" % scalapbVersion % "protobuf" artifacts(
+      "com.thesamet.scalapb" % "protoc-gen-scala" % scalapbVersion % "protobuf" artifacts (
         if (scala.util.Properties.isWin) {
           Artifact("protoc-gen-scala", PB.ProtocPlugin, "bat", "windows")
         } else {

--- a/build.sbt
+++ b/build.sbt
@@ -354,7 +354,7 @@ lazy val tests = crossProject(JSPlatform, JVMPlatform)
   )
   .jsSettings(
     commonJsSettings,
-    scalaJSModuleKind := ModuleKind.CommonJSModule
+    scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
   )
   .enablePlugins(BuildInfoPlugin)
   .dependsOn(scalameta)

--- a/build.sbt
+++ b/build.sbt
@@ -382,7 +382,7 @@ lazy val testSettings: List[Def.SettingsDefinition] = List(
   ),
   buildInfoPackage := "scala.meta.tests",
   libraryDependencies ++= {
-    if (isScala212.value) List("com.lihaoyi" %%% "fansi" % "0.2.8" % "test")
+    if (isScala212.value) List("com.lihaoyi" %%% "fansi" % "0.2.9" % "test")
     else Nil
   },
   libraryDependencies ++= List(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,7 +10,7 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.31")
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin-shaded" % (if (scalaVersion.value.startsWith("2.11.")) "0.10.2" else "0.10.3")
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin-shaded" % "0.10.3"
 
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,7 +20,9 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.1")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.32")
+val scalaJSVersion =
+  Option(System.getenv("SCALAJS_VERSION")).filter(_.nonEmpty).getOrElse("1.0.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 
 addSbtPlugin("org.scala-debugger" % "sbt-jdi-tools" % "1.1.1")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,7 +10,7 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.27")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.31")
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin-shaded" % "0.10.2"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin-shaded" % "0.10.3"
 
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ addSbtPlugin(
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
 
-addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.27")
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,7 +10,7 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.27")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.31")
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin-shaded" % "0.9.7"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin-shaded" % "0.10.2"
 
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,7 +10,7 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.2.27")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.31")
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin-shaded" % "0.10.3"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin-shaded" % (if (scalaVersion.value.startsWith("2.11.")) "0.10.2" else "0.10.3")
 
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,9 +20,7 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.1")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 
-val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).filter(_.nonEmpty).getOrElse("1.0.1")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.1")
 
 addSbtPlugin("org.scala-debugger" % "sbt-jdi-tools" % "1.1.1")
 

--- a/scalameta/parsers/js/src/main/scala/scala/meta/parsers/JSFacade.scala
+++ b/scalameta/parsers/js/src/main/scala/scala/meta/parsers/JSFacade.scala
@@ -4,9 +4,9 @@ package parsers
 import scala.scalajs.js
 import js.JSConverters._
 import js.annotation._
-
 import prettyprinters._
 import inputs._
+import scala.scalajs.js.UndefOr
 
 object JSFacade {
 
@@ -76,7 +76,7 @@ object JSFacade {
   }
 
   private[this] type Settings = js.UndefOr[js.Dictionary[String]]
-  private[this] val defaultSettings = None.orUndefined
+  private[this] val defaultSettings = js.undefined.asInstanceOf[Settings]
 
   private[this] def extractDialect(s: Settings): Either[String, Dialect] = {
     s.toOption.flatMap(_.get("dialect")) match {

--- a/scalameta/parsers/js/src/main/scala/scala/meta/parsers/JSFacade.scala
+++ b/scalameta/parsers/js/src/main/scala/scala/meta/parsers/JSFacade.scala
@@ -11,7 +11,7 @@ import inputs._
 object JSFacade {
 
   // https://stackoverflow.com/a/36573183/846273
-  private def mergeJSObjects(objs: js.Dynamic*): js.Dynamic = {
+  private[this] def mergeJSObjects(objs: js.Dynamic*): js.Dynamic = {
     val result = js.Dictionary.empty[Any]
     for (source <- objs) {
       for ((key, value) <- source.asInstanceOf[js.Dictionary[Any]])
@@ -22,28 +22,28 @@ object JSFacade {
 
   // https://github.com/scala-js/scala-js/issues/2170#issuecomment-176795604
   @js.native
-  private sealed trait JSLong extends js.Any
-  implicit private class LongJSOps(val x: Long) extends AnyVal {
+  private[this] sealed trait JSLong extends js.Any
+  implicit private[this] class LongJSOps(val x: Long) extends AnyVal {
     def toJSLong: JSLong = {
       if (x >= 0) (x & ((1L << 53) - 1)).toDouble
       else -((-x) & ((1L << 53) - 1)).toDouble
     }.asInstanceOf[JSLong]
   }
 
-  private def toNode(t: Any): js.Any = t match {
+  private[this] def toNode(t: Any): js.Any = t match {
     case t: Tree => toNode(t)
     case tt: List[_] => tt.map(toNode).toJSArray
     case t: Option[_] => t.map(toNode).orUndefined
     case _ => ()
   }
 
-  private def toPosition(p: Position): js.Dynamic =
+  private[this] def toPosition(p: Position): js.Dynamic =
     js.Dynamic.literal(
       "start" -> p.start,
       "end" -> p.end
     )
 
-  private def toNode(t: Tree): js.Dynamic = {
+  private[this] def toNode(t: Tree): js.Dynamic = {
     val base = js.Dynamic.literal(
       "type" -> t.productPrefix,
       "pos" -> toPosition(t.pos)
@@ -75,10 +75,10 @@ object JSFacade {
     mergeJSObjects(base, fields, value, syntax)
   }
 
-  private type Settings = js.UndefOr[js.Dictionary[String]]
-  private val defaultSettings = js.undefined.asInstanceOf[Settings]
+  private[this] type Settings = js.UndefOr[js.Dictionary[String]]
+  private[this] val defaultSettings = js.undefined.asInstanceOf[Settings]
 
-  private def extractDialect(s: Settings): Either[String, Dialect] = {
+  private[this] def extractDialect(s: Settings): Either[String, Dialect] = {
     s.toOption.flatMap(_.get("dialect")) match {
       case Some(dialectStr) =>
         Dialect.standards.get(dialectStr) match {
@@ -89,7 +89,7 @@ object JSFacade {
     }
   }
 
-  private def parse[A <: Tree: Parse](
+  private[this] def parse[A <: Tree: Parse](
       code: String,
       settings: Settings
   ): js.Dictionary[Any] =

--- a/scalameta/parsers/js/src/main/scala/scala/meta/parsers/JSFacade.scala
+++ b/scalameta/parsers/js/src/main/scala/scala/meta/parsers/JSFacade.scala
@@ -3,10 +3,8 @@ package parsers
 
 import scala.scalajs.js
 import js.JSConverters._
-import js.annotation._
 import prettyprinters._
 import inputs._
-import scala.scalajs.js.UndefOr
 
 object JSFacade {
 

--- a/scalameta/parsers/js/src/main/scala/scala/meta/parsers/JSFacade.scala
+++ b/scalameta/parsers/js/src/main/scala/scala/meta/parsers/JSFacade.scala
@@ -108,14 +108,11 @@ object JSFacade {
         }
     }
 
-  @JSExportTopLevel("default")
-  @JSExportTopLevel("parseSource")
   def parseSource(
       code: String,
       settings: Settings = defaultSettings
   ): js.Dictionary[Any] = parse[Source](code, settings)
 
-  @JSExportTopLevel("parseStat")
   def parseStat(
       code: String,
       settings: Settings = defaultSettings

--- a/scalameta/parsers/js/src/main/scala/scala/meta/parsers/JSFacade.scala
+++ b/scalameta/parsers/js/src/main/scala/scala/meta/parsers/JSFacade.scala
@@ -111,14 +111,25 @@ object JSFacade {
   @JSExportTopLevel("default")
   @JSExportTopLevel("parseSource")
   def parseSource(
+      code: String
+  ): js.Dictionary[Any] = parse[Source](code, defaultSettings)
+
+  @JSExportTopLevel("default")
+  @JSExportTopLevel("parseSource")
+  def parseSource(
       code: String,
-      settings: Settings = defaultSettings
+      settings: Settings
   ): js.Dictionary[Any] = parse[Source](code, settings)
 
   @JSExportTopLevel("parseStat")
   def parseStat(
+      code: String
+  ): js.Dictionary[Any] = parse[Stat](code, defaultSettings)
+
+  @JSExportTopLevel("parseStat")
+  def parseStat(
       code: String,
-      settings: Settings = defaultSettings
+      settings: Settings
   ): js.Dictionary[Any] = parse[Stat](code, settings)
 
 }

--- a/scalameta/parsers/js/src/main/scala/scala/meta/parsers/JSFacade.scala
+++ b/scalameta/parsers/js/src/main/scala/scala/meta/parsers/JSFacade.scala
@@ -3,13 +3,15 @@ package parsers
 
 import scala.scalajs.js
 import js.JSConverters._
+import js.annotation._
+
 import prettyprinters._
 import inputs._
 
 object JSFacade {
 
   // https://stackoverflow.com/a/36573183/846273
-  private[this] def mergeJSObjects(objs: js.Dynamic*): js.Dynamic = {
+  private def mergeJSObjects(objs: js.Dynamic*): js.Dynamic = {
     val result = js.Dictionary.empty[Any]
     for (source <- objs) {
       for ((key, value) <- source.asInstanceOf[js.Dictionary[Any]])
@@ -20,28 +22,28 @@ object JSFacade {
 
   // https://github.com/scala-js/scala-js/issues/2170#issuecomment-176795604
   @js.native
-  private[this] sealed trait JSLong extends js.Any
-  implicit private[this] class LongJSOps(val x: Long) extends AnyVal {
+  private sealed trait JSLong extends js.Any
+  implicit private class LongJSOps(val x: Long) extends AnyVal {
     def toJSLong: JSLong = {
       if (x >= 0) (x & ((1L << 53) - 1)).toDouble
       else -((-x) & ((1L << 53) - 1)).toDouble
     }.asInstanceOf[JSLong]
   }
 
-  private[this] def toNode(t: Any): js.Any = t match {
+  private def toNode(t: Any): js.Any = t match {
     case t: Tree => toNode(t)
     case tt: List[_] => tt.map(toNode).toJSArray
     case t: Option[_] => t.map(toNode).orUndefined
     case _ => ()
   }
 
-  private[this] def toPosition(p: Position): js.Dynamic =
+  private def toPosition(p: Position): js.Dynamic =
     js.Dynamic.literal(
       "start" -> p.start,
       "end" -> p.end
     )
 
-  private[this] def toNode(t: Tree): js.Dynamic = {
+  private def toNode(t: Tree): js.Dynamic = {
     val base = js.Dynamic.literal(
       "type" -> t.productPrefix,
       "pos" -> toPosition(t.pos)
@@ -73,10 +75,10 @@ object JSFacade {
     mergeJSObjects(base, fields, value, syntax)
   }
 
-  private[this] type Settings = js.UndefOr[js.Dictionary[String]]
-  private[this] val defaultSettings = js.undefined.asInstanceOf[Settings]
+  private type Settings = js.UndefOr[js.Dictionary[String]]
+  private val defaultSettings = js.undefined.asInstanceOf[Settings]
 
-  private[this] def extractDialect(s: Settings): Either[String, Dialect] = {
+  private def extractDialect(s: Settings): Either[String, Dialect] = {
     s.toOption.flatMap(_.get("dialect")) match {
       case Some(dialectStr) =>
         Dialect.standards.get(dialectStr) match {
@@ -87,7 +89,7 @@ object JSFacade {
     }
   }
 
-  private[this] def parse[A <: Tree: Parse](
+  private def parse[A <: Tree: Parse](
       code: String,
       settings: Settings
   ): js.Dictionary[Any] =
@@ -106,11 +108,14 @@ object JSFacade {
         }
     }
 
+  @JSExportTopLevel("default")
+  @JSExportTopLevel("parseSource")
   def parseSource(
       code: String,
       settings: Settings = defaultSettings
   ): js.Dictionary[Any] = parse[Source](code, settings)
 
+  @JSExportTopLevel("parseStat")
   def parseStat(
       code: String,
       settings: Settings = defaultSettings

--- a/semanticdb/semanticdb/semanticdb.proto
+++ b/semanticdb/semanticdb/semanticdb.proto
@@ -2,6 +2,12 @@ syntax = "proto3";
 
 package scala.meta.internal.semanticdb;
 
+import "scalapb/scalapb.proto";
+
+option (scalapb.options) = {
+  preserve_unknown_fields: false
+};
+
 enum Schema {
   LEGACY = 0;
   SEMANTICDB3 = 3;

--- a/semanticdb/semanticdb/semanticidx.proto
+++ b/semanticdb/semanticdb/semanticidx.proto
@@ -2,6 +2,12 @@ syntax = "proto3";
 
 package scala.meta.internal.semanticidx;
 
+import "scalapb/scalapb.proto";
+
+option (scalapb.options) = {
+  preserve_unknown_fields: false
+};
+
 message Indexes {
   repeated Index indexes = 1;
 }


### PR DESCRIPTION
Closes #2047

[Scala.js 0.6 support is dropped to avoid complexity of build and release process](https://github.com/scalameta/scalameta/pull/2021#discussion_r408742736).
Scala.js 0.6 users can still use existing versions of scalameta.