### PR TITLE
Add Decl.Given for abstract givens

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -313,6 +313,13 @@ object Decl {
       tparams: List[scala.meta.Type.Param],
       bounds: scala.meta.Type.Bounds
   ) extends Decl with Member.Type
+  @ast class Given(
+      mods: List[Mod],
+      name: Term.Name,
+      tparams: List[scala.meta.Type.Param],
+      sparams: List[List[Term.Param]],
+      decltpe: scala.meta.Type
+  ) extends Decl with Member.Term
 }
 
 @branch trait Defn extends Stat

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -872,6 +872,8 @@ object TreeSyntax {
       case t: Decl.Type => s(w(t.mods, " "), kw("type"), " ", t.name, t.tparams, t.bounds)
       case t: Decl.Def =>
         s(w(t.mods, " "), kw("def"), " ", t.name, t.tparams, t.paramss, kw(":"), " ", t.decltpe)
+      case t: Decl.Given =>
+        s(w(t.mods, " "), kw("given"), " ", t.name, t.tparams, t.sparams, kw(":"), " ", t.decltpe)
       case t: Defn.Val =>
         s(w(t.mods, " "), kw("val"), " ", r(t.pats, ", "), t.decltpe, " ", kw("="), " ", t.rhs)
       case t: Defn.Var =>

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -219,6 +219,7 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.Ctor.Secondary
       |scala.meta.Decl
       |scala.meta.Decl.Def
+      |scala.meta.Decl.Given
       |scala.meta.Decl.Type
       |scala.meta.Decl.Val
       |scala.meta.Decl.Var

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
@@ -21,7 +21,7 @@ class ReflectionSuite extends FunSuite {
   test("root") {
     assert(symbolOf[scala.meta.Tree].isRoot)
     assertEquals(symbolOf[scala.meta.Tree].asRoot.allBranches.length, 23)
-    assertEquals(symbolOf[scala.meta.Tree].asRoot.allLeafs.length, 341)
+    assertEquals(symbolOf[scala.meta.Tree].asRoot.allLeafs.length, 343)
   }
 
   test("If") {

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -79,6 +79,11 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |""".stripMargin
   )
   checkPositions[Stat](
+    "inline given intOrd: Ord[Int]",
+    """|Type.Apply Ord[Int]
+       |""".stripMargin
+  )
+  checkPositions[Stat](
     "export a.b",
     """|Importer a.b
        |""".stripMargin

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
@@ -28,7 +28,7 @@ class GivenUsingSuite extends BaseDottySuite {
     runTestAssert[Stat]("given intOrd: Ord[Int] with { def f(): Int = 1 }")(
       Defn.Given(
         Nil,
-        Type.Name("intOrd"),
+        Term.Name("intOrd"),
         Nil,
         Nil,
         Template(
@@ -46,7 +46,7 @@ class GivenUsingSuite extends BaseDottySuite {
     runTestAssert[Stat]("given intOrd: Ord[Int] with \n{ def f(): Int = 1 }", assertLayout = None)(
       Defn.Given(
         Nil,
-        Type.Name("intOrd"),
+        Term.Name("intOrd"),
         Nil,
         Nil,
         Template(
@@ -81,7 +81,7 @@ class GivenUsingSuite extends BaseDottySuite {
   test("given-multiple-inheritance") {
     val expectedGiven = Defn.Given(
       Nil,
-      Type.Name("intM"),
+      Term.Name("intM"),
       Nil,
       Nil,
       Template(
@@ -113,7 +113,7 @@ class GivenUsingSuite extends BaseDottySuite {
     )(
       Defn.Given(
         Nil,
-        Type.Name("intOrd"),
+        Term.Name("intOrd"),
         Nil,
         Nil,
         Template(
@@ -137,7 +137,7 @@ class GivenUsingSuite extends BaseDottySuite {
     )(
       Defn.Given(
         Nil,
-        Type.Name("intOrd"),
+        Term.Name("intOrd"),
         Nil,
         Nil,
         Template(
@@ -155,7 +155,7 @@ class GivenUsingSuite extends BaseDottySuite {
     runTestAssert[Stat]("given intOrd: Ord[Int] with { current => }")(
       Defn.Given(
         Nil,
-        Type.Name("intOrd"),
+        Term.Name("intOrd"),
         Nil,
         Nil,
         Template(
@@ -176,47 +176,11 @@ class GivenUsingSuite extends BaseDottySuite {
     )
   }
 
-  test("given-no-block") {
-    runTestAssert[Stat]("given intOrd: Ord[Int]")(
-      Defn.Given(
-        Nil,
-        Type.Name("intOrd"),
-        Nil,
-        Nil,
-        Template(
-          Nil,
-          List(Init(Type.Apply(Type.Name("Ord"), List(Type.Name("Int"))), Name(""), Nil)),
-          Self(Name(""), None),
-          Nil,
-          Nil
-        )
-      )
-    )
-  }
-
-  test("given-anonymous-no-block") {
-    runTestAssert[Stat]("given Ord[Int]")(
-      Defn.Given(
-        Nil,
-        Name(""),
-        Nil,
-        Nil,
-        Template(
-          Nil,
-          List(Init(Type.Apply(Type.Name("Ord"), List(Type.Name("Int"))), Name(""), Nil)),
-          Self(Name(""), None),
-          Nil,
-          Nil
-        )
-      )
-    )
-  }
-
   test("given-generic-named") {
     runTestAssert[Stat]("given listOrd[T]: Ord[List[T]] with { def f(): Int = 1 }")(
       Defn.Given(
         Nil,
-        Type.Name("listOrd"),
+        Term.Name("listOrd"),
         List(Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, Nil)),
         Nil,
         Template(
@@ -262,106 +226,11 @@ class GivenUsingSuite extends BaseDottySuite {
     )
   }
 
-  test("given-depend-given-named") {
-    runTestAssert[Stat]("given setOrd[T](using ord: Ord[T]): Ord[Set[T]]")(
-      Defn.Given(
-        Nil,
-        Type.Name("setOrd"),
-        List(Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, Nil)),
-        List(
-          List(
-            Term.Param(
-              List(Mod.Using()),
-              Term.Name("ord"),
-              Some(Type.Apply(Type.Name("Ord"), List(Type.Name("T")))),
-              None
-            )
-          )
-        ),
-        Template(
-          Nil,
-          List(
-            Init(
-              Type
-                .Apply(Type.Name("Ord"), List(Type.Apply(Type.Name("Set"), List(Type.Name("T"))))),
-              Name(""),
-              Nil
-            )
-          ),
-          Self(Name(""), None),
-          Nil,
-          Nil
-        )
-      )
-    )
-  }
-
-  test("given-depend-given-anonymous") {
-    runTestAssert[Stat]("given [T](using ord: Ord[T]): Ord[Set[T]]")(
-      Defn.Given(
-        Nil,
-        Name(""),
-        List(Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, Nil)),
-        List(
-          List(
-            Term.Param(
-              List(Mod.Using()),
-              Term.Name("ord"),
-              Some(Type.Apply(Type.Name("Ord"), List(Type.Name("T")))),
-              None
-            )
-          )
-        ),
-        Template(
-          Nil,
-          List(
-            Init(
-              Type
-                .Apply(Type.Name("Ord"), List(Type.Apply(Type.Name("Set"), List(Type.Name("T"))))),
-              Name(""),
-              Nil
-            )
-          ),
-          Self(Name(""), None),
-          Nil,
-          Nil
-        )
-      )
-    )
-  }
-
-  test("given-depend-given-anonymous-using") {
-    runTestAssert[Stat]("given (using Ord[String]): Ord[Int]")(
-      Defn.Given(
-        Nil,
-        Name(""),
-        Nil,
-        List(
-          List(
-            Term.Param(
-              List(Mod.Using()),
-              Name(""),
-              Some(Type.Apply(Type.Name("Ord"), List(Type.Name("String")))),
-              None
-            )
-          )
-        ),
-        Template(
-          Nil,
-          List(Init(Type.Apply(Type.Name("Ord"), List(Type.Name("Int"))), Name(""), Nil)),
-          Self(Name(""), None),
-          Nil,
-          Nil
-        )
-      )
-    )
-  }
-
   test("given-inline") {
     runTestAssert[Stat]("inline given intOrd: Ord[Int] with { def f(): Int = 1 }")(
       Defn.Given(
         List(Mod.Inline()),
-        Type.Name("intOrd"),
+        Term.Name("intOrd"),
         Nil,
         Nil,
         Template(
@@ -385,7 +254,7 @@ class GivenUsingSuite extends BaseDottySuite {
     runTestAssert[Stat]("given global: Option[Int] = Some(3)")(
       Defn.GivenAlias(
         Nil,
-        pname("global"),
+        tname("global"),
         Nil,
         Nil,
         Type.Apply(pname("Option"), List(pname("Int"))),
@@ -414,7 +283,7 @@ class GivenUsingSuite extends BaseDottySuite {
     )(
       Defn.GivenAlias(
         Nil,
-        pname("global"),
+        tname("global"),
         Nil,
         Nil,
         Type.Apply(pname("Option"), List(pname("Int"))),
@@ -427,7 +296,7 @@ class GivenUsingSuite extends BaseDottySuite {
     runTestAssert[Stat]("given ordInt(using ord: Ord[Int]): Ord[List[Int]] = ???")(
       Defn.GivenAlias(
         Nil,
-        pname("ordInt"),
+        tname("ordInt"),
         Nil,
         List(
           List(
@@ -471,12 +340,87 @@ class GivenUsingSuite extends BaseDottySuite {
     runTestAssert[Stat]("inline given intOrd: Ord[Int] = ???")(
       Defn.GivenAlias(
         List(Mod.Inline()),
-        Type.Name("intOrd"),
+        Term.Name("intOrd"),
         Nil,
         Nil,
         Type.Apply(Type.Name("Ord"), List(Type.Name("Int"))),
         Term.Name("???")
       )
+    )
+  }
+
+  // ---------------------------------
+  // Abstract given
+  // ---------------------------------
+
+  test("abstract-given") {
+    runTestAssert[Stat]("given intOrd: Ord[Int]")(
+      Decl.Given(
+        Nil,
+        Term.Name("intOrd"),
+        Nil,
+        Nil,
+        Type.Apply(Type.Name("Ord"), List(Type.Name("Int")))
+      )
+    )
+  }
+
+  test("abstract-given-inline") {
+    runTestAssert[Stat]("inline given intOrd: Ord[Int]")(
+      Decl.Given(
+        List(Mod.Inline()),
+        Term.Name("intOrd"),
+        Nil,
+        Nil,
+        Type.Apply(Type.Name("Ord"), List(Type.Name("Int")))
+      )
+    )
+  }
+
+  test("abstract-given-depend") {
+    runTestAssert[Stat]("given setOrd[T](using ord: Ord[T]): Ord[Set[T]]")(
+      Decl.Given(
+        Nil,
+        Term.Name("setOrd"),
+        List(Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, Nil)),
+        List(
+          List(
+            Term.Param(
+              List(Mod.Using()),
+              Term.Name("ord"),
+              Some(Type.Apply(Type.Name("Ord"), List(Type.Name("T")))),
+              None
+            )
+          )
+        ),
+        Type.Apply(Type.Name("Ord"), List(Type.Apply(Type.Name("Set"), List(Type.Name("T")))))
+      )
+    )
+  }
+
+  test("abstract-given-anonymous") {
+    runTestError(
+      "given Ord[Int]",
+      "abstract givens cannot be annonymous"
+    )
+    runTestError(
+      "given [T](using ord: Ord[T]): Ord[Set[T]]",
+      "abstract givens cannot be annonymous"
+    )
+    runTestError(
+      "given (using Ord[String]): Ord[Int]",
+      "abstract givens cannot be annonymous"
+    )
+  }
+
+  test("abstract-given-with") {
+    runTestError(
+      "given (using Ord[String]): Ord[Int] with Eq[Int]",
+      "expected 'with' <body>"
+    )
+    runTestError(
+      "given ordered(using Ord[String]): Ord[Int] with Eq[Int]",
+      "expected 'with' <body>"
     )
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -717,7 +717,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
     )(
       Defn.Given(
         Nil,
-        Type.Name("intOrd"),
+        Term.Name("intOrd"),
         Nil,
         Nil,
         Template(


### PR DESCRIPTION
All other tree nodes like val, var or def have a separate Tree node when they are declared abstract. To keep in line with that I added Decl.Given to handle abstract given declarations

Abstract givens cannot be annonymous or have multiple types declared using `with`, so I added checks for that.