### PR TITLE
Make sure children contains binary compat fields

### DIFF
--- a/scalameta/common/shared/src/main/scala/org/scalameta/adt/Reflection.scala
+++ b/scalameta/common/shared/src/main/scala/org/scalameta/adt/Reflection.scala
@@ -117,6 +117,11 @@ trait Reflection {
   class Leaf(sym: Symbol) extends Adt(sym) {
     if (!sym.isLeaf) sys.error(s"$sym is not a leaf")
     def fields: List[Field] = sym.fields.map(_.asField)
+    def binaryCompatFields: List[Field] = {
+      sym.info.decls.collect {
+        case s if s.hasAnnotation[AstMetadata.binaryCompatField] => s.asField
+      }.toList
+    }
     def allFields: List[Field] = sym.allFields.map(_.asField)
     override def toString = s"leaf $prefix"
   }

--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/transversers/transformer.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/transversers/transformer.scala
@@ -89,8 +89,7 @@ class TransformerMacros(val c: Context) extends TransverserMacros {
     if (relevantFields.isEmpty) return q"tree"
     val transformedFields: List[ValDef] = relevantFields.map(transformField)
 
-    val binaryCompatFields =
-      l.sym.info.decls.filter(_.hasAnnotation[AstMetadata.binaryCompatField]).map(_.asField)
+    val binaryCompatFields = l.binaryCompatFields
 
     val binaryCompatGetters = binaryCompatFields.map { field =>
       q"val ${field.name} = tree.${field.name}"

--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/TyperMacros.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/TyperMacros.scala
@@ -140,7 +140,9 @@ class CommonTyperMacrosBundle(val c: Context) extends AdtReflection with MacroHe
       streak = Nil
       result
     }
-    val acc = T.tpe.typeSymbol.asLeaf.fields.foldLeft(q"": Tree)((acc, f) =>
+    val leaf = T.tpe.typeSymbol.asLeaf
+    val allAnalyzedFields = leaf.fields ++ leaf.binaryCompatFields
+    val acc = allAnalyzedFields.foldLeft(q"": Tree)((acc, f) =>
       f.tpe match {
         case TreeTpe(_) =>
           streak :+= q"this.${f.sym}"

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2039,10 +2039,10 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
    * Since matches can also be chained in Scala 3 we need to create
    * the Match first and only then add the the inline modifier.
    */
-  def inlineMatchClause() = {
+  def inlineMatchClause(inlineMods: List[Mod]) = {
     autoPos(postfixExpr(allowRepeated = false)) match {
       case t: Term.Match =>
-        t.setMods(List(Mod.Inline()))
+        t.setMods(inlineMods)
         t
       case other =>
         syntaxError("`inline` must be followed by an `if` or a `match`", at = other.pos)
@@ -2057,9 +2057,8 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
     }
   }
 
-  def ifClause(isInline: Boolean = false) = {
+  def ifClause(mods: List[Mod] = Nil) = {
     accept[KwIf]
-
     val (cond, thenp) = if (token.isNot[LeftParen] && dialect.allowSignificantIndentation) {
       val cond = expr()
       acceptOpt[LF]
@@ -2077,10 +2076,6 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
       (cond, exprMaybeIndented())
     }
 
-    val mods = if (isInline) {
-      List(Mod.Inline())
-    } else Nil
-
     if (tryAcceptWithOptLF[KwElse]) {
       Term.If(cond, thenp, exprMaybeIndented(), mods)
     } else if (token.is[Semicolon] && ahead { token.is[KwElse] }) {
@@ -2094,14 +2089,16 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
   // if yes, then nothing has to change here
   // if no, we need eschew autoPos here, because it forces those parentheses on the result of calling prefixExpr
   // see https://github.com/scalameta/scalameta/issues/1083 and https://github.com/scalameta/scalameta/issues/1223
-  def expr(location: Location, allowRepeated: Boolean): Term =
+  def expr(location: Location, allowRepeated: Boolean): Term = {
+    def inlineMod() = autoPos {
+      accept[Ident]
+      Mod.Inline()
+    }
     autoPos(token match {
       case soft.KwInline() if ahead(token.is[KwIf]) =>
-        accept[Ident]
-        ifClause(isInline = true)
+        ifClause(List(inlineMod()))
       case InlineMatchMod() =>
-        accept[Ident]
-        inlineMatchClause()
+        inlineMatchClause(List(inlineMod()))
       case KwIf() =>
         ifClause()
       case KwTry() =>
@@ -2377,6 +2374,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
         }
         t
     })
+  }
 
   def implicitClosure(location: Location): Term.Function = {
     require(token.isNot[KwImplicit] && debug(token))
@@ -3835,9 +3833,9 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
       case KwCase() if dialect.allowEnums && ahead(token.is[Ident]) =>
         syntaxError("Enum cases are only allowed in enums", at = token.pos)
       case KwIf() if mods.size == 1 && mods.head.is[Mod.Inline] =>
-        ifClause(isInline = true)
+        ifClause(mods)
       case ExprIntro() if mods.size == 1 && mods.head.is[Mod.Inline] =>
-        inlineMatchClause()
+        inlineMatchClause(mods)
       case other =>
         tmplDef(mods)
     }
@@ -4111,7 +4109,11 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
     val name = typeName()
     val tparams = typeParamClauseOpt(ownerIsType = true, ctxBoundsAllowed = false)
 
-    def aliasType() = Defn.Type(mods, name, tparams, typeIndentedOpt())
+    def aliasType() = {
+      // empty bounds also need to have origin
+      val emptyBounds = autoPos(Type.Bounds(None, None))
+      Defn.Type(mods, name, tparams, typeIndentedOpt(), emptyBounds)
+    }
 
     def abstractType() = {
       val bounds = typeBounds()

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -128,6 +128,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |TypeCase case Char => String
        |TypeCase case Array[t] => t
        |Type.Apply Array[t]
+       |Type.Bounds type T = @@A match {
        |""".stripMargin
   )
   checkPositions[Stat](
@@ -179,6 +180,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |Type.ContextFunction List[T] ?=> Option[T]
        |Type.Apply List[T]
        |Type.Apply Option[T]
+       |Type.Bounds type F0 = @@[T] => List[T] ?=> Option[T]
        |""".stripMargin
   )
   checkPositions[Stat](
@@ -196,6 +198,16 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |Term.Tuple (x, x)
        |Case case x: Double => x
        |Pat.Typed x: Double
+       |""".stripMargin
+  )
+  checkPositions[Stat](
+    "class Alpha[T] derives Gamma[T], Beta[T]",
+    """|Type.Bounds class Alpha[T@@] derives Gamma[T], Beta[T]
+       |Ctor.Primary class Alpha[T] @@derives Gamma[T], Beta[T]
+       |Template derives Gamma[T], Beta[T]
+       |Self class Alpha[T] derives Gamma[T], Beta[T]@@
+       |Type.Apply Gamma[T]
+       |Type.Apply Beta[T]
        |""".stripMargin
   )
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
@@ -51,12 +51,12 @@ class ParseSuite extends FunSuite with CommonTrees {
 }
 
 object MoreHelpers {
-  def requireNonEmptyOrigin(tree: Tree): tree.type = {
+  def requireNonEmptyOrigin(tree: Tree)(implicit dialect: Dialect): tree.type = {
     val missingOrigin = tree.collect {
       case t if t.origin == Origin.None => t
     }
     Assertions.assertEquals(
-      missingOrigin,
+      missingOrigin.map(_.structure),
       Nil,
       "Expected all trees to have non-empty `.origin`.\n" +
         "To fix this failure, update ScalametaParser to use `autoPos()` where the trees below got constructed.\n" +

--- a/tests/shared/src/test/scala/scala/meta/tests/trees/ChildrenSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/trees/ChildrenSuite.scala
@@ -18,4 +18,20 @@ class ChildrenSuite extends FunSuite {
     assert(tree.children(1).productPrefix == "Ctor.Primary")
     assert(tree.children(2).productPrefix == "Template")
   }
+
+  test("derives-in-children") {
+    val source = """|
+                    |class Foo derives A[T], B[T] {  }
+                    |""".stripMargin
+    val tree = dialects.Scala3(source).parse[Stat].get
+    val containsBinaryCompatFields = tree.children.exists {
+      case t: Template =>
+        t.children.exists { c => c.is[Type.Apply] && c.toString() == "A[T]" }
+      case _ => false
+    }
+    assert(
+      containsBinaryCompatFields,
+      "Binary compatible fields should be contained in the children method"
+    )
+  }
 }


### PR DESCRIPTION
Binary compat fields were added to allow for the older AST nodes to be forward binary compatible.

Previously, when invoking `children` method on trees that contained binaryCompat fields, those fields would not exist in the resulting list. Now, they are contained and can be used to traverse the tree.

It's important to note that traverse will still not working with those additional fields, but in most places (for example scalafmt) the `children` method is being used. We can try to fix it in the future if need arises.

This came up when working on `derives` in scalafmt. @kitbellew could you take a look? You are probably the only other person that recently dealt with thise macros :sweat_smile:  