### PR TITLE
Fix remaining issues with parsing Dotty

### DIFF
--- a/community-test/src/test/scala/CommunityDottySuite.scala
+++ b/community-test/src/test/scala/CommunityDottySuite.scala
@@ -159,9 +159,8 @@ class CommunityDottySuite extends FunSuite {
     // most likely will become deprecated: if (cond) <ident>
     "tools/dotc/typer/Implicits.scala",
     "tools/dotc/typer/Checking.scala",
-    // [scalameta?] error: indent expected but override found
-    // "scala3doc/src/dotty/dokka/site/PartiallyRenderedContent.scala",
     // if then - else without outdentation before else.
+    // it's unlcear what to do in this case
     // https://github.com/lampepfl/dotty/issues/10372
     "dotty/dokka/tasty/ClassLikeSupport.scala",
     // extension will become a keyword, needs fix in dotty

--- a/community-test/src/test/scala/CommunityDottySuite.scala
+++ b/community-test/src/test/scala/CommunityDottySuite.scala
@@ -160,7 +160,10 @@ class CommunityDottySuite extends FunSuite {
     "tools/dotc/typer/Implicits.scala",
     "tools/dotc/typer/Checking.scala",
     // [scalameta?] error: indent expected but override found
-    "scala3doc/src/dotty/dokka/site/PartiallyRenderedContent.scala",
+    // "scala3doc/src/dotty/dokka/site/PartiallyRenderedContent.scala",
+    // if then - else without outdentation before else.
+    // https://github.com/lampepfl/dotty/issues/10372
+    "dotty/dokka/tasty/ClassLikeSupport.scala",
     // extension will become a keyword, needs fix in dotty
     "dotty/dokka/translators/ScalaSignatureProvider.scala",
     "dotty/tools/io/AbstractFile.scala",
@@ -168,22 +171,14 @@ class CommunityDottySuite extends FunSuite {
     "dotty/tools/io/Path.scala",
     "dotty/tools/dotc/core/StdNames.scala",
     "dotty/tools/dotc/core/Symbols.scala",
-    "dotty/tools/dotc/core/Decorators.scala",
-    "dotty/tools/dotc/typer/Nullables.scala",
     "dotty/tools/dotc/fromtasty/Debug.scala",
     "dotty/tools/dotc/config/Settings.scala",
     "dotty/tools/dotc/parsing/Parsers.scala",
-    "dotty/tools/dotc/ast/tpd.scala",
     "dotty/tools/dotc/sbt/ExtractDependencies.scala",
-    "dotty/tools/package.scala",
-    "scala/quoted/internal/impl/Matcher.scala",
-    "scala/quoted/internal/impl/QuoteContextImpl.scala",
     "dotty/tools/dotc/core/tasty/CommentPicklingTest.scala",
     "dotty/tools/dotc/printing/PrintingTest.scala",
     "dotty/tools/dotc/transform/PatmatExhaustivityTest.scala",
-    "scala/quoted/QuoteContext.scala",
     "dotty/tools/sbtplugin/DottyPlugin.scala",
-    "dotty/dokka/tasty/ClassLikeSupport.scala",
     "src/scala/tasty/inspector/TastyInspector.scala"
   )
 

--- a/community-test/src/test/scala/CommunityDottySuite.scala
+++ b/community-test/src/test/scala/CommunityDottySuite.scala
@@ -159,11 +159,32 @@ class CommunityDottySuite extends FunSuite {
     // most likely will become deprecated: if (cond) <ident>
     "tools/dotc/typer/Implicits.scala",
     "tools/dotc/typer/Checking.scala",
-    // extension will become a keyword, needs fix in dotty
-    // extension.getParameters.asScala(extension.get(MethodExtension).parametersListSizes(0))
-    "dotty/dokka/translators/ScalaSignatureProvider.scala",
     // [scalameta?] error: indent expected but override found
-    "scala3doc/src/dotty/dokka/site/PartiallyRenderedContent.scala"
+    "scala3doc/src/dotty/dokka/site/PartiallyRenderedContent.scala",
+    // extension will become a keyword, needs fix in dotty
+    "dotty/dokka/translators/ScalaSignatureProvider.scala",
+    "dotty/tools/io/AbstractFile.scala",
+    "dotty/tools/io/JarArchive.scala",
+    "dotty/tools/io/Path.scala",
+    "dotty/tools/dotc/core/StdNames.scala",
+    "dotty/tools/dotc/core/Symbols.scala",
+    "dotty/tools/dotc/core/Decorators.scala",
+    "dotty/tools/dotc/typer/Nullables.scala",
+    "dotty/tools/dotc/fromtasty/Debug.scala",
+    "dotty/tools/dotc/config/Settings.scala",
+    "dotty/tools/dotc/parsing/Parsers.scala",
+    "dotty/tools/dotc/ast/tpd.scala",
+    "dotty/tools/dotc/sbt/ExtractDependencies.scala",
+    "dotty/tools/package.scala",
+    "scala/quoted/internal/impl/Matcher.scala",
+    "scala/quoted/internal/impl/QuoteContextImpl.scala",
+    "dotty/tools/dotc/core/tasty/CommentPicklingTest.scala",
+    "dotty/tools/dotc/printing/PrintingTest.scala",
+    "dotty/tools/dotc/transform/PatmatExhaustivityTest.scala",
+    "scala/quoted/QuoteContext.scala",
+    "dotty/tools/sbtplugin/DottyPlugin.scala",
+    "dotty/dokka/tasty/ClassLikeSupport.scala",
+    "src/scala/tasty/inspector/TastyInspector.scala"
   )
 
   final def munitExclusionList = List(

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -348,7 +348,7 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
             while ((indentedRegion(sepRegionsProcess)
                 && sepRegionsProcess.head.indent > currentIndent && !isLeadingInfixOperator(
                   curr
-                )) ||
+                ) && !prev.is[CanContinueOnNextLine]) ||
               shouldCloseCaseOnNonCase(sepRegionsProcess)) {
               insertOutdent()
               // match can start an identation, block but if `match` follows it means it's chaining matches
@@ -878,6 +878,15 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
       token.text == "end" &&
       token.strictNext.is[EndMarkerWord] &&
       (token.next.strictNext.is[LineEnd] || token.next.strictNext.is[EOF])
+    }
+  }
+  // then  else  do  catch  finally  yield  match
+  @classifier
+  trait CanContinueOnNextLine {
+    def unapply(token: Token): Boolean = {
+      token.is[KwThen] || token.is[KwElse] || token.is[KwDo] ||
+      token.is[KwCatch] || token.is[KwFinally] || token.is[KwYield] ||
+      token.is[KwMatch]
     }
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EndMarkerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EndMarkerSuite.scala
@@ -48,6 +48,36 @@ class EndMarkerSuite extends BaseDottySuite {
     )(parseSource)
   }
 
+  test("end-marker-extension") {
+    val code = """|extension (a: Int):
+                  |  def b = a + 1
+                  |end extension
+                  |
+                  |type K = Map
+                  |""".stripMargin
+    runTestAssert[Source](code, assertLayout = None)(
+      Source(
+        List(
+          Defn.ExtensionGroup(
+            Term.Param(Nil, Term.Name("a"), Some(Type.Name("Int")), None),
+            Nil,
+            Nil,
+            Defn.Def(
+              Nil,
+              Term.Name("b"),
+              Nil,
+              Nil,
+              None,
+              Term.ApplyInfix(Term.Name("a"), Term.Name("+"), Nil, List(Lit.Int(1)))
+            )
+          ),
+          Term.EndMarker(Term.Name("extension")),
+          Defn.Type(Nil, Type.Name("K"), Nil, Type.Name("Map"))
+        )
+      )
+    )(parseSource)
+  }
+
   test("end-nomarker") {
     runTestAssert[Stat]("lista append end")(
       Term.ApplyInfix(Term.Name("lista"), Term.Name("append"), Nil, List(Term.Name("end")))

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -679,4 +679,41 @@ class SignificantIndentationSuite extends BaseDottySuite {
       )
     )
   }
+
+  test("nested-coloneol") {
+    runTestAssert[Stat](
+      """|case class Test(
+         |  a: A = new A,
+         |):
+         |  def hello = 1
+         |""".stripMargin,
+      assertLayout = Some("case class Test(a: A = new A) { def hello = 1 }")
+    )(
+      Defn.Class(
+        List(Mod.Case()),
+        Type.Name("Test"),
+        Nil,
+        Ctor.Primary(
+          Nil,
+          Name(""),
+          List(
+            List(
+              Term.Param(
+                Nil,
+                Term.Name("a"),
+                Some(Type.Name("A")),
+                Some(Term.New(Init(Type.Name("A"), Name(""), Nil)))
+              )
+            )
+          )
+        ),
+        Template(
+          Nil,
+          Nil,
+          Self(Name(""), None),
+          List(Defn.Def(Nil, Term.Name("hello"), Nil, Nil, None, Lit.Int(1)))
+        )
+      )
+    )
+  }
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -101,7 +101,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
     )
   }
 
-  test("indent-below-not-okay".ignore) {
+  test("then-no-indent") {
     // this test is related to dotty issue: https://github.com/lampepfl/dotty/issues/9790
     // It should either assert error during parsing: "illegal start of simple expression"
     // Or accept mismatch with parsing rules and parse as 'if (cond) { truep } else {falsep }'
@@ -112,15 +112,39 @@ class SignificantIndentationSuite extends BaseDottySuite {
                   |    else
                   |  falsep
                   |""".stripMargin
-    runTestAssert[Stat](code, assertLayout = Some("trait A { def f: Int }"))(
-      Defn.Trait(
+    runTestAssert[Stat](
+      code,
+      assertLayout = Some(
+        """|def fn: Unit = {
+           |  if (cond) truep else falsep
+           |}
+           |""".stripMargin
+      )
+    )(
+      Defn.Def(
         Nil,
-        Type.Name("A"),
+        Term.Name("fn"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
-        Template(Nil, Nil, Self(Name(""), None), List(defx))
+        Nil,
+        Some(Type.Name("Unit")),
+        Term.Block(List(Term.If(Term.Name("cond"), Term.Name("truep"), Term.Name("falsep"))))
       )
     )
+  }
+
+  test("then-no-indent-wrong") {
+    // this test is related to dotty issue: https://github.com/lampepfl/dotty/issues/9790
+    // It should either assert error during parsing: "illegal start of simple expression"
+    // Or accept mismatch with parsing rules and parse as 'if (cond) { truep } else {falsep }'
+    // Why error is thrown is described in mentioned issue.
+    val code = """|def fn: Unit =
+                  |    if cond then
+                  |  truep1
+                  |  truep2
+                  |    else
+                  |  falsep
+                  |""".stripMargin
+    runTestError[Stat](code, "expected but else found")
   }
 
   test("indent-inside-brace-ok") {


### PR DESCRIPTION
This includes:
- issues after `end extension`
- nested possible colonEol
- new outdentation rule based on https://github.com/lampepfl/dotty/pull/10331

I also found a new issue with indentation here: https://github.com/lampepfl/dotty/issues/10372
