### PR TITLE
Fix parsing Param tags

### DIFF
--- a/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/ScaladocParser.scala
+++ b/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/ScaladocParser.scala
@@ -101,9 +101,9 @@ object ScaladocParser {
         // Multiple parameter doc tokens
         case kind @ DocToken.TagKind(label, 2) =>
           def parser[_: P] = {
-            val nameParser = ((AnyChar ~ !" ").rep ~ AnyChar).!.map(_.trim)
+            def nameParser: P[String] = ((AnyChar ~ !" ").rep ~ AnyChar).!.map(_.trim)
 
-            val nameAndBodyParsers = {
+            def nameAndBodyParsers: P[DocToken] = {
               (nameParser ~ " ".rep.? ~ bodyParser.!).map { case (name, body) =>
                 DocToken(kind, name, body)
               }

--- a/tests/shared/src/test/scala/scala/meta/tests/contrib/ScaladocParserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/contrib/ScaladocParserSuite.scala
@@ -241,4 +241,26 @@ class ScaladocParserSuite extends FunSuite {
       )
     )
   }
+
+  test("param") {
+    val result = parseString(
+      """|/** @param a b */
+         |case class foo(a: String)
+         |""".stripMargin
+    )
+
+    val expectation =
+      Some(
+        List(
+          DocToken(
+            Param,
+            Some("a"),
+            Some("b")
+          )
+        )
+      )
+
+    assertEquals(result, expectation)
+  }
+
 }


### PR DESCRIPTION
Fixes https://github.com/scalameta/scalameta/issues/2283

This was working in the other `internal.parser.ScaladocParser`. I guess we can drop this one if we ever do a 5.0 release.
