### PR TITLE
Expand semanticdb spec to improve annotation modeling 

### DIFF
--- a/semanticdb/metacp/src/main/scala/scala/meta/internal/javacp/Javacp.scala
+++ b/semanticdb/metacp/src/main/scala/scala/meta/internal/javacp/Javacp.scala
@@ -407,11 +407,11 @@ object Javacp {
     }
   }
 
-  private def sannotations(access: Int): Seq[s.Annotation] = {
-    val buf = List.newBuilder[s.Annotation]
+  private def sannotations(access: Int): Seq[s.AnnotationTree] = {
+    val buf = List.newBuilder[s.AnnotationTree]
 
     def push(symbol: String): Unit =
-      buf += s.Annotation(styperef(symbol))
+      buf += s.AnnotationTree(styperef(symbol))
 
     if (access.hasFlag(o.ACC_STRICT)) push("scala/annotation/strictfp#")
 

--- a/semanticdb/metacp/src/main/scala/scala/meta/internal/scalacp/AnnotationOps.scala
+++ b/semanticdb/metacp/src/main/scala/scala/meta/internal/scalacp/AnnotationOps.scala
@@ -4,9 +4,9 @@ import scala.meta.internal.{semanticdb => s}
 
 trait AnnotationOps { self: Scalacp =>
   implicit class XtensionAnnotation(ann: Int) {
-    def toSemantic: s.Annotation = {
+    def toSemantic: s.AnnotationTree = {
       // FIXME: https://github.com/scalameta/scalameta/issues/1292
-      s.Annotation()
+      s.AnnotationTree()
     }
   }
 }

--- a/semanticdb/metacp/src/main/scala/scala/meta/internal/scalacp/SymbolInformationOps.scala
+++ b/semanticdb/metacp/src/main/scala/scala/meta/internal/scalacp/SymbolInformationOps.scala
@@ -202,17 +202,17 @@ trait SymbolInformationOps { self: Scalacp =>
     private val syntheticAnnotationsSymbols = Set(
       "scala/reflect/macros/internal/macroImpl#"
     )
-    private def syntheticAnnotations(annot: s.Annotation): Boolean = {
+    private def syntheticAnnotations(annot: s.AnnotationTree): Boolean = {
       annot.tpe match {
         case s.TypeRef(_, sym, _) => syntheticAnnotationsSymbols.contains(sym)
         case _ => false
       }
     }
 
-    private def annotations: List[s.Annotation] = {
+    private def annotations: List[s.AnnotationTree] = {
       val annots =
         sym.attributes
-          .map(attribute => s.Annotation(attribute.typeRef.toSemanticTpe))
+          .map(attribute => s.AnnotationTree(attribute.typeRef.toSemanticTpe))
           .toList
 
       annots.filterNot(syntheticAnnotations)

--- a/semanticdb/metap/src/main/scala/scala/meta/internal/metap/SymbolInformationPrinter.scala
+++ b/semanticdb/metap/src/main/scala/scala/meta/internal/metap/SymbolInformationPrinter.scala
@@ -85,7 +85,7 @@ trait SymbolInformationPrinter extends BasePrinter {
       }
     }
 
-    private def pprint(ann: Annotation): Unit = {
+    private def pprint(ann: AnnotationTree): Unit = {
       out.print("@")
       ann.tpe match {
         case NoType =>

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/AnnotationOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/AnnotationOps.scala
@@ -6,8 +6,8 @@ import scala.meta.internal.{semanticdb => s}
 trait AnnotationOps { self: SemanticdbOps =>
 
   implicit class XtensionAnnotationInfo(gann: g.AnnotationInfo) {
-    def toSemantic: s.Annotation = {
-      s.Annotation(gann.atp.toSemanticTpe)
+    def toSemantic: s.AnnotationTree = {
+      s.AnnotationTree(gann.atp.toSemanticTpe)
     }
   }
 }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SymbolInformationOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SymbolInformationOps.scala
@@ -193,7 +193,7 @@ trait SymbolInformationOps { self: SemanticdbOps =>
       }
     }
 
-    private def annotations: List[s.Annotation] = {
+    private def annotations: List[s.AnnotationTree] = {
       val ganns = gsym.annotations.filter { gann =>
         gann.atp.typeSymbol != definitions.MacroImplAnnotation
       }

--- a/semanticdb/semanticdb/semanticdb.proto
+++ b/semanticdb/semanticdb/semanticdb.proto
@@ -118,7 +118,7 @@ message StructuralType {
 
 message AnnotatedType {
   reserved 2;
-  repeated Annotation annotations = 3;
+  repeated AnnotationTree annotations = 3;
   Type tpe = 1;
 }
 
@@ -278,7 +278,7 @@ message SymbolInformation {
   int32 properties = 4;
   string display_name = 5;
   Signature signature = 17;
-  repeated Annotation annotations = 13;
+  repeated AnnotationTree annotations = 13;
   Access access = 18;
   repeated string overridden_symbols = 19;
   Documentation documentation = 20;
@@ -297,6 +297,7 @@ message Documentation {
 }
 
 message Annotation {
+  option deprecated = true;
   Type tpe = 1;
 }
 
@@ -374,6 +375,8 @@ message Tree {
     OriginalTree original_tree = 6;
     SelectTree select_tree = 7;
     TypeApplyTree type_apply_tree = 8;
+    AnnotationTree annotation_tree = 9;
+    AssignTree assign_tree = 10;
   }
 }
 
@@ -412,4 +415,14 @@ message SelectTree {
 message TypeApplyTree {
   Tree function = 1;
   repeated Type type_arguments = 2;
+}
+
+message AnnotationTree {
+  Type tpe = 1;
+  repeated Tree parameters = 2;
+}
+
+message AssignTree {
+  Tree lhs = 1;
+  Tree rhs = 2;
 }


### PR DESCRIPTION
This PR expands the SemanticDB spec to allow for representing Annotation AST's (incl. parameters) by introducing two new types to the `Tree` family: `AnnotationTree` and `AssignTree`. 

As `AnnotationTree` is binary compatible with the `Annotation` type, this proposal deprecates `Annotation` in favour of `AnnotationTree`, replacing its usages in `SymbolInformation` and `AnnotatedType`. Alternatively, I would also be open to adding `Annotation` to the `Tree` oneof instead, if source-level backwards compatibility is also strongly desired.

The specification doc is updated to include some more examples, given the new capabilities to also model the parameters of annotations.

Working example of rendering annotations from the structures built via the changes in this PR can be found at https://github.com/sourcegraph/lsif-java/pull/148