### PR TITLE
Allow indented block after `<-` and `?=>`

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1183,7 +1183,8 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
       token.is[KwYield] || token.is[KwTry] || token.is[KwCatch] || token.is[KwFinally] ||
       token.is[KwMatch] || token.is[KwDo] || token.is[KwFor] || token.is[KwThen] ||
       token.is[KwElse] || token.is[Equals] || token.is[KwWhile] || token.is[KwIf] ||
-      token.is[RightArrow] || token.is[KwReturn] || (token.is[KwWith] && token.next.is[DclIntro])
+      token.is[RightArrow] || token.is[KwReturn] || token.is[LeftArrow] ||
+      token.is[ContextArrow] || (token.is[KwWith] && token.next.is[DclIntro])
     }
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -1416,4 +1416,70 @@ class SignificantIndentationSuite extends BaseDottySuite {
       )
     )
   }
+
+  test("for-left-arrow") {
+    runTestAssert[Stat](
+      """|for
+         |  a <-
+         |    val b = 123
+         |    Some(b)
+         |yield
+         |  a
+         |""".stripMargin,
+      assertLayout = Some(
+        """|for (a <- {
+           |  val b = 123
+           |  Some(b)
+           |}) yield a
+           |""".stripMargin
+      )
+    )(
+      Term.ForYield(
+        List(
+          Enumerator.Generator(
+            Pat.Var(Term.Name("a")),
+            Term.Block(
+              List(
+                Defn.Val(Nil, List(Pat.Var(Term.Name("b"))), None, Lit.Int(123)),
+                Term.Apply(Term.Name("Some"), List(Term.Name("b")))
+              )
+            )
+          )
+        ),
+        Term.Name("a")
+      )
+    )
+  }
+
+  test("context-arrow") {
+    runTestAssert[Stat](
+      """|val a = (s: Int) ?=> 
+         |  val a = 123
+         |  s + a
+         |
+         |""".stripMargin,
+      assertLayout = Some(
+        """|val a = (s: Int) ?=> {
+           |  val a = 123
+           |  s + a
+           |}
+           |""".stripMargin
+      )
+    )(
+      Defn.Val(
+        Nil,
+        List(Pat.Var(Term.Name("a"))),
+        None,
+        Term.ContextFunction(
+          List(Term.Param(Nil, Term.Name("s"), Some(Type.Name("Int")), None)),
+          Term.Block(
+            List(
+              Defn.Val(Nil, List(Pat.Var(Term.Name("a"))), None, Lit.Int(123)),
+              Term.ApplyInfix(Term.Name("s"), Term.Name("+"), Nil, List(Term.Name("a")))
+            )
+          )
+        )
+      )
+    )
+  }
 }


### PR DESCRIPTION
We missed it previously and that seems to be the case according to https://dotty.epfl.ch/docs/reference/other-new-features/indentation.html#optional-braces