### PR TITLE
Add support for dependent function types

### DIFF
--- a/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
@@ -31,6 +31,7 @@ final class Dialect private (
     // Are literal types allowed, i.e. is `val a : 42 = 42` legal or not?
     val allowLiteralTypes: Boolean,
     // Are method types allowed, i.e. is `(x: X): x.T` legal or not?
+    @deprecated("Method type syntax is no longer supported in any dialect", "4.4.3")
     val allowMethodTypes: Boolean,
     // Are multiline programs allowed?
     // Some quasiquotes only support single-line snippets.
@@ -259,6 +260,7 @@ final class Dialect private (
   def withAllowLiteralTypes(newValue: Boolean): Dialect = {
     privateCopy(allowLiteralTypes = newValue)
   }
+  @deprecated("Method type syntax is no longer supported in any dialect", "4.4.3")
   def withAllowMethodTypes(newValue: Boolean): Dialect = {
     privateCopy(allowMethodTypes = newValue)
   }

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
@@ -127,7 +127,9 @@ final class Dialect private (
     // Scala 3 splices/quotes
     val allowSpliceAndQuote: Boolean,
     // Scala 3 disallowed symbol literals
-    val allowSymbolLiterals: Boolean
+    val allowSymbolLiterals: Boolean,
+    // Scala 3 disallowed symbol literals
+    val allowDependentFunctionTypes: Boolean
 ) extends Product with Serializable {
 
   // NOTE(olafur) checklist for adding a new dialect field in a binary compatible way:
@@ -215,7 +217,8 @@ final class Dialect private (
       allowTypeMatch = false,
       allowInfixMods = false,
       allowSpliceAndQuote = false,
-      allowSymbolLiterals = true
+      allowSymbolLiterals = true,
+      allowDependentFunctionTypes = false
       // NOTE(olafur): declare the default value for new fields above this comment.
     )
   }
@@ -389,6 +392,9 @@ final class Dialect private (
   def withAllowSymbolLiterals(newValue: Boolean): Dialect = {
     privateCopy(allowSymbolLiterals = newValue)
   }
+  def withAllowDependentFunctionTypes(newValue: Boolean): Dialect = {
+    privateCopy(allowDependentFunctionTypes = newValue)
+  }
   // NOTE(olafur): add the next `withX()` method above this comment. Please try
   // to use consistent formatting, use `newValue` as the parameter name and wrap
   // the body inside curly braces.
@@ -447,7 +453,8 @@ final class Dialect private (
       allowTypeMatch: Boolean = this.allowTypeMatch,
       allowInfixMods: Boolean = this.allowInfixMods,
       allowSpliceAndQuote: Boolean = this.allowSpliceAndQuote,
-      allowSymbolLiterals: Boolean = this.allowSymbolLiterals
+      allowSymbolLiterals: Boolean = this.allowSymbolLiterals,
+      allowDependentFunctionTypes: Boolean = this.allowDependentFunctionTypes
       // NOTE(olafur): add the next parameter above this comment.
   ): Dialect = {
     new Dialect(
@@ -503,7 +510,8 @@ final class Dialect private (
       allowTypeMatch,
       allowInfixMods,
       allowSpliceAndQuote,
-      allowSymbolLiterals
+      allowSymbolLiterals,
+      allowDependentFunctionTypes
       // NOTE(olafur): add the next argument above this comment.
     )
   }

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -132,7 +132,6 @@ package object dialects {
     require(!underlying.allowUnquotes)
     underlying.copy(
       allowTermUnquotes = true,
-      allowMethodTypes = true,
       allowMultilinePrograms = multiline,
       allowTypeLambdas = true
     )
@@ -142,7 +141,6 @@ package object dialects {
     require(!underlying.allowUnquotes)
     underlying.copy(
       allowPatUnquotes = true,
-      allowMethodTypes = true,
       allowMultilinePrograms = multiline,
       allowTypeLambdas = true
     )

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -126,6 +126,7 @@ package object dialects {
     .withAllowTypeMatch(true)
     .withAllowInfixMods(true)
     .withAllowSymbolLiterals(false)
+    .withAllowDependentFunctionTypes(true)
 
   private[meta] def QuasiquoteTerm(underlying: Dialect, multiline: Boolean) = {
     require(!underlying.allowUnquotes)

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -214,6 +214,8 @@ object Type {
     checkFields(name.value(0).isLower)
     checkParent(ParentChecks.TypeVar)
   }
+
+  @ast class TypedParam(name: Name, typ: Type) extends Type with Member.Type
   @ast class Param(
       mods: List[Mod],
       name: meta.Name,

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -199,6 +199,7 @@ object Type {
     checkParent(ParentChecks.TypeLambda)
   }
   @ast class Macro(body: Term) extends Type
+  @deprecated("Method type syntax is no longer supported in any dialect", "4.4.3")
   @ast class Method(paramss: List[List[Term.Param]], tpe: Type) extends Type {
     checkParent(ParentChecks.TypeMethod)
   }

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -649,7 +649,8 @@ object TreeSyntax {
           case Type.ContextFunction(params, res) => (s(), params, "?=>", res)
         }
         val params = tParams match {
-          case param +: Nil if param.isNot[Type.Tuple] && param.isNot[Type.TypedParam] => s(p(AnyInfixTyp, param))
+          case param +: Nil if param.isNot[Type.Tuple] && param.isNot[Type.TypedParam] =>
+            s(p(AnyInfixTyp, param))
           case params => s("(", r(params.map(param => p(ParamTyp, param)), ", "), ")")
         }
         m(Typ, s(prefix, params, " ", kw(arrow), " ", p(Typ, tRes)))
@@ -702,7 +703,6 @@ object TreeSyntax {
           Type,
           s(p(AnyInfixTyp, t.tpe), " ", kw("match"), " {", r(t.cases.map(i(_)), ""), n("}"))
         )
-      case t: Type.Method => m(Typ, t.paramss, kw(":"), " ", p(Typ, t.tpe))
       case t: Type.Placeholder =>
         if (dialect.allowQuestionMarkPlaceholder) m(SimpleTyp, s(kw("?"), t.bounds))
         else m(SimpleTyp, s(kw("_"), t.bounds))

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -649,7 +649,7 @@ object TreeSyntax {
           case Type.ContextFunction(params, res) => (s(), params, "?=>", res)
         }
         val params = tParams match {
-          case param +: Nil if !param.is[Type.Tuple] => s(p(AnyInfixTyp, param))
+          case param +: Nil if param.isNot[Type.Tuple] && param.isNot[Type.TypedParam] => s(p(AnyInfixTyp, param))
           case params => s("(", r(params.map(param => p(ParamTyp, param)), ", "), ")")
         }
         m(Typ, s(prefix, params, " ", kw(arrow), " ", p(Typ, tRes)))
@@ -720,6 +720,7 @@ object TreeSyntax {
         }
       case t: Type.ByName => m(ParamTyp, s(kw("=>"), " ", p(Typ, t.tpe)))
       case t: Type.Var => m(SimpleTyp, s(t.name.value))
+      case t: Type.TypedParam => m(SimpleTyp, s(t.name.value), ": ", p(Typ, t.typ))
       case t: Type.Param =>
         val mods = t.mods.filter(m => !m.is[Mod.Covariant] && !m.is[Mod.Contravariant])
         require(t.mods.length - mods.length <= 1)

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -384,6 +384,7 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.Type.Select
       |scala.meta.Type.Singleton
       |scala.meta.Type.Tuple
+      |scala.meta.Type.TypedParam
       |scala.meta.Type.Var
       |scala.meta.Type.With
       |scala.meta.TypeCase

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
@@ -21,7 +21,7 @@ class ReflectionSuite extends FunSuite {
   test("root") {
     assert(symbolOf[scala.meta.Tree].isRoot)
     assertEquals(symbolOf[scala.meta.Tree].asRoot.allBranches.length, 19)
-    assertEquals(symbolOf[scala.meta.Tree].asRoot.allLeafs.length, 335)
+    assertEquals(symbolOf[scala.meta.Tree].asRoot.allLeafs.length, 337)
   }
 
   test("If") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NewFunctionsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NewFunctionsSuite.scala
@@ -428,4 +428,121 @@ class NewFunctionsSuite extends BaseDottySuite {
       )
     )
   }
+
+  test("dependent-type") {
+    runTestAssert[Stat](
+      "val extractor: (e: Entry) => e.Key = extractKey"
+    )(
+      Defn.Val(
+        Nil,
+        List(Pat.Var(Term.Name("extractor"))),
+        Some(
+          Type.Function(
+            List(Type.TypedParam(Type.Name("e"), Type.Name("Entry"))),
+            Type.Select(Term.Name("e"), Type.Name("Key"))
+          )
+        ),
+        Term.Name("extractKey")
+      )
+    )
+  }
+
+  test("dependent-type-context") {
+    runTestAssert[Stat](
+      "val extractor: (e: Entry) ?=> e.Key = extractKey"
+    )(
+      Defn.Val(
+        Nil,
+        List(Pat.Var(Term.Name("extractor"))),
+        Some(
+          Type.ContextFunction(
+            List(Type.TypedParam(Type.Name("e"), Type.Name("Entry"))),
+            Type.Select(Term.Name("e"), Type.Name("Key"))
+          )
+        ),
+        Term.Name("extractKey")
+      )
+    )
+  }
+
+  test("dependent-type-multi") {
+    runTestAssert[Stat](
+      "val extractor: (e: Entry, f: Other) => e.Key = extractKey"
+    )(
+      Defn.Val(
+        Nil,
+        List(Pat.Var(Term.Name("extractor"))),
+        Some(
+          Type.Function(
+            List(
+              Type.TypedParam(Type.Name("e"), Type.Name("Entry")),
+              Type.TypedParam(Type.Name("f"), Type.Name("Other"))
+            ),
+            Type.Select(Term.Name("e"), Type.Name("Key"))
+          )
+        ),
+        Term.Name("extractKey")
+      )
+    )
+  }
+
+  test("dependent-type-term") {
+    runTestAssert[Stat](
+      "type T = (e: Entry) => e.Key"
+    )(
+      Defn.Type(
+        Nil,
+        Type.Name("T"),
+        Nil,
+        Type.Function(
+          List(Type.TypedParam(Type.Name("e"), Type.Name("Entry"))),
+          Type.Select(Term.Name("e"), Type.Name("Key"))
+        ),
+        Type.Bounds(None, None)
+      )
+    )
+  }
+
+  test("dependent-type-term-context") {
+    runTestAssert[Stat](
+      "type T = (e: Entry) ?=> e.Key"
+    )(
+      Defn.Type(
+        Nil,
+        Type.Name("T"),
+        Nil,
+        Type.ContextFunction(
+          List(Type.TypedParam(Type.Name("e"), Type.Name("Entry"))),
+          Type.Select(Term.Name("e"), Type.Name("Key"))
+        ),
+        Type.Bounds(None, None)
+      )
+    )
+  }
+
+  test("dependent-type-term-multi") {
+    runTestAssert[Stat](
+      "type T = (e: Entry, o: Other[? <: P]) => e.Key"
+    )(
+      Defn.Type(
+        Nil,
+        Type.Name("T"),
+        Nil,
+        Type.Function(
+          List(
+            Type.TypedParam(Type.Name("e"), Type.Name("Entry")),
+            Type.TypedParam(
+              Type.Name("o"),
+              Type.Apply(
+                Type.Name("Other"),
+                List(Type.Placeholder(Type.Bounds(None, Some(Type.Name("P")))))
+              )
+            )
+          ),
+          Type.Select(Term.Name("e"), Type.Name("Key"))
+        ),
+        Type.Bounds(None, None)
+      )
+    )
+  }
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -1051,21 +1051,6 @@ class SuccessSuite extends FunSuite {
     )
   }
 
-  test("1 t\"(...paramss): tpe\"") {
-    val t"(...$paramss): $tpe" = t"(x: X): x.T"
-    assert(paramss.toString == "List(List(x: X))")
-    assert(tpe.toString == "x.T")
-  }
-
-  test("2 t\"(...paramss): tpe\"") {
-    val paramss = List(List(param"x: X"))
-    val tpe = t"x.T"
-    assert(
-      t"(...$paramss): $tpe".structure ==
-        "Type.Method(List(List(Term.Param(Nil, Term.Name(\"x\"), Some(Type.Name(\"X\")), None))), Type.Select(Term.Name(\"x\"), Type.Name(\"T\")))"
-    )
-  }
-
   test("1 t\"_ >: tpeopt <: tpeopt\"") {
     val t"_ >: $tpe1 <: $tpe2" = t"_ >: X <: Y"
     assert(tpe1.structure == "Some(Type.Name(\"X\"))")


### PR DESCRIPTION
Dependent function types are a new features in Scala 3, which is explained [here](https://dotty.epfl.ch/docs/reference/new-types/dependent-function-types.html). While working on this I noticed that MethodType is something that is no longer in any dialect and is not really used at all. Because of that and the fact that it caused some issues parsing dependent function types I decided to get rid of it and deprecate all dialect methods.

