### PR TITLE
Remove `as` soft keyword in patterns and givens

### DIFF
--- a/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
@@ -110,7 +110,8 @@ final class Dialect private (
     val allowByNameRepeatedParameters: Boolean,
     // Dotty allows lazy val abstract values
     val allowLazyValAbstractValues: Boolean,
-    // Dotty allows `as` instead of `@` for pattern bindings
+    // Dotty used to allow `as` instead of `@` for pattern bindings
+    @deprecated("`as` in patterns is no longer supported in any dialect", "4.4.4")
     val allowAsPatternBinding: Boolean,
     // Dotty allows capital pattern vars in `case A @ _ =>`
     val allowUpperCasePatternVarBinding: Boolean,
@@ -365,6 +366,7 @@ final class Dialect private (
   def withAllowLazyValAbstractValues(newValue: Boolean): Dialect = {
     privateCopy(allowLazyValAbstractValues = newValue)
   }
+  @deprecated("`as` in patterns is no longer supported in any dialect", "4.4.4")
   def withAllowAsPatternBinding(newValue: Boolean): Dialect = {
     privateCopy(allowAsPatternBinding = newValue)
   }

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -117,7 +117,6 @@ package object dialects {
     .withAllowTypeParamUnderscore(false)
     .withAllowByNameRepeatedParameters(true)
     .withAllowLazyValAbstractValues(true)
-    .withAllowAsPatternBinding(true)
     .withAllowUpperCasePatternVarBinding(true)
     .withAllowDerives(true)
     .withAllowTypeInBlock(true)

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SoftKeywords.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SoftKeywords.scala
@@ -13,13 +13,6 @@ class SoftKeywords(dialect: Dialect) {
     isEnabled && isIdentAnd(token, _ == name)
 
   @classifier
-  trait KwAs {
-    val name = "as"
-    def unapply(token: Token): Boolean = {
-      matches(token, name, dialect.allowAsPatternBinding)
-    }
-  }
-  @classifier
   trait KwUsing {
     val name = "using"
     def unapply(token: Token): Boolean = {

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -743,15 +743,14 @@ object TreeSyntax {
       case _: Pat.SeqWildcard => m(SimplePattern, kw("_*"))
       case pat: Pat.Given => m(SimplePattern, s(kw("given"), " ", pat.tpe))
       case t: Pat.Bind =>
-        val binder = if (dialect.allowAsPatternBinding) "as" else "@"
         val separator = t.rhs match {
           case Pat.SeqWildcard() =>
-            if (dialect.allowAtForExtractorVarargs) s(" ", kw(binder))
+            if (dialect.allowAtForExtractorVarargs) s(" ", kw("@"))
             else if (dialect.allowColonForExtractorVarargs) s(kw(":"))
             else
               throw new UnsupportedOperationException(s"$dialect doesn't support extractor varargs")
           case _ =>
-            s(" ", kw(binder))
+            s(" ", kw("@"))
         }
         m(Pattern2, s(p(SimplePattern, t.lhs), separator, " ", p(AnyPattern3, t.rhs)))
       case t: Pat.Alternative =>
@@ -1156,10 +1155,10 @@ object TreeSyntax {
         sparams: List[List[Term.Param]]
     ): Show.Result = {
       if (!name.is[meta.Name.Anonymous]) {
-        s(name, tparams, sparams, " as ")
+        s(name, tparams, sparams, ": ")
       } else {
         if (tparams.nonEmpty || sparams.nonEmpty) {
-          s(tparams, sparams, " as ")
+          s(tparams, sparams, ": ")
         } else {
           s()
         }

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -68,10 +68,10 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |""".stripMargin
   )
   checkPositions[Stat](
-    "inline given intOrd as Ord[Int] { def f(): Int = 1 }",
+    "inline given intOrd: Ord[Int] { def f(): Int = 1 }",
     """|Type.Apply Ord[Int]
        |Template { def f(): Int = 1 }
-       |Self inline given intOrd as Ord[Int] { @@def f(): Int = 1 }
+       |Self inline given intOrd: Ord[Int] { @@def f(): Int = 1 }
        |Defn.Def def f(): Int = 1
        |""".stripMargin
   )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
@@ -23,7 +23,7 @@ class GivenUsingSuite extends BaseDottySuite {
   val defone = Defn.Def(Nil, tname("f"), Nil, List(Nil), Some(pname("Int")), int(1))
 
   test("given-named") {
-    runTestAssert[Stat]("given intOrd as Ord[Int] { def f(): Int = 1 }")(
+    runTestAssert[Stat]("given intOrd: Ord[Int] { def f(): Int = 1 }")(
       Defn.Given(
         Nil,
         pname("intOrd"),
@@ -36,7 +36,7 @@ class GivenUsingSuite extends BaseDottySuite {
   }
 
   test("given-named-newline") {
-    runTestAssert[Stat]("given intOrd as Ord[Int] \n { def f(): Int = 1 }", assertLayout = None)(
+    runTestAssert[Stat]("given intOrd: Ord[Int] \n { def f(): Int = 1 }", assertLayout = None)(
       Defn.Given(
         Nil,
         pname("intOrd"),
@@ -55,15 +55,8 @@ class GivenUsingSuite extends BaseDottySuite {
     )
   }
 
-  test("given-anon-as") {
-    runTestError(
-      "given as Context = ctx",
-      "; expected but identifier found"
-    )
-  }
-
   test("given-override-def") {
-    runTestAssert[Stat]("given intOrd as Ord[Int] { override def f(): Int = 1 }")(
+    runTestAssert[Stat]("given intOrd: Ord[Int] { override def f(): Int = 1 }")(
       Defn.Given(
         Nil,
         pname("intOrd"),
@@ -77,11 +70,11 @@ class GivenUsingSuite extends BaseDottySuite {
   test("given-override-def") {
     runTestAssert[Stat](
       """|given intOrd
-         |   as Ord[Int] {
+         |   : Ord[Int] {
          |  def fn = ()
          |}
          |""".stripMargin,
-      assertLayout = Some("given intOrd as Ord[Int] { def fn = () }")
+      assertLayout = Some("given intOrd: Ord[Int] { def fn = () }")
     )(
       Defn.Given(
         Nil,
@@ -100,7 +93,7 @@ class GivenUsingSuite extends BaseDottySuite {
   }
 
   test("given-self") {
-    runTestAssert[Stat]("given intOrd as Ord[Int] { current => }")(
+    runTestAssert[Stat]("given intOrd: Ord[Int] { current => }")(
       Defn.Given(
         Nil,
         pname("intOrd"),
@@ -114,13 +107,13 @@ class GivenUsingSuite extends BaseDottySuite {
 
   test("given-selftype-error".ignore) {
     runTestError(
-      "given intOrd as Ord[Int] { current: Ord[Int] => }",
+      "given intOrd: Ord[Int] { current: Ord[Int] => }",
       "objects must not have a self type"
     )
   }
 
   test("given-no-block") {
-    runTestAssert[Stat]("given intOrd as Ord[Int]")(
+    runTestAssert[Stat]("given intOrd: Ord[Int]")(
       Defn.Given(
         Nil,
         pname("intOrd"),
@@ -139,7 +132,7 @@ class GivenUsingSuite extends BaseDottySuite {
   }
 
   test("given-generic-named") {
-    runTestAssert[Stat]("given listOrd[T] as Ord[List[T]] { def f(): Int = 1 }")(
+    runTestAssert[Stat]("given listOrd[T]: Ord[List[T]] { def f(): Int = 1 }")(
       Defn.Given(
         Nil,
         pname("listOrd"),
@@ -165,7 +158,7 @@ class GivenUsingSuite extends BaseDottySuite {
   }
 
   test("given-depend-given-named") {
-    runTestAssert[Stat]("given setOrd[T](using ord: Ord[T]) as Ord[Set[T]]")(
+    runTestAssert[Stat]("given setOrd[T](using ord: Ord[T]): Ord[Set[T]]")(
       Defn.Given(
         Nil,
         pname("setOrd"),
@@ -187,7 +180,7 @@ class GivenUsingSuite extends BaseDottySuite {
   }
 
   test("given-depend-given-anonymous") {
-    runTestAssert[Stat]("given [T](using ord: Ord[T]) as Ord[Set[T]]")(
+    runTestAssert[Stat]("given [T](using ord: Ord[T]): Ord[Set[T]]")(
       Defn.Given(
         Nil,
         anon,
@@ -209,7 +202,7 @@ class GivenUsingSuite extends BaseDottySuite {
   }
 
   test("given-depend-given-anonymous-using") {
-    runTestAssert[Stat]("given (using Ord[String]) as Ord[Int]")(
+    runTestAssert[Stat]("given (using Ord[String]): Ord[Int]")(
       Defn.Given(
         Nil,
         anon,
@@ -231,7 +224,7 @@ class GivenUsingSuite extends BaseDottySuite {
   }
 
   test("given-inline") {
-    runTestAssert[Stat]("inline given intOrd as Ord[Int] { def f(): Int = 1 }")(
+    runTestAssert[Stat]("inline given intOrd: Ord[Int] { def f(): Int = 1 }")(
       Defn.Given(
         List(Mod.Inline()),
         pname("intOrd"),
@@ -245,7 +238,7 @@ class GivenUsingSuite extends BaseDottySuite {
 
   test("given-subtype-error".ignore) {
     // it is treaten as alias without '=' sign at the end and {...} is refinement part
-    runTestError("given intOrd as ? <: Ord[Int] { def f(): Int = 1 }", "missing = at the end")
+    runTestError("given intOrd: ? <: Ord[Int] { def f(): Int = 1 }", "missing = at the end")
   }
 
   // ---------------------------------
@@ -253,7 +246,7 @@ class GivenUsingSuite extends BaseDottySuite {
   // ---------------------------------
 
   test("given-alias-named") {
-    runTestAssert[Stat]("given global as Option[Int] = Some(3)")(
+    runTestAssert[Stat]("given global: Option[Int] = Some(3)")(
       Defn.GivenAlias(
         Nil,
         pname("global"),
@@ -280,7 +273,7 @@ class GivenUsingSuite extends BaseDottySuite {
 
   test("given-alias-block") {
     runTestAssert[Stat](
-      "given global as Option[Int] = { def f(): Int = 1; Some(3) }",
+      "given global: Option[Int] = { def f(): Int = 1; Some(3) }",
       assertLayout = None
     )(
       Defn.GivenAlias(
@@ -296,13 +289,13 @@ class GivenUsingSuite extends BaseDottySuite {
 
   test("given-alias-override-block-error".ignore) {
     runTestError(
-      "given global as Option[Int] = { override def f(): Int = 1; Some(3) }",
+      "given global: Option[Int] = { override def f(): Int = 1; Some(3) }",
       "no modifier allowed here"
     )
   }
 
   test("given-alias-using-named") {
-    runTestAssert[Stat]("given ordInt(using ord: Ord[Int]) as Ord[List[Int]] = ???")(
+    runTestAssert[Stat]("given ordInt(using ord: Ord[Int]): Ord[List[Int]] = ???")(
       Defn.GivenAlias(
         Nil,
         pname("ordInt"),
@@ -324,7 +317,7 @@ class GivenUsingSuite extends BaseDottySuite {
   }
 
   test("given-alias-using-anonymous") {
-    runTestAssert[Stat]("given (using ord: Ord[Int]) as Ord[List[Int]] = ???")(
+    runTestAssert[Stat]("given (using ord: Ord[Int]): Ord[List[Int]] = ???")(
       Defn.GivenAlias(
         Nil,
         anon,
@@ -346,7 +339,7 @@ class GivenUsingSuite extends BaseDottySuite {
   }
 
   test("given-alias-inline-subtype") {
-    runTestAssert[Stat]("inline given intOrd as ? <: Ord[Int] = ???")(
+    runTestAssert[Stat]("inline given intOrd: ? <: Ord[Int] = ???")(
       Defn.GivenAlias(
         List(Mod.Inline()),
         pname("intOrd"),
@@ -360,13 +353,13 @@ class GivenUsingSuite extends BaseDottySuite {
 
   test("given-alias-subtype-noinline-error".ignore) {
     runTestError(
-      "given intOrd as ? <: Ord[Int] = ???",
+      "given intOrd: ? <: Ord[Int] = ???",
       "is only allowed for given with inline modifier"
     )
   }
 
   test("given-alias-combo") {
-    runTestAssert[Stat]("inline given intOrd as ? <: Ord[Int] { val c: String } = ???")(
+    runTestAssert[Stat]("inline given intOrd: ? <: Ord[Int] { val c: String } = ???")(
       Defn.GivenAlias(
         List(Mod.Inline()),
         pname("intOrd"),
@@ -605,7 +598,7 @@ class GivenUsingSuite extends BaseDottySuite {
   test("given-pat") {
     runTestAssert[Stat](
       """|pair match {
-         |  case (ctx as given Context, y) =>
+         |  case (ctx @ given Context, y) =>
          |}
          |""".stripMargin
     )(

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -315,9 +315,9 @@ class MinorDottySuite extends BaseDottySuite {
     runTestError[Stat]("class F[_]", "identifier expected")
     runTestError[Stat]("enum X[T]{ case A[_] extends X[Int] }", "identifier expected")
     runTestError[Stat]("extension [_](x: Int) def inc: Int = x + 1", "identifier expected")
-    runTestError[Stat]("given [_](using Ord[T]) as Ord[List[T]]{}", "identifier expected")
+    runTestError[Stat]("given [_](using Ord[T]): Ord[List[T]]{}", "identifier expected")
 
-    runTestAssert[Stat]("given [T](using Ord[T]) as Ord[List[T]]")(
+    runTestAssert[Stat]("given [T](using Ord[T]): Ord[List[T]]")(
       Defn.Given(
         Nil,
         Name(""),
@@ -476,73 +476,6 @@ class MinorDottySuite extends BaseDottySuite {
     List(Case(Pat.Bind(Pat.Var(Term.Name("intValue")), Lit.Int(1)), None, Term.Block(Nil)))
   )
 
-  test("old-pattern-binding") {
-    runTestAssert[Stat](
-      """|1 match {
-         |  case intValue @ 1 =>
-         |}
-         |""".stripMargin,
-      assertLayout = Some(
-        """|1 match {
-           |  case intValue as 1 =>
-           |}
-           |""".stripMargin
-      )
-    )(patternBinding)
-
-  }
-
-  test("new-pattern-binding") {
-    runTestAssert[Stat]("""|1 match {
-                           |  case intValue as 1 =>
-                           |}
-                           |""".stripMargin)(patternBinding)
-  }
-
-  test("new-pattern-binding-soft") {
-    runTestAssert[Stat]("""|1 match {
-                           |  case as as 1 =>
-                           |}
-                           |""".stripMargin)(
-      Term.Match(
-        Lit.Int(1),
-        List(Case(Pat.Bind(Pat.Var(Term.Name("as")), Lit.Int(1)), None, Term.Block(Nil)))
-      )
-    )
-  }
-
-  test("new-pattern-binding-with-typed") {
-    // yes parens are allowed here and don't change semantics
-    val out = """|x match {
-                 |  case (three as Some(3)): Option[Int] => "OK"
-                 |}
-                 |""".stripMargin
-    runTestAssert[Stat](
-      """|x match {
-         |  case three as Some(3) : Option[Int] => "OK"
-         |}
-         |""".stripMargin,
-      assertLayout = Some(out)
-    )(
-      Term.Match(
-        Term.Name("x"),
-        List(
-          Case(
-            Pat.Typed(
-              Pat.Bind(
-                Pat.Var(Term.Name("three")),
-                Pat.Extract(Term.Name("Some"), List(Lit.Int(3)))
-              ),
-              Type.Apply(Type.Name("Option"), List(Type.Name("Int")))
-            ),
-            None,
-            Lit.String("OK")
-          )
-        )
-      )
-    )
-  }
-
   test("comment-after-coloneol") {
     val expected = "trait X { def x(): String }"
     runTestAssert[Stat](
@@ -621,7 +554,7 @@ class MinorDottySuite extends BaseDottySuite {
 
   test("capital-var-pattern-val") {
     runTestAssert[Stat](
-      """val Private as _ = flags()
+      """val Private @ _ = flags()
         |""".stripMargin
     )(
       Defn.Val(
@@ -636,7 +569,7 @@ class MinorDottySuite extends BaseDottySuite {
   test("capital-var-pattern-case") {
     runTestAssert[Stat](
       """|flags() match {
-         |  case Pattern as _ =>
+         |  case Pattern @ _ =>
          |}
          |""".stripMargin
     )(
@@ -904,7 +837,7 @@ class MinorDottySuite extends BaseDottySuite {
          |""".stripMargin,
       assertLayout = Some(
         """|a match {
-           |  case List(xs as _*) =>
+           |  case List(xs @ _*) =>
            |}
            |""".stripMargin
       )
@@ -931,7 +864,7 @@ class MinorDottySuite extends BaseDottySuite {
          |""".stripMargin,
       assertLayout = Some(
         """|a match {
-           |  case List(xs as _*) =>
+           |  case List(xs @ _*) =>
            |}
            |""".stripMargin
       )


### PR DESCRIPTION
Scala 3 no longer uses `as` in given declartions and instead uses a colon. Because of that and the limited need for
`as` it was also removed from patterns where it was a replacements for `@`

This still doesn't fix the givens with indentation that use the `with` keyword. The syntax is still fluctuating there, so we might need to work on it later.