### PR TITLE
Scaladoc: relax restrictions on text matching

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
@@ -94,7 +94,7 @@ object ScaladocParser {
   }
 
   private val trailTextParser: Parser[Text] = P(nlHspaces1 ~ textParser)
-  private val leadTextParser: Parser[Text] = P(leadHspaces0 ~ textParser)
+  private val leadTextParser: Parser[Text] = P((Start | space) ~ hspaces0 ~ textParser)
 
   private val tagParser: Parser[Tag] = {
     val tagTypeMap = TagType.predefined.map(x => x.tag -> x).toMap

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
@@ -367,6 +367,32 @@ class ScaladocParserSuite extends FunSuite {
     assertEquals(result, expected)
   }
 
+  test("lists 4") {
+    val list11 = "List11"
+    val list12 = "List12"
+
+    val result =
+      parseString(
+        s"""
+        /**
+          * @inheritdoc Some text:
+          * 1. $list11
+          * - $list12
+          */
+         """
+      )
+    val expected = Option(
+      Scaladoc(
+        Paragraph(
+          Unknown(""" @inheritdoc Some text:
+                    | 1. List11
+                    | - List12""".stripMargin)
+        )
+      )
+    )
+    assertEquals(result, expected)
+  }
+
   test("label parsing/merging") {
     val testStringToMerge = "Test DocText"
     val scaladoc: String = TagType.predefined

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
@@ -384,9 +384,10 @@ class ScaladocParserSuite extends FunSuite {
     val expected = Option(
       Scaladoc(
         Paragraph(
-          Unknown(""" @inheritdoc Some text:
-                    | 1. List11
-                    | - List12""".stripMargin)
+          Tag(TagType.InheritDoc),
+          Text(Word("Some"), Word("text:")),
+          ListBlock("1.", ListItem(Text(Word(list11)))),
+          ListBlock("-", ListItem(Text(Word(list12))))
         )
       )
     )


### PR DESCRIPTION
To avoid potentially valid structure being parsed as `Unknown`.