### PR TITLE
fix-new-catch-case-as-parameter

### DIFF
--- a/community-test/src/test/scala/CommunityDottySuite.scala
+++ b/community-test/src/test/scala/CommunityDottySuite.scala
@@ -168,11 +168,7 @@ class CommunityDottySuite extends FunSuite {
     "src/main/scala/dotty/tools/benchmarks/tuples/Map.scala",
     // erased modifier - for now used internally, will be available in 3.1
     "library/src/scala/compiletime/package.scala",
-    "/tools/dotc/core/Annotations.scala", // (Context ?=> Tree) = (using ctx) => bodyFn(using ctx)
     "/tools/dotc/core/Flags.scala", // val (^Private^ @ _, PrivateTerm @ _, PrivateType @ _) = newFlags
-    "compiler/src/dotty/tools/dotc/util/LinearSet.scala", // ???
-    "/compiler/src/dotty/tools/dotc/util/LinearMap.scala", // ???
-    "src/dotty/tools/dotc/semanticdb/Tools.scala", // ???
 
     // 'val refinTest:  '
     // '  SomeType = X  '  - Type provided in newline - parser needs to handle this
@@ -183,7 +179,6 @@ class CommunityDottySuite extends FunSuite {
     "tools/dotc/core/TypeComparer.scala",
     "/tools/dotc/core/SymDenotations.scala",
     "tools/dotc/core/OrderingConstraint.scala",
-    "tools/dotc/util/SourceFile.scala", // catch case error => sth ^)^
     "tools/dotc/ast/tpd.scala", // comment after extension before def
 
     // for (a, b) <- lst yield ...
@@ -191,8 +186,6 @@ class CommunityDottySuite extends FunSuite {
     "tools/dotc/typer/Checking.scala",
     "compiler/src/dotty/tools/dotc/core/Symbols.scala", // for (tparam ^,^ bound) <- tparams.lazyZip(bounds)
     "compiler/src/dotty/tools/dotc/transform/Splicer.scala",
-    // if () block
-    "compiler/src/dotty/tools/dotc/typer/Implicits.scala",
     // match <indent> case => match <indent> case => (match in match indented)
     "tools/dotc/semanticdb/ExtractSemanticDB.scala",
     "doc-tool/test/dotty/tools/dottydoc/GenDocs.scala" // +: ^"^-project" +: "Dotty"

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -432,12 +432,6 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
     loop(-1, 0, Nil, -1, false)
     val underlying = parserTokens.result
 
-    // underlying.foreach { t =>
-    //   try {
-    //   println(s"TOKEN ${t.name} :: ${t.text}")
-    //   } catch { case e => println(s"TOKEN ERR ${t.name}") }
-    // }
-
     (Tokens(underlying, 0, underlying.length), parserTokenPositions.result)
   }
 

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
@@ -135,6 +135,8 @@ class LegacyScanner(input: Input, dialect: Dialect) {
           token = IDENTIFIER
         if (token == TYPELAMBDAARROW && !dialect.allowTypeLambdas)
           token = IDENTIFIER
+        if (token == CTXARROW && !dialect.allowGivenUsing)
+          token = IDENTIFIER
 
       }
       if (token == IDENTIFIER && name.startsWith("$") && dialect.allowWhiteboxMacro) {
@@ -739,6 +741,8 @@ class LegacyScanner(input: Input, dialect: Dialect) {
             if (next.token == THEN && !dialect.allowSignificantIndentation)
               next.token = IDENTIFIER
             if (next.token == TYPELAMBDAARROW && !dialect.allowTypeLambdas)
+              next.token = IDENTIFIER
+            if (next.token == CTXARROW && !dialect.allowGivenUsing)
               next.token = IDENTIFIER
 
             if (next.token != IDENTIFIER && next.token != THIS)

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyToken.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyToken.scala
@@ -114,6 +114,7 @@ object LegacyToken {
   final val SUPERTYPE = 135
   final val VIEWBOUND = 136
   final val TYPELAMBDAARROW = 137
+  final val CTXARROW = 138
 
   final val WHITESPACE = 201
   final val COMMENT = 300
@@ -172,6 +173,7 @@ object LegacyToken {
     "<:"        -> SUBTYPE,
     "<%"        -> VIEWBOUND,
     "=>>"       -> TYPELAMBDAARROW,
+    "?=>"       -> CTXARROW,
     ">:"        -> SUPERTYPE,
     "#"         -> HASH,
     "@"         -> AT,

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
@@ -126,6 +126,7 @@ class ScalametaTokenizer(input: Input, dialect: Dialect) {
         case SUPERTYPE => Token.Supertype(input, dialect, curr.offset)
         case VIEWBOUND => Token.Viewbound(input, dialect, curr.offset)
         case TYPELAMBDAARROW => Token.TypeLambdaArrow(input, dialect, curr.offset)
+        case CTXARROW => Token.ContextArrow(input, dialect, curr.offset)
 
         case MACROQUOTE => Token.MacroQuote(input, dialect, curr.offset)
         case MACROSPLICE => Token.MacroSplice(input, dialect, curr.offset)

--- a/scalameta/tokens/shared/src/main/scala/scala/meta/tokens/Token.scala
+++ b/scalameta/tokens/shared/src/main/scala/scala/meta/tokens/Token.scala
@@ -85,6 +85,7 @@ object Token {
   @fixed("@") class At extends Token
   @fixed("_") class Underscore extends Token
   @fixed("=>>") class TypeLambdaArrow extends Token
+  @fixed("?=>") class ContextArrow extends Token
   @fixed("'") class MacroQuote extends Token
   @fixed("$") class MacroSplice extends Token
 

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -112,6 +112,18 @@ object Term {
   @ast class Match(expr: Term, cases: List[Case] @nonEmpty) extends Term
   @ast class Try(expr: Term, catchp: List[Case], finallyp: Option[Term]) extends Term
   @ast class TryWithHandler(expr: Term, catchp: Term, finallyp: Option[Term]) extends Term
+  @ast class ContextFunction(params: List[Term.Param], body: Term) extends Term {
+    checkFields(
+      params.forall(param =>
+        param.is[Term.Param.Quasi] ||
+          (param.name.is[scala.meta.Name.Anonymous] ==> param.default.isEmpty)
+      )
+    )
+    checkFields(
+      params.exists(_.is[Term.Param.Quasi]) ||
+        params.exists(_.mods.exists(_.is[Mod.Implicit])) ==> (params.length == 1)
+    )
+  }
   @ast class Function(params: List[Term.Param], body: Term) extends Term {
     checkFields(
       params.forall(param =>
@@ -162,6 +174,7 @@ object Type {
   @ast class Apply(tpe: Type, args: List[Type] @nonEmpty) extends Type
   @ast class ApplyInfix(lhs: Type, op: Name, rhs: Type) extends Type
   @ast class Function(params: List[Type], res: Type) extends Type
+  @ast class ContextFunction(params: List[Type], res: Type) extends Type
   @ast class ImplicitFunction(params: List[Type], res: Type) extends Type
   @ast class Tuple(args: List[Type] @nonEmpty) extends Type {
     checkFields(args.length > 1 || (args.length == 1 && args.head.is[Type.Quasi]))

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -119,10 +119,6 @@ object Term {
           (param.name.is[scala.meta.Name.Anonymous] ==> param.default.isEmpty)
       )
     )
-    checkFields(
-      params.exists(_.is[Term.Param.Quasi]) ||
-        params.exists(_.mods.exists(_.is[Mod.Implicit])) ==> (params.length == 1)
-    )
   }
   @ast class Function(params: List[Term.Param], body: Term) extends Term {
     checkFields(

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -592,7 +592,7 @@ object TreeSyntax {
       case t: Term.ForYield =>
         m(Expr1, s(kw("for"), " (", r(t.enums, "; "), ") ", kw("yield"), " ", t.body))
       case t: Term.New => m(SimpleExpr, s(kw("new"), " ", t.init))
-      case t: Term.EndMarker => s(kw("end"), " ", t.name)
+      case t: Term.EndMarker => s(kw("end"), " ", t.name.value)
       case t: Term.NewAnonymous =>
         val needsExplicitBraces = {
           val selfIsEmpty = t.templ.self.name.is[Name.Anonymous] && t.templ.self.decltpe.isEmpty

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -493,6 +493,41 @@ object TreeSyntax {
               .getOrElse(s())
           )
         )
+      case t: Term.ContextFunction =>
+        t match {
+          case Term.ContextFunction(Term.Param(mods, name: Term.Name, tptopt, _) :: Nil, body)
+              if mods.exists(_.is[Mod.Implicit]) =>
+            m(
+              Expr,
+              s(
+                kw("implicit"),
+                " ",
+                name,
+                tptopt.map(s(kw(":"), " ", _)).getOrElse(s()),
+                " ",
+                kw("?=>"),
+                " ",
+                p(Expr, body)
+              )
+            )
+          case Term.ContextFunction(Term.Param(mods, name: Term.Name, None, _) :: Nil, body) =>
+            m(Expr, s(name, " ", kw("?=>"), " ", p(Expr, body)))
+          case Term.ContextFunction(Term.Param(_, _: Name.Anonymous, decltpeOpt, _) :: Nil, body) =>
+            val param = decltpeOpt match {
+              case Some(decltpe) => s(kw("("), kw("_"), kw(":"), decltpe, kw(")"))
+              case None => s(kw("_"))
+            }
+            m(Expr, param, " ", kw("?=>"), " ", p(Expr, body))
+          case Term.ContextFunction(params, body) =>
+            if (params.headOption.exists(_.mods.exists(_.is[Mod.Using]))) {
+              m(
+                Expr,
+                s("(", kw("using"), " ", r(params, ", "), ") ", kw("?=>"), " ", p(Expr, body))
+              )
+            } else {
+              m(Expr, s("(", r(params, ", "), ") ", kw("?=>"), " ", p(Expr, body)))
+            }
+        }
       case t: Term.Function =>
         t match {
           case Term.Function(Term.Param(mods, name: Term.Name, tptopt, _) :: Nil, body)
@@ -511,7 +546,11 @@ object TreeSyntax {
               )
             )
           case Term.Function(Term.Param(mods, name: Term.Name, None, _) :: Nil, body) =>
-            m(Expr, s(name, " ", kw("=>"), " ", p(Expr, body)))
+            if (mods.exists(_.is[Mod.Using])) {
+              m(Expr, s("(", kw("using"), " ", name, ") ", kw("=>"), " ", p(Expr, body)))
+            } else {
+              m(Expr, s(name, " ", kw("=>"), " ", p(Expr, body)))
+            }
           case Term.Function(Term.Param(_, _: Name.Anonymous, decltpeOpt, _) :: Nil, body) =>
             val param = decltpeOpt match {
               case Some(decltpe) => s(kw("("), kw("_"), kw(":"), decltpe, kw(")"))
@@ -598,16 +637,17 @@ object TreeSyntax {
             p(InfixTyp(t.op.value), t.rhs, right = true)
           )
         )
-      case t @ (_: Type.Function | _: Type.ImplicitFunction) =>
-        val (prefix, tParams, tRes) = t match {
-          case Type.Function(params, res) => (s(), params, res)
-          case Type.ImplicitFunction(params, res) => (s(kw("implicit"), " "), params, res)
+      case t @ (_: Type.Function | _: Type.ImplicitFunction | _: Type.ContextFunction) =>
+        val (prefix, tParams, arrow, tRes) = t match {
+          case Type.Function(params, res) => (s(), params, "=>", res)
+          case Type.ContextFunction(params, res) => (s(), params, "?=>", res)
+          case Type.ImplicitFunction(params, res) => (s(kw("implicit"), " "), params, "=>", res)
         }
         val params = tParams match {
           case param +: Nil if !param.is[Type.Tuple] => s(p(AnyInfixTyp, param))
           case params => s("(", r(params.map(param => p(ParamTyp, param)), ", "), ")")
         }
-        m(Typ, s(prefix, params, " ", kw("=>"), " ", p(Typ, tRes)))
+        m(Typ, s(prefix, params, " ", kw(arrow), " ", p(Typ, tRes)))
       case t: Type.Tuple => m(SimpleTyp, s("(", r(t.args, ", "), ")"))
       case t: Type.With =>
         if (!dialect.allowWithTypes)

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/package.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/package.scala
@@ -113,6 +113,7 @@ package object trees {
       case _: Type.Select => true
       case _: Type.Project => true
       case _: Type.Function => true
+      case _: Type.ContextFunction => true
       case _: Type.Annotate => true
       case _: Type.Apply => true
       case _: Type.ApplyInfix => true

--- a/tests/jvm/src/test/scala-2.12/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.12/scala/meta/tests/api/SurfaceSuite.scala
@@ -310,6 +310,7 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.Term.Ascribe
       |scala.meta.Term.Assign
       |scala.meta.Term.Block
+      |scala.meta.Term.ContextFunction
       |scala.meta.Term.Do
       |scala.meta.Term.EndMarker
       |scala.meta.Term.Eta
@@ -348,6 +349,7 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.Type.ApplyInfix
       |scala.meta.Type.Bounds
       |scala.meta.Type.ByName
+      |scala.meta.Type.ContextFunction
       |scala.meta.Type.Existential
       |scala.meta.Type.Function
       |scala.meta.Type.ImplicitFunction
@@ -390,6 +392,7 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.tokens.Token.Constant.Long
       |scala.meta.tokens.Token.Constant.String
       |scala.meta.tokens.Token.Constant.Symbol
+      |scala.meta.tokens.Token.ContextArrow
       |scala.meta.tokens.Token.Dot
       |scala.meta.tokens.Token.EOF
       |scala.meta.tokens.Token.Equals

--- a/tests/jvm/src/test/scala-2.12/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.12/scala/meta/tests/trees/ReflectionSuite.scala
@@ -21,7 +21,7 @@ class ReflectionSuite extends FunSuite {
   test("root") {
     assert(symbolOf[scala.meta.Tree].isRoot)
     assertEquals(symbolOf[scala.meta.Tree].asRoot.allBranches.length, 19)
-    assertEquals(symbolOf[scala.meta.Tree].asRoot.allLeafs.length, 317)
+    assertEquals(symbolOf[scala.meta.Tree].asRoot.allLeafs.length, 321)
   }
 
   test("If") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -1258,7 +1258,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
                     |  x match {
                     |    case 2 => "ERROR"
                     |  }
-                    |  end `match`
+                    |  end match
                     |}
                     |""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EndMarkerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EndMarkerSuite.scala
@@ -13,6 +13,9 @@ class EndMarkerSuite extends BaseDottySuite {
     runTestAssert[Stat]("end token")(
       Term.EndMarker(Term.Name("token"))
     )
+    runTestAssert[Stat]("end match")(
+      Term.EndMarker(Term.Name("match"))
+    )
   }
 
   test("end-marker-keyword") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
@@ -546,6 +546,17 @@ class GivenUsingSuite extends BaseDottySuite {
       )
     )
 
+    runTestAssert[Stat]("val fun = (using ctx) => ctx.open")(
+      Defn.Val(
+        Nil,
+        List(Pat.Var(Term.Name("fun"))),
+        None,
+        Term.Function(
+          List(Term.Param(List(Mod.Using()), Term.Name("ctx"), None, None)),
+          Term.Select(Term.Name("ctx"), Term.Name("open"))
+        )
+      )
+    )
   }
 
   // ---------------------------------


### PR DESCRIPTION
- try catch as parameter of method :)
- context functions (they are syntactic sugar for given/using that's why hidden under this flag)

ContextFunctions:
https://github.com/lampepfl/dotty/commit/576e535ac5314da253d2a0abb7887b1a02fd4ef9
https://dotty.epfl.ch/docs/reference/contextual/context-functions.html


Sooo unrewarding to implement this and only improve parsing dotty codebase with 1 more file ech