### PR TITLE
Fix TypeCase positions to not include a previous character

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1430,8 +1430,10 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
     def typeCaseClauses(): List[TypeCase] = {
       def cases() = {
         val allCases = new ListBuffer[TypeCase]
-        while (token.is[KwCase])
+        while (token.is[KwCase]) {
           allCases += typeCaseClause()
+          acceptOpt[LF]
+        }
         allCases.toList
       }
       if (token.is[LeftBrace]) {
@@ -1448,12 +1450,11 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
 
     }
 
-    def typeCaseClause(): TypeCase = atPos(in.prevTokenPos, auto) {
+    def typeCaseClause(): TypeCase = autoPos {
       accept[KwCase]
       val pat = infixTypeOrTuple(allowFunctionType = false)
       accept[RightArrow]
       val tpe = typ()
-      acceptOpt[LF]
       TypeCase(
         pat,
         tpe


### PR DESCRIPTION
Previously, type case would include the opening `{` due to the code being copied from `caseClause` method. Now it only included the exact position.

I also added more tests to see if the positions are incorrect anywhere else.