### PR TITLE
Update fastparse to 2.3.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -157,9 +157,9 @@ lazy val trees = crossProject(JSPlatform, JVMPlatform)
     enableHardcoreMacros,
     protobufSettings,
     libraryDependencies ++= List(
-      // NOTE(olafur): use shaded version of fastparse because the latest version v2.0.0
-      // has binary incompatibilites with the v1.0.0 version used by Scalameta.
-      "org.scalameta" %%% "fastparse" % "1.0.1"
+      // NOTE(olafur): use shaded version of fastparse 2.3.1 to avoid any
+      // binary incompatibilites with the v2.3.1 version used by Scalameta.
+      "org.scalameta" %%% "fastparse-v2" % "2.3.1"
     ),
     mergedModule({ base =>
       val scalameta = base / "scalameta"

--- a/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/DocToken.scala
+++ b/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/DocToken.scala
@@ -1,7 +1,7 @@
 package scala.meta.contrib
 
-import scala.meta.internal.fastparse.all._
-import scala.meta.internal.fastparse.core.Parsed
+import scala.meta.internal.fastparse._
+import scala.meta.internal.fastparse.NoWhitespace._
 
 /**
  * Represents a scaladoc line.
@@ -23,7 +23,7 @@ case class DocToken(kind: DocToken.Kind, name: Option[String], body: Option[Stri
     body
       .map { b =>
         def parseBodyFrom(idx: Int): List[DocToken.Reference] = {
-          DocToken.referenceParser.parse(b, idx) match {
+          parse(b, DocToken.referenceParser(_), startIndex = idx) match {
             case Parsed.Success(value, index) =>
               List(DocToken.Reference(value)) ++ parseBodyFrom(index)
             case _ => List[DocToken.Reference]()
@@ -46,7 +46,7 @@ object DocToken {
   /**
    * Parser that for obtaining a class reference from an scaladoc body.
    */
-  private val referenceParser: Parser[String] = P(
+  private def referenceParser[_: P]: P[String] = P(
     // Removes the elements previous to the references.
     ((AnyChar ~ !"[[").rep ~ AnyChar).?
     // Retrieves the element within a

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/XmlParser.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/XmlParser.scala
@@ -4,81 +4,89 @@ import scala.annotation.switch
 import scala.meta.Dialect
 import scala.meta.inputs.Input
 
-import scala.meta.internal.fastparse
-import scala.meta.internal.fastparse.all._
+import scala.meta.internal.fastparse._
+import scala.meta.internal.fastparse.NoWhitespace._
+import scala.annotation.tailrec
 
 /**
  * Copy-pasta from this lihaoyi comment:
  * [[https://github.com/scalameta/fastparse/pull/1#issuecomment-244940542]]
- * and adapted to more closely match scala-xml
+ * and adapted to more closely match scala-xml and then adapted to fastparse 2.3.1
  */
-class XmlParser(Block: P0, Patterns: P0 = Fail) {
+class XmlParser(dialect: Dialect) {
 
-  private val S = CharsWhileIn("\t\n\r ")
+  val blockParser = new ScalaExprPositionParser(dialect)
 
-  val XmlExpr: P0 = P(Xml.XmlContent.rep(min = 1, sep = S.?))
-  val XmlPattern: P0 = P(Xml.ElemPattern)
+  def splicePositions: List[blockParser.XmlTokenRange] = blockParser.splicePositions
+  def Patterns[_: P]: P0 = Fail
+
+  def S[_: P]: P0 = P(CharsWhileIn("\t\n\r "))
+  def XmlExpr[_: P]: P0 = P(Xml.XmlContent.rep(min = 1, sep = S.?))
+  def XmlPattern[_: P]: P0 = P(Xml.ElemPattern)
 
   private[this] object Xml {
-    val Element = P(TagHeader ~/ ("/>" | ">" ~/ Content ~/ ETag)) // FIXME tag must be balanced
-    val TagHeader = P("<" ~ Name ~/ (S ~ Attribute).rep ~ S.?)
-    val ETag = P("</" ~ Name ~ S.? ~ ">")
+    def Element[_: P] = P(
+      TagHeader ~/ ("/>" | ">" ~/ Content ~/ ETag)
+    ) // FIXME tag must be balanced
+    def TagHeader[_: P] = P("<" ~ Name ~/ (S ~ Attribute).rep ~ S.?)
+    def ETag[_: P] = P("</" ~ Name ~ S.? ~ ">")
 
-    val Attribute = P(Name ~/ Eq ~/ AttValue)
-    val Eq = P(S.? ~ "=" ~ S.?)
-    val AttValue = P(
+    def Attribute[_: P] = P(Name ~/ Eq ~/ AttValue)
+    def Eq[_: P] = P(S.? ~ "=" ~ S.?)
+    def AttValue[_: P] = P(
       "\"" ~/ (CharQ | Reference).rep ~ "\"" |
         "'" ~/ (CharA | Reference).rep ~ "'" |
         ScalaExpr
     )
 
-    val Content = P((CharData | Reference | ScalaExpr | XmlContent).rep)
-    val XmlContent: P0 = P(Unparsed | CDSect | PI | Comment | Element)
+    def Content[_: P] = P((CharData | Reference | ScalaExpr | XmlContent).rep)
+    def XmlContent[_: P]: P0 = P(Unparsed | CDSect | PI | Comment | Element)
 
-    val ScalaExpr = P("{" ~ Block ~ "}")
+    def ScalaExpr[_: P] = P("{" ~ blockParser.blockRun(implicitly[P[_]]) ~ "}")
 
-    val Unparsed = P(UnpStart ~/ UnpData ~ UnpEnd)
-    val UnpStart = P("<xml:unparsed" ~/ (S ~ Attribute).rep ~ S.? ~ ">")
-    val UnpEnd = P("</xml:unparsed>")
-    val UnpData = P((!UnpEnd ~ Char).rep)
+    def Unparsed[_: P] = P(UnpStart ~/ UnpData ~ UnpEnd)
+    def UnpStart[_: P] = P("<xml:unparsed" ~/ (S ~ Attribute).rep ~ S.? ~ ">")
+    def UnpEnd[_: P] = P("</xml:unparsed>")
+    def UnpData[_: P] = P((!UnpEnd ~ Char).rep)
 
-    val CDSect = P(CDStart ~/ CData ~ CDEnd)
-    val CDStart = P("<![CDATA[")
-    val CData = P((!"]]>" ~ Char).rep)
-    val CDEnd = P("]]>")
+    def CDSect[_: P] = P(CDStart ~/ CData ~ CDEnd)
+    def CDStart[_: P] = P("<![CDATA[")
+    def CData[_: P] = P((!"]]>" ~ Char).rep)
+    def CDEnd[_: P] = P("]]>")
 
-    val Comment = P("<!--" ~/ ComText ~ "-->")
-    val ComText = P((!"-->" ~ Char).rep)
+    def Comment[_: P] = P("<!--" ~/ ComText ~ "-->")
+    def ComText[_: P] = P((!"-->" ~ Char).rep)
 
-    val PI = P("<?" ~ Name ~ S.? ~ PIProcText ~ "?>")
-    val PIProcText = P((!"?>" ~ Char).rep)
+    def PI[_: P] = P("<?" ~ Name ~ S.? ~ PIProcText ~ "?>")
+    def PIProcText[_: P] = P((!"?>" ~ Char).rep)
 
-    val Reference = P(EntityRef | CharRef)
-    val EntityRef = P("&" ~ Name ~/ ";")
-    val CharRef = P("&#" ~ Num ~ ";" | "&#x" ~ HexNum ~ ";")
-    val Num = P(CharIn('0' to '9').rep)
-    val HexNum = P(CharIn('0' to '9', 'a' to 'f', 'A' to 'F').rep)
+    def Reference[_: P] = P(EntityRef | CharRef)
+    def EntityRef[_: P] = P("&" ~ Name ~/ ";")
+    def CharRef[_: P] = P("&#" ~ Num ~ ";" | "&#x" ~ HexNum ~ ";")
+    def Num[_: P] = P(CharIn("0-9").rep)
+    def HexNum[_: P] = P(CharIn("0-9", "a-f", "A-F").rep)
 
-    val CharData = P((CharB | "{{" | "}}").rep(1))
+    def CharData[_: P] = P((CharB | "{{" | "}}").rep(1))
 
-    val Char = P(AnyChar)
-    val Char1 = P(!("<" | "&") ~ Char)
-    val CharQ = P(!"\"" ~ Char1)
-    val CharA = P(!"'" ~ Char1)
-    val CharB = P(!("{" | "}") ~ Char1)
+    def Char[_: P] = P(AnyChar)
+    def Char1[_: P] = P(!("<" | "&") ~ Char)
+    def CharQ[_: P] = P(!"\"" ~ Char1)
+    def CharA[_: P] = P(!"'" ~ Char1)
+    def CharB[_: P] = P(!("{" | "}") ~ Char1)
 
     // discard result
-    val Name: P0 = P(NameStart ~ NameChar.rep).!.filter(_.last != ':').opaque("Name").map(_ => ())
-    val NameStart = P(CharPred.raw(isNameStart))
-    val NameChar = P(CharPred.raw(isNameChar))
+    def Name[_: P]: P0 =
+      P(NameStart ~ NameChar.rep).!.filter(_.last != ':').opaque("Name").map(_ => ())
+    def NameStart[_: P] = P(CharPred(isNameStart))
+    def NameChar[_: P] = P(CharPred(isNameChar))
 
-    val ElemPattern: P0 = P(TagPHeader ~/ ("/>" | ">" ~/ ContentP ~/ ETag))
-    val TagPHeader = P("<" ~ Name ~ S.?)
+    def ElemPattern[_: P]: P0 = P(TagPHeader ~/ ("/>" | ">" ~/ ContentP ~/ ETag))
+    def TagPHeader[_: P] = P("<" ~ Name ~ S.?)
 
-    val ContentP: P0 = P((CharDataP | ScalaPatterns | ElemPattern).rep)
-    val ScalaPatterns = P("{" ~ Patterns ~ "}")
+    def ContentP[_: P]: P0 = P((CharDataP | ScalaPatterns | ElemPattern).rep)
+    def ScalaPatterns[_: P] = P("{" ~ Patterns ~ "}")
     // matches weirdness of scalac parser on xml reference.
-    val CharDataP = P("&" ~ CharData.? | CharData)
+    def CharDataP[_: P] = P("&" ~ CharData.? | CharData)
 
     //======================================================
     // From `scala.xml.parsing.TokenTests`
@@ -132,30 +140,37 @@ class XmlParser(Block: P0, Patterns: P0 = Fail) {
  * Doesn't really parse scala expressions, only reads until the curly brace
  * balance hits 0.
  */
-class ScalaExprPositionParser(dialect: Dialect) extends Parser[Unit] {
+class ScalaExprPositionParser(dialect: Dialect) {
   case class XmlTokenRange(from: Int, to: Int) // from is inclusive, to is exclusive
   private val _splicePositions = List.newBuilder[XmlTokenRange]
   def splicePositions: List[XmlTokenRange] = _splicePositions.result()
 
-  def parseRec(cfg: ParseCtx, index: Int): fastparse.core.Mutable[Unit, Char, String] = {
+  def blockRun = { implicit ctx: ParsingRun[_] =>
     var curlyBraceCount = 1
-    val input = cfg.input
+    val input = ctx.input
+    val index = ctx.index
     val scanner =
       new LegacyScanner(Input.String(input.slice(index, input.length)), dialect)
     scanner.reader.nextChar()
-    while (curlyBraceCount > 0) {
+
+    @tailrec
+    def rec(curlyBraceCount: Int): Boolean = {
       scanner.nextToken()
       (scanner.curr.token: @switch) match {
-        case LegacyToken.LBRACE => curlyBraceCount += 1
-        case LegacyToken.RBRACE => curlyBraceCount -= 1
-        case LegacyToken.EOF =>
-          return fail(cfg.failure, index + scanner.curr.offset)
-        case _ =>
+        case LegacyToken.LBRACE => rec(curlyBraceCount + 1)
+        case LegacyToken.RBRACE if curlyBraceCount == 1 => true
+        case LegacyToken.RBRACE => rec(curlyBraceCount - 1)
+        case LegacyToken.EOF => false
+        case _ => rec(curlyBraceCount)
       }
     }
-
+    val parsedSuccesfully = rec(1)
     val nextIndex = index + scanner.curr.offset
-    _splicePositions += XmlTokenRange(index, nextIndex)
-    success(cfg.success, (), nextIndex, Set.empty, cut = false)
+    if (parsedSuccesfully) {
+      _splicePositions += XmlTokenRange(index, nextIndex)
+      ctx.freshSuccessUnit(index = nextIndex)
+    } else {
+      ctx.freshFailure(nextIndex)
+    }
   }
 }


### PR DESCRIPTION
This PR updates the fork of fastparse to use the newest 2.3.1 version, which we also backpublished for 2.11. This way we will be able to support:
- JVM 2.11, 2.12, 2.13
- JS 2.12, 2.13
- Native 2.12, 2.13 (in the next PR)