### PR TITLE
Update ScalaJS to `1.4.0` along with some of the libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -139,7 +139,7 @@ lazy val common = crossProject(JSPlatform, JVMPlatform)
   .in(file("scalameta/common"))
   .settings(
     publishableSettings,
-    libraryDependencies += "com.lihaoyi" %%% "sourcecode" % "0.2.1",
+    libraryDependencies += "com.lihaoyi" %%% "sourcecode" % "0.2.3",
     description := "Bag of private and public helpers used in scalameta APIs and implementations",
     enableMacros
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,10 +17,10 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.1")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.3.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.4.0")
 
 addSbtPlugin("org.scala-debugger" % "sbt-jdi-tools" % "1.1.1")
 
-addSbtPlugin("org.scalameta" % "sbt-munit" % "0.7.20")
+addSbtPlugin("org.scalameta" % "sbt-munit" % "0.7.21")
 
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.2.14")


### PR DESCRIPTION
Succeeds https://github.com/scalameta/scalameta/pull/2227 and https://github.com/scalameta/scalameta/pull/2223

