### PR TITLE
Add option for additional binary compatible fields and add derives

### DIFF
--- a/community-test/src/test/scala/CommunityDottySuite.scala
+++ b/community-test/src/test/scala/CommunityDottySuite.scala
@@ -176,7 +176,9 @@ class CommunityDottySuite extends FunSuite {
     "compiler/src/dotty/tools/dotc/transform/Splicer.scala",
     // match <indent> case => match <indent> case => (match in match indented)
     "tools/dotc/semanticdb/ExtractSemanticDB.scala",
-    "doc-tool/test/dotty/tools/dottydoc/GenDocs.scala" // +: ^"^-project" +: "Dotty"
+    "doc-tool/test/dotty/tools/dottydoc/GenDocs.scala", // +: ^"^-project" +: "Dotty"
+    // Not fixable
+    "tools/dotc/typer/Implicits.scala" // if without then but using significant identation
   )
 
   final def munitExclusionList = List(

--- a/community-test/src/test/scala/CommunityDottySuite.scala
+++ b/community-test/src/test/scala/CommunityDottySuite.scala
@@ -148,16 +148,6 @@ class CommunityDottySuite extends FunSuite {
   }
 
   final def dottyExclusionList = List(
-    // 'trait X derives Y' - not supported currently
-    "/tools/dotc/core/Names.scala",
-    "tools/dotc/semanticdb/TextDocuments.scala",
-    "tools/dotc/semanticdb/TextDocument.scala",
-    "tools/dotc/semanticdb/Range.scala",
-    "/tools/dotc/semanticdb/SymbolOccurrence.scala",
-    "tools/dotc/semanticdb/Scala3.scala",
-    "tools/dotc/semanticdb/Schema.scala",
-    "tools/dotc/semanticdb/SymbolInformation.scala",
-    "tools/dotc/semanticdb/Language.scala",
     // 'type T' - as statement in block, rejected by tree check
     "library/src-bootstrapped/scala/quoted/util/ExprMap.scala",
     // '[t] => t => F[t]'  - polymorphic functions - not supported currently

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -30,6 +30,8 @@ object Mima {
     ProblemFilters.exclude[MissingClassProblem]("scala.meta.testkit.DiffAssertions"),
     ProblemFilters.exclude[MissingClassProblem]("scala.meta.testkit.DiffAssertions$DiffFailure"),
     ProblemFilters.exclude[MissingClassProblem]("scala.meta.testkit.DiffAssertions$DiffFailure$"),
-    ProblemFilters.exclude[MissingTypesProblem]("scala.meta.testkit.DiffAssertions")
+    ProblemFilters.exclude[MissingTypesProblem]("scala.meta.testkit.DiffAssertions"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.meta.Template.getDerives"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.meta.Template.setDerives")
   )
 }

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -31,7 +31,7 @@ object Mima {
     ProblemFilters.exclude[MissingClassProblem]("scala.meta.testkit.DiffAssertions$DiffFailure"),
     ProblemFilters.exclude[MissingClassProblem]("scala.meta.testkit.DiffAssertions$DiffFailure$"),
     ProblemFilters.exclude[MissingTypesProblem]("scala.meta.testkit.DiffAssertions"),
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.meta.Template.getDerives"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.meta.Template.derives"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.meta.Template.setDerives")
   )
 }

--- a/scalameta/common/shared/src/main/scala/org/scalameta/adt/Reflection.scala
+++ b/scalameta/common/shared/src/main/scala/org/scalameta/adt/Reflection.scala
@@ -121,7 +121,8 @@ trait Reflection {
     override def toString = s"leaf $prefix"
   }
   class Field(val sym: Symbol) {
-    if (!sym.isField) sys.error(s"$sym is not a field")
+    if (!sym.isField && !sym.hasAnnotation[AstMetadata.binaryCompatField])
+      sys.error(s"$sym is not a field")
     def owner: Leaf = sym.owner.asLeaf
     def name: TermName = TermName(sym.name.toString.stripPrefix("_"))
     def tpe: Type = sym.info.finalResultType

--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/NamerMacros.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/NamerMacros.scala
@@ -70,10 +70,10 @@ trait CommonNamerMacros extends MacroHelpers {
     })
     qstats += q"def copy(...$qcopyParamss): $name = ${stub()}"
 
-    val extraAbtractStubs = extraAbtractDefs.collect { case vr: DefDef =>
+    val extraAbstractStubs = extraAbtractDefs.collect { case vr: DefDef =>
       q"def ${vr.name} (...${vr.vparamss}) =  ${stub()} "
     }
-    qstats ++= extraAbtractStubs
+    qstats ++= extraAbstractStubs
 
     q"$qmods class $qname(rank: $IntClass, tree: $TreeClass) extends ..$qparents { ..$qstats }"
   }

--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/NamerMacros.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/NamerMacros.scala
@@ -38,6 +38,7 @@ trait CommonNamerMacros extends MacroHelpers {
       name: TypeName,
       parents: List[Tree],
       paramss: List[List[ValDef]],
+      extraAbtractDefs: List[Tree],
       extraStubs: String*
   ): ClassDef = {
     val qmods = Modifiers(NoFlags, TypeName("meta"), List(q"new $AstAnnotation"))
@@ -68,6 +69,11 @@ trait CommonNamerMacros extends MacroHelpers {
       q"val $name: $tpt = this.$name"
     })
     qstats += q"def copy(...$qcopyParamss): $name = ${stub()}"
+
+    val extraAbtractStubs = extraAbtractDefs.collect { case vr: DefDef =>
+      q"def ${vr.name} (...${vr.vparamss}) =  ${stub()} "
+    }
+    qstats ++= extraAbtractStubs
 
     q"$qmods class $qname(rank: $IntClass, tree: $TreeClass) extends ..$qparents { ..$qstats }"
   }

--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/branch.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/branch.scala
@@ -36,7 +36,7 @@ class BranchNamerMacros(val c: Context) extends AstReflection with CommonNamerMa
         mstats1 += q"$CommonTyperMacrosModule.hierarchyCheck[$name]"
         val anns1 = anns :+ q"new $AdtMetadataModule.branch" :+ q"new $AstMetadataModule.branch"
         mstats1 ++= mkClassifier(name)
-        if (!isQuasi) mstats1 += mkQuasi(name, parents, Nil, "value", "name", "tpe")
+        if (!isQuasi) mstats1 += mkQuasi(name, parents, Nil, Nil, "value", "name", "tpe")
 
         val cdef1 =
           q"${Modifiers(flags1, privateWithin, anns1)} trait $name[..$tparams] extends { ..$earlydefns } with ..$parents { $self => ..$stats1 }"

--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/metadata.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/metadata.scala
@@ -11,6 +11,7 @@ object Metadata {
   class root extends StaticAnnotation
   class branch extends StaticAnnotation
   class astClass extends StaticAnnotation
+  class binaryCompatField extends StaticAnnotation
   class astCompanion extends StaticAnnotation
   @getter class astField extends StaticAnnotation
   @getter class auxiliary extends StaticAnnotation

--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/root.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/root.scala
@@ -37,7 +37,7 @@ class RootNamerMacros(val c: Context) extends AstReflection with CommonNamerMacr
         val parents1 =
           parents :+ tq"$AstMetadataModule.Ast" :+ tq"$ProductClass" :+ tq"$SerializableClass"
         mstats1 ++= mkClassifier(name)
-        mstats1 += mkQuasi(name, Nil, Nil)
+        mstats1 += mkQuasi(name, Nil, Nil, Nil)
 
         val cdef1 =
           q"${Modifiers(flags1, privateWithin, anns1)} trait $name[..$tparams] extends { ..$earlydefns } with ..$parents1 { $self => ..$stats1 }"

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
@@ -109,7 +109,9 @@ final class Dialect private (
     // Dotty allows `as` instead of `@` for pattern bindings
     val allowAsPatternBinding: Boolean,
     // Dotty allows capital pattern vars in `case A @ _ =>`
-    val allowUpperCasePatternVarBinding: Boolean
+    val allowUpperCasePatternVarBinding: Boolean,
+    // Dotty allows to use derives to automatically generate given instances for type classes
+    val allowDerives: Boolean
 ) extends Product with Serializable {
 
   // NOTE(olafur) checklist for adding a new dialect field in a binary compatible way:
@@ -189,7 +191,8 @@ final class Dialect private (
       allowByNameRepeatedParameters = false,
       allowLazyValAbstractValues = false,
       allowAsPatternBinding = false,
-      allowUpperCasePatternVarBinding = false
+      allowUpperCasePatternVarBinding = false,
+      allowDerives = false
       // NOTE(olafur): declare the default value for new fields above this comment.
     )
   }
@@ -336,6 +339,9 @@ final class Dialect private (
   def withAllowUpperCasePatternVarBinding(newValue: Boolean): Dialect = {
     privateCopy(allowUpperCasePatternVarBinding = newValue)
   }
+  def withAllowDerives(newValue: Boolean): Dialect = {
+    privateCopy(allowDerives = newValue)
+  }
   // NOTE(olafur): add the next `withX()` method above this comment. Please try
   // to use consistent formatting, use `newValue` as the parameter name and wrap
   // the body inside curly braces.
@@ -386,7 +392,8 @@ final class Dialect private (
       allowByNameRepeatedParameters: Boolean = this.allowByNameRepeatedParameters,
       allowLazyValAbstractValues: Boolean = this.allowLazyValAbstractValues,
       allowAsPatternBinding: Boolean = this.allowAsPatternBinding,
-      allowUpperCasePatternVarBinding: Boolean = this.allowUpperCasePatternVarBinding
+      allowUpperCasePatternVarBinding: Boolean = this.allowUpperCasePatternVarBinding,
+      allowDerives: Boolean = this.allowDerives
       // NOTE(olafur): add the next parameter above this comment.
   ): Dialect = {
     new Dialect(
@@ -434,7 +441,8 @@ final class Dialect private (
       allowByNameRepeatedParameters,
       allowLazyValAbstractValues,
       allowAsPatternBinding,
-      allowUpperCasePatternVarBinding
+      allowUpperCasePatternVarBinding,
+      allowDerives
       // NOTE(olafur): add the next argument above this comment.
     )
   }

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -121,6 +121,7 @@ package object dialects {
     .withAllowLazyValAbstractValues(true)
     .withAllowAsPatternBinding(true)
     .withAllowUpperCasePatternVarBinding(true)
+    .withAllowDerives(true)
 
   private[meta] def QuasiquoteTerm(underlying: Dialect, multiline: Boolean) = {
     require(!underlying.allowUnquotes)

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -4110,15 +4110,13 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
     parents.toList
   }
 
-  def derivesClasses: List[Init] = {
+  def derivesClasses(): List[Type] = {
     if (isSoftKw(token, SoftKeyword.SkDerives) && dialect.allowDerives) {
       next()
-      def isCommaSeparated(token: Token): Boolean =
-        token.is[Comma]
-      val deriving = ListBuffer[Init]()
+      val deriving = ListBuffer[Type]()
       def readInit() = token match {
-        case Ellipsis(_) => deriving += ellipsis(1, astInfo[Init])
-        case _ => deriving += initInsideTemplate()
+        case Ellipsis(_) => deriving += ellipsis(1, astInfo[Type])
+        case _ => deriving += startModType()
       }
       readInit()
       while (token.is[Comma]) { next(); readInit() }
@@ -4134,7 +4132,6 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
     val template = Template(edefs, parents, self, body)
     template.setDerives(derived)
     template
-
   }
 
   def template(afterExtend: Boolean = false): Template = autoPos {
@@ -4538,9 +4535,11 @@ object InfixMode extends Enumeration {
 
 object SoftKeyword {
   sealed trait SoftKeyword { val name: String }
+
   case object SkAs extends SoftKeyword { override val name = "as" }
 
   case object SkUsing extends SoftKeyword { override val name = "using" }
+
   case object SkInline extends SoftKeyword { override val name = "inline" }
 
   case object SkExtension extends SoftKeyword { override val name = "extension" }

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -6,6 +6,7 @@ import scala.meta.inputs._
 import scala.meta.tokens._
 import scala.meta.prettyprinters._
 import scala.meta.internal.trees._
+import scala.meta.internal.trees.Metadata.binaryCompatField
 
 @root trait Tree extends InternalTree {
   def parent: Option[Tree]
@@ -447,6 +448,8 @@ object Ctor {
     self: Self,
     stats: List[Stat]
 ) extends Tree {
+  @binaryCompatField
+  private var derives: List[Init] = Nil
   checkFields(early.forall(_.isEarlyStat && inits.nonEmpty))
   checkFields(stats.forall(_.isTemplateStat))
 }

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -449,7 +449,7 @@ object Ctor {
     stats: List[Stat]
 ) extends Tree {
   @binaryCompatField
-  private var derives: List[Init] = Nil
+  private var _derives: List[Type] = Nil
   checkFields(early.forall(_.isEarlyStat && inits.nonEmpty))
   checkFields(stats.forall(_.isTemplateStat))
 }

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -1032,6 +1032,7 @@ object TreeSyntax {
         else {
           val pearly = if (!t.early.isEmpty) s("{ ", r(t.early, "; "), " } with ") else s()
           val pparents = w(r(t.inits, " with "), " ", !t.inits.isEmpty && !isBodyEmpty)
+          val derived = w("derives ", r(t.getDerives(), ", "), " ", t.getDerives().nonEmpty)
           val pbody = {
             val isOneLiner =
               t.stats.length == 0 ||
@@ -1045,7 +1046,7 @@ object TreeSyntax {
               case (true, stats) => s("{ ", t.self, " =>", r(stats.map(i(_)), ""), n("}"))
             }
           }
-          s(pearly, pparents, pbody)
+          s(pearly, pparents, derived, pbody)
         }
 
       // Mod

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -1032,7 +1032,7 @@ object TreeSyntax {
         else {
           val pearly = if (!t.early.isEmpty) s("{ ", r(t.early, "; "), " } with ") else s()
           val pparents = w(r(t.inits, " with "), " ", !t.inits.isEmpty && !isBodyEmpty)
-          val derived = w("derives ", r(t.getDerives(), ", "), " ", t.getDerives().nonEmpty)
+          val derived = w("derives ", r(t.derives, ", "), " ", t.derives.nonEmpty)
           val pbody = {
             val isOneLiner =
               t.stats.length == 0 ||

--- a/tests/shared/src/test/scala/scala/meta/tests/transversers/TransformerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/transversers/TransformerSuite.scala
@@ -53,4 +53,25 @@ class TransformerSuite extends FunSuite {
     val tree1 = tree0.transform { case Term.Name(s) => Term.Name(s + s) }
     assert(tree1.toString == "xx ++ yy")
   }
+
+  test("dotty-derives-transform") {
+
+    import scala.meta.dialects.Dotty
+
+    val before = "case class Node(name: String) extends Tree derives a.b.OldName { def a = 1 }"
+    val after = "case class Node(name: String) extends Tree derives a.b.NewName { def a = 1 }"
+
+    val beforeTree =
+      before
+        .parse[Source]
+        .get
+
+    val afterTree = beforeTree
+      .transform({ case Type.Name("OldName") =>
+        Type.Name("NewName")
+      })
+
+    assertEquals(afterTree.toString, after)
+
+  }
 }


### PR DESCRIPTION
This adds an additional option to define new fields in existing ast classes, but still make them binary compatible with previous versions.