### PR TITLE
Fix issue with a match expression in an if statement

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -233,7 +233,7 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
             else '\u21d2' :: sepRegions
           } else if (curr.is[RightBrace]) {
             var sepRegions1 = sepRegions
-            while (!sepRegions1.isEmpty && (sepRegions1.head != '}' || sepRegions1.head != '$'))
+            while (!sepRegions1.isEmpty && (sepRegions1.head != '}' && sepRegions1.head != '$'))
               sepRegions1 = sepRegions1.tail
             if (!sepRegions1.isEmpty) sepRegions1 = sepRegions1.tail
             sepRegions1

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -168,6 +168,39 @@ class TermSuite extends ParseSuite {
     val iff @ If(Lit(true), Lit(true), Lit(())) = term("if (true) true")
   }
 
+  test("if (true && '' match...") {
+    val file =
+      """|
+         |if (
+         |  true && ("" match {
+         |    case other ⇒ true
+         |  })
+         |  && true
+         |) ""
+         |""".stripMargin
+
+    val Term.If(
+      Term.ApplyInfix(
+        Term.ApplyInfix(
+          Lit.Boolean(true),
+          Term.Name("&&"),
+          Nil,
+          List(
+            Term.Match(
+              Lit.String(""),
+              List(Case(Pat.Var(Term.Name("other")), None, Lit.Boolean(true)))
+            )
+          )
+        ),
+        Term.Name("&&"),
+        Nil,
+        List(Lit.Boolean(true))
+      ),
+      Lit.String(""),
+      Lit.Unit()
+    ) = term(file)
+  }
+
   test("() => x") {
     val Term.Function(Nil, Term.Name("x")) = term("() => x")
     val Term.Function(Nil, Term.Name("x")) = blockStat("() => x")


### PR DESCRIPTION
Found the issue while testing inside Metals. The code is a bit convoluted around the separate regions part, but in essence  the condition was wrong.

`sepRegions1.head != '}' || sepRegions1.head != '$'` will always be true, which was the issue.