### PR TITLE
Move soft keyword definitions outside the parser

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -36,6 +36,9 @@ import scala.util.Failure
 class ScalametaParser(input: Input, dialect: Dialect) { parser =>
   require(Set("", EOL).contains(dialect.toplevelSeparator))
   implicit val currentDialect: Dialect = dialect
+  val softKeywords = new SoftKeywords(currentDialect)
+  import softKeywords._
+
   /* ------------- PARSER ENTRY POINTS -------------------------------------------- */
 
   def parseRule[T <: Tree](rule: this.type => T): T = {
@@ -835,77 +838,6 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
 
     def isCaseClassOrObjectOrEnum =
       (isCaseClassOrObject || (token.is[KwCase] && token.next.is[Ident] && dialect.allowEnums))
-  }
-
-  @classifier
-  trait SkAs {
-    val name = "as"
-    def unapply(token: Token): Boolean = {
-      isSoftKw(token, name) && dialect.allowAsPatternBinding
-    }
-  }
-  @classifier
-  trait SkUsing {
-    val name = "using"
-    def unapply(token: Token): Boolean = {
-      isSoftKw(token, name) && dialect.allowGivenUsing
-    }
-  }
-
-  @classifier
-  trait SkInline {
-    val name = "inline"
-    def unapply(token: Token): Boolean = {
-      isSoftKw(token, name) && dialect.allowInlineMods
-    }
-  }
-
-  @classifier
-  trait SkOpaque {
-    val name = "opaque"
-    def unapply(token: Token): Boolean = {
-      isSoftKw(token, name) && dialect.allowOpaqueTypes
-    }
-  }
-
-  @classifier
-  trait SkOpen {
-    val name = "open"
-    def unapply(token: Token): Boolean = {
-      isSoftKw(token, name) && dialect.allowOpenClass
-    }
-  }
-
-  @classifier
-  trait SkTransparent {
-    val name = "transparent"
-    def unapply(token: Token): Boolean = {
-      isSoftKw(token, name) && dialect.allowInlineMods
-    }
-  }
-
-  @classifier
-  trait SkDerives {
-    val name = "derives"
-    def unapply(token: Token): Boolean = {
-      isSoftKw(token, name) && dialect.allowDerives
-    }
-  }
-
-  @classifier
-  trait SkEnd {
-    val name = "end"
-    def unapply(token: Token): Boolean = {
-      isSoftKw(token, name) && dialect.allowSignificantIndentation
-    }
-  }
-
-  @classifier
-  trait SkInfix {
-    val name = "infix"
-    def unapply(token: Token): Boolean = {
-      isSoftKw(token, name) && dialect.allowInfixMods
-    }
   }
 
   @classifier

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SoftKeywords.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SoftKeywords.scala
@@ -7,81 +7,79 @@ import scala.meta.internal.classifiers.classifier
 
 class SoftKeywords(dialect: Dialect) {
 
-  def isIdentAnd(token: Token, pred: String => Boolean): Boolean = token match {
-    case Ident(value) if pred(value.stripPrefix("`").stripSuffix("`")) => true
-    case _ => false
-  }
+  import ScalametaParser.isIdentAnd
 
-  def isSoftKw(token: Token, name: String): Boolean = isIdentAnd(token, _ == name)
+  private def matches(token: Token, name: String, isEnabled: => Boolean): Boolean =
+    isEnabled && isIdentAnd(token, _ == name)
 
   @classifier
-  trait SkAs {
+  trait KwAs {
     val name = "as"
     def unapply(token: Token): Boolean = {
-      isSoftKw(token, name) && dialect.allowAsPatternBinding
+      matches(token, name, dialect.allowAsPatternBinding)
     }
   }
   @classifier
-  trait SkUsing {
+  trait KwUsing {
     val name = "using"
     def unapply(token: Token): Boolean = {
-      isSoftKw(token, name) && dialect.allowGivenUsing
+      matches(token, name, dialect.allowGivenUsing)
     }
   }
 
   @classifier
-  trait SkInline {
+  trait KwInline {
     val name = "inline"
     def unapply(token: Token): Boolean = {
-      isSoftKw(token, name) && dialect.allowInlineMods
+      matches(token, name, dialect.allowInlineMods)
     }
   }
 
   @classifier
-  trait SkOpaque {
+  trait KwOpaque {
     val name = "opaque"
     def unapply(token: Token): Boolean = {
-      isSoftKw(token, name) && dialect.allowOpaqueTypes
+      matches(token, name, dialect.allowOpaqueTypes)
     }
   }
 
   @classifier
-  trait SkOpen {
+  trait KwOpen {
     val name = "open"
     def unapply(token: Token): Boolean = {
-      isSoftKw(token, name) && dialect.allowOpenClass
+      matches(token, name, dialect.allowOpenClass)
     }
   }
 
   @classifier
-  trait SkTransparent {
+  trait KwTransparent {
     val name = "transparent"
     def unapply(token: Token): Boolean = {
-      isSoftKw(token, name) && dialect.allowInlineMods
+      matches(token, name, dialect.allowInlineMods)
     }
   }
 
   @classifier
-  trait SkDerives {
+  trait KwDerives {
     val name = "derives"
     def unapply(token: Token): Boolean = {
-      isSoftKw(token, name) && dialect.allowDerives
+      matches(token, name, dialect.allowDerives)
     }
   }
 
   @classifier
-  trait SkEnd {
+  trait KwEnd {
     val name = "end"
     def unapply(token: Token): Boolean = {
-      isSoftKw(token, name) && dialect.allowSignificantIndentation
+      matches(token, name, dialect.allowSignificantIndentation)
     }
   }
 
   @classifier
-  trait SkInfix {
+  trait KwInfix {
     val name = "infix"
     def unapply(token: Token): Boolean = {
-      isSoftKw(token, name) && dialect.allowInfixMods
+      matches(token, name, dialect.allowInfixMods)
     }
   }
 }

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SoftKeywords.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SoftKeywords.scala
@@ -1,0 +1,87 @@
+package scala.meta.internal.parsers
+
+import scala.meta.Dialect
+import scala.meta.tokens.Token
+import scala.meta.tokens.Token.Ident
+import scala.meta.internal.classifiers.classifier
+
+class SoftKeywords(dialect: Dialect) {
+
+  def isIdentAnd(token: Token, pred: String => Boolean): Boolean = token match {
+    case Ident(value) if pred(value.stripPrefix("`").stripSuffix("`")) => true
+    case _ => false
+  }
+
+  def isSoftKw(token: Token, name: String): Boolean = isIdentAnd(token, _ == name)
+
+  @classifier
+  trait SkAs {
+    val name = "as"
+    def unapply(token: Token): Boolean = {
+      isSoftKw(token, name) && dialect.allowAsPatternBinding
+    }
+  }
+  @classifier
+  trait SkUsing {
+    val name = "using"
+    def unapply(token: Token): Boolean = {
+      isSoftKw(token, name) && dialect.allowGivenUsing
+    }
+  }
+
+  @classifier
+  trait SkInline {
+    val name = "inline"
+    def unapply(token: Token): Boolean = {
+      isSoftKw(token, name) && dialect.allowInlineMods
+    }
+  }
+
+  @classifier
+  trait SkOpaque {
+    val name = "opaque"
+    def unapply(token: Token): Boolean = {
+      isSoftKw(token, name) && dialect.allowOpaqueTypes
+    }
+  }
+
+  @classifier
+  trait SkOpen {
+    val name = "open"
+    def unapply(token: Token): Boolean = {
+      isSoftKw(token, name) && dialect.allowOpenClass
+    }
+  }
+
+  @classifier
+  trait SkTransparent {
+    val name = "transparent"
+    def unapply(token: Token): Boolean = {
+      isSoftKw(token, name) && dialect.allowInlineMods
+    }
+  }
+
+  @classifier
+  trait SkDerives {
+    val name = "derives"
+    def unapply(token: Token): Boolean = {
+      isSoftKw(token, name) && dialect.allowDerives
+    }
+  }
+
+  @classifier
+  trait SkEnd {
+    val name = "end"
+    def unapply(token: Token): Boolean = {
+      isSoftKw(token, name) && dialect.allowSignificantIndentation
+    }
+  }
+
+  @classifier
+  trait SkInfix {
+    val name = "infix"
+    def unapply(token: Token): Boolean = {
+      isSoftKw(token, name) && dialect.allowInfixMods
+    }
+  }
+}

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
@@ -52,10 +52,10 @@ class ParseSuite extends FunSuite with CommonTrees {
 object MoreHelpers {
   implicit class XtensionCode(code: String) {
     def applyRule[T <: Tree](rule: ScalametaParser => T)(implicit dialect: Dialect): T = {
-      rule(new ScalametaParser(Input.String(code), dialect))
+      rule(new ScalametaParser(Input.String(code)))
     }
     def parseRule[T <: Tree](rule: ScalametaParser => T)(implicit dialect: Dialect): T = {
-      new ScalametaParser(Input.String(code), dialect).parseRule(rule)
+      new ScalametaParser(Input.String(code)).parseRule(rule)
     }
   }
 }


### PR DESCRIPTION
Based on https://github.com/scalameta/scalafmt/pull/2284#discussion_r538886558

This way they can be reused inside scalafmt.