### PR TITLE
Add variable to track if we are inside quotes/splices 

### DIFF
--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -31,6 +31,16 @@ object Mima {
     // under the standard Scalameta binary-compatibility policy. This is done to
     // buy time to refine the design of the Scalameta AST in preparation for the
     // Scala 3 release.
-    ProblemFilters.exclude[Problem]("scala.meta.Export*")
+    ProblemFilters.exclude[Problem]("scala.meta.Export*"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.meta.tokens.Token$MacroSplicedIdent$"),
+    ProblemFilters.exclude[MissingClassProblem](
+      "scala.meta.tokens.Token$MacroQuotedIdent$sharedClassifier$"
+    ),
+    ProblemFilters.exclude[MissingClassProblem]("scala.meta.tokens.Token$MacroQuotedIdent$"),
+    ProblemFilters.exclude[MissingClassProblem](
+      "scala.meta.tokens.Token$MacroSplicedIdent$sharedClassifier$"
+    ),
+    ProblemFilters.exclude[MissingClassProblem]("scala.meta.tokens.Token$MacroSplicedIdent"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.meta.tokens.Token$MacroQuotedIdent")
   )
 }

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
@@ -78,7 +78,8 @@ final class Dialect private (
     val allowExtensionMethods: Boolean,
     // Open modifier for classes introduced in dotty
     val allowOpenClass: Boolean,
-    // Whitebox macros introduced in dotty (splices/quotes)
+    // Scala 3 splices/quotes
+    @deprecated("Replaced with allowSpliceAndQuote", "4.4.1")
     val allowWhiteboxMacro: Boolean,
     // Top level statements introduced in dotty.
     // differs from ToplevelTerms because here you can define packages
@@ -122,7 +123,11 @@ final class Dialect private (
     // Dotty allows `match` on type
     val allowTypeMatch: Boolean,
     // Dotty allows to define types and methods with an `infix` soft keyword modifier
-    val allowInfixMods: Boolean
+    val allowInfixMods: Boolean,
+    // Scala 3 splices/quotes
+    val allowSpliceAndQuote: Boolean,
+    // Scala 3 disallowed symbol literals
+    val allowSymbolLiterals: Boolean
 ) extends Product with Serializable {
 
   // NOTE(olafur) checklist for adding a new dialect field in a binary compatible way:
@@ -208,7 +213,9 @@ final class Dialect private (
       allowPolymorphicFunctions = false,
       allowMatchAsOperator = false,
       allowTypeMatch = false,
-      allowInfixMods = false
+      allowInfixMods = false,
+      allowSpliceAndQuote = false,
+      allowSymbolLiterals = true
       // NOTE(olafur): declare the default value for new fields above this comment.
     )
   }
@@ -236,7 +243,7 @@ final class Dialect private (
   def withAllowImplicitByNameParameters(newValue: Boolean): Dialect = {
     privateCopy(allowImplicitByNameParameters = newValue)
   }
-  @deprecated("Implicit functions are not supported in any dialect")
+  @deprecated("Implicit functions are not supported in any dialect", "4.4.1")
   def withAllowImplicitFunctionTypes(newValue: Boolean): Dialect = {
     privateCopy(allowImplicitFunctionTypes = newValue)
   }
@@ -306,6 +313,7 @@ final class Dialect private (
   def withAllowOpenClass(newValue: Boolean): Dialect = {
     privateCopy(allowOpenClass = newValue)
   }
+  @deprecated("Replaced by withAllowSplicesAndQuotes", "4.4.1")
   def withAllowWhiteboxMacro(newValue: Boolean): Dialect = {
     privateCopy(allowWhiteboxMacro = newValue)
   }
@@ -322,7 +330,7 @@ final class Dialect private (
   def withAllowInterpolationDolarQuoteEscape(newValue: Boolean): Dialect = {
     privateCopy(allowInterpolationDolarQuoteEscape = newValue)
   }
-  @deprecated("Super traits are not supported in any dialect")
+  @deprecated("Super traits are not supported in any dialect", "4.4.1")
   def withAllowSuperTrait(newValue: Boolean): Dialect = {
     privateCopy(allowSuperTrait = newValue)
   }
@@ -374,6 +382,12 @@ final class Dialect private (
   }
   def withAllowInfixMods(newValue: Boolean): Dialect = {
     privateCopy(allowInfixMods = newValue)
+  }
+  def withAllowSpliceAndQuote(newValue: Boolean): Dialect = {
+    privateCopy(allowSpliceAndQuote = newValue)
+  }
+  def withAllowSymbolLiterals(newValue: Boolean): Dialect = {
+    privateCopy(allowSymbolLiterals = newValue)
   }
   // NOTE(olafur): add the next `withX()` method above this comment. Please try
   // to use consistent formatting, use `newValue` as the parameter name and wrap
@@ -431,7 +445,9 @@ final class Dialect private (
       allowPolymorphicFunctions: Boolean = this.allowPolymorphicFunctions,
       allowMatchAsOperator: Boolean = this.allowMatchAsOperator,
       allowTypeMatch: Boolean = this.allowTypeMatch,
-      allowInfixMods: Boolean = this.allowInfixMods
+      allowInfixMods: Boolean = this.allowInfixMods,
+      allowSpliceAndQuote: Boolean = this.allowSpliceAndQuote,
+      allowSymbolLiterals: Boolean = this.allowSymbolLiterals
       // NOTE(olafur): add the next parameter above this comment.
   ): Dialect = {
     new Dialect(
@@ -485,7 +501,9 @@ final class Dialect private (
       allowPolymorphicFunctions,
       allowMatchAsOperator,
       allowTypeMatch,
-      allowInfixMods
+      allowInfixMods,
+      allowSpliceAndQuote,
+      allowSymbolLiterals
       // NOTE(olafur): add the next argument above this comment.
     )
   }

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -104,7 +104,7 @@ package object dialects {
     .withAllowGivenUsing(true)
     .withAllowExtensionMethods(true)
     .withAllowOpenClass(true)
-    .withAllowWhiteboxMacro(true)
+    .withAllowSpliceAndQuote(true)
     .withAllowToplevelStatements(true)
     .withAllowOpaqueTypes(true)
     .withAllowLiteralUnitType(false)
@@ -125,6 +125,7 @@ package object dialects {
     .withAllowMatchAsOperator(true)
     .withAllowTypeMatch(true)
     .withAllowInfixMods(true)
+    .withAllowSymbolLiterals(false)
 
   private[meta] def QuasiquoteTerm(underlying: Dialect, multiline: Boolean) = {
     require(!underlying.allowUnquotes)

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
@@ -139,11 +139,6 @@ class LegacyScanner(input: Input, dialect: Dialect) {
           token = IDENTIFIER
         if (token == CTXARROW && !dialect.allowGivenUsing)
           token = IDENTIFIER
-
-      }
-      if (token == IDENTIFIER && name.startsWith("$") && dialect.allowWhiteboxMacro) {
-        strVal = name.stripPrefix("$")
-        token = SPLICED_IDENT
       }
     }
   }
@@ -352,7 +347,7 @@ class LegacyScanner(input: Input, dialect: Dialect) {
           val prevChar = ch
           putChar(ch)
           nextChar()
-          if (prevChar == '$' && ch == '{' && dialect.allowWhiteboxMacro) {
+          if (prevChar == '$' && ch == '{' && dialect.allowSpliceAndQuote) {
             token = MACROSPLICE
             setStrVal()
           } else {
@@ -463,7 +458,7 @@ class LegacyScanner(input: Input, dialect: Dialect) {
           else {
             val lookahead = lookaheadReader
             lookahead.nextRawChar()
-            if ((ch == '{' || ch == '[') && lookahead.ch != '\'' && dialect.allowWhiteboxMacro) {
+            if ((ch == '{' || ch == '[') && lookahead.ch != '\'' && dialect.allowSpliceAndQuote) {
               token = MACROQUOTE
               setStrVal()
             } else {
@@ -1028,11 +1023,7 @@ class LegacyScanner(input: Input, dialect: Dialect) {
       setStrVal()
     } else {
       op()
-      if (dialect.allowWhiteboxMacro) {
-        token = QUOTED_IDENT
-      } else {
-        token = SYMBOLLIT
-      }
+      token = SYMBOLLIT
       strVal = name.toString
     }
   }

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyToken.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyToken.scala
@@ -31,8 +31,6 @@ object LegacyToken {
   /** identifiers */
   final val IDENTIFIER = 10
   final val BACKQUOTED_IDENT = 11
-  final val QUOTED_IDENT = 12
-  final val SPLICED_IDENT = 13
 
   /** keywords */
   final val NEW = 20

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
@@ -23,11 +23,6 @@ class ScalametaTokenizer(input: Input, dialect: Dialect) {
         case IDENTIFIER => Token.Ident(input, dialect, curr.offset, curr.endOffset + 1, curr.name)
         case BACKQUOTED_IDENT =>
           Token.Ident(input, dialect, curr.offset, curr.endOffset + 1, curr.name)
-        case QUOTED_IDENT =>
-          Token.MacroQuotedIdent(input, dialect, curr.offset, curr.endOffset + 1, curr.strVal)
-        case SPLICED_IDENT =>
-          Token.MacroSplicedIdent(input, dialect, curr.offset, curr.endOffset + 1, curr.strVal)
-
         case INTLIT =>
           Token.Constant.Int(input, dialect, curr.offset, curr.endOffset + 1, curr.intVal)
         case LONGLIT =>

--- a/scalameta/tokens/shared/src/main/scala/scala/meta/tokens/Token.scala
+++ b/scalameta/tokens/shared/src/main/scala/scala/meta/tokens/Token.scala
@@ -23,8 +23,6 @@ import scala.meta.internal.prettyprinters._
 object Token {
   // Identifiers
   @freeform("identifier") class Ident(value: String) extends Token
-  @freeform("quotedident") class MacroQuotedIdent(value: String) extends Token
-  @freeform("splicedident") class MacroSplicedIdent(value: String) extends Token
 
   // Alphanumeric keywords
   @fixed("abstract") class KwAbstract extends Token

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -475,9 +475,7 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.tokens.Token.LeftBracket
       |scala.meta.tokens.Token.LeftParen
       |scala.meta.tokens.Token.MacroQuote
-      |scala.meta.tokens.Token.MacroQuotedIdent
       |scala.meta.tokens.Token.MacroSplice
-      |scala.meta.tokens.Token.MacroSplicedIdent
       |scala.meta.tokens.Token.RightArrow
       |scala.meta.tokens.Token.RightBrace
       |scala.meta.tokens.Token.RightBracket

--- a/tests/jvm/src/test/scala/scala/meta/tests/tokens/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/tokens/ReflectionSuite.scala
@@ -40,8 +40,6 @@ class ReflectionSuite extends FunSuite {
       |Token.Interpolation.Start
       |Token.LFLF
       |Token.LeftArrow
-      |Token.MacroQuotedIdent
-      |Token.MacroSplicedIdent
       |Token.RightArrow
       |Token.Unquote
       |Token.Xml.End

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
@@ -90,12 +90,7 @@ class MacroSuite extends BaseDottySuite {
       )
     )
     val layoutMatchSimple = "x match {\n  case 'c => 1\n}"
-    runTestAssert[Stat]("x match { case 'c => 1 }", assertLayout = Some(layoutMatchSimple))(
-      Term.Match(
-        tname("x"),
-        List(Case(Pat.Macro(Term.QuotedMacroExpr(tname("c"))), None, Lit.Int(1)))
-      )
-    )
+    runTestError[Stat]("x match { case 'c => 1 }", "Symbol literals are no longer allowed")
     val layoutMatchComplex = "x match {\n  case '{ a } => 1\n}"
     runTestAssert[Stat]("x match { case '{ a } => 1 }", assertLayout = Some(layoutMatchComplex))(
       Term.Match(
@@ -224,7 +219,7 @@ class MacroSuite extends BaseDottySuite {
     )
   }
 
-  test("non-macro-dolar-ident") {
+  test("non-macro-dollar-ident") {
     val code = "a.map($d => $d.a)"
     runTestAssert[Stat](code)(
       Term.Apply(
@@ -239,7 +234,7 @@ class MacroSuite extends BaseDottySuite {
     )
   }
 
-  test("non-macro-dolar-type") {
+  test("non-macro-dollar-type") {
     val code = "type $F2 = [$T] => $T => Option[$T]"
     runTestAssert[Stat](code)(
       Defn.Type(

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
@@ -224,6 +224,38 @@ class MacroSuite extends BaseDottySuite {
     )
   }
 
+  test("non-macro-dolar-ident") {
+    val code = "a.map($d => $d.a)"
+    runTestAssert[Stat](code)(
+      Term.Apply(
+        Term.Select(Term.Name("a"), Term.Name("map")),
+        List(
+          Term.Function(
+            List(Term.Param(Nil, Term.Name("$d"), None, None)),
+            Term.Select(Term.Name("$d"), Term.Name("a"))
+          )
+        )
+      )
+    )
+  }
+
+  test("non-macro-dolar-type") {
+    val code = "type $F2 = [$T] => $T => Option[$T]"
+    runTestAssert[Stat](code)(
+      Defn.Type(
+        Nil,
+        Type.Name("$F2"),
+        Nil,
+        Type.PolyFunction(
+          List(Type.Param(Nil, Type.Name("$T"), Nil, Type.Bounds(None, None), Nil, Nil)),
+          Type
+            .Function(List(Type.Name("$T")), Type.Apply(Type.Name("Option"), List(Type.Name("$T"))))
+        ),
+        Type.Bounds(None, None)
+      )
+    )
+  }
+
   test("macro-quote-complex") {
     runTestAssert[Stat]("'{ ClassTag[T](${ Expr(ct.runtimeClass.asInstanceOf[Class[T]]) }) }")(
       Term.QuotedMacroExpr(


### PR DESCRIPTION
In order to figure out if something is a spliced or quoted variable we need to know what is the current context. I haven't found a better way to actually figure out if something is an identifier or spliced/quoted identifier. Anything else would require us to add an additional parameter to all of the methods and I figured that since we are already in a mutable context this is a much easier solution.

We could possibly remove `MacroSplicedIdent`, since we can just check if identifier starts with $ inside the context, but it does work together with `MacroQuotedIdent` - kind of looks symetrical. But it does mean we have to handle `MacroSplicedIdent` specially.

Fix #2191 
