### PR TITLE
Disallow `given as <ident>` syntax

### DIFF
--- a/community-test/src/test/scala/CommunityDottySuite.scala
+++ b/community-test/src/test/scala/CommunityDottySuite.scala
@@ -171,15 +171,16 @@ class CommunityDottySuite extends FunSuite {
   )
 
   final def scala3DocExclusionList = List(
+    // extension will most likely become a keyword
     // [scalameta] extension.getParameters.asScala(extension.get(MethodExtension).parametersListSizes(0))
     "main/scala/dotty/dokka/translators/ScalaSignatureProvider.scala",
-    // [scalameta] issues already fix with colonEol
-    "main/scala/example/level2/Documentation.scala",
-    // Below syntax is no longer valid
-    // val result: List[Int] = fmap[F = List, A = Int, B = Int](List(1,2,3))(i => i + 1)
+    // Below syntax is no longer valid:
+    // - val result: List[Int] = fmap[F = List, A = Int, B = Int](List(1,2,3))(i => i + 1)
     "main/scala/NamedTypeArguments.scala",
-    // def (s: String).doesntStartWithAnyOfThese(c: Char*) = c.forall(char => !s.startsWith(char.toString))
-    "test/scala/dotty/dokka/DottyTestRunner.scala"
+    // - def (s: String).doesntStartWithAnyOfThese(c: Char*) = c.forall(char => !s.startsWith(char.toString))
+    "test/scala/dotty/dokka/DottyTestRunner.scala",
+    // - given as Context = ctx
+    "main/scala/dotty/tools/dottydoc/Main.scala"
   )
 
   final val ignoreParts = List(

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -3782,7 +3782,7 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
 
     val forked = in.fork
     val name: meta.Name =
-      if (token.is[Ident] && !isSoftKw(token, SkAs)) typeName() else anonymousName
+      if (token.is[Ident]) typeName() else anonymousName
     val tparams = typeParamClauseOpt(
       ownerIsType = false,
       ctxBoundsAllowed = true,

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
@@ -56,8 +56,9 @@ class GivenUsingSuite extends BaseDottySuite {
   }
 
   test("given-anon-as") {
-    runTestAssert[Stat]("given as Context = ctx", assertLayout = Some("given Context = ctx"))(
-      Defn.GivenAlias(Nil, Name(""), Nil, Nil, Type.Name("Context"), Term.Name("ctx"))
+    runTestError(
+      "given as Context = ctx",
+      "; expected but identifier found"
     )
   }
 


### PR DESCRIPTION
Based on https://github.com/lampepfl/dotty/pull/10089