### PR TITLE
Add repository/homepage so users can reach scalameta pages

### DIFF
--- a/scalameta/parsers/js/npm/package.json
+++ b/scalameta/parsers/js/npm/package.json
@@ -8,6 +8,11 @@
   "scripts": {
     "prepublish": "export current=$PWD && cd ../../../.. && sbt parsersJS/fullOptJS && cd $current && cp ../target/scala-2.12/parsers-opt.js index.js"
   },
+  "homepage": "https://scalameta.org/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/scalameta/scalameta"
+  },
   "author": "scalameta",
   "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
Currently, the npm page of `scalameta-parsers` has no links to repository/homepage.
This PR adds them, so users can reach to repo/homepage.

Example:
![image](https://user-images.githubusercontent.com/127635/82791974-9d10b180-9ea9-11ea-972e-093a71629069.png)
