### PR TITLE
Fix scala library incompatibility between 2.13.2 and 2.13.1 

### DIFF
--- a/scalameta/tokens/shared/src/main/scala/scala/meta/tokens/Tokens.scala
+++ b/scalameta/tokens/shared/src/main/scala/scala/meta/tokens/Tokens.scala
@@ -39,6 +39,15 @@ import scala.meta.internal.prettyprinters._
     val hi = lo.max(start + until.min(length))
     Tokens(tokens, lo, hi)
   }
+
+  /* Both head and headOption need to be implemented here due to
+   * binary incompatibility caused by
+   * https://github.com/scala/scala/commit/b20dd00b11f06c14c823d277cdfb58043a2586fc
+   */
+  override def head: Token = apply(0)
+
+  override def headOption: Option[Token] = if (isEmpty) None else Some(head)
+
   override def toString = scala.meta.internal.prettyprinters.TokensToString(this)
 
   override def segmentLength(p: Token => Boolean, from: Int = 0): Int = super.segmentLength(p, from)


### PR DESCRIPTION
The issues were caused by https://github.com/scala/scala/commit/b20dd00b11f06c14c823d277cdfb58043a2586fc

The headOption and head would absent from IndexedSeqOps and cause 2.13.2 compiled scalameta parser fail for 2.13.1