### PR TITLE
Fix givens to accept `with` keyword for refinements

### DIFF
--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -40,6 +40,42 @@ object Mima {
       "scala.meta.tokens.Token$KwExtension$sharedClassifier$"
     ),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.meta.Term#Match.mods"),
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.meta.Term#Match.setMods")
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.meta.Term#Match.setMods"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.meta.Defn#Given.apply"),
+    ProblemFilters.exclude[IncompatibleSignatureProblem]("scala.meta.Defn#Given.unapply"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.meta.Defn#Given.decltpe"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.meta.Defn#Given.copy"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.meta.Defn#Given.copy$default$5"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.meta.Defn#Given.copy$default$6"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.meta.Defn#Given.copy"),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "scala.meta.Defn#Given#Quasi#DefnGivenQuasiImpl.decltpe"
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "scala.meta.Defn#Given#Quasi#DefnGivenQuasiImpl.copy"
+    ),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem](
+      "scala.meta.Defn#Given#Quasi#DefnGivenQuasiImpl.copy$default$5"
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "scala.meta.Defn#Given#Quasi#DefnGivenQuasiImpl.copy$default$6"
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "scala.meta.Defn#Given#DefnGivenImpl._decltpe"
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "scala.meta.Defn#Given#DefnGivenImpl._decltpe_="
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "scala.meta.Defn#Given#DefnGivenImpl.decltpe"
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.meta.Defn#Given#DefnGivenImpl.copy"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem](
+      "scala.meta.Defn#Given#DefnGivenImpl.copy$default$5"
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem](
+      "scala.meta.Defn#Given#DefnGivenImpl.copy$default$6"
+    ),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.meta.Defn#Given#DefnGivenImpl.this")
   )
 }

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -331,7 +331,6 @@ object Defn {
       name: scala.meta.Name,
       tparams: List[scala.meta.Type.Param],
       sparams: List[List[Term.Param]],
-      decltpe: scala.meta.Type,
       templ: Template
   ) extends Defn
   @ast class Enum(

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -942,8 +942,7 @@ object TreeSyntax {
           kw("given"),
           " ",
           givenName(t.name, t.tparams, t.sparams),
-          t.decltpe,
-          templ(t.templ)
+          s(t.templ)
         )
 
       case t: Defn.Enum =>
@@ -1073,6 +1072,7 @@ object TreeSyntax {
           val pearly = if (!t.early.isEmpty) s("{ ", r(t.early, "; "), " } with ") else s()
           val pparents = w(r(t.inits, " with "), " ", !t.inits.isEmpty && !isBodyEmpty)
           val derived = w("derives ", r(t.derives, ", "), " ", t.derives.nonEmpty)
+          val withGiven = if (t.parent.exists(_.is[Defn.Given]) && !isBodyEmpty) "with " else ""
           val pbody = {
             val isOneLiner =
               t.stats.length == 0 ||
@@ -1086,7 +1086,7 @@ object TreeSyntax {
               case (true, stats) => s("{ ", t.self, " =>", r(stats.map(i(_)), ""), n("}"))
             }
           }
-          s(pearly, pparents, derived, pbody)
+          s(pearly, pparents, derived, withGiven, pbody)
         }
 
       // Mod

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -68,10 +68,13 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |""".stripMargin
   )
   checkPositions[Stat](
-    "inline given intOrd: Ord[Int] { def f(): Int = 1 }",
-    """|Type.Apply Ord[Int]
-       |Template { def f(): Int = 1 }
-       |Self inline given intOrd: Ord[Int] { @@def f(): Int = 1 }
+    "inline given intOrd: Ord[Int] with Eq[Int] with { def f(): Int = 1 }",
+    """|Template Ord[Int] with Eq[Int] with { def f(): Int = 1 }
+       |Init Ord[Int]
+       |Type.Apply Ord[Int]
+       |Init Eq[Int]
+       |Type.Apply Eq[Int]
+       |Self inline given intOrd: Ord[Int] with Eq[Int] with { @@def f(): Int = 1 }
        |Defn.Def def f(): Int = 1
        |""".stripMargin
   )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -316,26 +316,6 @@ class MinorDottySuite extends BaseDottySuite {
     runTestError[Stat]("enum X[T]{ case A[_] extends X[Int] }", "identifier expected")
     runTestError[Stat]("extension [_](x: Int) def inc: Int = x + 1", "identifier expected")
     runTestError[Stat]("given [_](using Ord[T]): Ord[List[T]]{}", "identifier expected")
-
-    runTestAssert[Stat]("given [T](using Ord[T]): Ord[List[T]]")(
-      Defn.Given(
-        Nil,
-        Name(""),
-        List(Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, Nil)),
-        List(
-          List(
-            Term.Param(
-              List(Mod.Using()),
-              Name(""),
-              Some(Type.Apply(Type.Name("Ord"), List(Type.Name("T")))),
-              None
-            )
-          )
-        ),
-        Type.Apply(Type.Name("Ord"), List(Type.Apply(Type.Name("List"), List(Type.Name("T"))))),
-        Template(Nil, Nil, Self(Name(""), None), Nil)
-      )
-    )
   }
 
   test("repeated-byname-class-parameter") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -702,6 +702,77 @@ class SignificantIndentationSuite extends BaseDottySuite {
     )
   }
 
+  test("given-block-indent") {
+    runTestAssert[Stat](
+      """|given intOrd: Ord[Int] with
+         |   def fa: Int = 1
+         |   def fb: Int = 2
+         |""".stripMargin,
+      assertLayout = Some(
+        """|given intOrd: Ord[Int] with {
+           |  def fa: Int = 1
+           |  def fb: Int = 2
+           |}""".stripMargin
+      )
+    )(
+      Defn.Given(
+        Nil,
+        Type.Name("intOrd"),
+        Nil,
+        Nil,
+        Template(
+          Nil,
+          List(Init(Type.Apply(Type.Name("Ord"), List(Type.Name("Int"))), Name(""), Nil)),
+          Self(Name(""), None),
+          List(
+            Defn.Def(Nil, Term.Name("fa"), Nil, Nil, Some(Type.Name("Int")), Lit.Int(1)),
+            Defn.Def(Nil, Term.Name("fb"), Nil, Nil, Some(Type.Name("Int")), Lit.Int(2))
+          ),
+          Nil
+        )
+      )
+    )
+  }
+
+  test("given-block-indent-edge-cases") {
+    runTestError[Stat](
+      """|given intOrd: Ord[Int] with
+         |def fa: Int = 1
+         |def fb: Int = 2
+         |""".stripMargin,
+      "expected '{' or indentation"
+    )
+
+    runTestError[Stat](
+      """|given intOrd: Ord[Int]:
+         |  def fa: Int = 1
+         |  def fb: Int = 2
+         |""".stripMargin,
+      "; expected but : found"
+    )
+
+    runTestAssert[Stat](
+      """|class A extends A with 
+         |  B
+         |""".stripMargin,
+      assertLayout = Some("class A extends A with B")
+    )(
+      Defn.Class(
+        Nil,
+        Type.Name("A"),
+        Nil,
+        Ctor.Primary(Nil, Name(""), Nil),
+        Template(
+          Nil,
+          List(Init(Type.Name("A"), Name(""), Nil), Init(Type.Name("B"), Name(""), Nil)),
+          Self(Name(""), None),
+          Nil,
+          Nil
+        )
+      )
+    )
+  }
+
   test("nested-coloneol") {
     runTestAssert[Stat](
       """|case class Test(


### PR DESCRIPTION
In the previous PR that touched the changes in givens I forgot to include `with`, which I am fixing in this PR. I also removed any test cases that were ignored, but don't have an easy way for the parser to show an error (also Dotty parser mostly works in those case also).