### PR TITLE
internal.Scaladoc: another way to parse a scaladoc

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
@@ -1,0 +1,187 @@
+package scala.meta.internal.parsers
+
+import java.util.regex.Pattern
+
+import scala.meta.internal.Scaladoc
+import scala.meta.internal.fastparse.all._
+
+/**
+ * Represents a scaladoc line.
+ */
+object ScaladocParser {
+
+  import Scaladoc._
+
+  private val numberOfSupportedHeadingLevels = 6
+
+  private val hspaceChars = "\t\r "
+  private def hspacesMin(min: Int) = CharsWhileIn(hspaceChars, min)
+  private val hspaces0 = hspacesMin(0)
+  private def hspacesMinWithLen(min: Int): Parser[Int] =
+    (Index ~ hspacesMin(min) ~ Index).map { case (b, e) => e - b }
+
+  private val nl: Parser[Unit] = "\n"
+  private val startOrNl = Start | nl
+
+  private val spaceChars = hspaceChars + "\n"
+  private val space = CharIn(spaceChars)
+  private def spacesMin(min: Int) = CharsWhileIn(spaceChars, min)
+  private val spaces1 = spacesMin(1)
+  private val nlHspaces1 = space ~ hspaces0
+  private val leadHspaces0 = startOrNl ~ hspaces0
+
+  private val labelParser: Parser[Unit] = (!space ~ AnyChar).rep(1)
+  private val wordParser: Parser[Word] = P(labelParser.!.map(Word.apply))
+  private val trailWordParser = nlHspaces1 ~ wordParser
+
+  private val listPrefix = "-" | CharIn("1aiI") ~ "."
+
+  private val codePrefix = P("{{{")
+  private val codeSuffix = P(hspaces0 ~ "}}}")
+
+  private val linkPrefix = P("[[" ~ hspaces0)
+  private val linkSuffix = P(hspaces0 ~ "]]")
+
+  private val codeLineParser: Parser[String] = {
+    val codeLineEnd = P(nl | codeSuffix)
+    P((!codeLineEnd ~ AnyChar).rep.!)
+  }
+
+  private val codeExprParser: Parser[CodeExpr] = {
+    val pattern = codePrefix ~ hspaces0 ~ codeLineParser ~ codeSuffix
+    P(pattern.map(x => CodeExpr(x.trim)))
+  }
+
+  private val codeBlockParser: Parser[CodeBlock] = {
+    val code = codeLineParser.rep(1, sep = nl)
+    val pattern = leadHspaces0 ~ codePrefix ~ nl ~ code ~ codeSuffix
+    P(pattern.map { x =>
+      val lines = if (x.last.nonEmpty) x.toSeq else x.view.dropRight(1).toSeq
+      CodeBlock(lines: _*)
+    })
+  }
+
+  private val headingParser: Parser[Heading] = {
+    val delimParser = leadHspaces0 ~ CharsWhileIn("=", 1).!
+    P(
+      // heading delimiter
+      delimParser.flatMap { delim =>
+        val level = delim.length
+        if (level > numberOfSupportedHeadingLevels) Fail
+        else {
+          val title = (!delim ~ AnyChar).rep(1)
+          // Heading description and delimiter
+          (title.! ~/ delim ~/ &(nl)).map(x => Heading(level, x.trim))
+        }
+      }
+    )
+  }
+
+  private val linkParser: Parser[Link] = {
+    val end = space | linkSuffix
+    val anchor = P((!end ~ AnyChar).rep(1).!.rep(1, sep = spaces1))
+    val pattern = linkPrefix ~ anchor ~ linkSuffix
+    P(pattern.map(x => Link(x.head, x.tail.toSeq: _*)))
+  }
+
+  private val textParser: Parser[Text] = {
+    val anotherBeg = P(hspaces0 ~/ (CharIn("@=") | (codePrefix ~ nl) | listPrefix))
+    val end = P(End | nl ~/ anotherBeg)
+    val part: Parser[TextPart] = P(codeExprParser | linkParser | wordParser)
+    val sep = P(!end ~ nlHspaces1)
+    val text = hspaces0 ~ part.rep(1, sep = sep)
+    P(text.map(x => Text(x.toSeq: _*)))
+  }
+
+  private val trailTextParser: Parser[Text] = P(nlHspaces1 ~ textParser)
+  private val leadTextParser: Parser[Text] = P(leadHspaces0 ~ textParser)
+
+  private val tagParser: Parser[Tag] = {
+    val tagTypeMap = TagType.predefined.map(x => x.tag -> x).toMap
+    def getParserByTag(tag: String): Parser[Tag] = {
+      val tagTypeOpt = tagTypeMap.get(tag)
+      tagTypeOpt.fold[Parser[Tag]] {
+        trailTextParser.map { desc => Tag(TagType.UnknownTag(tag), desc = desc) }
+      } { tagType =>
+        (tagType.hasLabel, tagType.hasDesc) match {
+          case (false, false) => PassWith(Tag(tagType))
+          case (false, true) => trailTextParser.map(x => Tag(tagType, desc = x))
+          case (true, false) => trailWordParser.map(x => Tag(tagType, label = x))
+          case (true, true) =>
+            (trailWordParser ~ trailTextParser).map {
+              case (label, desc) => Tag(tagType, label, desc)
+            }
+        }
+      }
+    }
+    val tagLabelParser = P(("@" ~/ labelParser).!)
+    P(leadHspaces0 ~ tagLabelParser.flatMap(getParserByTag))
+  }
+
+  private def listBlockParser(minIndent: Int = 1): Parser[ListBlock] = {
+    val listParser = (hspacesMinWithLen(minIndent) ~ listPrefix.! ~ hspaces0).flatMap {
+      case (indent, prefix) =>
+        val sep = (nl ~ hspacesMinWithLen(indent) ~ prefix).flatMap { x =>
+          if (x != indent) Fail else Pass
+        }
+        (textParser ~ listBlockParser(indent + 1).?)
+          .map { case (desc, list) => ListItem(desc, list) }
+          .rep(1, sep = sep)
+          .map(x => ListBlock(prefix, x.toSeq: _*))
+    }
+    P(startOrNl ~ listParser)
+  }
+
+  /** Contains all scaladoc parsers */
+  private val parser: Parser[collection.Seq[Term]] = {
+    val allParsers = Seq(
+      listBlockParser(),
+      codeBlockParser,
+      headingParser,
+      tagParser,
+      leadTextParser // keep at the end, this is the fallback
+    )
+    P(allParsers.reduce(_ | _).rep(1) ~/ End)
+  }
+
+  private val scaladocLine = Pattern.compile("^[ \t]*\\**(.*?)[ \t]*$")
+
+  /** Parses a scaladoc comment */
+  def parse(comment: String): Option[Scaladoc] = {
+    val isScaladoc = comment.startsWith("/**") && comment.endsWith("*/")
+    if (!isScaladoc) None
+    else Some(parseImpl(comment.substring(3, comment.length - 2)))
+  }
+
+  private def parseImpl(comment: String): Scaladoc = {
+    val sb = new java.lang.StringBuilder
+    val res = Seq.newBuilder[Scaladoc.Paragraph]
+    def flush: Unit =
+      if (sb.length() != 0) {
+        val paragraph = sb.toString
+        sb.setLength(0)
+        parser.parse(paragraph) match {
+          case p: Parsed.Success[collection.Seq[Scaladoc.Term]] =>
+            if (p.value.nonEmpty)
+              res += Scaladoc.Paragraph(p.value.toSeq: _*)
+          case _ =>
+            res += Scaladoc.Paragraph(Unknown(paragraph))
+        }
+      }
+
+    comment.linesIterator.foreach { line =>
+      val matcher = scaladocLine.matcher(line)
+      matcher.matches() // shouldn always match
+      val beg = matcher.start(1)
+      val end = matcher.end(1)
+      if (beg == end) flush
+      else {
+        if (sb.length() != 0) sb.append('\n')
+        sb.append(line, beg, end)
+      }
+    }
+    flush
+    Scaladoc(res.result(): _*)
+  }
+
+}

--- a/scalameta/testkit/src/test/scala/scala/meta/tests/contrib/ScaladocParserPropsSuite.scala
+++ b/scalameta/testkit/src/test/scala/scala/meta/tests/contrib/ScaladocParserPropsSuite.scala
@@ -1,0 +1,23 @@
+package scala.meta.tests.contrib
+
+import scala.meta._
+import scala.meta.internal.parsers.ScaladocParser
+import scala.meta.testkit._
+import scala.util.Try
+
+import munit.FunSuite
+
+class ScaladocParserPropsSuite extends FunSuite {
+
+  test("parser does not crash") {
+    val errors = SyntaxAnalysis.onParsed[Tree](ContribSuite.corpus) { ast =>
+      val failed = ast.tokens.toList.exists {
+        case c: Token.Comment => Try(ScaladocParser.parse(c)).isFailure
+        case _ => false
+      }
+      if (failed) List(ast) else Nil
+    }
+    assert(errors.isEmpty)
+  }
+
+}

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/Scaladoc.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/Scaladoc.scala
@@ -1,0 +1,205 @@
+package scala.meta.internal
+
+/** The full document */
+final case class Scaladoc(para: Scaladoc.Paragraph*)
+
+/**
+ * The available tokens and their documentation are obtained from:
+ * @see http://docs.scala-lang.org/overviews/scaladoc/for-library-authors.html
+ */
+object Scaladoc {
+
+  sealed abstract class Term
+
+  /** A single paragraph of the document */
+  final case class Paragraph(term: Term*)
+
+  /** A paragraph which failed parsing */
+  final case class Unknown(text: String) extends Term
+
+  /* Text */
+
+  /** An inline part of a text block */
+  trait TextPart {
+    def syntax: String
+  }
+
+  /** A description or other inline text block */
+  final case class Text(parts: TextPart*) extends Term
+
+  /** A single word, without whitespace */
+  final case class Word(value: String) extends TextPart {
+    override def syntax: String = value
+  }
+
+  /** A reference to a symbol */
+  final case class Link(ref: String, anchor: String*) extends TextPart {
+    override def syntax: String = anchor.mkString(s"[[$ref", " ", "]]")
+  }
+
+  /** A single embedded code expression */
+  final case class CodeExpr(code: String) extends TextPart {
+    override def syntax: String = s"{{{$code}}}"
+  }
+
+  /** A block of one or more lines of code */
+  final case class CodeBlock(code: String*) extends Term
+
+  /** A heading */
+  final case class Heading(level: Int, title: String) extends Term
+
+  /* List blocks */
+
+  /** Represents a list item */
+  final case class ListItem(text: Text, nested: Option[ListBlock] = None)
+
+  /** Represents a list block */
+  final case class ListBlock(prefix: String, items: ListItem*) extends Term
+
+  /* Tags */
+
+  // https://docs.scala-lang.org/overviews/scaladoc/for-library-authors.html#tags
+  sealed abstract class TagType(
+      val tag: String,
+      val hasLabel: Boolean = false,
+      val hasDesc: Boolean = false
+  )
+
+  /**
+   * Represents a tagged documentation remark
+   * @param label set iff [[tag.hasLabel]]
+   * @param desc set iff [[tag.hasDesc]]
+   */
+  final case class Tag(tag: TagType, label: Word = null, desc: Text = null) extends Term
+
+  object TagType {
+
+    type Base = TagType
+
+    /** Represents an unknown tag */
+    final case class UnknownTag(override val tag: String) extends Base(tag, hasDesc = true)
+
+    /* Class specific tags */
+
+    /** Placed in the class comment will describe the primary constructor */
+    case object Ctor extends Base("@constructor", hasDesc = true)
+
+    /* Method specific tags */
+
+    /** Detail the return value from a method */
+    case object Return extends Base("@return", hasDesc = true)
+
+    /* Method, Constructor and/or Class tags */
+
+    /** What exceptions (if any) the method or constructor may throw */
+    case object Throws extends Base("@throws", hasDesc = true)
+
+    /** Detail a value parameter for a method or constructor */
+    case object Param extends Base("@param", hasLabel = true, hasDesc = true)
+
+    /** Detail a type parameter for a method, constructor or class */
+    case object TypeParam extends Base("@tparam", hasLabel = true, hasDesc = true)
+
+    /* Usage tags */
+
+    /**
+     * Reference other sources of information like external document links or
+     * related entities in the documentation
+     */
+    case object See extends Base("@see", hasDesc = true)
+
+    /** Add a note for pre or post conditions, or any other notable restrictions or expectations */
+    case object Note extends Base("@note", hasDesc = true)
+
+    /** Provide example code and related descriptions. */
+    case object Example extends Base("@example", hasDesc = true)
+
+    /**
+     * Provide a simplified method definition for when the full method definition is too complex
+     * or noisy
+     */
+    case object UseCase extends Base("@usecase", hasDesc = true)
+
+    /* Member grouping tags */
+
+    /** Mark the entity as member of a group */
+    case object Group extends Base("@group", hasLabel = true)
+
+    /** Provide an optional name for the group */
+    case object GroupName extends Base("@groupname", hasLabel = true, hasDesc = true)
+
+    /** Add optional descriptive text to display under the group name */
+    case object GroupDesc extends Base("@groupdesc", hasLabel = true, hasDesc = true)
+
+    /** Control the order of the group on the page */
+    case object GroupPriority extends Base("@groupprio", hasLabel = true, hasDesc = true)
+
+    /* Diagram tags */
+
+    // @contentDiagram
+    // @inheritanceDiagram
+
+    /* Other tags */
+
+    /** Provide author information for the following entity */
+    case object Author extends Base("@author", hasDesc = true)
+
+    /** The version of the system or API that this entity is a part of */
+    case object Version extends Base("@version", hasDesc = true)
+
+    /** The version of the system or API that this entity was first defined in */
+    case object Since extends Base("@since", hasDesc = true)
+
+    /** Documents unimplemented features in an entity */
+    case object Todo extends Base("@todo", hasDesc = true)
+
+    /** Marks an entity as deprecated, describing replacement implementation */
+    case object Deprecated extends Base("@deprecated", hasDesc = true)
+
+    /**
+     * Like [[Deprecated]] but provides advanced warning of
+     * planned changes ahead of deprecation.
+     */
+    case object Migration extends Base("@migration", hasDesc = true)
+
+    /** Take comments from a superclass as defaults if comments are not provided locally */
+    case object InheritDoc extends Base("@inheritdoc")
+
+    /** Expand a type alias and abstract type into a full template page */
+    case object Documentable extends Base("@documentable", hasDesc = true)
+
+    /* Macros tags */
+    // @define <name> <definition>
+
+    /* 2.12 tags */
+    // @shortDescription
+    // @hideImplicitConversion
+
+    /** Contains all unknown tags */
+    val predefined: Seq[Base] = Seq(
+      Ctor,
+      Return,
+      Throws,
+      Param,
+      TypeParam,
+      See,
+      Note,
+      Example,
+      UseCase,
+      Group,
+      GroupName,
+      GroupDesc,
+      GroupPriority,
+      Author,
+      Version,
+      Since,
+      Todo,
+      Deprecated,
+      Migration,
+      InheritDoc,
+      Documentable
+    )
+
+  }
+
+}

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
@@ -1,0 +1,452 @@
+package scala.meta.tests.parsers
+
+import scala.meta.internal.Scaladoc
+import scala.meta.internal.Scaladoc._
+import scala.meta.internal.parsers.ScaladocParser
+
+import munit.FunSuite
+
+/**
+ * Test for [[ScaladocParser]]
+ */
+class ScaladocParserSuite extends FunSuite {
+
+  private def parseString(comment: String) =
+    ScaladocParser.parse(comment.trim)
+
+  private def generateTestString(tagType: TagType): String = {
+    val sb = new StringBuilder
+    sb.append(tagType.tag)
+    if (tagType.hasLabel) sb.append(" TestLabel")
+    if (tagType.hasDesc) sb.append("\n *  Test Description")
+    sb.result()
+  }
+
+  test("example usage") {
+    assertEquals(
+      parseString("/** Example scaladoc */"),
+      Some(Scaladoc(Paragraph(Text(Word("Example"), Word("scaladoc")))))
+    )
+  }
+
+  test("indentation checks") {
+
+    val expectedBody: String = "BODY"
+    val expectedBodyToken = Text(Word(expectedBody))
+
+    assertEquals(
+      parseString(s"/** $expectedBody*/"),
+      Some(Scaladoc(Paragraph(expectedBodyToken)))
+    )
+    assertEquals(
+      parseString(
+        s"""
+         /** $expectedBody
+          */
+         """
+      ),
+      Some(Scaladoc(Paragraph(expectedBodyToken)))
+    )
+    assertEquals(
+      parseString(
+        s"""
+         /**       $expectedBody
+          */
+         """
+      ),
+      Some(Scaladoc(Paragraph(expectedBodyToken)))
+    )
+    assertEquals(
+      parseString(
+        s"""
+         /**
+          *$expectedBody
+          */
+         """
+      ),
+      Some(Scaladoc(Paragraph(expectedBodyToken)))
+    )
+  }
+
+  test("paragraph parsing") {
+    val descriptionBody = "Description Body"
+    val words = descriptionBody.split("\\s+").map(Word.apply)
+    assertEquals(
+      parseString(
+        s"""
+         /**
+          *
+          *$descriptionBody
+          *
+          *$descriptionBody
+          *
+          */
+         """
+      ),
+      Option(
+        Scaladoc(
+          Paragraph(Text(words: _*)),
+          Paragraph(Text(words: _*))
+        )
+      )
+    )
+  }
+
+  test("paragraph parsing with leading space") {
+    val descriptionBody = "Description Body"
+    val words = descriptionBody.split("\\s+").map(Word.apply)
+    assertEquals(
+      parseString(
+        s"""
+         /**
+          *
+          * $descriptionBody
+          *
+          * $descriptionBody
+          *
+          */
+         """
+      ),
+      Option(
+        Scaladoc(
+          Paragraph(Text(words: _*)),
+          Paragraph(Text(words: _*))
+        )
+      )
+    )
+  }
+
+  test("paragraph parsing with references") {
+    val descriptionBody = "Description Body"
+    val words = descriptionBody.split("\\s+").toSeq.map(Word.apply)
+    val ref = Seq(Link("Description", "Body"))
+    assertEquals(
+      parseString(
+        s"""
+         /**
+          *
+          * $descriptionBody [[ $descriptionBody ]]
+          *
+          * $descriptionBody [[ $descriptionBody ]]
+          * $descriptionBody
+          *
+          * [[ $descriptionBody ]] $descriptionBody
+          *
+          * $descriptionBody
+          * [[ $descriptionBody ]] $descriptionBody
+          *
+          */
+         """
+      ),
+      Option(
+        Scaladoc(
+          Paragraph(Text(words ++ ref: _*)),
+          Paragraph(Text(words ++ ref ++ words: _*)),
+          Paragraph(Text(ref ++ words: _*)),
+          Paragraph(Text(words ++ ref ++ words: _*))
+        )
+      )
+    )
+  }
+
+  test("code blocks") {
+
+    val testDescription = "This is a codeblock:"
+    val words: Seq[Word] = testDescription.split("\\s+").map(Word.apply)
+
+    val codeBlock1 = "\"HELLO MARIANO\""
+    val codeBlock2 = "\"HELLO SORAYA\""
+    val complexCodeBlock = // keep all newlines and leading spaces
+      """|  ggmqwogmwogmqwomgq
+         |    val x = 1 // sdfdfh
+         |   // zzz
+         |   gmqwgoiqmgoqmwomw""".stripMargin.split("\n")
+    val complexCodeBlockAsComment = complexCodeBlock.mkString("\n *")
+
+    val result =
+      parseString(
+        s"""
+          /**
+            * $testDescription {{{ $codeBlock1 }}}
+            * $testDescription
+            * {{{ $codeBlock2 }}}
+            *
+            * $testDescription
+            *
+            * {{{
+            *$complexCodeBlockAsComment
+            * }}}
+            * {{{
+            *$complexCodeBlockAsComment }}}
+            */
+       """.stripMargin
+      )
+
+    val expectation = Option(
+      Scaladoc(
+        Paragraph(Text((words :+ CodeExpr(codeBlock1)) ++ (words :+ CodeExpr(codeBlock2)): _*)),
+        Paragraph(Text(words: _*)),
+        Paragraph(CodeBlock(complexCodeBlock: _*), CodeBlock(complexCodeBlock: _*))
+      )
+    )
+    assertEquals(result, expectation)
+  }
+
+  test("headings") {
+    val level1HeadingBody = "Level 1"
+    val level2HeadingBody = "Level 2"
+    val level3HeadingBody = "Level 3"
+    val level4HeadingBody = "Level 4"
+    val level5HeadingBody = "Level 5"
+    val level6HeadingBody = "Level 6"
+    val bad1 = "=======7isTooMuch======="
+    val bad2 = "======6left,5right====="
+    val bad3 = "=====5left,5right=====debris"
+    val bad4 = "debris=====5left,5right====="
+
+    val result =
+      parseString(
+        s"""
+        /**
+          * =$level1HeadingBody=
+          * ==$level2HeadingBody==
+          * ===$level3HeadingBody===
+          * ====$level4HeadingBody====
+          * =====$level5HeadingBody=====
+          * ======$level6HeadingBody======
+          * $bad1
+          * $bad2
+          * $bad3
+          * $bad4
+          */
+         """
+      )
+    val expectation = Option(
+      Scaladoc(
+        Paragraph(
+          Heading(1, level1HeadingBody),
+          Heading(2, level2HeadingBody),
+          Heading(3, level3HeadingBody),
+          Heading(4, level4HeadingBody),
+          Heading(5, level5HeadingBody),
+          Heading(6, level6HeadingBody),
+          Text(Word(bad1)),
+          Text(Word(bad2)),
+          Text(Word(bad3), Word(bad4))
+        )
+      )
+    )
+    assertEquals(result, expectation)
+  }
+
+  test("lists 1") {
+    val list11 = "List11"
+    val list12 = "List12"
+    val list21 = "List21"
+    val list22 = "List22"
+
+    val result =
+      parseString(
+        s"""
+        /**
+          * Some text:
+          * - $list11
+          *    1. $list21
+          * - $list12
+          *    a. $list21
+          *    a. $list22
+          */
+         """
+      )
+    val expected = Option(
+      Scaladoc(
+        Paragraph(
+          Text(Word("Some"), Word("text:")),
+          ListBlock(
+            "-",
+            ListItem(Text(Word(list11)), Some(ListBlock("1.", ListItem(Text(Word(list21)))))),
+            ListItem(
+              Text(Word(list12)),
+              Some(ListBlock("a.", ListItem(Text(Word(list21))), ListItem(Text(Word(list22)))))
+            )
+          )
+        )
+      )
+    )
+    assertEquals(result, expected)
+  }
+
+  test("lists 2") {
+    val list11 = "List11"
+    val list12 = "List12"
+    val list21 = "List21"
+    val list22 = "List22"
+    val list31 = "List31"
+    val list32 = "List32"
+
+    val result =
+      parseString(
+        s"""
+        /**
+          * Some text:
+          * 1. $list11
+          *  i. $list21
+          *   I. $list31
+          * - $list12
+          *  I. $list22
+          *   I. $list32
+          */
+         """
+      )
+    val expected = Option(
+      Scaladoc(
+        Paragraph(
+          Text(Word("Some"), Word("text:")),
+          ListBlock(
+            "1.",
+            ListItem(
+              Text(Word(list11)),
+              Some(
+                ListBlock(
+                  "i.",
+                  ListItem(Text(Word(list21)), Some(ListBlock("I.", ListItem(Text(Word(list31))))))
+                )
+              )
+            )
+          ),
+          ListBlock(
+            "-",
+            ListItem(
+              Text(Word(list12)),
+              Some(
+                ListBlock(
+                  "I.",
+                  ListItem(Text(Word(list22)), Some(ListBlock("I.", ListItem(Text(Word(list32))))))
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    assertEquals(result, expected)
+  }
+
+  test("lists 3") {
+    val list11 = "List11"
+    val list12 = "List12"
+    val list21 = "List21"
+
+    val result =
+      parseString(
+        s"""
+        /**
+          * Some text:
+          * - $list11
+          * $list11
+          *    - $list21
+          * - $list12
+          */
+         """
+      )
+    val expected = Option(
+      Scaladoc(
+        Paragraph(
+          Text(Word("Some"), Word("text:")),
+          ListBlock(
+            "-",
+            ListItem(
+              Text(Word(list11), Word(list11)),
+              Some(ListBlock("-", ListItem(Text(Word(list21)))))
+            ),
+            ListItem(Text(Word(list12)))
+          )
+        )
+      )
+    )
+    assertEquals(result, expected)
+  }
+
+  test("label parsing/merging") {
+    val testStringToMerge = "Test DocText"
+    val scaladoc: String = TagType.predefined
+      .flatMap(token => List(generateTestString(token), testStringToMerge))
+      .mkString("/** ", "\n * ", " */")
+    val words = testStringToMerge.split("\\s+").map(Word.apply).toSeq
+
+    val parsedScaladoc = parseString(scaladoc)
+
+    val expectedCount = TagType.predefined.length + TagType.predefined.count(!_.hasDesc)
+    assertEquals(parsedScaladoc.map(_.para.length), Option(1))
+    assertEquals(parsedScaladoc.map(_.para.head.term.length), Option(expectedCount))
+
+    // Inherit doc does not merge
+    parsedScaladoc.foreach {
+      _.para.head.term.foreach {
+        case t: Tag if t.tag.hasDesc =>
+          assertEquals(t.desc.parts.takeRight(words.length), words)
+        case _ =>
+      }
+    }
+  }
+
+  test("parse tag") {
+    assertEquals(
+      parseString(
+        s"""
+         /**
+          * @param foo
+          * bar-baz
+          */
+         """
+      ),
+      Option(Scaladoc(Paragraph(Tag(TagType.Param, Word("foo"), Text(Word("bar-baz"))))))
+    )
+  }
+
+  test("failing to parse 1") {
+    assertEquals(
+      parseString(
+        """
+         /**
+          * @param
+          */
+         """
+      ),
+      Option(Scaladoc(Paragraph(Unknown(" @param"))))
+    )
+  }
+
+  test("failing to parse 2") {
+    assertEquals(
+      parseString(
+        """
+         /**
+          * @param
+          * @return
+          */
+         """
+      ),
+      Option(Scaladoc(Paragraph(Unknown(" @param\n @return"))))
+    )
+  }
+
+  test("using an unrecognized tag") {
+    assertEquals(
+      parseString(
+        """
+         /**
+          * @newtag
+          * newtag text
+          */
+         """
+      ),
+      Option(
+        Scaladoc(
+          Paragraph(Tag(TagType.UnknownTag("@newtag"), desc = Text(Word("newtag"), Word("text"))))
+        )
+      )
+    )
+  }
+
+}


### PR DESCRIPTION
The existing `DocToken`/`ScaladocParser` pair is missing support for list blocks and has incomplete support for tags.

To avoid breaking any existing usage, propose creating a new pair of classes, to add the missing support. Also, as the code is already using a sophisticated parsing library, let's add more structure into the tokens.

Needed in order to address:
https://github.com/scalameta/scalafmt/issues/891
https://github.com/scalameta/scalafmt/issues/1387
