### PR TITLE
Add additional logic to only add indent on correct colons

### DIFF
--- a/community-test/src/test/scala/CommunityDottySuite.scala
+++ b/community-test/src/test/scala/CommunityDottySuite.scala
@@ -152,9 +152,6 @@ class CommunityDottySuite extends FunSuite {
     "library/src/scala/Tuple.scala",
     // erased modifier - for now used internally, will be available in 3.1
     "library/src/scala/compiletime/package.scala",
-    // 'val refinTest:  '
-    // '  SomeType = X  '  - Type provided in newline - parser needs to handle this
-    "input/src/main/scala/example/level2/Documentation.scala",
     // most likely will become deprecated: if (cond) <ident>
     "tools/dotc/typer/Implicits.scala",
     "tools/dotc/typer/Checking.scala"

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -32,6 +32,11 @@ object Mima {
     ProblemFilters.exclude[MissingClassProblem]("scala.meta.testkit.DiffAssertions$DiffFailure$"),
     ProblemFilters.exclude[MissingTypesProblem]("scala.meta.testkit.DiffAssertions"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.meta.Template.derives"),
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.meta.Template.setDerives")
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.meta.Template.setDerives"),
+    ProblemFilters.exclude[MissingClassProblem](
+      "scala.meta.tokens.Token$ColonEol$sharedClassifier$"
+    ),
+    ProblemFilters.exclude[MissingClassProblem]("scala.meta.tokens.Token$ColonEol"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.meta.tokens.Token$ColonEol$")
   )
 }

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
@@ -117,7 +117,6 @@ class ScalametaTokenizer(input: Input, dialect: Dialect) {
         case COLON => Token.Colon(input, dialect, curr.offset)
         case EQUALS => Token.Equals(input, dialect, curr.offset)
         case AT => Token.At(input, dialect, curr.offset)
-        case COLONEOL => Token.ColonEol(input, dialect, curr.offset)
         case HASH => Token.Hash(input, dialect, curr.offset)
         case USCORE => Token.Underscore(input, dialect, curr.offset)
         case ARROW => Token.RightArrow(input, dialect, curr.offset, curr.endOffset + 1)
@@ -194,16 +193,8 @@ class ScalametaTokenizer(input: Input, dialect: Dialect) {
       def nextToken() = legacyIndex += 1
       if (legacyIndex >= legacyTokens.length) return legacyIndex
 
-      if (dialect.allowSignificantIndentation && curr.token == COLON && aheadIsNewLine(
-          legacyIndex
-        )) {
-        curr.token = COLONEOL
-        emitToken()
-        legacyIndex += 2
-      } else {
-        emitToken()
-        nextToken()
-      }
+      emitToken()
+      nextToken()
 
       // NOTE: need to track this in order to correctly emit SpliceEnd tokens after splices end
       var braceBalance1 = braceBalance

--- a/scalameta/tokens/shared/src/main/scala/scala/meta/tokens/Token.scala
+++ b/scalameta/tokens/shared/src/main/scala/scala/meta/tokens/Token.scala
@@ -75,7 +75,6 @@ object Token {
   // Symbolic keywords
   @fixed("#") class Hash extends Token
   @fixed(":") class Colon extends Token
-  @fixed("colonEol") class ColonEol extends Token
   @fixed("<%") class Viewbound extends Token
   @freeform("<-") class LeftArrow extends Token
   @fixed("<:") class Subtype extends Token

--- a/tests/jvm/src/test/scala-2.12/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.12/scala/meta/tests/api/SurfaceSuite.scala
@@ -384,7 +384,6 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.tokens.Token.BOF
       |scala.meta.tokens.Token.CR
       |scala.meta.tokens.Token.Colon
-      |scala.meta.tokens.Token.ColonEol
       |scala.meta.tokens.Token.Comma
       |scala.meta.tokens.Token.Comment
       |scala.meta.tokens.Token.Constant.Char

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -435,4 +435,249 @@ class SignificantIndentationSuite extends BaseDottySuite {
     )
   }
 
+  test("indent-equals") {
+    runTestAssert[Stat](
+      """|def genApply() = {
+         |      app match {
+         |        case Apply2() =>
+         |          generatedType =
+         |            genTypeApply(t)
+         |
+         |        case Apply() =>
+         |      }
+         |} 
+         |""".stripMargin,
+      assertLayout = Some(
+        """|def genApply() = {
+           |  app match {
+           |    case Apply2() =>
+           |      generatedType = {
+           |        genTypeApply(t)
+           |      }
+           |    case Apply() =>
+           |  }
+           |}
+           |""".stripMargin
+      )
+    )(
+      Defn.Def(
+        Nil,
+        Term.Name("genApply"),
+        Nil,
+        List(List()),
+        None,
+        Term.Block(
+          List(
+            Term.Match(
+              Term.Name("app"),
+              List(
+                Case(
+                  Pat.Extract(Term.Name("Apply2"), Nil),
+                  None,
+                  Term.Assign(
+                    Term.Name("generatedType"),
+                    Term.Block(List(Term.Apply(Term.Name("genTypeApply"), List(Term.Name("t")))))
+                  )
+                ),
+                Case(Pat.Extract(Term.Name("Apply"), Nil), None, Term.Block(Nil))
+              )
+            )
+          )
+        )
+      )
+    )
+  }
+
+  test("outdent-with-prev-check") {
+    runTestAssert[Stat](
+      """|def wrapPlaceholders(t: Tree) = try
+         |    if (placeholderParams.isEmpty) t
+         |    else new WildcardFunction(placeholderParams.reverse, t)
+         |  finally placeholderParams = saved
+         |""".stripMargin,
+      assertLayout = Some(
+        """|def wrapPlaceholders(t: Tree) = try {
+           |  if (placeholderParams.isEmpty) t else new WildcardFunction(placeholderParams.reverse, t)
+           |} finally placeholderParams = saved
+           |""".stripMargin
+      )
+    )(
+      Defn.Def(
+        Nil,
+        Term.Name("wrapPlaceholders"),
+        Nil,
+        List(List(Term.Param(Nil, Term.Name("t"), Some(Type.Name("Tree")), None))),
+        None,
+        Term.Try(
+          Term.Block(
+            List(
+              Term.If(
+                Term.Select(Term.Name("placeholderParams"), Term.Name("isEmpty")),
+                Term.Name("t"),
+                Term.New(
+                  Init(
+                    Type.Name("WildcardFunction"),
+                    Name(""),
+                    List(
+                      List(
+                        Term.Select(Term.Name("placeholderParams"), Term.Name("reverse")),
+                        Term.Name("t")
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          ),
+          Nil,
+          Some(Term.Assign(Term.Name("placeholderParams"), Term.Name("saved")))
+        )
+      )
+    )
+  }
+
+  test("type-in-next-line") {
+    runTestAssert[Stat](
+      """|abstract class Documentation{
+         |
+         |  class Graph {
+         |    type Node = Int
+         |    val a:
+         |      Int = 3
+         |  }
+         |
+         |  val refinementTest:
+         |    Graph {
+         |      def x: Int
+         |    }
+         |
+         |}
+         |""".stripMargin,
+      assertLayout = Some(
+        """|abstract class Documentation {
+           |  class Graph {
+           |    type Node = Int
+           |    val a: Int = 3
+           |  }
+           |  val refinementTest: Graph { def x: Int }
+           |}
+           |""".stripMargin
+      )
+    )(
+      Defn.Class(
+        List(Mod.Abstract()),
+        Type.Name("Documentation"),
+        Nil,
+        Ctor.Primary(Nil, Name(""), Nil),
+        Template(
+          Nil,
+          Nil,
+          Self(Name(""), None),
+          List(
+            Defn.Class(
+              Nil,
+              Type.Name("Graph"),
+              Nil,
+              Ctor.Primary(Nil, Name(""), Nil),
+              Template(
+                Nil,
+                Nil,
+                Self(Name(""), None),
+                List(
+                  Defn.Type(Nil, Type.Name("Node"), Nil, Type.Name("Int")),
+                  Defn.Val(Nil, List(Pat.Var(Term.Name("a"))), Some(Type.Name("Int")), Lit.Int(3))
+                )
+              )
+            ),
+            Decl.Val(
+              Nil,
+              List(Pat.Var(Term.Name("refinementTest"))),
+              Type.Refine(
+                Some(Type.Name("Graph")),
+                List(Decl.Def(Nil, Term.Name("x"), Nil, Nil, Type.Name("Int")))
+              )
+            )
+          )
+        )
+      )
+    )
+  }
+
+  test("type-in-next-line-equals") {
+    runTestAssert[Stat](
+      """|val refinementTest:
+         |      Int = 3
+         |""".stripMargin,
+      assertLayout = Some("val refinementTest: Int = 3")
+    )(
+      Defn.Val(Nil, List(Pat.Var(Term.Name("refinementTest"))), Some(Type.Name("Int")), Lit.Int(3))
+    )
+  }
+
+  test("type-in-next-line-equals-newline") {
+    runTestAssert[Stat](
+      """|val refinementTest:
+         |      Int = 
+         |3
+         |""".stripMargin,
+      assertLayout = Some("val refinementTest: Int = 3")
+    )(
+      Defn.Val(Nil, List(Pat.Var(Term.Name("refinementTest"))), Some(Type.Name("Int")), Lit.Int(3))
+    )
+  }
+
+  test("type-equals-separate") {
+    runTestAssert[Stat](
+      """|def refinementTest(a :
+         |      Int = 
+         |3) = a
+         |""".stripMargin,
+      assertLayout = Some("def refinementTest(a: Int = 3) = a")
+    )(
+      Defn.Def(
+        Nil,
+        Term.Name("refinementTest"),
+        Nil,
+        List(List(Term.Param(Nil, Term.Name("a"), Some(Type.Name("Int")), Some(Lit.Int(3))))),
+        None,
+        Term.Name("a")
+      )
+    )
+  }
+
+  test("type-multi-seq") {
+    runTestAssert[Stat](
+      """|val refinementTest:
+         |    Int = 
+         |  fx
+         |  fy
+         |""".stripMargin,
+      assertLayout = Some("val refinementTest: Int = {\n  fx\n  fy\n}")
+    )(
+      Defn.Val(
+        Nil,
+        List(Pat.Var(Term.Name("refinementTest"))),
+        Some(Type.Name("Int")),
+        Term.Block(List(Term.Name("fx"), Term.Name("fy")))
+      )
+    )
+  }
+
+  test("equals-block") {
+    runTestAssert[Stat](
+      """|val refinementTest:
+         |  Int = 
+         |    fx
+         |    fy
+         |""".stripMargin,
+      assertLayout = Some("val refinementTest: Int = {\n  fx\n  fy\n}")
+    )(
+      Defn.Val(
+        Nil,
+        List(Pat.Var(Term.Name("refinementTest"))),
+        Some(Type.Name("Int")),
+        Term.Block(List(Term.Name("fx"), Term.Name("fy")))
+      )
+    )
+  }
 }


### PR DESCRIPTION
This removes colonEol token, since we can better determine it later while preparing tokens for parsing.

This might cause Mima errors, but will be neccessary for now.