### PR TITLE
[Scala 3] Fix given alias with complex types

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -4047,7 +4047,10 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
       ctxBoundsAllowed = true,
       allowUnderscore = dialect.allowTypeParamUnderscore
     )
-    val uparamss = paramClauses(ownerIsType = false)
+    val uparamss =
+      if (token.is[LeftParen] && ahead(token.is[soft.KwUsing]))
+        paramClauses(ownerIsType = false)
+      else Nil
     val (sigName, sigTparams, sigUparamss) = if (token.is[Colon]) {
       accept[Colon]
       (name, tparams, uparamss)

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -945,7 +945,7 @@ object TreeSyntax {
           kw("given"),
           " ",
           givenName(t.name, t.tparams, t.sparams),
-          t.decltpe,
+          p(SimpleTyp, t.decltpe),
           " ",
           kw("="),
           " ",

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
@@ -316,6 +316,19 @@ class GivenUsingSuite extends BaseDottySuite {
     )
   }
 
+  test("given-alias-anon-or") {
+    runTestAssert[Stat]("given (Cancelable & Movable) = ???")(
+      Defn.GivenAlias(
+        Nil,
+        Name(""),
+        Nil,
+        Nil,
+        Type.And(Type.Name("Cancelable"), Type.Name("Movable")),
+        Term.Name("???")
+      )
+    )
+  }
+
   test("given-alias-block") {
     runTestAssert[Stat](
       "given global: Option[Int] = { def f(): Int = 1; Some(3) }",


### PR DESCRIPTION
Complex types such as `A & B` need to be wrapped in parenthesis when used as a type for given alias. Previously, we would try to parse parens as using parameters, which is not always the case. Now we also check for the `using` keyword, which allows us to parse complex types in given aliases type declarations.