### PR TITLE
Fix product names in macros for 2.13

### DIFF
--- a/scalameta/common/shared/src/main/scala-2.11/org/scalameta/internal/MacroCompat.scala
+++ b/scalameta/common/shared/src/main/scala-2.11/org/scalameta/internal/MacroCompat.scala
@@ -4,6 +4,10 @@ import scala.collection.immutable
 
 trait MacroCompat
 
+object MacroCompat {
+  val productFieldNamesAvailable = false
+}
+
 object ScalaCompat {
   type IndexedSeqOptimized[+A] = scala.collection.IndexedSeqOptimized[A, immutable.IndexedSeq[A]]
   implicit class XtensionScala213ToSeq[T](seq: collection.Seq[T]) {

--- a/scalameta/common/shared/src/main/scala-2.12/org/scalameta/internal/MacroCompat.scala
+++ b/scalameta/common/shared/src/main/scala-2.12/org/scalameta/internal/MacroCompat.scala
@@ -5,6 +5,10 @@ import scala.collection.mutable.ArrayBuffer
 
 trait MacroCompat
 
+object MacroCompat {
+  val productFieldNamesAvailable = false
+}
+
 object ScalaCompat {
   type IndexedSeqOptimized[+A] = scala.collection.IndexedSeqOptimized[A, immutable.IndexedSeq[A]]
   implicit class XtensionScala213ToSeq[T](seq: collection.Seq[T]) {

--- a/scalameta/common/shared/src/main/scala-2.13/org/scalameta/internal/MacroCompat.scala
+++ b/scalameta/common/shared/src/main/scala-2.13/org/scalameta/internal/MacroCompat.scala
@@ -9,6 +9,10 @@ trait MacroCompat {
   type AssignOrNamedArg = NamedArg
 }
 
+object MacroCompat {
+  val productFieldNamesAvailable = true
+}
+
 object ScalaCompat {
   // Removed in 2.13
   trait IndexedSeqOptimized[+A]


### PR DESCRIPTION
`productElementName` was introduced in 2.13 and some libraries might use it to print names for field. When for example using pprint, previously we would get:

```scala
Source(
   = List(
    Defn.Def( = List(),  = Term.Name( = "b"),  = List(),  = List(),  = None,  = Lit.Int( = 1))
  )
)
```

now we get
```
Source(
  stats = List(
    Defn.Def(
      mods = List(),
      name = Term.Name(value = "b"),
      tparams = List(),
      paramss = List(),
      decltpe = None,
      body = Lit.Int(value = 1)
    )
  )
)
```
