### PR TITLE
Scaladoc: require space after list prefix

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
@@ -17,6 +17,7 @@ object ScaladocParser {
   private val hspaceChars = "\t\r "
   private def hspacesMin(min: Int) = CharsWhileIn(hspaceChars, min)
   private val hspaces0 = hspacesMin(0)
+  private val hspaces1 = hspacesMin(1)
   private def hspacesMinWithLen(min: Int): Parser[Int] =
     (Index ~ hspacesMin(min) ~ Index).map { case (b, e) => e - b }
 
@@ -119,9 +120,9 @@ object ScaladocParser {
   }
 
   private def listBlockParser(minIndent: Int = 1): Parser[ListBlock] = {
-    val listParser = (hspacesMinWithLen(minIndent) ~ listPrefix.! ~ hspaces0).flatMap {
+    val listParser = (hspacesMinWithLen(minIndent) ~ listPrefix.! ~ hspaces1).flatMap {
       case (indent, prefix) =>
-        val sep = (nl ~ hspacesMinWithLen(indent) ~ prefix).flatMap { x =>
+        val sep = (nl ~ hspacesMinWithLen(indent) ~ prefix ~ hspaces1).flatMap { x =>
           if (x != indent) Fail else Pass
         }
         (textParser ~ listBlockParser(indent + 1).?)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
@@ -394,6 +394,26 @@ class ScaladocParserSuite extends FunSuite {
     assertEquals(result, expected)
   }
 
+  test("lists 5") {
+    // looks like list but isn't
+    val result = parseString(
+      """
+        /**
+          * -5
+          *
+          * 1.0%
+          */
+         """
+    )
+    val expected = Option(
+      Scaladoc(
+        Paragraph(Text(Word("-5"))),
+        Paragraph(Text(Word("1.0%")))
+      )
+    )
+    assertEquals(result, expected)
+  }
+
   test("label parsing/merging") {
     val testStringToMerge = "Test DocText"
     val scaladoc: String = TagType.predefined


### PR DESCRIPTION
Otherwise, we get false positives.