### PR TITLE
Don't create block on indentation with a single statement

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -34,11 +34,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
                   |else
                   |  gx
                   |""".stripMargin
-    val output = """|if (cond) fx else {
-                    |  gx
-                    |}""".stripMargin
+    val output = """|if (cond) fx else gx""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.If(Term.Name("cond"), Term.Name("fx"), Term.Block(List(Term.Name("gx"))))
+      Term.If(Term.Name("cond"), Term.Name("fx"), Term.Name("gx"))
     )
   }
 
@@ -76,16 +74,12 @@ class ControlSyntaxSuite extends BaseDottySuite {
                   |else 
                   |  gx
                   |""".stripMargin
-    val output = """|if (cond) {
-                    |  fx
-                    |} else {
-                    |  gx
-                    |}""".stripMargin
+    val output = "if (cond) fx else gx"
     runTestAssert[Stat](code, assertLayout = Some(output))(
       Term.If(
         Term.Name("cond"),
-        Term.Block(List(Term.Name("fx"))),
-        Term.Block(List(Term.Name("gx")))
+        Term.Name("fx"),
+        Term.Name("gx")
       )
     )
   }
@@ -96,13 +90,11 @@ class ControlSyntaxSuite extends BaseDottySuite {
                   |then
                   |  gx
                   |""".stripMargin
-    val output = """|if (cond1 && cond2) {
-                    |  gx
-                    |}""".stripMargin
+    val output = "if (cond1 && cond2) gx"
     runTestAssert[Stat](code, assertLayout = Some(output))(
       Term.If(
         Term.ApplyInfix(Term.Name("cond1"), Term.Name("&&"), Nil, List(Term.Name("cond2"))),
-        Term.Block(List(Term.Name("gx"))),
+        Term.Name("gx"),
         Lit.Unit()
       )
     )
@@ -166,15 +158,12 @@ class ControlSyntaxSuite extends BaseDottySuite {
                   |  else
                   |    B)
                   |""".stripMargin
-    val output = """|fx(if (cond) A else {
-                    |  B
-                    |})
-                    |""".stripMargin
+    val output = "fx(if (cond) A else B)"
     runTestAssert[Stat](code, assertLayout = Some(output))(
       Term.Apply(
         Term.Name("fx"),
         List(
-          Term.If(Term.Name("cond"), Term.Name("A"), Term.Block(List(Term.Name("B"))))
+          Term.If(Term.Name("cond"), Term.Name("A"), Term.Name("B"))
         )
       )
     )
@@ -280,17 +269,12 @@ class ControlSyntaxSuite extends BaseDottySuite {
                   |finally
                   |  ok
                   |""".stripMargin
-    val output = """|try {
-                    |  fx
-                    |} finally {
-                    |  ok
-                    |}
-                    |""".stripMargin
+    val output = "try fx finally ok"
     runTestAssert[Stat](code, assertLayout = Some(output))(
       Term.Try(
-        Term.Block(List(Term.Name("fx"))),
+        Term.Name("fx"),
         Nil,
-        Some(Term.Block(List(Term.Name("ok"))))
+        Some(Term.Name("ok"))
       )
     )
   }
@@ -461,9 +445,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
                     |  case x =>
                     |    ax
                     |    bx
-                    |} finally {
-                    |  fx
-                    |}
+                    |} finally fx
                     |""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(
       Term.Try(
@@ -471,7 +453,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
         List(
           Case(Pat.Var(Term.Name("x")), None, Term.Block(List(Term.Name("ax"), Term.Name("bx"))))
         ),
-        Some(Term.Block(List(Term.Name("fx"))))
+        Some(Term.Name("fx"))
       )
     )
   }
@@ -680,13 +662,11 @@ class ControlSyntaxSuite extends BaseDottySuite {
                   |do
                   |  fx
                   |""".stripMargin
-    val output = """|for (a <- gen) {
-                    |  fx
-                    |}""".stripMargin
+    val output = "for (a <- gen) fx"
     runTestAssert[Stat](code, assertLayout = Some(output))(
       Term.For(
         List(Enumerator.Generator(Pat.Var(Term.Name("a")), Term.Name("gen"))),
-        Term.Block(List(Term.Name("fx")))
+        Term.Name("fx")
       )
     )
   }
@@ -772,16 +752,14 @@ class ControlSyntaxSuite extends BaseDottySuite {
                   |yield
                   |  fx
                   |""".stripMargin
-    val output = """|for (a <- gen; if cnd) yield {
-                    |  fx
-                    |}""".stripMargin
+    val output = "for (a <- gen; if cnd) yield fx"
     runTestAssert[Stat](code, assertLayout = Some(output))(
       Term.ForYield(
         List(
           Enumerator.Generator(Pat.Var(Term.Name("a")), Term.Name("gen")),
           Enumerator.Guard(Term.Name("cnd"))
         ),
-        Term.Block(List(Term.Name("fx")))
+        Term.Name("fx")
       )
     )
   }
@@ -814,9 +792,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
     val code = """|for case a: TP <- iter do
                   |  echo
                   |""".stripMargin
-    val output = """|for ( case a: TP <- iter) {
-                    |  echo
-                    |}
+    val output = """|for ( case a: TP <- iter) echo
                     |""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(
       Term.For(
@@ -824,7 +800,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
           Enumerator
             .CaseGenerator(Pat.Typed(Pat.Var(Term.Name("a")), Type.Name("TP")), Term.Name("iter"))
         ),
-        Term.Block(List(Term.Name("echo")))
+        Term.Name("echo")
       )
     )
   }
@@ -833,9 +809,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
     val code = """|for case a: TP <- iter if cnd do
                   |  echo
                   |""".stripMargin
-    val output = """|for ( case a: TP <- iter; if cnd) {
-                    |  echo
-                    |}
+    val output = """|for ( case a: TP <- iter; if cnd) echo
                     |""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(
       Term.For(
@@ -844,7 +818,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
             .CaseGenerator(Pat.Typed(Pat.Var(Term.Name("a")), Type.Name("TP")), Term.Name("iter")),
           Enumerator.Guard(Term.Name("cnd"))
         ),
-        Term.Block(List(Term.Name("echo")))
+        Term.Name("echo")
       )
     )
   }
@@ -922,9 +896,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
     val code = """|for (arg, param) <- args.zip(vparams) yield
                   |  arg
                   |""".stripMargin
-    val output = """|for ((arg, param) <- args.zip(vparams)) yield {
-                    |  arg
-                    |}
+    val output = """|for ((arg, param) <- args.zip(vparams)) yield arg
                     |""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(
       Term.ForYield(
@@ -934,7 +906,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
             Term.Apply(Term.Select(Term.Name("args"), Term.Name("zip")), List(Term.Name("vparams")))
           )
         ),
-        Term.Block(List(Term.Name("arg")))
+        Term.Name("arg")
       )
     )
   }
@@ -988,18 +960,14 @@ class ControlSyntaxSuite extends BaseDottySuite {
                   |  fx
                   |  fy
                   |""".stripMargin
-    val output = """|while ({
-                    |  fx + fy
-                    |}) {
+    val output = """|while (fx + fy) {
                     |  fx
                     |  fy
                     |}
                     |""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(
       Term.While(
-        Term.Block(
-          List(Term.ApplyInfix(Term.Name("fx"), Term.Name("+"), Nil, List(Term.Name("fy"))))
-        ),
+        Term.ApplyInfix(Term.Name("fx"), Term.Name("+"), Nil, List(Term.Name("fy"))),
         Term.Block(List(Term.Name("fx"), Term.Name("fy")))
       )
     )
@@ -1571,22 +1539,18 @@ class ControlSyntaxSuite extends BaseDottySuite {
       Nil,
       List(List(Term.Param(Nil, Term.Name("x"), Some(Type.Name("Int")), None))),
       Some(Type.Name("String")),
-      Term.Block(
-        List(
-          Term.Apply(
-            Term.Select(
-              Term.Match(
-                Term.Name("x"),
-                List(
-                  Case(Lit.Int(1), None, Lit.String("1")),
-                  Case(Pat.Wildcard(), None, Lit.String("ERR"))
-                )
-              ),
-              Term.Name("trim")
-            ),
-            Nil
-          )
-        )
+      Term.Apply(
+        Term.Select(
+          Term.Match(
+            Term.Name("x"),
+            List(
+              Case(Lit.Int(1), None, Lit.String("1")),
+              Case(Pat.Wildcard(), None, Lit.String("ERR"))
+            )
+          ),
+          Term.Name("trim")
+        ),
+        Nil
       )
     )
 
@@ -1608,12 +1572,10 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |   .trim()
          |""".stripMargin,
       assertLayout = Some(
-        """|def mtch(x: Int): String = {
-           |  (x match {
-           |    case 1 => "1"
-           |    case _ => "ERR"
-           |  }).trim()
-           |}
+        """|def mtch(x: Int): String = (x match {
+           |  case 1 => "1"
+           |  case _ => "ERR"
+           |}).trim()
            |""".stripMargin
       )
     )(expected)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InlineSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InlineSuite.scala
@@ -200,7 +200,7 @@ class InlineSuite extends BaseDottySuite {
     assert(ifExpr.mods.head.is[Mod.Inline], "if should have an inline modifier")
   }
 
-  test("inline-if") {
+  test("inline-if-method") {
     val input = """|def fn: Unit =
                    |    inline if cond then
                    |  truep
@@ -209,10 +209,7 @@ class InlineSuite extends BaseDottySuite {
     runTestAssert[Stat](
       input,
       assertLayout = Some(
-        """|def fn: Unit = {
-           |  inline if (cond) truep
-           |}
-           |""".stripMargin
+        "def fn: Unit = inline if (cond) truep"
       )
     )(
       Defn.Def(
@@ -221,12 +218,37 @@ class InlineSuite extends BaseDottySuite {
         Nil,
         Nil,
         Some(Type.Name("Unit")),
-        Term.Block(List(Term.If(Term.Name("cond"), Term.Name("truep"), Lit.Unit())))
+        Term.If(Term.Name("cond"), Term.Name("truep"), Lit.Unit())
       )
     )(parseTempl)
 
     val defnDef = parseTempl(input).asInstanceOf[Defn.Def]
-    val ifExpr = defnDef.body.asInstanceOf[Term.Block].stats.head.asInstanceOf[Term.If]
+    val ifExpr = defnDef.body.asInstanceOf[Term.If]
+    assert(ifExpr.mods.head.is[Mod.Inline], "if should have an inline modifier")
+  }
+
+  test("inline-if-method-oneline") {
+    val input = """|def fn: Unit = inline if cond then truep
+                   |""".stripMargin
+
+    runTestAssert[Stat](
+      input,
+      assertLayout = Some(
+        "def fn: Unit = inline if (cond) truep"
+      )
+    )(
+      Defn.Def(
+        Nil,
+        Term.Name("fn"),
+        Nil,
+        Nil,
+        Some(Type.Name("Unit")),
+        Term.If(Term.Name("cond"), Term.Name("truep"), Lit.Unit())
+      )
+    )(parseTempl)
+
+    val defnDef = parseTempl(input).asInstanceOf[Defn.Def]
+    val ifExpr = defnDef.body.asInstanceOf[Term.If]
     assert(ifExpr.mods.head.is[Mod.Inline], "if should have an inline modifier")
   }
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -773,9 +773,7 @@ class MinorDottySuite extends BaseDottySuite {
   test("catch-end-def") {
     val layout =
       """|object X {
-         |  def fx = try {
-         |    action()
-         |  } catch {
+         |  def fx = try action() catch {
          |    case ex =>
          |      err()
          |  }
@@ -808,7 +806,7 @@ class MinorDottySuite extends BaseDottySuite {
               Nil,
               None,
               Term.Try(
-                Term.Block(List(Term.Apply(Term.Name("action"), Nil))),
+                Term.Apply(Term.Name("action"), Nil),
                 List(Case(Pat.Var(Term.Name("ex")), None, Term.Apply(Term.Name("err"), Nil))),
                 None
               )
@@ -884,12 +882,7 @@ class MinorDottySuite extends BaseDottySuite {
          |       "-siteroot" +: "../docs"
          |    +: "-project" +: Nil
          |""".stripMargin,
-      assertLayout = Some(
-        """|def withClasspath = {
-           |  "-siteroot" +: "../docs" +: "-project" +: Nil
-           |}
-           |""".stripMargin
-      )
+      assertLayout = Some("""def withClasspath = "-siteroot" +: "../docs" +: "-project" +: Nil""")
     )(
       Defn.Def(
         Nil,
@@ -897,25 +890,21 @@ class MinorDottySuite extends BaseDottySuite {
         Nil,
         Nil,
         None,
-        Term.Block(
+        Term.ApplyInfix(
+          Lit.String("-siteroot"),
+          Term.Name("+:"),
+          Nil,
           List(
             Term.ApplyInfix(
-              Lit.String("-siteroot"),
+              Lit.String("../docs"),
               Term.Name("+:"),
               Nil,
               List(
                 Term.ApplyInfix(
-                  Lit.String("../docs"),
+                  Lit.String("-project"),
                   Term.Name("+:"),
                   Nil,
-                  List(
-                    Term.ApplyInfix(
-                      Lit.String("-project"),
-                      Term.Name("+:"),
-                      Nil,
-                      List(Term.Name("Nil"))
-                    )
-                  )
+                  List(Term.Name("Nil"))
                 )
               )
             )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -111,12 +111,14 @@ class SignificantIndentationSuite extends BaseDottySuite {
                   |  truep
                   |    else
                   |  falsep
+                  |    otherStatement()
                   |""".stripMargin
     runTestAssert[Stat](
       code,
       assertLayout = Some(
         """|def fn: Unit = {
            |  if (cond) truep else falsep
+           |  otherStatement()
            |}
            |""".stripMargin
       )
@@ -127,7 +129,12 @@ class SignificantIndentationSuite extends BaseDottySuite {
         Nil,
         Nil,
         Some(Type.Name("Unit")),
-        Term.Block(List(Term.If(Term.Name("cond"), Term.Name("truep"), Term.Name("falsep"))))
+        Term.Block(
+          List(
+            Term.If(Term.Name("cond"), Term.Name("truep"), Term.Name("falsep")),
+            Term.Apply(Term.Name("otherStatement"), Nil)
+          )
+        )
       )
     )
   }
@@ -357,9 +364,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
     val output = """|class A {
                     |  def forward: Unit = parents match {
                     |    case a =>
-                    |      for ( case a: TP <- body) {
-                    |        fordo
-                    |      }
+                    |      for ( case a: TP <- body) fordo
                     |    case b =>
                     |      ok
                     |  }
@@ -393,7 +398,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
                           Term.Name("body")
                         )
                       ),
-                      Term.Block(List(Term.Name("fordo")))
+                      Term.Name("fordo")
                     )
                   ),
                   Case(Pat.Var(Term.Name("b")), None, Term.Name("ok"))
@@ -519,10 +524,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |  finally placeholderParams = saved
          |""".stripMargin,
       assertLayout = Some(
-        """|def wrapPlaceholders(t: Tree) = try {
-           |  if (placeholderParams.isEmpty) t else new WildcardFunction(placeholderParams.reverse, t)
-           |} finally placeholderParams = saved
-           |""".stripMargin
+        "def wrapPlaceholders(t: Tree) = try if (placeholderParams.isEmpty) t else new WildcardFunction(placeholderParams.reverse, t) finally placeholderParams = saved"
       )
     )(
       Defn.Def(
@@ -532,21 +534,17 @@ class SignificantIndentationSuite extends BaseDottySuite {
         List(List(Term.Param(Nil, Term.Name("t"), Some(Type.Name("Tree")), None))),
         None,
         Term.Try(
-          Term.Block(
-            List(
-              Term.If(
-                Term.Select(Term.Name("placeholderParams"), Term.Name("isEmpty")),
-                Term.Name("t"),
-                Term.New(
-                  Init(
-                    Type.Name("WildcardFunction"),
-                    Name(""),
-                    List(
-                      List(
-                        Term.Select(Term.Name("placeholderParams"), Term.Name("reverse")),
-                        Term.Name("t")
-                      )
-                    )
+          Term.If(
+            Term.Select(Term.Name("placeholderParams"), Term.Name("isEmpty")),
+            Term.Name("t"),
+            Term.New(
+              Init(
+                Type.Name("WildcardFunction"),
+                Name(""),
+                List(
+                  List(
+                    Term.Select(Term.Name("placeholderParams"), Term.Name("reverse")),
+                    Term.Name("t")
                   )
                 )
               )


### PR DESCRIPTION
After working a bit on scalafmt it seems that most problematic is the case with a single statement, which now is sometimes be treated as an indented block. So reformatting could sometimes cause a new block to be created even if there was none before.

