### PR TITLE
ScalametaParser: fix try of partial enclosed expr

### DIFF
--- a/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
@@ -69,6 +69,8 @@ final class Dialect private (
     val toplevelSeparator: String,
     // Are numeric literal underscore separators, i.e. `1_000_000` legal or not?
     val allowNumericLiteralUnderscoreSeparators: Boolean,
+    // Can try body contain any expression? (2.13.1 https://github.com/scala/scala/pull/8071)
+    val allowTryWithAnyExpr: Boolean,
     // Given/using introduced in dotty
     val allowGivenUsing: Boolean,
     // Extension methods introduced in dotty
@@ -144,6 +146,7 @@ final class Dialect private (
       allowXmlLiterals,
       toplevelSeparator,
       allowNumericLiteralUnderscoreSeparators = false,
+      allowTryWithAnyExpr = false,
       allowGivenUsing = false,
       allowExtensionMethods = false,
       allowOpenClass = false,
@@ -232,10 +235,11 @@ final class Dialect private (
   def withToplevelSeparator(newValue: String): Dialect = {
     privateCopy(toplevelSeparator = newValue)
   }
-  def withAllowNumericLiteralUnderscoreSeparators(
-      newValue: Boolean
-  ): Dialect = {
+  def withAllowNumericLiteralUnderscoreSeparators(newValue: Boolean): Dialect = {
     privateCopy(allowNumericLiteralUnderscoreSeparators = newValue)
+  }
+  def withAllowTryWithAnyExpr(newValue: Boolean): Dialect = {
+    privateCopy(allowTryWithAnyExpr = newValue)
   }
   def withAllowGivenUsing(newValue: Boolean): Dialect = {
     privateCopy(allowGivenUsing = newValue)
@@ -291,6 +295,7 @@ final class Dialect private (
       toplevelSeparator: String = this.toplevelSeparator,
       allowNumericLiteralUnderscoreSeparators: Boolean =
         this.allowNumericLiteralUnderscoreSeparators,
+      allowTryWithAnyExpr: Boolean = this.allowTryWithAnyExpr,
       allowGivenUsing: Boolean = this.allowGivenUsing,
       allowExtensionMethods: Boolean = this.allowExtensionMethods,
       allowOpenClass: Boolean = this.allowOpenClass,
@@ -326,6 +331,7 @@ final class Dialect private (
       allowXmlLiterals,
       toplevelSeparator,
       allowNumericLiteralUnderscoreSeparators,
+      allowTryWithAnyExpr,
       allowGivenUsing,
       allowExtensionMethods,
       allowOpenClass,

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -57,6 +57,7 @@ package object dialects {
     .withAllowLiteralTypes(true)
     .withAllowNumericLiteralUnderscoreSeparators(true)
     .withAllowLiteralUnitType(true)
+    .withAllowTryWithAnyExpr(true)
 
   implicit val Scala = Scala213 // alias for latest Scala dialect.
 

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1606,17 +1606,7 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
         val body: Term = token match {
           case _ if dialect.allowTryWithAnyExpr => expr()
           case LeftBrace() => autoPos(inBracesOrUnit(block()))
-          case p @ LeftParen() =>
-            val term = inParensOrTupleOrUnit(location, allowRepeated)
-            term match {
-              case _: Lit.Unit | _: Term.Tuple =>
-                // NOTE: the position needs to be adapted to include parentheses
-                // when parsing a tuple or unit.
-                // See comments to makeTupleType for discussion
-                atPos(p, auto)(term)
-              case _ =>
-                term
-            }
+          case LeftParen() => inParensOrUnit(expr())
           case _ => expr()
         }
         val catchopt =

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1604,6 +1604,7 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
       case KwTry() =>
         next()
         val body: Term = token match {
+          case _ if dialect.allowTryWithAnyExpr => expr()
           case LeftBrace() => autoPos(inBracesOrUnit(block()))
           case p @ LeftParen() =>
             val term = inParensOrTupleOrUnit(location, allowRepeated)

--- a/tests/shared/src/test/scala-2.12/scala/meta/tests/tokenizers/BaseTokenizerCoverageSuite.scala
+++ b/tests/shared/src/test/scala-2.12/scala/meta/tests/tokenizers/BaseTokenizerCoverageSuite.scala
@@ -133,7 +133,7 @@ abstract class BaseTokenizerCoverageSuite extends FunSuite {
 
   private var oddTest = true
 
-  private def check0[T <: Tree](annotedSource: String)(
+  protected def check0[T <: Tree](annotedSource: String)(
       project: T => Tree = identity[Tree] _,
       checkChilds: Boolean = true,
       parser: Parse[_ <: Tree] = Parse.parseStat,

--- a/tests/shared/src/test/scala-2.12/scala/meta/tests/tokenizers/TokenizerCoverageSuite.scala
+++ b/tests/shared/src/test/scala-2.12/scala/meta/tests/tokenizers/TokenizerCoverageSuite.scala
@@ -98,8 +98,13 @@ class TokenizerCoverageSuite() extends BaseTokenizerCoverageSuite {
   check[Term.Try]("try (→f←) catch { →case x => x;← →case y => y← } finally →{ }←")
   check[Term.Try]("try →()←")
   check[Term.Try]("try →(true, false)←")
+  check0[Term.Try]("try →{1 + 2}.toString←")(dialect = dialects.Scala213)
+  check0[Term.Try]("try →(a.b).c←")(dialect = dialects.Scala213)
   check[Term.TryWithHandler]("try (→f←) catch →(h)← finally →{ }←")
   check[Term.TryWithHandler]("try →(true, false)← catch →(h)← finally →(1, 2)←")
+  check0[Term.TryWithHandler]("try →(a.b).c← catch →(h)← finally →(1, 2)←")(dialect =
+    dialects.Scala213
+  )
   check[Term.Tuple]("(→(a)←, →(b)←)")
   check[Term.While]("while (→p←) →{d}←")
   check[Term.Xml]("→<a>b←{→c←}→d</a>←")

--- a/tests/shared/src/test/scala-2.12/scala/meta/tests/tokenizers/TokenizerCoverageSuite.scala
+++ b/tests/shared/src/test/scala-2.12/scala/meta/tests/tokenizers/TokenizerCoverageSuite.scala
@@ -96,12 +96,14 @@ class TokenizerCoverageSuite() extends BaseTokenizerCoverageSuite {
   check[Term.This]("→a←.this")
   check[Term.Throw]("throw →(e)←")
   check[Term.Try]("try (→f←) catch { →case x => x;← →case y => y← } finally →{ }←")
-  check[Term.Try]("try →()←")
-  check[Term.Try]("try →(true, false)←")
+  check0[Term.Try]("try →()←")(dialect = dialects.Scala213)
+  check0[Term.Try]("try →(true, false)←")(dialect = dialects.Scala213)
   check0[Term.Try]("try →{1 + 2}.toString←")(dialect = dialects.Scala213)
   check0[Term.Try]("try →(a.b).c←")(dialect = dialects.Scala213)
   check[Term.TryWithHandler]("try (→f←) catch →(h)← finally →{ }←")
-  check[Term.TryWithHandler]("try →(true, false)← catch →(h)← finally →(1, 2)←")
+  check0[Term.TryWithHandler]("try →(true, false)← catch →(h)← finally →(1, 2)←")(dialect =
+    dialects.Scala213
+  )
   check0[Term.TryWithHandler]("try →(a.b).c← catch →(h)← finally →(1, 2)←")(dialect =
     dialects.Scala213
   )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/Scala213Suite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/Scala213Suite.scala
@@ -1,7 +1,6 @@
 package scala.meta.tests
 package parsers
 
-import scala.meta._
 import scala.meta.dialects.Scala213
 
 class Scala213Suite extends ParseSuite {
@@ -38,13 +37,13 @@ class Scala213Suite extends ParseSuite {
 
   test("identifier-types") {
     // "x" is a class with def =>>(x: Int): Int, in dotty ==> is keyword and it will be error here
-    assertNoDiff(
-      templStat("val c = x =>> 3").structure,
+    runAssert(
+      "val c = x =>> 3",
       """Defn.Val(Nil, List(Pat.Var(Term.Name("c"))), None, Term.ApplyInfix(Term.Name("x"), Term.Name("=>>"), Nil, List(Lit.Int(3))))"""
     )
 
-    assertNoDiff(
-      templStat("val given = 3").structure,
+    runAssert(
+      "val given = 3",
       """Defn.Val(Nil, List(Pat.Var(Term.Name("given"))), None, Lit.Int(3))"""
     )
 
@@ -54,10 +53,26 @@ class Scala213Suite extends ParseSuite {
     )
   }
 
+  test("try with any expr") {
+    runAssert(
+      "try (1 + 2).toString",
+      """Term.Try(Term.Select(Term.ApplyInfix(Lit.Int(1), Term.Name("+"), Nil, List(Lit.Int(2))), Term.Name("toString")), Nil, None)"""
+    )
+    runAssert(
+      "try { 1 + 2 }.toString",
+      """Term.Try(Term.Select(Term.Block(List(Term.ApplyInfix(Lit.Int(1), Term.Name("+"), Nil, List(Lit.Int(2))))), Term.Name("toString")), Nil, None)"""
+    )
+    runAssert(
+      "try (1 :: Nil) map fn",
+      """Term.Try(Term.ApplyInfix(Term.ApplyInfix(Lit.Int(1), Term.Name("::"), Nil, List(Term.Name("Nil"))), Term.Name("map"), Nil, List(Term.Name("fn"))), Nil, None)"""
+    )
+  }
+
   private def runAssert(code: String, expected: String): Unit = {
     assertNoDiff(
       templStat(code).structure,
       expected
     )
   }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/Scala213Suite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/Scala213Suite.scala
@@ -66,6 +66,11 @@ class Scala213Suite extends ParseSuite {
       "try (1 :: Nil) map fn",
       """Term.Try(Term.ApplyInfix(Term.ApplyInfix(Lit.Int(1), Term.Name("::"), Nil, List(Term.Name("Nil"))), Term.Name("map"), Nil, List(Term.Name("fn"))), Nil, None)"""
     )
+    runAssert(
+      "try (true, false)",
+      """Term.Try(Term.Tuple(List(Lit.Boolean(true), Lit.Boolean(false))), Nil, None)"""
+    )
+    runAssert("try ()", """Term.Try(Lit.Unit(()), Nil, None)""")
   }
 
   private def runAssert(code: String, expected: String): Unit = {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -358,14 +358,6 @@ class TermSuite extends ParseSuite {
     val TryWithHandler(Lit(1), Lit(1), None) = term("try 1 catch 1")
   }
 
-  test("try (true, false)") {
-    val Try(Tuple(Lit(true) :: Lit(false) :: Nil), Nil, None) = term("try (true, false)")
-  }
-
-  test("try ()") {
-    val Try(Lit(()), Nil, None) = term("try ()")
-  }
-
   test("try (2)") {
     val Try(Lit(2), Nil, None) = term("try (2)")
   }


### PR DESCRIPTION
Previously, if try was followed by `{` or `(`, the code assumed the
entire body is enclosed. This is an attempt to fix this.

Fixes #2031. Fixes #2009.