### PR TITLE
Fix for \u005c causing an unclosed quote error

### DIFF
--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
@@ -451,7 +451,7 @@ class LegacyScanner(input: Input, dialect: Dialect) {
             syntaxError("can't unquote into character literals", at = charOffset - 1)
           else if (isIdentifierStart(ch))
             charLitOr(getIdentRest _)
-          else if (isOperatorPart(ch) && (ch != '\\'))
+          else if (isOperatorPart(ch) && (ch != '\\' || isUnicodeEscape))
             charLitOr(getOperatorRest _)
           else {
             val lookahead = lookaheadReader
@@ -806,7 +806,7 @@ class LegacyScanner(input: Input, dialect: Dialect) {
    *  and advance to next character.
    */
   protected def getLitChar(): Unit =
-    if (ch == '\\') {
+    if (ch == '\\' && !isUnicodeEscape) {
       nextChar()
       if ('0' <= ch && ch <= '7') {
         val start = charOffset - 2

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/LitSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/LitSuite.scala
@@ -115,10 +115,6 @@ class LitSuite extends ParseSuite {
       term("raw\"\"\"\"\"\"\"\"\"\"\"\"\"")
   }
 
-  test("unicode_escaped_backslash") {
-    val Lit("\u005c") = term("\"\\\\\"")
-  }
-
   test("minus-sign") {
     val code = """|object X {
                   |  sealed trait Foo {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/LitSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/LitSuite.scala
@@ -116,7 +116,7 @@ class LitSuite extends ParseSuite {
   }
 
   test("unicode_escaped_backslash") {
-    val Lit("\u005c") = term("\"\\\"")
+    val Lit("\u005c") = term("\"\\\\\"")
   }
 
   test("minus-sign") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/LitSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/LitSuite.scala
@@ -115,6 +115,10 @@ class LitSuite extends ParseSuite {
       term("raw\"\"\"\"\"\"\"\"\"\"\"\"\"")
   }
 
+  test("unicode_escaped_backslash") {
+    val Lit("\u005c") = term("\"\\\"")
+  }
+
   test("minus-sign") {
     val code = """|object X {
                   |  sealed trait Foo {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/UnclosedTokenSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/UnclosedTokenSuite.scala
@@ -24,6 +24,12 @@ class UnclosedTokenSuite extends ParseSuite {
     assert(e.getMessage().contains("unclosed string literal"))
   }
 
+  test("unclosed-escape") {
+    val e = intercept[TokenizeException] {
+      stat(""" "start \" """)
+    }
+  }
+
   test("unclosed-interpolation") {
     val e = intercept[ParseException] {
       stat(""" s"${1+ """)


### PR DESCRIPTION
I believe this fixes issue #2228 where `'\u005c'` would cause an unclosed character literal error.