### PR TITLE
[Scala 3] Add support for single start vararg splices

### DIFF
--- a/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
@@ -136,7 +136,15 @@ final class Dialect private (
     // Scala 3 disallowed symbol literals
     val allowSymbolLiterals: Boolean,
     // Scala 3 disallowed symbol literals
-    val allowDependentFunctionTypes: Boolean
+    val allowDependentFunctionTypes: Boolean,
+    /* Scala 3 added possibility to use simpler splices such as:
+     * val arr = Array(1, 2, 3)
+     * val lst = List(0, arr*)                  // vararg splice argument
+     *  lst match
+     *    case List(0, 1, xs*) => println(xs)   // binds xs to Seq(2, 3)
+     *    case List(1, _*) =>                   // wildcard pattern
+     */
+    val allowPostfixStarVarargSplices: Boolean
 ) extends Product with Serializable {
 
   // NOTE(olafur) checklist for adding a new dialect field in a binary compatible way:
@@ -225,7 +233,8 @@ final class Dialect private (
       allowInfixMods = false,
       allowSpliceAndQuote = false,
       allowSymbolLiterals = true,
-      allowDependentFunctionTypes = false
+      allowDependentFunctionTypes = false,
+      allowPostfixStarVarargSplices = false
       // NOTE(olafur): declare the default value for new fields above this comment.
     )
   }
@@ -408,6 +417,9 @@ final class Dialect private (
   def withAllowDependentFunctionTypes(newValue: Boolean): Dialect = {
     privateCopy(allowDependentFunctionTypes = newValue)
   }
+  def withAllowPostfixStarVarargSplices(newValue: Boolean): Dialect = {
+    privateCopy(allowPostfixStarVarargSplices = newValue)
+  }
   // NOTE(olafur): add the next `withX()` method above this comment. Please try
   // to use consistent formatting, use `newValue` as the parameter name and wrap
   // the body inside curly braces.
@@ -467,7 +479,8 @@ final class Dialect private (
       allowInfixMods: Boolean = this.allowInfixMods,
       allowSpliceAndQuote: Boolean = this.allowSpliceAndQuote,
       allowSymbolLiterals: Boolean = this.allowSymbolLiterals,
-      allowDependentFunctionTypes: Boolean = this.allowDependentFunctionTypes
+      allowDependentFunctionTypes: Boolean = this.allowDependentFunctionTypes,
+      allowPostfixStarVarargSplices: Boolean = this.allowPostfixStarVarargSplices
       // NOTE(olafur): add the next parameter above this comment.
   ): Dialect = {
     new Dialect(
@@ -524,7 +537,8 @@ final class Dialect private (
       allowInfixMods,
       allowSpliceAndQuote,
       allowSymbolLiterals,
-      allowDependentFunctionTypes
+      allowDependentFunctionTypes,
+      allowPostfixStarVarargSplices
       // NOTE(olafur): add the next argument above this comment.
     )
   }

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -87,8 +87,10 @@ package object dialects {
 
   implicit val Scala3 = Scala213
     .withAllowAndTypes(true)
+    // there 3 different ways to specify vargs, some will be removed in future Scala 3 versions
     .withAllowAtForExtractorVarargs(true) // both @ and : work currently for Scala 3
     .withAllowColonForExtractorVarargs(true) // both @ and : work currently for Scala 3
+    .withAllowPostfixStarVarargSplices(true)
     .withAllowEnums(true)
     .withAllowImplicitByNameParameters(true)
     .withAllowInlineMods(true)

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2209,6 +2209,10 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
         implicitClosure(location)
       case _ =>
         var t: Term = autoPos(postfixExpr(allowRepeated))
+        def repeatedTerm(nextTokens: () => Unit) = {
+          if (allowRepeated) t = atPos(t, auto)({ nextTokens(); Term.Repeated(t) })
+          else syntaxError("repeated argument not allowed here", at = token)
+        }
         if (token.is[Equals]) {
           t match {
             case _: Term.Ref | _: Term.Apply | _: Quasi =>
@@ -2221,13 +2225,14 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
           if (token.is[At] || (token.is[Ellipsis] && ahead(token.is[At]))) {
             t = atPos(t, auto)(Term.Annotate(t, annots(skipNewLines = false)))
           } else if (token.is[Underscore] && ahead(isStar)) {
-            if (allowRepeated) t = atPos(t, auto)({ next(); next(); Term.Repeated(t) })
-            else syntaxError("repeated argument not allowed here", at = token)
+            repeatedTerm(() => nextTwice())
           } else {
             // this does not necessarily correspond to syntax, but is necessary to accept lambdas
             // check out the `if (token.is[RightArrow]) { ... }` block below
             t = atPos(t, auto)(Term.Ascribe(t, typeOrInfixType(location)))
           }
+        } else if (dialect.allowPostfixStarVarargSplices && isStar) {
+          repeatedTerm(() => next())
         } else if (token.is[KwMatch]) {
           next()
           t = matchClause(t)
@@ -2565,11 +2570,14 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
     // rhsStartK/rhsEndK may be bigger than then extent of rhsK,
     // so we really have to track them separately.
     def loop(rhsStartK: Pos, rhsK: ctx.Rhs, rhsEndK: Pos): ctx.Rhs = {
-      if (!token.is[Ident] && !token
-          .is[Unquote] && !(token.is[KwMatch] && dialect.allowMatchAsOperator)) {
+      def isVarargParam = dialect.allowPostfixStarVarargSplices && isStar && allowRepeated
+      if (!token.is[Ident] && !token.is[Unquote] &&
+        !(token.is[KwMatch] && dialect.allowMatchAsOperator)) {
         // Infix chain has ended.
         // In the running example, we're at `a + b[]`
         // with base = List([a +]), rhsK = List([b]).
+        rhsK
+      } else if (isVarargParam) {
         rhsK
       } else {
         // Infix chain continues.
@@ -3198,6 +3206,11 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
         case Ident(_) | KwThis() | Unquote() =>
           val isBackquoted = parser.isBackquoted
           val sid = stableId()
+          val isRepeated = sid match {
+            case _: Quasi => false
+            case Term.Name(value) => dialect.allowPostfixStarVarargSplices && isStar
+            case _ => false
+          }
           val isVarPattern = sid match {
             case _: Quasi => false
             case Term.Name(value) =>
@@ -3227,6 +3240,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
               Pat.Extract(fun, checkNoTripleDots(argumentPatterns()))
             case (_, _) if targs.nonEmpty => syntaxError("pattern must be a value", at = token)
             case (_, name: Term.Name.Quasi) => name.become[Pat.Quasi]
+            case (_, name: Term.Name) if isRepeated => accept[Ident]; Pat.Repeated(name)
             case (_, name: Term.Name) if isVarPattern => Pat.Var(name)
             case (_, name: Term.Name) => name
             case (_, select: Term.Select) => select

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -261,6 +261,7 @@ object Pat {
   @ast class Tuple(args: List[Pat] @nonEmpty) extends Pat {
     checkFields(args.length > 1 || (args.length == 1 && args.head.is[Pat.Quasi]))
   }
+  @ast class Repeated(name: scala.meta.Term.Name) extends Pat
   @ast class Extract(fun: Term, args: List[Pat]) extends Pat {
     checkFields(fun.isExtractor)
   }

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -304,6 +304,7 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.Pat.Given
       |scala.meta.Pat.Interpolate
       |scala.meta.Pat.Macro
+      |scala.meta.Pat.Repeated
       |scala.meta.Pat.SeqWildcard
       |scala.meta.Pat.Tuple
       |scala.meta.Pat.Typed

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
@@ -21,7 +21,7 @@ class ReflectionSuite extends FunSuite {
   test("root") {
     assert(symbolOf[scala.meta.Tree].isRoot)
     assertEquals(symbolOf[scala.meta.Tree].asRoot.allBranches.length, 23)
-    assertEquals(symbolOf[scala.meta.Tree].asRoot.allLeafs.length, 341)
+    assertEquals(symbolOf[scala.meta.Tree].asRoot.allLeafs.length, 343)
   }
 
   test("If") {

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -192,6 +192,15 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |""".stripMargin
   )
   checkPositions[Stat](
+    """|x match {
+       |  case List(xs*) => 1
+       |}""".stripMargin,
+    """|Case case List(xs*) => 1
+       |Pat.Extract List(xs*)
+       |Pat.Repeated xs*
+       |""".stripMargin
+  )
+  checkPositions[Stat](
     "val extractor: (e: Entry, f: Other) => e.Key = extractKey",
     """|Type.Function (e: Entry, f: Other) => e.Key
        |Type.TypedParam e: Entry

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -746,6 +746,44 @@ class MinorDottySuite extends BaseDottySuite {
     )
   }
 
+  test("vararg-wildcard-postfix-star") {
+    runTestAssert[Stat](
+      "val lst = List(0, arr*)"
+    )(
+      Defn.Val(
+        Nil,
+        List(Pat.Var(Term.Name("lst"))),
+        None,
+        Term.Apply(Term.Name("List"), List(Lit.Int(0), Term.Repeated(Term.Name("arr"))))
+      )
+    )
+  }
+
+  test("vararg-wildcard-postfix-start-pat") {
+    runTestAssert[Stat](
+      """|a match {case List(xs*) => }
+         |""".stripMargin,
+      assertLayout = Some(
+        """|a match {
+           |  case List(xs*) =>
+           |}
+           |""".stripMargin
+      )
+    )(
+      Term.Match(
+        Term.Name("a"),
+        List(
+          Case(
+            Pat.Extract(Term.Name("List"), List(Pat.Repeated(Term.Name("xs")))),
+            None,
+            Term.Block(Nil)
+          )
+        ),
+        Nil
+      )
+    )
+  }
+
   test("empty-case-class") {
     val error = "case classes must have a parameter list"
     runTestError[Stat]("case class A", error)


### PR DESCRIPTION
Starting with Scala 3 RC1 it's now possible to use a single * for vararg splices:

https://dotty.epfl.ch/docs/reference/changed-features/vararg-splices.html

To support this I added a new Pat.Repeated, since the prevoius Pat.Wildcard did not fit with how it's currently represented.