### PR TITLE
[Scala3] Fix selftype parsing for enum.

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -251,6 +251,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
     def observeIndented(): Boolean
     def observeOutdented(): Boolean
     def observeIndentedEnum(): Boolean
+    def undoIndent(): Unit
   }
   var in: TokenIterator = {
     new LazyTokenIterator(
@@ -300,6 +301,15 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
           )
           true
         } else false
+      }
+    }
+
+    def undoIndent(): Unit = {
+      sepRegions = sepRegions match {
+        case region :: others if region.isIndented && curr.token.is[Indentation.Indent] =>
+          next()
+          others
+        case regions => regions
       }
     }
 
@@ -4892,6 +4902,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
           in = beforeFirst
           selfOpt = Some(self())
           next()
+          in.undoIndent
         } catch {
           case ex: ParseException =>
             in = afterFirst

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EnumSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EnumSuite.scala
@@ -385,6 +385,108 @@ class EnumSuite extends BaseDottySuite {
     )
   }
 
+  test("enum-self-braces") {
+    val code =
+      """|enum A { self =>
+         |  case B(v: Int)
+         |  case C(v: String)
+         |}
+      """.stripMargin
+    runTestAssert[Stat](code)(
+      Defn.Enum(
+        Nil,
+        Type.Name("A"),
+        Nil,
+        Ctor.Primary(Nil, Name(""), Nil),
+        Template(
+          Nil,
+          Nil,
+          Self(Term.Name("self"), None),
+          List(
+            Defn.EnumCase(
+              Nil,
+              Term.Name("B"),
+              Nil,
+              Ctor.Primary(
+                Nil,
+                Name(""),
+                List(List(Term.Param(Nil, Term.Name("v"), Some(Type.Name("Int")), None)))
+              ),
+              Nil
+            ),
+            Defn.EnumCase(
+              Nil,
+              Term.Name("C"),
+              Nil,
+              Ctor.Primary(
+                Nil,
+                Name(""),
+                List(List(Term.Param(Nil, Term.Name("v"), Some(Type.Name("String")), None)))
+              ),
+              Nil
+            )
+          ),
+          Nil
+        )
+      )
+    )
+  }
+
+  test("enum-self-indented") {
+    val code =
+      """|enum A:
+         |  self =>
+         |    case B(v: Int)
+         |    case C(v: String)
+         |  def fx: Int = 4
+      """.stripMargin
+    val expected =
+      """|enum A { self =>
+         |  case B(v: Int)
+         |  case C(v: String)
+         |  def fx: Int = 4
+         |}""".stripMargin
+    runTestAssert[Stat](code, assertLayout = Some(expected))(
+      Defn.Enum(
+        Nil,
+        Type.Name("A"),
+        Nil,
+        Ctor.Primary(Nil, Name(""), Nil),
+        Template(
+          Nil,
+          Nil,
+          Self(Term.Name("self"), None),
+          List(
+            Defn.EnumCase(
+              Nil,
+              Term.Name("B"),
+              Nil,
+              Ctor.Primary(
+                Nil,
+                Name(""),
+                List(List(Term.Param(Nil, Term.Name("v"), Some(Type.Name("Int")), None)))
+              ),
+              Nil
+            ),
+            Defn.EnumCase(
+              Nil,
+              Term.Name("C"),
+              Nil,
+              Ctor.Primary(
+                Nil,
+                Name(""),
+                List(List(Term.Param(Nil, Term.Name("v"), Some(Type.Name("String")), None)))
+              ),
+              Nil
+            ),
+            Defn.Def(Nil, Term.Name("fx"), Nil, Nil, Some(Type.Name("Int")), Lit.Int(4))
+          ),
+          Nil
+        )
+      )
+    )
+  }
+
   test("enum-colon-sep-after") {
     val code =
       """|object Main :


### PR DESCRIPTION
In the following example: `enum A { self => ...`  right arrow should start `RegionIndentedEnum`  instead of `RegionIndented` to not to break `cases` parsing.