### PR TITLE
Add inline match available in Scala 3

### DIFF
--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -38,6 +38,8 @@ object Mima {
     ),
     ProblemFilters.exclude[MissingClassProblem](
       "scala.meta.tokens.Token$KwExtension$sharedClassifier$"
-    )
+    ),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.meta.Term#Match.mods"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.meta.Term#Match.setMods")
   )
 }

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -113,7 +113,10 @@ object Term {
   @ast class QuotedMacroExpr(body: Term) extends Term
   @ast class QuotedMacroType(tpe: Type) extends Term
   @ast class SplicedMacroExpr(body: Term) extends Term
-  @ast class Match(expr: Term, cases: List[Case] @nonEmpty) extends Term
+  @ast class Match(expr: Term, cases: List[Case] @nonEmpty) extends Term {
+    @binaryCompatField(since = "4.4.5")
+    private var _mods: List[Mod] = Nil
+  }
   @ast class Try(expr: Term, catchp: List[Case], finallyp: Option[Term]) extends Term
   @ast class TryWithHandler(expr: Term, catchp: Term, finallyp: Option[Term]) extends Term
   @ast class ContextFunction(params: List[Term.Param], body: Term) extends Term {

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -265,10 +265,12 @@ object TreeSyntax {
         looksLikePatVar && thisLocationAlsoAcceptsPatVars
       }
       // soft keywords might need to be written with backquotes in some places
-      def isEscapableSoftKeyword(t: Term.Name, parent: Tree) = {
+      def isEscapableSoftKeyword(t: Term.Name, parent: Tree): Boolean = {
         t.value match {
           case "extension" if dialect.allowExtensionMethods =>
             parent.is[Term.Apply] || parent.is[Term.ApplyUsing]
+          case "inline" if dialect.allowInlineMods =>
+            parent.is[Term.Apply] || parent.is[Term.ApplyUsing] || parent.is[Term.ApplyInfix]
           case _ => false
         }
       }
@@ -471,7 +473,15 @@ object TreeSyntax {
       case t: Term.Match =>
         m(
           Expr1,
-          s(p(PostfixExpr, t.expr), " ", kw("match"), " {", r(t.cases.map(i(_)), ""), n("}"))
+          s(
+            w(t.mods, " "),
+            p(PostfixExpr, t.expr),
+            " ",
+            kw("match"),
+            " {",
+            r(t.cases.map(i(_)), ""),
+            n("}")
+          )
         )
       case t: Term.Try =>
         m(

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -177,4 +177,21 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |Type.Apply Option[T]
        |""".stripMargin
   )
+  checkPositions[Stat](
+    """|inline def g: Any = inline x match {
+       |  case x: String => (x, x) 
+       |  case x: Double => x
+       |}""".stripMargin,
+    """|Term.Match inline x match {
+       |  case x: String => (x, x) 
+       |  case x: Double => x
+       |}
+       |Case case x: String => (x, x) 
+       |
+       |Pat.Typed x: String
+       |Term.Tuple (x, x)
+       |Case case x: Double => x
+       |Pat.Typed x: Double
+       |""".stripMargin
+  )
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -599,9 +599,9 @@ class SuccessSuite extends FunSuite {
   test("4 q\"expr match { ..case cases }\"") {
     val expr = q"foo"
     val casez = List(p"case a => b", p"case q => w")
-    assert(
-      q"$expr match { ..case $casez }".structure ==
-        "Term.Match(Term.Name(\"foo\"), List(Case(Pat.Var(Term.Name(\"a\")), None, Term.Name(\"b\")), Case(Pat.Var(Term.Name(\"q\")), None, Term.Name(\"w\"))))"
+    assertEquals(
+      q"$expr match { ..case $casez }".structure,
+      "Term.Match(Term.Name(\"foo\"), List(Case(Pat.Var(Term.Name(\"a\")), None, Term.Name(\"b\")), Case(Pat.Var(Term.Name(\"q\")), None, Term.Name(\"w\"))), Nil)"
     )
   }
 


### PR DESCRIPTION
Scala 3 introduces the concept of inline match that can be created within an inline method:
```scala
inline def g(x: Any): Any = inline x match {
  case x: String => (x, x) // Tuple2[String, String](x, x)
  case x: Double => x
}
```
This needs to be parse accordingly and also makes it imporrisble to use `inline` as identifiers in Apply trees.