### PR TITLE
Allow extension to declare using and braces in another line

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -3965,6 +3965,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
       param(ownerIsCase = false, ownerIsType = false, isImplicit = false, isUsing = false)
     )
 
+    newLineOptWhenFollowedBy[LeftParen]
     var uparams = ListBuffer[List[Term.Param]]()
     while (token.is[LeftParen]) {
       uparams += inParens {
@@ -3979,8 +3980,10 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
           )
         )
       }
+      newLineOptWhenFollowedBy[LeftParen]
     }
 
+    newLineOptWhenFollowedBy[LeftBrace]
     val methodsAll: List[Stat] = if (isColonEol(token)) {
       accept[Colon]
       indented(templateStats())

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExtensionMethodsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExtensionMethodsSuite.scala
@@ -141,6 +141,29 @@ class ExtensionMethodsSuite extends BaseDottySuite {
     )
   }
 
+  test("extension-using-newline") {
+    val code = """|extension (c: Circle)
+                  |  (using Context, x: Int) 
+                  |{
+                  |  def crc: Int = 2
+                  |}
+                  |""".stripMargin
+    val output = "extension (c: Circle)(using Context, x: Int) def crc: Int = 2"
+    runTestAssert[Stat](code, assertLayout = Some(output))(
+      Defn.ExtensionGroup(
+        Term.Param(Nil, Term.Name("c"), Some(pname("Circle")), None),
+        Nil,
+        List(
+          List(
+            Term.Param(List(Mod.Using()), Name.Anonymous(), Some(pname("Context")), None),
+            Term.Param(List(Mod.Using()), Term.Name("x"), Some(pname("Int")), None)
+          )
+        ),
+        Defn.Def(Nil, tname("crc"), Nil, Nil, Some(pname("Int")), int(2))
+      )
+    )
+  }
+
   test("extension-using-multi") {
     val code = """|extension (c: Circle)(using Context, x: Int)(using y: String, File) {
                   |  def crc: Int = 2


### PR DESCRIPTION
This is done the same way when working with templates and method definitions.