### PR TITLE
[Scala 3] Allow to have some of the keywords on the same indentation level as the preceeding block

### DIFF
--- a/community-test/src/test/scala/CommunityDottySuite.scala
+++ b/community-test/src/test/scala/CommunityDottySuite.scala
@@ -60,8 +60,8 @@ class CommunityDottySuite extends FunSuite {
   val communityBuilds = List(
     CommunityBuild(
       "https://github.com/lampepfl/dotty.git",
-      //commit hash from 16.12.2020
-      "73d942cca5936e3f760be327a5a4d6ee9f9c194f",
+      //commit hash from 17.02.2021
+      "8bbb0ba745453a0d2ffdb94c5966752dfe57bb5f",
       "dotty",
       dottyExclusionList
     ),
@@ -156,16 +156,11 @@ class CommunityDottySuite extends FunSuite {
 
   final def dottyExclusionList = List(
     // [scalameta] erased modifier - for now used internally, will be available in 3.1
-    "library/src/scala/compiletime/package.scala",
-    // if then - else without outdentation before else.
-    // it's unclear what to do in this case
-    // https://github.com/lampepfl/dotty/issues/10372
-    "dotty/dokka/tasty/ClassLikeSupport.scala"
+    "library/src/scala/compiletime/package.scala"
   )
 
   final def munitExclusionList = List(
-    // Syntax no longer valid in Scala 3
-    //xml literals
+    // xml literals are longer valid in Scala 3
     "main/scala/docs/MUnitModifier.scala"
   )
 

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/CharArrayReader.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/CharArrayReader.scala
@@ -4,6 +4,7 @@ package tokenizers
 
 import Chars._
 import scala.meta.inputs._
+import scala.util.control.NonFatal
 
 trait CharArrayReaderData {
 
@@ -101,10 +102,14 @@ class CharArrayReader(input: Input, dialect: Dialect, reporter: Reporter)
     val end = charOffset
     if (charOffset < buf.length && buf(charOffset) == 'u' && evenSlashPrefix) {
       do charOffset += 1 while (charOffset < buf.length && buf(charOffset) == 'u')
-      val code = udigit << 12 | udigit << 8 | udigit << 4 | udigit
-      lastUnicodeOffset = charOffset
-      isUnicodeEscape = true
-      ch = code.toChar
+      try {
+        val code = udigit << 12 | udigit << 8 | udigit << 4 | udigit
+        lastUnicodeOffset = charOffset
+        isUnicodeEscape = true
+        ch = code.toChar
+      } catch {
+        case NonFatal(_) =>
+      }
     }
 
     // restore the charOffset to the saved position

--- a/tests/jvm/src/test/resources/unicode.txt
+++ b/tests/jvm/src/test/resources/unicode.txt
@@ -3,3 +3,4 @@ s"]2;SBT${titleName}${titleBranch}\u0007"
 case (r, \u03c6) =>
 case (r,\u03c6) =>
 scala.meta.\u03c6
+f"\u$oct%04x"

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -802,4 +802,12 @@ class TermSuite extends ParseSuite {
       Lit.Unit()
     ) = term(code)
   }
+
+  test("fstring-interpolation") {
+    val Term.Interpolate(
+      Term.Name("f"),
+      List(Lit.String("\\\\u"), Lit.String("%04x")),
+      List(Term.Name("oct"))
+    ) = term("""f"\\u$oct%04x"""")
+  }
 }


### PR DESCRIPTION
This PR also fixes any related issues that were still not working in case dotty source code, which includes:
- indentation start in `{ a => ` block
- unicode escapes like `f"\u$oct%04x"`