### PR TITLE
[Scala 3] Fix givens to actually contain the given keyword 

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -3894,18 +3894,14 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
     }
   }
 
-  // Given             ::= 'given' GivenDef
-  private def givenDecl(mods: List[Mod]): Stat = {
-    accept[KwGiven]
-    givenDef(mods)
-  }
-
   /**
+   * Given             ::= 'given' GivenDef
    * GivenDef          ::=  [GivenSig] (Type [‘=’ Expr] | StructuralInstance)
    * GivenSig          ::=  [id] [DefTypeParamClause] {UsingParamClause} ‘:’
    * StructuralInstance ::=  ConstrApp {‘with’ ConstrApp} ‘with’ TemplateBody
    */
-  private def givenDef(mods: List[Mod]): Stat = autoPos {
+  private def givenDecl(mods: List[Mod]): Stat = autoPos {
+    accept[KwGiven]
     val anonymousName = autoPos(scala.meta.Name.Anonymous())
 
     val forked = in.fork

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -79,13 +79,39 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |""".stripMargin
   )
   checkPositions[Stat](
-    "inline given intOrd: Ord[Int]",
-    """|Type.Apply Ord[Int]
+    """|object A{
+       |  inline given intOrd: Ord[Int]
+       |}""".stripMargin,
+    """|Template {
+       |  inline given intOrd: Ord[Int]
+       |}
+       |Self   @@inline given intOrd: Ord[Int]
+       |Decl.Given given intOrd: Ord[Int]
+       |Type.Apply Ord[Int]
        |""".stripMargin
   )
   checkPositions[Stat](
-    "export a.b",
-    """|Importer a.b
+    """|object A{
+       |  given intOrd: Ord[Int] = intOrd
+       |}""".stripMargin,
+    """|Template {
+       |  given intOrd: Ord[Int] = intOrd
+       |}
+       |Self   @@given intOrd: Ord[Int] = intOrd
+       |Defn.GivenAlias given intOrd: Ord[Int] = intOrd
+       |Type.Apply Ord[Int]
+       |""".stripMargin
+  )
+  checkPositions[Stat](
+    """|object A {
+       |  export a.b
+       |}""".stripMargin,
+    """|Template {
+       |  export a.b
+       |}
+       |Self   @@export a.b
+       |Export export a.b
+       |Importer a.b
        |""".stripMargin
   )
   checkPositions[Stat](


### PR DESCRIPTION
It seems that positions are sometimes different depending on whether we are in a top level tree or not. I adjusted the test for givens and also added one for exports.