### PR TITLE
[Scala3] Fix Oudent position before `}`, `)`, `,`

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -412,7 +412,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
         else if (curr.is[Comma] &&
           sepRegions.headOption.exists(_.isInstanceOf[RegionIndent]) &&
           sepRegions.tail.headOption.contains(RegionParen)) {
-          (sepRegions.tail, mkOutdent(currPos))
+          (sepRegions.tail, mkOutdent(prevPos))
         } else if (curr.is[LeftBrace]) {
           val indentInBrace = if (isAheadNewLine(currPos)) countIndent(nextPos) else -1
           // After encountering keyword Enum we add artificial '{' on top of stack.
@@ -453,7 +453,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
             def nextRegions(in: List[SepRegion]): (List[SepRegion], TokenRef) = {
               in match {
                 case x :: xs if x.isIndented && !isBraceOrEnum(x) =>
-                  (xs, mkOutdent(currPos))
+                  (xs, mkOutdent(prevPos))
                 case x :: xs if isBraceOrEnum(x) =>
                   (xs, currRef)
                 case x :: xs =>
@@ -487,7 +487,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
           }
         } else if (curr.is[RightParen]) {
           sepRegions match {
-            case x :: xs if x.isIndented => (xs, mkOutdent(currPos))
+            case x :: xs if x.isIndented => (xs, mkOutdent(prevPos))
             case x :: xs if x == RegionParen => (xs, currRef)
             case _ => (sepRegions, currRef)
           }

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -418,4 +418,67 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |Defn.GivenAlias private given x: X = ???
        |""".stripMargin
   )
+
+  checkPositions[Stat](
+    """|val a = foo.fold(
+       |   err =>
+       |  {
+       |    42
+       |  })
+       |""".stripMargin,
+    """|Term.Apply foo.fold(
+       |   err =>
+       |  {
+       |    42
+       |  })
+       |Term.Select foo.fold
+       |Term.Function err =>
+       |  {
+       |    42
+       |  }
+       |Term.Param err
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """|def a: Unit = 
+       |  {
+       |    val x = (z: String) =>
+       |      fx
+       |      gx}
+       |""".stripMargin,
+    """|Term.Block {
+       |    val x = (z: String) =>
+       |      fx
+       |      gx}
+       |Defn.Val val x = (z: String) =>
+       |      fx
+       |      gx
+       |Term.Function (z: String) =>
+       |      fx
+       |      gx
+       |Term.Param (z: String)
+       |Term.Block fx
+       |      gx
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """|foo(
+       |  s => 
+       |    fx
+       |    gx(s),
+       |  "yo"
+       |)
+       |""".stripMargin,
+    """|Term.Function s => 
+       |    fx
+       |    gx(s)
+       |Term.Param s
+       |Term.Block fx
+       |    gx(s)
+       |Term.Apply gx(s)
+       |Lit.String "yo"
+       |""".stripMargin
+  )
 }


### PR DESCRIPTION
It addresses this problem - https://github.com/scalameta/scalafmt/pull/2447#issuecomment-824851176.
In previous similar fixes about position and indentation tokens, I forgot about these cases :disappointed: 

I double-checked all places where these artificial tokens are created and hope there will be no more such bugs.