### PR TITLE
Fix asserting trees equality and update sbt-munit 0.7.7

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -24,6 +24,6 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.0.1")
 
 addSbtPlugin("org.scala-debugger" % "sbt-jdi-tools" % "1.1.1")
 
-addSbtPlugin("org.scalameta" % "sbt-munit" % "0.7.5")
+addSbtPlugin("org.scalameta" % "sbt-munit" % "0.7.7")
 
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.0")

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/VarargParameterSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/VarargParameterSuite.scala
@@ -117,7 +117,9 @@ class VarargParameterSuite extends ParseSuite {
   }
 
   private def check(definition: String, expected: scala.meta.Stat): Unit = {
-    assertEquals(templStat(definition), expected)
+    val obtained = templStat(definition)
+    assertNoDiff(obtained.structure, expected.structure)
+    assertNoDiff(obtained.syntax, expected.syntax)
   }
 
   private def checkError(definition: String, expected: String): Unit = {


### PR DESCRIPTION
in newest munit `assertEquals` requires objects to be equal by '=='. This is not the case for tree structures. 
Assertion changed to only assert `.structure` and `.syntax`

Also update munit which superseedes this PR by scala-steward: https://github.com/scalameta/scalameta/pull/2055