### PR TITLE
Introduce `ExportGiven`, remove `Export.given: Boolean`.

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -4,4 +4,4 @@
 -XX:ReservedCodeCacheSize=1024m
 -XX:+TieredCompilation
 -XX:+CMSClassUnloadingEnabled
-
+-Dsbt.server.autostart=false

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -26,5 +26,11 @@ object Mima {
       true
   }
 
-  val apiCompatibilityExceptions: Seq[ProblemFilter] = Seq()
+  val apiCompatibilityExceptions: Seq[ProblemFilter] = Seq(
+    // Exceptions for Scala 3. Changes to Scala 3-related AST nodes don't fall
+    // under the standard Scalameta binary-compatibility policy. This is done to
+    // buy time to refine the design of the Scalameta AST in preparation for the
+    // Scala 3 release.
+    ProblemFilters.exclude[Problem]("scala.meta.Export*")
+  )
 }

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -3712,13 +3712,14 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
 
   /* -------- DEFS ------------------------------------------- */
 
-  def exportStmt(): Export = autoPos {
+  def exportStmt(): Stat = autoPos {
     accept[KwExport]
-    val givenExport = if (token.is[KwGiven]) {
+    if (token.is[KwGiven]) {
       accept[KwGiven]
-      true
-    } else false
-    Export(givenExport, commaSeparated(importer()))
+      ExportGiven(commaSeparated(importer()))
+    } else {
+      Export(commaSeparated(importer()))
+    }
   }
 
   def importStmt(): Import = autoPos {

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -504,7 +504,8 @@ object Enumerator {
 }
 
 @ast class Import(importers: List[Importer] @nonEmpty) extends Stat
-@ast class Export(given: Boolean, importers: List[Importer] @nonEmpty) extends Stat
+@ast class Export(importers: List[Importer] @nonEmpty) extends Stat
+@ast class ExportGiven(importers: List[Importer] @nonEmpty) extends Stat
 
 @ast class Importer(ref: Term.Ref, importees: List[Importee] @nonEmpty) extends Tree {
   checkFields(ref.isStableId)

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -1116,8 +1116,9 @@ object TreeSyntax {
       case t: Importer => s(t.ref, ".", t.importees)
       case t: Import => s(kw("import"), " ", r(t.importers, ", "))
       case t: Export =>
-        if (t.given) s(kw("export"), " ", kw("given"), " ", r(t.importers, ", "))
-        else s(kw("export"), " ", r(t.importers, ", "))
+        s(kw("export"), " ", r(t.importers, ", "))
+      case t: ExportGiven =>
+        s(kw("export"), " ", kw("given"), " ", r(t.importers, ", "))
 
       // Case
       case t: Case =>

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
@@ -21,7 +21,7 @@ class ReflectionSuite extends FunSuite {
   test("root") {
     assert(symbolOf[scala.meta.Tree].isRoot)
     assertEquals(symbolOf[scala.meta.Tree].asRoot.allBranches.length, 19)
-    assertEquals(symbolOf[scala.meta.Tree].asRoot.allLeafs.length, 333)
+    assertEquals(symbolOf[scala.meta.Tree].asRoot.allLeafs.length, 335)
   }
 
   test("If") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExportSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExportSuite.scala
@@ -10,7 +10,6 @@ class ExportSuite extends BaseDottySuite {
   test("export-single") {
     runTestAssert[Stat]("export A.b.c")(
       Export(
-        false,
         List(Importer(Term.Select(Term.Name("A"), Term.Name("b")), List(Importee.Name(Name("c")))))
       )
     )
@@ -18,8 +17,7 @@ class ExportSuite extends BaseDottySuite {
 
   test("export-given") {
     runTestAssert[Stat]("export given A.b.c")(
-      Export(
-        true,
+      ExportGiven(
         List(Importer(Term.Select(Term.Name("A"), Term.Name("b")), List(Importee.Name(Name("c")))))
       )
     )
@@ -28,7 +26,6 @@ class ExportSuite extends BaseDottySuite {
   test("export-multiple") {
     runTestAssert[Stat]("export A.{ b, c, d, _ }")(
       Export(
-        false,
         List(
           Importer(
             Term.Name("A"),
@@ -47,7 +44,6 @@ class ExportSuite extends BaseDottySuite {
   test("export-multiple-rename") {
     runTestAssert[Stat]("export A.{ b => x, c => _ }")(
       Export(
-        false,
         List(
           Importer(
             Term.Name("A"),

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
@@ -245,56 +245,24 @@ class PublicSuite extends FunSuite {
     // NOTE: come up with a platform-independent test
   }
 
-  test("scala.meta.metac.Settings.toString") {
-    // n/a
-  }
-
-  test("scala.meta.metacp.Result.toString") {
-    // n/a
-  }
-
-  test("scala.meta.metacp.Settings.toString") {
-    // n/a
-  }
-
-  test("scala.meta.metai.Result.toString") {
-    // n/a
-  }
-
-  test("scala.meta.metai.Settings.toString") {
-    // n/a
-  }
-
-  test("scala.meta.metap.Format.toString") {
-    // n/a
-  }
-
-  test("scala.meta.metap.Format.Pretty.toString") {
-    // n/a
-  }
-
-  test("scala.meta.metap.Format.Compact.toString") {
-    // n/a
-  }
-
-  test("scala.meta.metap.Format.Detailed.toString") {
-    // n/a
-  }
-
-  test("scala.meta.metap.Format.Proto.toString") {
-    // n/a
-  }
-
-  test("scala.meta.metap.Settings.toString") {
-    // n/a
-  }
-
-  test("scala.meta.parsers.Parse.toString") {
-    // n/a
-  }
-
-  test("scala.meta.tokens.Token.Indentation.toString") {
-    // n/a
+  val untestedClasses = List(
+    "scala.meta.metap.Format.Proto",
+    "scala.meta.metac.Settings",
+    "scala.meta.metap.Settings",
+    "scala.meta.metacp.Result",
+    "scala.meta.metap.Format.Compact",
+    "scala.meta.tokens.Token.Indentation",
+    "scala.meta.metap.Format",
+    "scala.meta.metacp.Settings",
+    "scala.meta.metap.Format.Detailed",
+    "scala.meta.tokens.Token.Unquote",
+    "scala.meta.tokens.Token.LFLF",
+    "scala.meta.tokens.Token.Ellipsis"
+  )
+  untestedClasses.foreach { name =>
+    test(name + ".toString") {
+      // n/a
+    }
   }
 
   test("scala.meta.parsers.ParseException.toString") {


### PR DESCRIPTION
Previously, the `scala.meta.Export` tree had a `given: Boolean` field.
This goes against a design principle in the Scalameta AST, which tries
to represent as much as possible with syntax. There's no other AST node that
has a boolean field to distinguish between two cases. This commit
introduces a new `ExportGiven` class to represent `export given a.b`
syntax.

This is a binary breaking change so the next release should strictly
speaking be Scalameta v5. However, I think it's fair to change the
compatibility policy to state that Dotty-specific tree nodes are
experimental for time being and subject to breaking changes. This policy
buys us time to refine the Scala 3 AST nodes so that they are well
designed and consistent with the rest of the Scalameta AST nodes.
Normal Scalameta users should not be affected by this change as long as
they don't use Scalameta to parse Scala 3 programs.