### PR TITLE
ThisType should only occur when actually in the code

### DIFF
--- a/semanticdb/integration/src/main/scala/example/Issue2116.scala
+++ b/semanticdb/integration/src/main/scala/example/Issue2116.scala
@@ -1,0 +1,22 @@
+// See https://github.com/scalameta/scalameta/issues/2116
+package example
+
+import scala.concurrent.ExecutionContext
+
+abstract class Issue2116 {
+
+  def check(
+      includeDocs: Boolean = false,
+      includeCommitCharacter: Boolean = false
+  )(implicit loc: ExecutionContext): Unit = {}
+}
+
+class Issue2116_2 extends Issue2116 {
+
+  implicit val ec = scala.concurrent.ExecutionContext.global
+
+  check(
+    includeCommitCharacter = true
+  )
+
+}

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
@@ -315,10 +315,6 @@ trait TextDocumentOps { self: SemanticdbOps =>
             val gstart = gtree.pos.start
             val gpoint = gtree.pos.point
             val gend = gtree.pos.end
-            gtree match {
-              case _: g.ValDef | _: g.DefDef =>
-              case _ =>
-            }
 
             tryNamedArg(gtree, gstart, gpoint)
 
@@ -378,7 +374,8 @@ trait TextDocumentOps { self: SemanticdbOps =>
                 tryMstart(gpoint)
               case gtree: g.DefTree =>
                 tryMstart(gpoint)
-              case gtree: g.This =>
+              case gtree: g.This
+                  if mstarts.get(gpoint).exists(name => gsym.nameString == name.value) =>
                 tryMstart(gpoint)
               case gtree: g.Super =>
                 tryMend(gend - 1)

--- a/tests/jvm/src/test/resources/example/Classes.scala
+++ b/tests/jvm/src/test/resources/example/Classes.scala
@@ -14,7 +14,7 @@ object M/*<=classes.M.*/ {
   implicit class C5/*<=classes.M.C5#*/(x/*<=classes.M.C5#x.*/: Int/*=>scala.Int#*/)
 }
 
-case class C6/*<=classes.C6#*/(private val x/*<=classes.C6#*/: Int/*=>scala.Int#*/)
+case class C6/*<=classes.C6#*/(private val x/*<=classes.C6#x.*/: Int/*=>scala.Int#*/)
 
 class C7/*<=classes.C7#*/(x/*<=classes.C7#x.*/: Int/*=>scala.Int#*/)
 

--- a/tests/jvm/src/test/resources/example/Issue2116.scala
+++ b/tests/jvm/src/test/resources/example/Issue2116.scala
@@ -1,0 +1,22 @@
+// See https://github.com/scalameta/scalameta/issues/2116
+package example
+
+import scala.concurrent.ExecutionContext/*=>scala.concurrent.ExecutionContext.*//*=>scala.concurrent.ExecutionContext#*/
+
+abstract class Issue2116/*<=example.Issue2116#*/ {
+
+  def check/*<=example.Issue2116#check().*/(
+      includeDocs/*<=example.Issue2116#check().(includeDocs)*/: Boolean/*=>scala.Boolean#*/ = false,
+      includeCommitCharacter/*<=example.Issue2116#check().(includeCommitCharacter)*/: Boolean/*=>scala.Boolean#*/ = false
+  )(implicit loc/*<=example.Issue2116#check().(loc)*/: ExecutionContext/*=>scala.concurrent.ExecutionContext#*/): Unit/*=>scala.Unit#*/ = {}
+}
+
+class Issue2116_2/*<=example.Issue2116_2#*/ extends Issue2116/*=>example.Issue2116#*/ {
+
+  implicit val ec/*<=example.Issue2116_2#ec.*/ = scala.concurrent.ExecutionContext/*=>scala.concurrent.ExecutionContext.*/.global/*=>scala.concurrent.ExecutionContext.global().*/
+
+  check/*=>example.Issue2116#check().*/(
+    includeCommitCharacter/*=>example.Issue2116#check().(includeCommitCharacter)*/ = true
+  )
+
+}

--- a/tests/jvm/src/test/resources/metac-metacp.diff
+++ b/tests/jvm/src/test/resources/metac-metacp.diff
@@ -283,6 +283,30 @@ example/InstrumentTyper#existential().
                          display_name: "T"
 
 
+====================================
+example/Issue2116#check$default$1().
+====================================
+--- metac
++++ metacp
+         annotations {
+           tpe {
+-            type_ref {
+-              prefix {
+-              symbol: "scala/annotation/unchecked/uncheckedVariance#"
+
+
+====================================
+example/Issue2116#check$default$2().
+====================================
+--- metac
++++ metacp
+         annotations {
+           tpe {
+-            type_ref {
+-              prefix {
+-              symbol: "scala/annotation/unchecked/uncheckedVariance#"
+
+
 =========================
 example/Methods#m13().(x)
 =========================

--- a/tests/jvm/src/test/resources/metac.expect
+++ b/tests/jvm/src/test/resources/metac.expect
@@ -907,7 +907,7 @@ Occurrences:
 [13:23..13:26): Int => scala/Int#
 [16:11..16:13): C6 <= classes/C6#
 [16:13..16:13):  <= classes/C6#`<init>`().
-[16:26..16:27): x <= classes/C6#
+[16:26..16:27): x <= classes/C6#x.
 [16:29..16:32): Int => scala/Int#
 [18:6..18:8): C7 <= classes/C7#
 [18:8..18:8):  <= classes/C7#`<init>`().
@@ -2104,6 +2104,78 @@ Synthetics:
 [30:4..30:5): i => convertToAnyShouldWrapper(*)(default)
   convertToAnyShouldWrapper => example/Issue2040.BarSpec#convertToAnyShouldWrapper().
   default => example/Issue2040.Prettifier.default.
+
+semanticdb/integration/src/main/scala/example/Issue2116.scala
+-------------------------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => semanticdb/integration/src/main/scala/example/Issue2116.scala
+Text => non-empty
+Language => Scala
+Symbols => 13 entries
+Occurrences => 26 entries
+
+Symbols:
+example/Issue2116# => abstract class Issue2116 extends AnyRef { +4 decls }
+  AnyRef => scala/AnyRef#
+example/Issue2116#`<init>`(). => primary ctor <init>()
+example/Issue2116#check$default$1(). => method check$default$1: Boolean @uncheckedVariance
+  Boolean => scala/Boolean#
+  uncheckedVariance => scala/annotation/unchecked/uncheckedVariance#
+example/Issue2116#check$default$2(). => method check$default$2: Boolean @uncheckedVariance
+  Boolean => scala/Boolean#
+  uncheckedVariance => scala/annotation/unchecked/uncheckedVariance#
+example/Issue2116#check(). => method check(includeDocs: Boolean, includeCommitCharacter: Boolean)(implicit loc: ExecutionContext): Unit
+  includeDocs => example/Issue2116#check().(includeDocs)
+  Boolean => scala/Boolean#
+  includeCommitCharacter => example/Issue2116#check().(includeCommitCharacter)
+  loc => example/Issue2116#check().(loc)
+  ExecutionContext => scala/concurrent/ExecutionContext#
+  Unit => scala/Unit#
+example/Issue2116#check().(includeCommitCharacter) => default param includeCommitCharacter: Boolean
+  Boolean => scala/Boolean#
+example/Issue2116#check().(includeDocs) => default param includeDocs: Boolean
+  Boolean => scala/Boolean#
+example/Issue2116#check().(loc) => implicit param loc: ExecutionContext
+  ExecutionContext => scala/concurrent/ExecutionContext#
+example/Issue2116_2# => class Issue2116_2 extends Issue2116 { +2 decls }
+  Issue2116 => example/Issue2116#
+example/Issue2116_2#`<init>`(). => primary ctor <init>()
+example/Issue2116_2#ec. => implicit val method ec: ExecutionContextExecutor
+  ExecutionContextExecutor => scala/concurrent/ExecutionContextExecutor#
+local0 => val local x$1: Boolean
+  Boolean => scala/Boolean#
+local1 => val local x$2: Boolean
+  Boolean => scala/Boolean#
+
+Occurrences:
+[1:8..1:15): example <= example/
+[3:7..3:12): scala => scala/
+[3:13..3:23): concurrent => scala/concurrent/
+[3:24..3:40): ExecutionContext => scala/concurrent/ExecutionContext#
+[3:24..3:40): ExecutionContext => scala/concurrent/ExecutionContext.
+[5:15..5:24): Issue2116 <= example/Issue2116#
+[5:25..5:25):  <= example/Issue2116#`<init>`().
+[7:6..7:11): check <= example/Issue2116#check().
+[8:6..8:17): includeDocs <= example/Issue2116#check().(includeDocs)
+[8:19..8:26): Boolean => scala/Boolean#
+[9:6..9:28): includeCommitCharacter <= example/Issue2116#check().(includeCommitCharacter)
+[9:30..9:37): Boolean => scala/Boolean#
+[10:13..10:16): loc <= example/Issue2116#check().(loc)
+[10:18..10:34): ExecutionContext => scala/concurrent/ExecutionContext#
+[10:37..10:41): Unit => scala/Unit#
+[13:6..13:17): Issue2116_2 <= example/Issue2116_2#
+[13:18..13:18):  <= example/Issue2116_2#`<init>`().
+[13:26..13:35): Issue2116 => example/Issue2116#
+[13:36..13:36):  => example/Issue2116#`<init>`().
+[15:15..15:17): ec <= example/Issue2116_2#ec.
+[15:20..15:25): scala => scala/
+[15:26..15:36): concurrent => scala/concurrent/
+[15:37..15:53): ExecutionContext => scala/concurrent/ExecutionContext.
+[15:54..15:60): global => scala/concurrent/ExecutionContext.global().
+[17:2..17:7): check => example/Issue2116#check().
+[18:4..18:26): includeCommitCharacter => example/Issue2116#check().(includeCommitCharacter)
 
 semanticdb/integration/src/main/scala/example/local-file.scala
 --------------------------------------------------------------

--- a/tests/jvm/src/test/resources/metacp.expect
+++ b/tests/jvm/src/test/resources/metacp.expect
@@ -1933,6 +1933,55 @@ example/Issue2040.Prettifier. => final object Prettifier extends AnyRef { +1 dec
 example/Issue2040.Prettifier.default. => implicit val method default: Prettifier
   Prettifier => example/Issue2040.Prettifier#
 
+example/Issue2116.class
+-----------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => example/Issue2116.class
+Text => empty
+Language => Scala
+Symbols => 8 entries
+
+Symbols:
+example/Issue2116# => abstract class Issue2116 extends AnyRef { +4 decls }
+  AnyRef => scala/AnyRef#
+example/Issue2116#`<init>`(). => primary ctor <init>()
+example/Issue2116#check$default$1(). => method check$default$1: Boolean @<?>
+  Boolean => scala/Boolean#
+example/Issue2116#check$default$2(). => method check$default$2: Boolean @<?>
+  Boolean => scala/Boolean#
+example/Issue2116#check(). => method check(includeDocs: Boolean, includeCommitCharacter: Boolean)(implicit loc: ExecutionContext): Unit
+  includeDocs => example/Issue2116#check().(includeDocs)
+  Boolean => scala/Boolean#
+  includeCommitCharacter => example/Issue2116#check().(includeCommitCharacter)
+  loc => example/Issue2116#check().(loc)
+  ExecutionContext => scala/concurrent/ExecutionContext#
+  Unit => scala/Unit#
+example/Issue2116#check().(includeCommitCharacter) => default param includeCommitCharacter: Boolean
+  Boolean => scala/Boolean#
+example/Issue2116#check().(includeDocs) => default param includeDocs: Boolean
+  Boolean => scala/Boolean#
+example/Issue2116#check().(loc) => implicit param loc: ExecutionContext
+  ExecutionContext => scala/concurrent/ExecutionContext#
+
+example/Issue2116_2.class
+-------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => example/Issue2116_2.class
+Text => empty
+Language => Scala
+Symbols => 3 entries
+
+Symbols:
+example/Issue2116_2# => class Issue2116_2 extends Issue2116 { +2 decls }
+  Issue2116 => example/Issue2116#
+example/Issue2116_2#`<init>`(). => primary ctor <init>()
+example/Issue2116_2#ec. => implicit val method ec: ExecutionContextExecutor
+  ExecutionContextExecutor => scala/concurrent/ExecutionContextExecutor#
+
 example/local$minusfile.class
 -----------------------------
 


### PR DESCRIPTION
Fixes https://github.com/scalameta/scalameta/issues/2116

Looks like we are getting ThisType sometimes on class members, but I am no 100% sure where is that coming from or sure about the solution. IS it possible to better check if ThisType is not actually synthetic and actually exits in the code?