### PR TITLE
keep a reference to the semanticdb reporter

### DIFF
--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/HijackReporter.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/HijackReporter.scala
@@ -2,14 +2,15 @@ package scala.meta.internal.semanticdb.scalac
 
 trait HijackReporter { self: SemanticdbPlugin =>
 
-  def hijackReporter(): Unit = {
-    if (!isSupportedCompiler) return
+  def hijackReporter(): Option[SemanticdbReporter] = {
+    if (!isSupportedCompiler) return None
 
     g.reporter match {
-      case _: SemanticdbReporter => // do nothing, already hijacked
+      case reporter: SemanticdbReporter => Some(reporter) // do nothing, already hijacked
       case underlying =>
         val semanticdbReporter = new SemanticdbReporter(underlying)
         g.reporter = semanticdbReporter
+        Some(semanticdbReporter)
     }
   }
 }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/ReporterOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/ReporterOps.scala
@@ -5,12 +5,14 @@ import scala.tools.nsc.reporters.StoreReporter
 import scala.reflect.internal.util.{Position => gPosition}
 
 trait ReporterOps { self: SemanticdbOps =>
+  val semanticdbReporter: Option[SemanticdbReporter] = None
+
   // Hack, keep track of how many messages we have returns for each path to avoid
   // duplicate messages. The key is System.identityHashCode to keep memory usage low.
   private val returnedMessagesByPath = mutable.Map.empty[g.CompilationUnit, Int]
   implicit class XtensionCompilationUnitReporter(unit: g.CompilationUnit) {
     def hijackedDiagnostics: List[(gPosition, Int, String)] = {
-      g.reporter match {
+      semanticdbReporter.getOrElse(g.reporter) match {
         case r: StoreReporter =>
           object RelevantMessage {
             def unapply(info: r.Info): Option[(gPosition, Int, String)] = {

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SemanticdbPlugin.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SemanticdbPlugin.scala
@@ -1,6 +1,5 @@
 package scala.meta.internal.semanticdb.scalac
 
-import java.io.File
 import scala.meta.internal.io.PathIO
 import scala.meta.io.AbsolutePath
 import scala.tools.nsc.Global
@@ -13,7 +12,8 @@ class SemanticdbPlugin(val global: Global)
   val name = SemanticdbPlugin.name
   val description = SemanticdbPlugin.description
 
-  hijackReporter()
+  override val semanticdbReporter = hijackReporter()
+
   val components = {
     if (isSupportedCompiler) List(SemanticdbTyperComponent, SemanticdbJvmComponent)
     else Nil


### PR DESCRIPTION
Keep a reference to the reporter we're overriding. Other compiler plugins (silencer compiler plugin) can change the reporter and we're not guaranteed that it will be a StoreReporter. We can end up in a situation where the reporter is replaced and the messages aren't passed to the underlying reporter or ignored.

---
We (@laughedelic and myself) discovered this issue when I tried to use the silencer plugin in combination with scalafix. Both compiler plugins swap out the reporter with there own but pass the messages to the underlying reporter.