### PR TITLE
Fix given exports to adhere to current spec

### DIFF
--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -31,53 +31,15 @@ object Mima {
     // under the standard Scalameta binary-compatibility policy. This is done to
     // buy time to refine the design of the Scalameta AST in preparation for the
     // Scala 3 release.
-    ProblemFilters.exclude[MissingClassProblem]("scala.meta.tokens.Token$KwExtension"),
-    ProblemFilters.exclude[MissingClassProblem]("scala.meta.tokens.Token$KwExtension$"),
-    ProblemFilters.exclude[DirectMissingMethodProblem](
-      "scala.meta.tokens.Aliases#Token.KwExtension"
-    ),
+    ProblemFilters.exclude[MissingClassProblem]("scala.meta.ExportGiven$"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.meta.ExportGiven$ExportGivenImpl"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.meta.ExportGiven$Quasi$"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.meta.ExportGiven$Quasi"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.meta.ExportGiven$sharedClassifier$"),
+    ProblemFilters.exclude[MissingClassProblem]("scala.meta.ExportGiven$Quasi$sharedClassifier$"),
     ProblemFilters.exclude[MissingClassProblem](
-      "scala.meta.tokens.Token$KwExtension$sharedClassifier$"
+      "scala.meta.ExportGiven$Quasi$ExportGivenQuasiImpl"
     ),
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.meta.Term#Match.mods"),
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.meta.Term#Match.setMods"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.meta.Defn#Given.apply"),
-    ProblemFilters.exclude[IncompatibleSignatureProblem]("scala.meta.Defn#Given.unapply"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.meta.Defn#Given.decltpe"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.meta.Defn#Given.copy"),
-    ProblemFilters.exclude[IncompatibleResultTypeProblem]("scala.meta.Defn#Given.copy$default$5"),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.meta.Defn#Given.copy$default$6"),
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.meta.Defn#Given.copy"),
-    ProblemFilters.exclude[DirectMissingMethodProblem](
-      "scala.meta.Defn#Given#Quasi#DefnGivenQuasiImpl.decltpe"
-    ),
-    ProblemFilters.exclude[DirectMissingMethodProblem](
-      "scala.meta.Defn#Given#Quasi#DefnGivenQuasiImpl.copy"
-    ),
-    ProblemFilters.exclude[IncompatibleResultTypeProblem](
-      "scala.meta.Defn#Given#Quasi#DefnGivenQuasiImpl.copy$default$5"
-    ),
-    ProblemFilters.exclude[DirectMissingMethodProblem](
-      "scala.meta.Defn#Given#Quasi#DefnGivenQuasiImpl.copy$default$6"
-    ),
-    ProblemFilters.exclude[DirectMissingMethodProblem](
-      "scala.meta.Defn#Given#DefnGivenImpl._decltpe"
-    ),
-    ProblemFilters.exclude[DirectMissingMethodProblem](
-      "scala.meta.Defn#Given#DefnGivenImpl._decltpe_="
-    ),
-    ProblemFilters.exclude[DirectMissingMethodProblem](
-      "scala.meta.Defn#Given#DefnGivenImpl.decltpe"
-    ),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.meta.Defn#Given#DefnGivenImpl.copy"),
-    ProblemFilters.exclude[IncompatibleResultTypeProblem](
-      "scala.meta.Defn#Given#DefnGivenImpl.copy$default$5"
-    ),
-    ProblemFilters.exclude[DirectMissingMethodProblem](
-      "scala.meta.Defn#Given#DefnGivenImpl.copy$default$6"
-    ),
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.meta.Defn#Given#DefnGivenImpl.this"),
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.meta.CaseTree.pat"),
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("scala.meta.CaseTree.body")
+    ProblemFilters.exclude[MissingClassProblem]("scala.meta.ExportGiven")
   )
 }

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -3717,12 +3717,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
 
   def exportStmt(): Stat = autoPos {
     accept[KwExport]
-    if (token.is[KwGiven]) {
-      accept[KwGiven]
-      ExportGiven(commaSeparated(importer()))
-    } else {
-      Export(commaSeparated(importer()))
-    }
+    Export(commaSeparated(importer()))
   }
 
   def importStmt(): Import = autoPos {

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -533,7 +533,6 @@ object Enumerator {
 }
 @ast class Import(importers: List[Importer] @nonEmpty) extends ImportExportStat
 @ast class Export(importers: List[Importer] @nonEmpty) extends ImportExportStat
-@ast class ExportGiven(importers: List[Importer] @nonEmpty) extends ImportExportStat
 
 @ast class Importer(ref: Term.Ref, importees: List[Importee] @nonEmpty) extends Tree {
   checkFields(ref.isStableId)

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -1135,8 +1135,6 @@ object TreeSyntax {
       case t: Import => s(kw("import"), " ", r(t.importers, ", "))
       case t: Export =>
         s(kw("export"), " ", r(t.importers, ", "))
-      case t: ExportGiven =>
-        s(kw("export"), " ", kw("given"), " ", r(t.importers, ", "))
 
       // Case
       case t: Case =>

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -244,7 +244,6 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.Enumerator.Guard
       |scala.meta.Enumerator.Val
       |scala.meta.Export
-      |scala.meta.ExportGiven
       |scala.meta.Import
       |scala.meta.ImportExportStat
       |scala.meta.Importee

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
@@ -21,7 +21,7 @@ class ReflectionSuite extends FunSuite {
   test("root") {
     assert(symbolOf[scala.meta.Tree].isRoot)
     assertEquals(symbolOf[scala.meta.Tree].asRoot.allBranches.length, 23)
-    assertEquals(symbolOf[scala.meta.Tree].asRoot.allLeafs.length, 343)
+    assertEquals(symbolOf[scala.meta.Tree].asRoot.allLeafs.length, 341)
   }
 
   test("If") {

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -94,8 +94,9 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |""".stripMargin
   )
   checkPositions[Stat](
-    "export given a.b",
-    """|Importer a.b
+    "export a.{given Int}",
+    """|Importer a.{given Int}
+       |Importee.Given given Int
        |""".stripMargin
   )
   checkPositions[Stat](
@@ -111,11 +112,6 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
     "import File.given",
     """|Importer File.given
        |Importee.GivenAll given
-       |""".stripMargin
-  )
-  checkPositions[Stat](
-    "export given A.{ b, c, d, _ }",
-    """|Importer A.{ b, c, d, _ }
        |""".stripMargin
   )
   checkPositions[Type]("A & B")

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExportSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExportSuite.scala
@@ -16,10 +16,20 @@ class ExportSuite extends BaseDottySuite {
   }
 
   test("export-given") {
-    runTestAssert[Stat]("export given A.b.c")(
-      ExportGiven(
-        List(Importer(Term.Select(Term.Name("A"), Term.Name("b")), List(Importee.Name(Name("c")))))
-      )
+    runTestAssert[Stat]("export A.{ given Int }")(
+      Export(List(Importer(Term.Name("A"), List(Importee.Given(Type.Name("Int"))))))
+    )
+  }
+
+  test("export-given-all") {
+    runTestAssert[Stat]("export A.given")(
+      Export(List(Importer(Term.Name("A"), List(Importee.GivenAll()))))
+    )
+  }
+
+  test("export-given-all-mixed") {
+    runTestAssert[Stat]("export A.{ given, a }")(
+      Export(List(Importer(Term.Name("A"), List(Importee.GivenAll(), Importee.Name(Name("a"))))))
     )
   }
 


### PR DESCRIPTION
Previously, given exports would be written like this:
```scala
export given A
```

now it got changed to be similar to imports:
```scala
export A.given
```