### PR TITLE
Trees: Support branch methods

### DIFF
--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/NamerMacros.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/NamerMacros.scala
@@ -5,6 +5,12 @@ package trees
 import scala.collection.mutable.ListBuffer
 import org.scalameta.internal.MacroHelpers
 
+object CommonNamerMacros {
+
+  private val quasiName = "Quasi"
+
+}
+
 trait CommonNamerMacros extends MacroHelpers {
   import c.universe._
 
@@ -34,6 +40,9 @@ trait CommonNamerMacros extends MacroHelpers {
     classifierBoilerplate
   }
 
+  private val quasiTypeName = TypeName(CommonNamerMacros.quasiName)
+  def isQuasiClass(cdef: ClassDef) = cdef.name.toString == CommonNamerMacros.quasiName
+
   def mkQuasi(
       name: TypeName,
       parents: List[Tree],
@@ -42,10 +51,10 @@ trait CommonNamerMacros extends MacroHelpers {
       extraStubs: String*
   ): ClassDef = {
     val qmods = Modifiers(NoFlags, TypeName("meta"), List(q"new $AstAnnotation"))
-    val qname = TypeName("Quasi")
+    val qname = quasiTypeName
     val qparents = tq"$name" +: tq"$QuasiClass" +: parents.map({
-      case Ident(name) => Select(Ident(name.toTermName), TypeName("Quasi"))
-      case Select(qual, name) => Select(Select(qual, name.toTermName), TypeName("Quasi"))
+      case Ident(name) => Select(Ident(name.toTermName), quasiTypeName)
+      case Select(qual, name) => Select(Select(qual, name.toTermName), quasiTypeName)
       case unsupported => c.abort(unsupported.pos, "implementation restriction: unsupported parent")
     })
 

--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/NamerMacros.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/NamerMacros.scala
@@ -96,7 +96,8 @@ trait CommonNamerMacros extends MacroHelpers {
     qstats += q"def copy(...$qcopyParamss): $name = $stub"
 
     extraAbstractDefs.foreach {
-      case x: DefDefApi => addStubbedOverrideMember(x)
+      case x: ValOrDefDefApi if x.mods.hasFlag(Flag.ABSTRACT) || x.rhs.isEmpty =>
+        addStubbedOverrideMember(x)
       case _ =>
     }
 

--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/ast.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/ast.scala
@@ -25,10 +25,8 @@ class AstNamerMacros(val c: Context) extends AstReflection with CommonNamerMacro
   def impl(annottees: Tree*): Tree =
     annottees.transformAnnottees(new ImplTransformer {
       override def transformClass(cdef: ClassDef, mdef: ModuleDef): List[ImplDef] = {
-        def fullName = c.internal.enclosingOwner.fullName.toString + "." + cdef.name.toString
-        def abbrevName = fullName.stripPrefix("scala.meta.")
-        def is(abbrev: String) = abbrevName == abbrev
-        def isQuasi = cdef.name.toString == "Quasi"
+        val fullName = c.internal.enclosingOwner.fullName + "." + cdef.name.toString
+        def isQuasi = isQuasiClass(cdef)
         val q"$imods class $iname[..$tparams] $ctorMods(...$rawparamss) extends { ..$earlydefns } with ..$iparents { $aself => ..$stats }" =
           cdef
         // NOTE: For stack traces, we'd like to have short class names, because stack traces print full names anyway.
@@ -41,10 +39,7 @@ class AstNamerMacros(val c: Context) extends AstReflection with CommonNamerMacro
         //  class NameAnonymousImpl needs to be abstract, since method withDenot in trait Name
         //  of type (denot: scala.meta.internal.semantic.Denotation)NameAnonymousImpl.this.ThisType is not defined
         val descriptivePrefix = fullName.stripPrefix("scala.meta.").replace(".", "")
-        val name = TypeName(descriptivePrefix.replace(".", "") + "Impl")
-        // val name = TypeName("Impl")
-        val qname = TypeName("Quasi")
-        val qmname = TermName("Quasi")
+        val name = TypeName(descriptivePrefix + "Impl")
         val q"$mmods object $mname extends { ..$mearlydefns } with ..$mparents { $mself => ..$mstats }" =
           mdef
         val bparams1 = ListBuffer[ValDef]() // boilerplate params

--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/ast.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/ast.scala
@@ -6,9 +6,6 @@ import scala.language.experimental.macros
 import scala.annotation.StaticAnnotation
 import scala.reflect.macros.whitebox.Context
 import scala.collection.mutable.ListBuffer
-import scala.meta.internal.trees.{Reflection => AstReflection}
-import scala.meta.internal.trees.{Metadata => AstMetadata}
-import scala.util.Success
 import org.scalameta.internal.MacroCompat
 
 // @ast is a specialized version of @org.scalameta.adt.leaf for scala.meta ASTs.
@@ -16,7 +13,7 @@ class ast extends StaticAnnotation {
   def macroTransform(annottees: Any*): Any = macro AstNamerMacros.impl
 }
 
-class AstNamerMacros(val c: Context) extends AstReflection with CommonNamerMacros {
+class AstNamerMacros(val c: Context) extends Reflection with CommonNamerMacros {
   lazy val u: c.universe.type = c.universe
   lazy val mirror = c.mirror
   import c.universe._
@@ -460,7 +457,7 @@ class AstNamerMacros(val c: Context) extends AstReflection with CommonNamerMacro
             iname,
             iparents,
             fieldParamss,
-            binaryCompatAbstractFields,
+            binaryCompatAbstractFields ++ otherDefns,
             "name",
             "value",
             "tpe"

--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/branch.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/branch.scala
@@ -36,7 +36,7 @@ class BranchNamerMacros(val c: Context) extends AstReflection with CommonNamerMa
         mstats1 += q"$CommonTyperMacrosModule.hierarchyCheck[$name]"
         val anns1 = anns :+ q"new $AdtMetadataModule.branch" :+ q"new $AstMetadataModule.branch"
         mstats1 ++= mkClassifier(name)
-        if (!isQuasi) mstats1 += mkQuasi(name, parents, Nil, Nil, "value", "name", "tpe")
+        if (!isQuasi) mstats1 += mkQuasi(name, parents, Nil, stats, "value", "name", "tpe")
 
         val cdef1 =
           q"${Modifiers(flags1, privateWithin, anns1)} trait $name[..$tparams] extends { ..$earlydefns } with ..$parents { $self => ..$stats1 }"

--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/branch.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/branch.scala
@@ -22,7 +22,7 @@ class BranchNamerMacros(val c: Context) extends AstReflection with CommonNamerMa
   def impl(annottees: Tree*): Tree =
     annottees.transformAnnottees(new ImplTransformer {
       override def transformTrait(cdef: ClassDef, mdef: ModuleDef): List[ImplDef] = {
-        def isQuasi = cdef.name.toString == "Quasi"
+        def isQuasi = isQuasiClass(cdef)
         val q"${mods @ Modifiers(flags, privateWithin, anns)} trait $name[..$tparams] extends { ..$earlydefns } with ..$parents { $self => ..$stats }" =
           cdef
         val q"$mmods object $mname extends { ..$mearlydefns } with ..$mparents { $mself => ..$mstats }" =


### PR DESCRIPTION
Currently, the code hardcodes exactly three methods (`value`, `name` and `tpe`) which can be declared in a `@branch` trait.

This is an attempt to support other methods as well, although it still is not flexible enough to support methods in a branch which is a parent of another branch.

Required for #2207 to work.