### PR TITLE
Fix syntax errors

### DIFF
--- a/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
@@ -93,6 +93,7 @@ final class Dialect private (
     // Opaque types introduced in dotty
     val allowOpaqueTypes: Boolean,
     // Literal Unit Type
+    @deprecated("Literal unit types are longer supported in any dialect", "4.4.9")
     val allowLiteralUnitType: Boolean,
     // Super traits introduced in dotty, but later removed.
     val allowSuperTrait: Boolean,
@@ -338,6 +339,7 @@ final class Dialect private (
   def withAllowOpaqueTypes(newValue: Boolean): Dialect = {
     privateCopy(allowOpaqueTypes = newValue)
   }
+  @deprecated("Literal unit types are longer supported in any dialect", "4.4.9")
   def withAllowLiteralUnitType(newValue: Boolean): Dialect = {
     privateCopy(allowLiteralUnitType = newValue)
   }

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -56,7 +56,6 @@ package object dialects {
     .withAllowImplicitByNameParameters(true)
     .withAllowLiteralTypes(true)
     .withAllowNumericLiteralUnderscoreSeparators(true)
-    .withAllowLiteralUnitType(true)
     .withAllowTryWithAnyExpr(true)
 
   implicit val Scala = Scala213 // alias for latest Scala dialect.
@@ -106,7 +105,6 @@ package object dialects {
     .withAllowSpliceAndQuote(true)
     .withAllowToplevelStatements(true)
     .withAllowOpaqueTypes(true)
-    .withAllowLiteralUnitType(false)
     .withAllowExportClause(true)
     .withAllowCommaSeparatedExtend(true)
     .withAllowEndMarker(true)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -350,6 +350,13 @@ class TermSuite extends ParseSuite {
       term("1 match { case 1 if true => }")
   }
 
+  test("1 match { case case 1 if true => }") {
+    val intercepted = intercept[ParseException] {
+      term("1 match { case case 1 if true => }")
+    }
+    assertNoDiff(intercepted.shortMessage, "Unexpected `case`")
+  }
+
   test("try 1") {
     val Try(Lit(1), Nil, None) = term("try 1")
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TypeSuite.scala
@@ -148,10 +148,15 @@ class TypeSuite extends ParseSuite {
     val Lit(false) = tpe("false")(dialects.Dotty)
     val Lit(true) = tpe("true")(dialects.Dotty)
 
-    val Lit.Unit() = tpe("()")(dialects.Scala213)
-    val Type.Function(Nil, Lit.Unit()) = tpe("() => ()")(dialects.Scala213)
-    intercept[org.scalameta.UnreachableError] {
-      tpe("()")(dialects.Dotty)
+    val exceptionScala3 = intercept[ParseException] {
+      tpe("() => ()")(dialects.Scala3)
     }
+    assertNoDiff(exceptionScala3.shortMessage, "illegal literal type (), use Unit instead")
+
+    val exceptionScala2 = intercept[ParseException] {
+      tpe("() => ()")(dialects.Scala213)
+    }
+    assertNoDiff(exceptionScala2.shortMessage, "illegal literal type (), use Unit instead")
+
   }
 }


### PR DESCRIPTION
Fixes two issues:
- `case case` statement that cause InvariantException now shows a nice error
- `()` literal type is no longer supported in any dialect (checked with 2.13.4) and added a ncie message instead of unreachable.