### PR TITLE
Fix issues with complex types in anonymous given

### DIFF
--- a/community-test/src/test/scala/CommunityDottySuite.scala
+++ b/community-test/src/test/scala/CommunityDottySuite.scala
@@ -84,14 +84,17 @@ class CommunityDottySuite extends FunSuite {
     fetchCommunityBuild(build)
 
     val stats = checkFilesRecursive(communityDirectory.resolve(build.name))
-    val timePer1KLines = stats.timeTaken / (stats.linesParsed / 1000)
+    val timePer1KLines = Math.round(stats.timeTaken / (stats.linesParsed / 1000.0))
 
     println("--------------------------")
     println(build.name)
     println(s"Files parsed correctly ${stats.checkedFiles - stats.errors}")
     println(s"Files errored: ${stats.errors}")
     println(s"Time taken: ${stats.timeTaken}ms")
-    println(s"Lines parsed: ~${stats.linesParsed / 1000}k")
+    if (stats.linesParsed < 1000)
+      println(s"Lines parsed: ${stats.linesParsed}")
+    else
+      println(s"Lines parsed: ~${stats.linesParsed / 1000}k")
     println(s"Parsing speed per 1k lines ===> ${timePer1KLines} ms/1klines")
     println("--------------------------")
     stats.lastError.foreach(e => throw e)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
@@ -401,6 +401,46 @@ class GivenUsingSuite extends BaseDottySuite {
       )
     )
   }
+  test("given-alias-type-apply") {
+    runTestAssert[Stat](
+      """|object AppliedName:
+         |  given Conversion[AppliedName, Expr.Apply[Id]] = _.toExpr
+         |""".stripMargin,
+      assertLayout = Some(
+        "object AppliedName { given Conversion[AppliedName, Expr.Apply[Id]] = _.toExpr }"
+      )
+    )(
+      Defn.Object(
+        Nil,
+        Term.Name("AppliedName"),
+        Template(
+          Nil,
+          Nil,
+          Self(Name(""), None),
+          List(
+            Defn.GivenAlias(
+              Nil,
+              Name(""),
+              Nil,
+              Nil,
+              Type.Apply(
+                Type.Name("Conversion"),
+                List(
+                  Type.Name("AppliedName"),
+                  Type.Apply(
+                    Type.Select(Term.Name("Expr"), Type.Name("Apply")),
+                    List(Type.Name("Id"))
+                  )
+                )
+              ),
+              Term.Select(Term.Placeholder(), Term.Name("toExpr"))
+            )
+          ),
+          Nil
+        )
+      )
+    )
+  }
 
   // ---------------------------------
   // Abstract given


### PR DESCRIPTION
The issue popped up when parsing https://github.com/kubukoz/slang/tree/165fc48c1a3bfff4a0349378855ca89c6d90873f

Connected to https://github.com/scalameta/scalafmt/issues/2216#issuecomment-823910262

We are first trying to parse non-anonymous given, which
 - requires `:` for type, if none is found it means it's anonymous
 - might fail in cases that anonymous type looks like type param
   `given Conversion[AppliedName, Expr.Apply[Id]] = ???`
   This will fail because type params cannot have `.`