### PR TITLE
Dialect: allow copying with all internal vars

### DIFF
--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -101,11 +101,15 @@ import scala.compat.Platform.EOL
   override def canEqual(that: Any): Boolean = this eq that.asInstanceOf[AnyRef]
   override def equals(other: Any): Boolean = this eq other.asInstanceOf[AnyRef]
   override def hashCode: Int = System.identityHashCode(this)
+
   // Create new reference that copies over internal var settings from this instance.
   private def copyWithInternalVars(): Dialect = {
+    copyWithInternalVarsFrom(this)
+  }
+  def copyWithInternalVarsFrom(from: Dialect): Dialect = {
     val result = copy()
     result.internalAllowNumericLiteralUnderscoreSeparators =
-      this.internalAllowNumericLiteralUnderscoreSeparators
+      from.internalAllowNumericLiteralUnderscoreSeparators
     result
   }
 


### PR DESCRIPTION
For now, there's only one; but others are added in the future, copying
will not be possible as the number of `.withXxx` methods will grow.