### PR TITLE
Make Type.With show up always instead of Type.And where `with` keywor…

### DIFF
--- a/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
@@ -62,6 +62,10 @@ final class Dialect private (
     // Removed in Dotty.
     val allowViewBounds: Boolean,
     // Are `with` intersection types supported by this dialect?
+    @deprecated(
+      "With types are supported in every dialect currently and this option is unused",
+      "4.4.6"
+    )
     val allowWithTypes: Boolean,
     // Are XML literals supported by this dialect?
     // We plan to deprecate XML literal syntax, and some dialects
@@ -296,6 +300,10 @@ final class Dialect private (
   def withAllowViewBounds(newValue: Boolean): Dialect = {
     privateCopy(allowViewBounds = newValue)
   }
+  @deprecated(
+    "With types are supported in every dialect currently and this option is unused",
+    "4.4.6"
+  )
   def withAllowWithTypes(newValue: Boolean): Dialect = {
     privateCopy(allowWithTypes = newValue)
   }

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -99,7 +99,6 @@ package object dialects {
     .withAllowTraitParameters(true)
     .withAllowTypeLambdas(true)
     .withAllowViewBounds(false) // View bounds have been removed in Dotty
-    .withAllowWithTypes(false) // removed in Dotty in favour of `&`, `with` will be treated as `&`
     .withAllowXmlLiterals(false) // Scala 3: parser doesn't support xml
     .withAllowGivenUsing(true)
     .withAllowExtensionMethods(true)

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1551,10 +1551,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
           while (token.is[KwWith]) {
             next()
             val rhs = annotType()
-            t = atPos(t, rhs)({
-              if (dialect.allowWithTypes) Type.With(t, rhs)
-              else Type.And(t, rhs)
-            })
+            t = atPos(t, rhs)(Type.With(t, rhs))
           }
           newLineOptWhenFollowedBy[LeftBrace]
           if (token.is[LeftBrace]) Type.Refine(Some(t), refinement())

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -674,10 +674,7 @@ object TreeSyntax {
         }
         m(Typ, s(prefix, params, " ", kw(arrow), " ", p(Typ, tRes)))
       case t: Type.Tuple => m(SimpleTyp, s("(", r(t.args, ", "), ")"))
-      case t: Type.With =>
-        if (!dialect.allowWithTypes)
-          throw new UnsupportedOperationException(s"$dialect doesn't support with types")
-        m(WithTyp, s(p(WithTyp, t.lhs), " with ", p(WithTyp, t.rhs)))
+      case t: Type.With => m(WithTyp, s(p(WithTyp, t.lhs), " with ", p(WithTyp, t.rhs)))
       case t: Type.And =>
         if (!dialect.allowAndTypes)
           throw new UnsupportedOperationException(s"$dialect doesn't support and types")

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/AndOrTypesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/AndOrTypesSuite.scala
@@ -22,7 +22,7 @@ class AndOrTypesSuite extends BaseDottySuite {
 
   test("A with B") {
     runTestAssert[Type]("A with B", None)(
-      And(Type.Name("A"), Type.Name("B"))
+      With(Type.Name("A"), Type.Name("B"))
     )
   }
 


### PR DESCRIPTION
…d is involved

Without this change it's not possible to see where `With` is still used and the parser should show the code as is.

This came up as an issue in scalafmt where `with` chains were translated as `Type.And` and it causes the formatter to behave differently. Having Type.With translated as Type.And despite initial ideas does not seem to be actually helpful