### PR TITLE
semanticdb: `toTextDocument` add Dialect parameter

### DIFF
--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/ParseOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/ParseOps.scala
@@ -5,9 +5,15 @@ import scala.{meta => m}
 trait ParseOps { self: SemanticdbOps =>
 
   implicit class XtensionCompilationUnitSource(unit: g.CompilationUnit) {
-    def toSource: m.Source = {
+    def toSource: m.Source =
+      toSource(None)
+
+    def toSource(explicitDialect: Option[m.Dialect]): m.Source = {
       val dialect =
-        m.Dialect.standards.getOrElse(language, sys.error(s"unsupported dialect $language"))
+        explicitDialect
+          .orElse(m.Dialect.standards.get(language))
+          .getOrElse(sys.error(s"unsupported dialect $language"))
+
       dialect(unit.source.toInput).parse[m.Source].get
     }
   }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
@@ -12,6 +12,7 @@ import scala.reflect.internal.{Flags => gf}
 import scala.reflect.io.{PlainFile => GPlainFile}
 import scala.{meta => m}
 import scala.meta.internal.semanticdb.Scala._
+import scala.meta.Dialect
 
 trait TextDocumentOps { self: SemanticdbOps =>
   def validateCompilerState(): Unit = {
@@ -47,7 +48,10 @@ trait TextDocumentOps { self: SemanticdbOps =>
   }
 
   implicit class XtensionCompilationUnitDocument(unit: g.CompilationUnit) {
-    def toTextDocument: s.TextDocument = {
+    def toTextDocument: s.TextDocument =
+      toTextDocument(None)
+
+    def toTextDocument(explicitDialect: Option[m.Dialect]): s.TextDocument = {
       pointsCache.clear()
       val binders = mutable.Set[m.Position]()
       val occurrences = mutable.Map[m.Position, String]()
@@ -193,7 +197,8 @@ trait TextDocumentOps { self: SemanticdbOps =>
             super.apply(mtree)
           }
         }
-        traverser(unit.toSource)
+
+        traverser(unit.toSource(explicitDialect))
       }
 
       locally {


### PR DESCRIPTION
Required for metals in order to get semantic documents for sbt files and worksheets