### PR TITLE
Fix #2106 - properly escape non-letter non-ascii characters

### DIFF
--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/prettyprinters/Enquote.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/prettyprinters/Enquote.scala
@@ -25,7 +25,9 @@ object enquote {
         case '\'' if style eq SingleQuotes =>
           sb.append("\\\'")
         case c =>
-          sb.append(c)
+          val isNonReadableAscii = c < ' ' || c > '~'
+          if (isNonReadableAscii && !Character.isLetter(c)) sb.append("\\u%04x".format(c.toInt))
+          else sb.append(c)
       }
     }
     sb.append(style.toString)

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -924,8 +924,22 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     checkTree(q"""x _""", "x _")
   }
 
-  def checkTree(original: Tree, expected: String): Unit = {
-    assert(original.syntax == expected)
-    assert(original.structure == (expected.parse[Stat]).get.structure)
+  test("#2106 unicode characters are properly escaped in string literals") {
+    checkTree(Lit.String("xy\u001az"), "\"xy\\u001az\"")
+    checkTree(Lit.String("þæö"), "\"þæö\"")
+    checkTree(Lit.String(">"), "\">\"")
+    checkTree(Lit.String("~"), "\"~\"")
+    checkTree(Lit.String(" "), "\" \"")
+    checkTree(Lit.String("="), "\"=\"")
+    checkTree(Lit.String("\u007f"), "\"\\u007f\"")
+    checkTree(Lit.String("\u001f"), "\"\\u001f\"")
+    checkTree(Lit.String("\\"), "\"\\\\\"")
+    checkTree(Lit.String("\u00fe\u00e6\u00f6"), "\"þæö\"")
+    checkTree(Lit.String("ラーメン"), "\"ラーメン\"")
+  }
+
+  def checkTree(original: Tree, expected: String)(implicit loc: munit.Location): Unit = {
+    assertNoDiff(original.syntax, expected)
+    assertNoDiff(original.structure, expected.parse[Stat].get.structure)
   }
 }


### PR DESCRIPTION
Previously, the pretty printer incorrectly escaped characters in
string literals like `Lit.String("xy\u001az")`. Now, we format
these characters with the correct unicode escapes.