### PR TITLE
Use type in givens, which makes working on the tree easier

### DIFF
--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -72,6 +72,20 @@ object Mima {
     ),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.meta.Importee#Given.importee"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.meta.Importee#Given.copy"),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "scala.meta.Importee#Given#ImporteeGivenImpl._importee"
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "scala.meta.Importee#Given#ImporteeGivenImpl._importee_="
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "scala.meta.Importee#Given#ImporteeGivenImpl.importee"
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "scala.meta.Importee#Given#Quasi#ImporteeGivenQuasiImpl.importee"
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.meta.Importee#Given.importee"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.meta.Importee#Given.tpe"),
     ProblemFilters.exclude[MissingClassProblem]("scala.meta.Defn$OpaqueTypeAlias$Quasi"),
     ProblemFilters.exclude[MissingClassProblem](
       "scala.meta.Defn$OpaqueTypeAlias$Quasi$sharedClassifier$"

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -3696,9 +3696,7 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
     } else if (token.is[KwGiven]) {
       next();
       if (token.is[Ident])
-        Importee.Given(
-          typeParam(ownerIsType = false, ctxBoundsAllowed = true, allowUnderscore = true)
-        )
+        Importee.Given(typ())
       else Importee.GivenAll()
     } else if (token.is[Unquote]) Importee.Name(unquote[Name.Quasi])
     else {

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -501,7 +501,7 @@ object Enumerator {
 @branch trait Importee extends Tree with Ref
 object Importee {
   @ast class Wildcard() extends Importee
-  @ast class Given(importee: Type.Param) extends Importee
+  @ast class Given(tpe: Type) extends Importee
   @ast class GivenAll() extends Importee
   @ast class Name(name: scala.meta.Name) extends Importee {
     checkFields(name.is[scala.meta.Name.Quasi] || name.is[scala.meta.Name.Indeterminate])

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -1104,7 +1104,7 @@ object TreeSyntax {
 
       // Import
       case t: Importee.Name => s(t.name)
-      case t: Importee.Given => s(kw("given"), " ", t.importee)
+      case t: Importee.Given => s(kw("given"), " ", t.tpe)
       case t: Importee.GivenAll => s(kw("given"))
       case t: Importee.Rename => s(t.name, " ", kw("=>"), " ", t.rename)
       case t: Importee.Unimport => s(t.name, " ", kw("=>"), " ", kw("_"))

--- a/tests/jvm/src/test/scala-2.12/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.12/scala/meta/tests/trees/ReflectionSuite.scala
@@ -102,7 +102,6 @@ class ReflectionSuite extends FunSuite {
       |scala.meta.Type
       |scala.meta.Type.Bounds
       |scala.meta.Type.Name
-      |scala.meta.Type.Param
     """.trim.stripMargin.split('\n').mkString(EOL)
     )
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
@@ -603,7 +603,7 @@ class GivenUsingSuite extends BaseDottySuite {
             Term.Name("File"),
             List(
               Importee.Given(
-                pparam("TC")
+                Type.Name("TC")
               )
             )
           )
@@ -617,8 +617,8 @@ class GivenUsingSuite extends BaseDottySuite {
           Importer(
             Term.Name("File"),
             List(
-              Importee.Given(pparam("TC")),
-              Importee.Given(pparam("AC")),
+              Importee.Given(Type.Name("TC")),
+              Importee.Given(Type.Name("AC")),
               Importee.Wildcard()
             )
           )
@@ -634,14 +634,7 @@ class GivenUsingSuite extends BaseDottySuite {
             List(
               Importee.Name(Name("im")),
               Importee.Given(
-                Type.Param(
-                  Nil,
-                  Type.Name("Ordering"),
-                  List(Type.Param(Nil, Type.Name("?"), Nil, Type.Bounds(None, None), Nil, Nil)),
-                  Type.Bounds(None, None),
-                  Nil,
-                  Nil
-                )
+                Type.Apply(Type.Name("Ordering"), List(Type.Placeholder(Type.Bounds(None, None))))
               )
             )
           )


### PR DESCRIPTION
Just updating this, since Type.Param is better used to statements like  `[A,B]` and I overdid it with Type.Param.