### PR TITLE
Remove most checks for Pat.Type

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -278,10 +278,6 @@ object Pat {
     checkFields(parts.length == args.length + 1)
   }
   @ast class Typed(lhs: Pat, rhs: Type) extends Pat {
-    checkFields(
-      lhs.is[Pat.Wildcard] || lhs.is[Pat.Var] || lhs.is[Pat.Quasi] ||
-        lhs.is[Pat.Bind] || lhs.is[Pat.Tuple]
-    )
     checkFields(!rhs.is[Type.Var] && !rhs.is[Type.Placeholder])
   }
   @ast class Macro(body: Term) extends Pat {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -904,4 +904,69 @@ class MinorDottySuite extends BaseDottySuite {
       )
     )
   }
+
+  test("regex-pattern") {
+    runTestAssert[Stat](
+      """|s match
+         |  case re(v): String => v.toDouble
+         |  case other => o
+         |""".stripMargin,
+      assertLayout = Some(
+        """|s match {
+           |  case re(v): String =>
+           |    v.toDouble
+           |  case other =>
+           |    o
+           |}
+           |""".stripMargin
+      )
+    )(
+      Term.Match(
+        Term.Name("s"),
+        List(
+          Case(
+            Pat.Typed(
+              Pat.Extract(Term.Name("re"), List(Pat.Var(Term.Name("v")))),
+              Type.Name("String")
+            ),
+            None,
+            Term.Select(Term.Name("v"), Term.Name("toDouble"))
+          ),
+          Case(Pat.Var(Term.Name("other")), None, Term.Name("o"))
+        ),
+        Nil
+      )
+    )
+  }
+
+  test("typed-typed-pattern") {
+    runTestAssert[Stat](
+      """|s match
+         |  case (v: String): String => v.toDouble
+         |  case other => o
+         |""".stripMargin,
+      assertLayout = Some(
+        """|s match {
+           |  case (v: String): String =>
+           |    v.toDouble
+           |  case other =>
+           |    o
+           |}
+           |""".stripMargin
+      )
+    )(
+      Term.Match(
+        Term.Name("s"),
+        List(
+          Case(
+            Pat.Typed(Pat.Typed(Pat.Var(Term.Name("v")), Type.Name("String")), Type.Name("String")),
+            None,
+            Term.Select(Term.Name("v"), Term.Name("toDouble"))
+          ),
+          Case(Pat.Var(Term.Name("other")), None, Term.Name("o"))
+        ),
+        Nil
+      )
+    )
+  }
 }


### PR DESCRIPTION
Dotty allows type to almost always be defined

More info about the syntax is here https://dotty.epfl.ch/docs/internals/syntax.html#expressions

Connected to https://github.com/scalameta/scalafmt/issues/2424