### PR TITLE
Fix if continuation as dot and using lambda

### DIFF
--- a/community-test/src/test/scala/CommunityDottySuite.scala
+++ b/community-test/src/test/scala/CommunityDottySuite.scala
@@ -155,10 +155,6 @@ class CommunityDottySuite extends FunSuite {
     // 'val refinTest:  '
     // '  SomeType = X  '  - Type provided in newline - parser needs to handle this
     "input/src/main/scala/example/level2/Documentation.scala",
-    // if (hi1 & hi2).isEmpty then return orType(tp1, tp2)
-    "tools/dotc/core/TypeComparer.scala",
-    // private val NoSymbolFn = (using _: Context) => NoSymbol
-    "tools/dotc/core/SymDenotations.scala",
     // most likely will become deprecated: if (cond) <ident>
     "tools/dotc/typer/Implicits.scala",
     "tools/dotc/typer/Checking.scala"

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -553,8 +553,11 @@ object TreeSyntax {
             } else {
               m(Expr, s(name, " ", kw("=>"), " ", p(Expr, body)))
             }
-          case Term.Function(Term.Param(_, _: Name.Anonymous, decltpeOpt, _) :: Nil, body) =>
+          case Term.Function(Term.Param(mods, _: Name.Anonymous, decltpeOpt, _) :: Nil, body) =>
+            val isUsing = mods.exists(_.is[Mod.Using])
             val param = decltpeOpt match {
+              case Some(decltpe) if isUsing =>
+                s(kw("("), kw("using"), " ", kw("_"), kw(":"), " ", decltpe, kw(")"))
               case Some(decltpe) => s(kw("("), kw("_"), kw(":"), decltpe, kw(")"))
               case None => s(kw("_"))
             }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -126,6 +126,14 @@ class ControlSyntaxSuite extends BaseDottySuite {
     )
   }
 
+  test("new-if-single3") {
+    val code = "if (cond1).cont then ok"
+    val output = "if (cond1.cont) ok"
+    runTestAssert[Stat](code, assertLayout = Some(output))(
+      Term.If(Term.Select(Term.Name("cond1"), Term.Name("cont")), Term.Name("ok"), Lit.Unit())
+    )
+  }
+
   test("new-if-else-multiple") {
     val code = """|if cond then
                   |  fx1

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
@@ -557,6 +557,18 @@ class GivenUsingSuite extends BaseDottySuite {
         )
       )
     )
+
+    runTestAssert[Stat]("val fun = (using _: Context) => ctx.open")(
+      Defn.Val(
+        Nil,
+        List(Pat.Var(Term.Name("fun"))),
+        None,
+        Term.Function(
+          List(Term.Param(List(Mod.Using()), Name(""), Some(Type.Name("Context")), None)),
+          Term.Select(Term.Name("ctx"), Term.Name("open"))
+        )
+      )
+    )
   }
 
   // ---------------------------------

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -733,6 +733,62 @@ class MinorDottySuite extends BaseDottySuite {
 
   }
 
+  test("catch-end-def") {
+    val layout =
+      """|object X {
+         |  def fx = try {
+         |    action()
+         |  } catch {
+         |    case ex =>
+         |      err()
+         |  }
+         |  private abstract class X()
+         |}
+         |""".stripMargin
+    runTestAssert[Stat](
+      """|object X {
+         |  def fx = try
+         |    action()
+         |  catch case ex => err()
+         |
+         |  private abstract class X()
+         |}
+         |""".stripMargin,
+      assertLayout = Some(layout)
+    )(
+      Defn.Object(
+        Nil,
+        Term.Name("X"),
+        Template(
+          Nil,
+          Nil,
+          Self(Name(""), None),
+          List(
+            Defn.Def(
+              Nil,
+              Term.Name("fx"),
+              Nil,
+              Nil,
+              None,
+              Term.Try(
+                Term.Block(List(Term.Apply(Term.Name("action"), Nil))),
+                List(Case(Pat.Var(Term.Name("ex")), None, Term.Apply(Term.Name("err"), Nil))),
+                None
+              )
+            ),
+            Defn.Class(
+              List(Mod.Private(Name("")), Mod.Abstract()),
+              Type.Name("X"),
+              Nil,
+              Ctor.Primary(Nil, Name(""), List(List())),
+              Template(Nil, Nil, Self(Name(""), None), Nil)
+            )
+          )
+        )
+      )
+    )
+  }
+
   test("type-in-block") {
     runTestAssert[Stat](
       """|def hello = {


### PR DESCRIPTION
- Fix condition checking in if for "." to continue `if (cond).rest then ...`
- Fix lambda with unnamed using `val lbda = (using _: Context) => ...`
- Fix catch case, new-style catch-case supports only expr: `catch case ex => singleExprOnly()`