### PR TITLE
Scaladoc: relax parsing, to avoid unknown

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
@@ -72,7 +72,7 @@ object ScaladocParser {
         else {
           val title = (!delim ~ AnyChar).rep(1)
           // Heading description and delimiter
-          (title.! ~/ delim ~/ &(nl)).map(x => Heading(level, x.trim))
+          (title.! ~ delim ~ &(nl)).map(x => Heading(level, x.trim))
         }
       }
     )
@@ -115,7 +115,7 @@ object ScaladocParser {
         }
       }
     }
-    val tagLabelParser = P(("@" ~/ labelParser).!)
+    val tagLabelParser = P(("@" ~ labelParser).!)
     P(leadHspaces0 ~ tagLabelParser.flatMap(getParserByTag))
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
@@ -437,6 +437,62 @@ class ScaladocParserSuite extends FunSuite {
     }
   }
 
+  test("tags valid then invalid") {
+    val result = parseString(
+      """
+          /** @param foo - bar baz
+            * @return
+            */
+       """.stripMargin
+    )
+
+    val expectation = Option(
+      Scaladoc(
+        Paragraph(
+          Tag(TagType.Param, Word("foo"), Text(Word("-"), Word("bar"), Word("baz"))),
+          Text(Word("@return"))
+        )
+      )
+    )
+    assertEquals(result, expectation)
+  }
+
+  test("known tag looks like list") {
+    val result = parseString(
+      """
+          /** @param foo
+            *   - bar baz
+            */
+       """.stripMargin
+    )
+
+    val expectation = Option(
+      Scaladoc(
+        Paragraph(Tag(TagType.Param, Word("foo"), Text(Word("-"), Word("bar"), Word("baz"))))
+      )
+    )
+    assertEquals(result, expectation)
+  }
+
+  test("unknown tag looks like list") {
+    val result = parseString(
+      """
+          /** @foo
+            *   - bar baz
+            */
+       """.stripMargin
+    )
+
+    val expectation = Option(
+      Scaladoc(
+        Paragraph(
+          Tag(TagType.UnknownTag("@foo"), null, Text(Word("-"), Word("bar"), Word("baz")))
+        )
+      )
+    )
+    assertEquals(result, expectation)
+  }
+
   test("parse tag") {
     assertEquals(
       parseString(
@@ -460,7 +516,7 @@ class ScaladocParserSuite extends FunSuite {
           */
          """
       ),
-      Option(Scaladoc(Paragraph(Unknown(" @param"))))
+      Option(Scaladoc(Paragraph(Text(Word("@param")))))
     )
   }
 
@@ -474,7 +530,7 @@ class ScaladocParserSuite extends FunSuite {
           */
          """
       ),
-      Option(Scaladoc(Paragraph(Unknown(" @param\n @return"))))
+      Option(Scaladoc(Paragraph(Text(Word("@param")), Text(Word("@return")))))
     )
   }
 


### PR DESCRIPTION
If one element is incorrectly parsed, the entire passage is returned as
rather than having it partially valid.