### PR TITLE
ClassSignature specification had swapped self and declaration fields

### DIFF
--- a/docs/semanticdb/specification.md
+++ b/docs/semanticdb/specification.md
@@ -542,8 +542,8 @@ language types map onto this model.
 message ClassSignature {
   Scope type_parameters = 1;
   repeated Type parents = 2;
-  Scope declarations = 3;
-  Type self = 4;
+  Type self = 3;
+  Scope declarations = 4;
 }
 ```
 

--- a/semanticdb/semanticdb3/semanticdb3.md
+++ b/semanticdb/semanticdb3/semanticdb3.md
@@ -575,8 +575,8 @@ on how language types map onto this model.
 message ClassSignature {
   Scope type_parameters = 1;
   repeated Type parents = 2;
-  Scope declarations = 3;
-  Type self = 4;
+  Type self = 3;
+  Scope declarations = 4;
 }
 ```
 


### PR DESCRIPTION
Sync specification docs with actual [definition](https://github.com/scalameta/scalameta/blob/master/semanticdb/semanticdb/semanticdb.proto#L215-L216).