### PR TITLE
Fix given and TypeLambdaArrow being identifier in scala2

### DIFF
--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
@@ -127,6 +127,11 @@ class LegacyScanner(input: Input, dialect: Dialect) {
 
         if (token == ENUM && !dialect.allowEnums)
           token = IDENTIFIER
+        if (token == GIVEN && !dialect.allowGivenUsing)
+          token = IDENTIFIER
+        if (token == TYPELAMBDAARROW && !dialect.allowTypeLambdas)
+          token = IDENTIFIER
+
       }
       if (token == IDENTIFIER && name.startsWith("$") && dialect.allowWhiteboxMacro) {
         strVal = name.stripPrefix("$")
@@ -720,8 +725,14 @@ class LegacyScanner(input: Input, dialect: Dialect) {
           cbuf.clear()
           if (kw2legacytoken contains next.name) {
             next.token = kw2legacytoken(next.name)
+
             if (next.token == ENUM && !dialect.allowEnums)
               next.token = IDENTIFIER
+            if (next.token == GIVEN && !dialect.allowGivenUsing)
+              next.token = IDENTIFIER
+            if (next.token == TYPELAMBDAARROW && !dialect.allowTypeLambdas)
+              next.token = IDENTIFIER
+
             if (next.token != IDENTIFIER && next.token != THIS)
               syntaxError("invalid unquote: `$'ident, `$'BlockExpr, `$'this or `$'_ expected", at = offset)
           }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/Scala213Suite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/Scala213Suite.scala
@@ -14,4 +14,21 @@ class Scala213Suite extends ParseSuite {
     )
   }
 
+  test("identifier-types") {
+    // "x" is a class with def =>>(x: Int): Int, in dotty ==> is keyword and it will be error here
+    assertNoDiff(
+      templStat("val c = x =>> 3").structure,
+      """Defn.Val(Nil, List(Pat.Var(Term.Name("c"))), None, Term.ApplyInfix(Term.Name("x"), Term.Name("=>>"), Nil, List(Lit.Int(3))))"""
+    )
+
+    assertNoDiff(
+      templStat("val given = 3").structure,
+      """Defn.Val(Nil, List(Pat.Var(Term.Name("given"))), None, Lit.Int(3))"""
+    )
+
+    assertNoDiff(
+      templStat("val enum = 3").structure,
+      """Defn.Val(Nil, List(Pat.Var(Term.Name("enum"))), None, Lit.Int(3))"""
+    )
+  }
 }


### PR DESCRIPTION
Given and TypeLambdaArrow were interpreted as KW.
Enum was handled already ok. Applied the same rules to Given and TypeLambdaArrow as they were for enum.

Only Given and TypeLambdaArrow were introduced as new dotty KW in my dotty PR.

Fixes #2083 
