### PR TITLE
Make sure enum cases can only be created within an enum

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -341,11 +341,15 @@ object Defn {
       tparams: List[scala.meta.Type.Param],
       ctor: Ctor.Primary,
       inits: List[Init]
-  ) extends Defn with Member.Term
+  ) extends Defn with Member.Term {
+    checkParent(ParentChecks.EnumCase)
+  }
   @ast class RepeatedEnumCase(
       mods: List[Mod],
       cases: List[Term.Name]
-  ) extends Defn
+  ) extends Defn {
+    checkParent(ParentChecks.EnumCase)
+  }
   @ast class GivenAlias(
       mods: List[Mod],
       name: scala.meta.Name,

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/ParentChecks.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/ParentChecks.scala
@@ -105,6 +105,10 @@ object ParentChecks {
     tree.tpe.is[Type.Singleton] ==> (parent.is[Ctor.Secondary] && destination == "init")
   }
 
+  def EnumCase(tree: Tree, parent: Tree, destination: String): Boolean = {
+    parent.is[Template] && parent.parent.map(_.is[Defn.Enum]).getOrElse(true)
+  }
+
   def TypeLambda(tree: Type.Lambda, parent: Tree, destination: String): Boolean = {
     parent.is[Type] || parent.is[Defn.Type] || parent.is[Term.ApplyType]
   }


### PR DESCRIPTION
Previously, parser would allow enum cases to be created anywhere, which is not allowed in the language itself. Now, we make sure that enums are the only ones that can own enum cases. 

This has added a number of parameters to a bunch of methods, but I think it's the cleanest solution that we can have.