### PR TITLE
Allow indented partial function values

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2154,7 +2154,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
 
   private def exprMaybeIndented(): Term = {
     if (token.is[Indentation.Indent]) {
-      block()
+      blockExpr()
     } else {
       expr()
     }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -1379,4 +1379,41 @@ class SignificantIndentationSuite extends BaseDottySuite {
       )
     )
   }
+
+  test("partial-function") {
+    runTestAssert[Stat](
+      """|val withDefault: Option[Int] => Int =
+         |  case Some(x) => x
+         |  case None => 0
+         |""".stripMargin,
+      assertLayout = Some(
+        """|val withDefault: Option[Int] => Int = {
+           |  case Some(x) => x
+           |  case None => 0
+           |}
+           |""".stripMargin
+      )
+    )(
+      Defn.Val(
+        Nil,
+        List(Pat.Var(Term.Name("withDefault"))),
+        Some(
+          Type.Function(
+            List(Type.Apply(Type.Name("Option"), List(Type.Name("Int")))),
+            Type.Name("Int")
+          )
+        ),
+        Term.PartialFunction(
+          List(
+            Case(
+              Pat.Extract(Term.Name("Some"), List(Pat.Var(Term.Name("x")))),
+              None,
+              Term.Name("x")
+            ),
+            Case(Term.Name("None"), None, Lit.Int(0))
+          )
+        )
+      )
+    )
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/scalameta/scalameta/issues/2289