### PR TITLE
[Scala 3] Fix minor issues and make dotty community test run on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           - "++2.13.4 testsJVM/test"
           - "++2.13.4 testsJS/test"
           - "++2.13.4 download-scala-library testsJVM/slow:test"
+          - "communitytest/test"
           - "mima"
     steps:
       - uses: actions/checkout@v2

--- a/community-test/src/test/scala/CommunityDottySuite.scala
+++ b/community-test/src/test/scala/CommunityDottySuite.scala
@@ -67,8 +67,8 @@ class CommunityDottySuite extends FunSuite {
     ),
     CommunityBuild(
       "https://github.com/scalameta/munit.git",
-      // latest commit from 27.11.2020
-      "5f384b548960ee7731649f5f900eb1d854e7827a",
+      // latest commit from 16.02.2021
+      "bf6fd2294decdd89f887d47461f12af8f6083c5a",
       "munit",
       munitExclusionList
     )
@@ -166,9 +166,7 @@ class CommunityDottySuite extends FunSuite {
   final def munitExclusionList = List(
     // Syntax no longer valid in Scala 3
     //xml literals
-    "main/scala/docs/MUnitModifier.scala",
-    // old given syntax
-    "src/main/scala-0.27/munit/internal/MacroCompat.scala"
+    "main/scala/docs/MUnitModifier.scala"
   )
 
   final val ignoreParts = List(

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
@@ -145,7 +145,12 @@ final class Dialect private (
      *    case List(0, 1, xs*) => println(xs)   // binds xs to Seq(2, 3)
      *    case List(1, _*) =>                   // wildcard pattern
      */
-    val allowPostfixStarVarargSplices: Boolean
+    val allowPostfixStarVarargSplices: Boolean,
+    /* Scala 3 allows us to specify:
+     * `case tp @ OrNull(tp1): OrType`
+     * the last section after : was not allowed previously.
+     */
+    val allowAllTypedPatterns: Boolean
 ) extends Product with Serializable {
 
   // NOTE(olafur) checklist for adding a new dialect field in a binary compatible way:
@@ -235,7 +240,8 @@ final class Dialect private (
       allowSpliceAndQuote = false,
       allowSymbolLiterals = true,
       allowDependentFunctionTypes = false,
-      allowPostfixStarVarargSplices = false
+      allowPostfixStarVarargSplices = false,
+      allowAllTypedPatterns = false
       // NOTE(olafur): declare the default value for new fields above this comment.
     )
   }
@@ -422,6 +428,9 @@ final class Dialect private (
   def withAllowPostfixStarVarargSplices(newValue: Boolean): Dialect = {
     privateCopy(allowPostfixStarVarargSplices = newValue)
   }
+  def withAllowAllTypedPatterns(newValue: Boolean): Dialect = {
+    privateCopy(allowAllTypedPatterns = newValue)
+  }
   // NOTE(olafur): add the next `withX()` method above this comment. Please try
   // to use consistent formatting, use `newValue` as the parameter name and wrap
   // the body inside curly braces.
@@ -482,7 +491,8 @@ final class Dialect private (
       allowSpliceAndQuote: Boolean = this.allowSpliceAndQuote,
       allowSymbolLiterals: Boolean = this.allowSymbolLiterals,
       allowDependentFunctionTypes: Boolean = this.allowDependentFunctionTypes,
-      allowPostfixStarVarargSplices: Boolean = this.allowPostfixStarVarargSplices
+      allowPostfixStarVarargSplices: Boolean = this.allowPostfixStarVarargSplices,
+      allowAllTypedPatterns: Boolean = this.allowAllTypedPatterns
       // NOTE(olafur): add the next parameter above this comment.
   ): Dialect = {
     new Dialect(
@@ -540,7 +550,8 @@ final class Dialect private (
       allowSpliceAndQuote,
       allowSymbolLiterals,
       allowDependentFunctionTypes,
-      allowPostfixStarVarargSplices
+      allowPostfixStarVarargSplices,
+      allowAllTypedPatterns
       // NOTE(olafur): add the next argument above this comment.
     )
   }

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -125,6 +125,7 @@ package object dialects {
     .withAllowInfixMods(true)
     .withAllowSymbolLiterals(false)
     .withAllowDependentFunctionTypes(true)
+    .withAllowAllTypedPatterns(true)
 
   @deprecated("Use Scala3 instead", "4.4.2")
   implicit val Dotty = Scala3

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -764,7 +764,7 @@ object TreeSyntax {
       case _: Pat.Wildcard => m(SimplePattern, kw("_"))
       case _: Pat.SeqWildcard => m(SimplePattern, kw("_*"))
       case t: Pat.Repeated => m(SimplePattern, t.name, kw("*"))
-      case pat: Pat.Given => m(SimplePattern, s(kw("given"), " ", pat.tpe))
+      case pat: Pat.Given => m(AnyPattern3, s(kw("given"), " ", p(RefineTyp, pat.tpe)))
       case t: Pat.Bind =>
         val separator = t.rhs match {
           case Pat.SeqWildcard() =>

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/package.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/package.scala
@@ -168,6 +168,7 @@ package object trees {
       case _: Defn.ExtensionGroup => true
       case _: Defn.Val => true
       case _: Defn.Type => true
+      case _: Decl.Type => true
       case _: Term.EndMarker => true
       case _: Defn.Var => true
       case _: Pkg.Object => true

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -224,18 +224,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
                   |else
                   |  gx
                   |""".stripMargin
-    val output = """|if (cond) {
-                    |  fx1
-                    |  fx2
-                    |} else gx
-                    |""".stripMargin
-    runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.If(
-        Term.Name("cond"),
-        Term.Block(List(Term.Name("fx1"), Term.Name("fx2"))),
-        Term.Name("gx")
-      )
-    )
+    runTestError[Stat](code, "then expected but identifier found")
   }
 
   test("if-else-in-parens-3") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
@@ -678,6 +678,44 @@ class GivenUsingSuite extends BaseDottySuite {
       )
     )
   }
+  test("given-pat-new") {
+    runTestAssert[Stat](
+      """|pair match {
+         | case ctx @ given Context => new Provider
+         | case ctx @ given (Context => String) => new Provider
+         |}
+         |""".stripMargin,
+      assertLayout = Some(
+        """|pair match {
+           |  case ctx @ given Context =>
+           |    new Provider
+           |  case ctx @ given (Context => String) =>
+           |    new Provider
+           |}
+           |""".stripMargin
+      )
+    )(
+      Term.Match(
+        Term.Name("pair"),
+        List(
+          Case(
+            Pat.Bind(Pat.Var(Term.Name("ctx")), Pat.Given(Type.Name("Context"))),
+            None,
+            Term.New(Init(Type.Name("Provider"), Name(""), Nil))
+          ),
+          Case(
+            Pat.Bind(
+              Pat.Var(Term.Name("ctx")),
+              Pat.Given(Type.Function(List(Type.Name("Context")), Type.Name("String")))
+            ),
+            None,
+            Term.New(Init(Type.Name("Provider"), Name(""), Nil))
+          )
+        ),
+        Nil
+      )
+    )
+  }
 
   test("given-pat-for") {
     runTestAssert[Stat](

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -866,4 +866,62 @@ class SignificantIndentationSuite extends BaseDottySuite {
     )
   }
 
+  test("match-case-same-line") {
+    runTestAssert[Stat](
+      """|widen match
+         |  case tp @ OrNull(tp1): OrType =>
+         |  case tp => tp
+         |""".stripMargin,
+      assertLayout = Some(
+        """|widen match {
+           |  case (tp @ OrNull(tp1)): OrType =>
+           |  case tp => tp
+           |}
+           |""".stripMargin
+      )
+    )(
+      Term.Match(
+        Term.Name("widen"),
+        List(
+          Case(
+            Pat.Typed(
+              Pat.Bind(
+                Pat.Var(Term.Name("tp")),
+                Pat.Extract(Term.Name("OrNull"), List(Pat.Var(Term.Name("tp1"))))
+              ),
+              Type.Name("OrType")
+            ),
+            None,
+            Term.Block(Nil)
+          ),
+          Case(Pat.Var(Term.Name("tp")), None, Term.Name("tp"))
+        ),
+        Nil
+      )
+    )
+  }
+
+  test("object-type") {
+    runTestAssert[Stat](
+      """|object typeAndObjects:
+         |  type Ala
+         |""".stripMargin,
+      assertLayout = Some(
+        "object typeAndObjects { type Ala }"
+      )
+    )(
+      Defn.Object(
+        Nil,
+        Term.Name("typeAndObjects"),
+        Template(
+          Nil,
+          Nil,
+          Self(Name(""), None),
+          List(Decl.Type(Nil, Type.Name("Ala"), Nil, Type.Bounds(None, None))),
+          Nil
+        )
+      )
+    )
+  }
+
 }


### PR DESCRIPTION
This also fixes issues:
- `type T` being the only thing in an indented block
- given patterns work properly with functions
- typed pattern is not always allowed at the end, which is a change from Scala 2
- no longer allow for `if cond <indentation>`