### PR TITLE
pretty printer: backquote importees when needed

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -279,17 +279,17 @@ object TreeSyntax {
             false
         }
       }
-      (t, t.parent) match {
-        case (t: Term.Name, Some(p: Tree)) =>
-          isAmbiguousWithPatVarTerm(t, p) ||
-            cantBeWrittenWithoutBackquotes(t) ||
-            isEscapableSoftKeyword(t, p)
-        case (t: Type.Name, Some(p: Tree)) =>
-          cantBeWrittenWithoutBackquotes(t)
-        case (t: Name, Some(p: Tree)) =>
-          isEscapableSoftKeyword(t, p)
-        case _ => cantBeWrittenWithoutBackquotes(t)
+      def isAmbiguousInParent(t: Tree, parent: Tree): Boolean = {
+        t match {
+          case t: Term.Name =>
+            isAmbiguousWithPatVarTerm(t, parent) || isEscapableSoftKeyword(t, parent)
+          case t: Name =>
+            isEscapableSoftKeyword(t, parent)
+          case _ =>
+            false
+        }
       }
+      cantBeWrittenWithoutBackquotes(t) || t.parent.exists(isAmbiguousInParent(t, _))
     }
     def guessIsPostfix(t: Term.Select): Boolean = false
     def guessHasExpr(t: Term.Return): Boolean = t.expr match {

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -807,6 +807,11 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     assert(q"import a.{b=>c}".syntax == "import a.{b => c}")
   }
 
+  test("backquote importees when needed - scalafix #1337") {
+    assert(q"import a.`{ q }`".syntax == "import a.`{ q }`")
+    assert(q"import a.`macro`".syntax == "import a.`macro`")
+  }
+
   test("show[Structure] should uppercase long literals suffix: '2l' -> '2L'") {
     assert(
       templStat("foo(1l, 1L)").structure ==


### PR DESCRIPTION
Originally reported as https://github.com/scalacenter/scalafix/issues/1337.
Fix regression introduced in https://github.com/scalameta/scalameta/pull/2239.