### PR TITLE
Drop procedure syntax for the Scala 3 dialect

### DIFF
--- a/scalameta/common/shared/src/main/scala/org/scalameta/explore/package.scala
+++ b/scalameta/common/shared/src/main/scala/org/scalameta/explore/package.scala
@@ -8,5 +8,5 @@ package object explore {
 
   def allStatics(packageName: String): List[String] = macro ExploreMacros.allStaticsImpl
 
-  def allSurface(packageName: String): List[String] = macro ExploreMacros.allSurfaceImpl
+  def extensionSurface(packageName: String): List[String] = macro ExploreMacros.extensionSurfaceImpl
 }

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
@@ -154,7 +154,9 @@ final class Dialect private (
     // Scala 3 import renames can use as soft keyword `import a.b.C as D`
     val allowAsForImportRename: Boolean,
     // Scala 3 wildcard imports can be specified as `import a.b.*`
-    val allowStarWildcardImport: Boolean
+    val allowStarWildcardImport: Boolean,
+    // Scala 3 no longer allows def hello(){} - `=` is always needed
+    val allowProcedureSyntax: Boolean
 ) extends Product with Serializable {
 
   // NOTE(olafur) checklist for adding a new dialect field in a binary compatible way:
@@ -247,7 +249,8 @@ final class Dialect private (
       allowPostfixStarVarargSplices = false,
       allowAllTypedPatterns = false,
       allowAsForImportRename = false,
-      allowStarWildcardImport = false
+      allowStarWildcardImport = false,
+      allowProcedureSyntax = true
       // NOTE(olafur): declare the default value for new fields above this comment.
     )
   }
@@ -443,6 +446,9 @@ final class Dialect private (
   def withAllowStarWildcardImport(newValue: Boolean): Dialect = {
     privateCopy(allowStarWildcardImport = newValue)
   }
+  def withAllowProcedureSyntax(newValue: Boolean): Dialect = {
+    privateCopy(allowProcedureSyntax = newValue)
+  }
   // NOTE(olafur): add the next `withX()` method above this comment. Please try
   // to use consistent formatting, use `newValue` as the parameter name and wrap
   // the body inside curly braces.
@@ -506,7 +512,8 @@ final class Dialect private (
       allowPostfixStarVarargSplices: Boolean = this.allowPostfixStarVarargSplices,
       allowAllTypedPatterns: Boolean = this.allowAllTypedPatterns,
       allowAsRenames: Boolean = this.allowAsForImportRename,
-      allowStarWildcardImport: Boolean = this.allowStarWildcardImport
+      allowStarWildcardImport: Boolean = this.allowStarWildcardImport,
+      allowProcedureSyntax: Boolean = this.allowProcedureSyntax
       // NOTE(olafur): add the next parameter above this comment.
   ): Dialect = {
     new Dialect(
@@ -567,7 +574,8 @@ final class Dialect private (
       allowPostfixStarVarargSplices,
       allowAllTypedPatterns,
       allowAsRenames,
-      allowStarWildcardImport
+      allowStarWildcardImport,
+      allowProcedureSyntax
       // NOTE(olafur): add the next argument above this comment.
     )
   }

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -128,6 +128,7 @@ package object dialects {
     .withAllowAllTypedPatterns(true)
     .withAllowAsForImportRename(true)
     .withAllowStarWildcardImport(true)
+    .withAllowProcedureSyntax(false)
 
   @deprecated("Use Scala3 instead", "4.4.2")
   implicit val Dotty = Scala3

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -4255,11 +4255,16 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
     if (!mods.has[Mod.Override])
       rejectMod[Mod.Abstract](mods, Messages.InvalidAbstract)
     val name = termName()
-    def warnProcedureDeprecation =
-      deprecationWarning(
-        s"Procedure syntax is deprecated. Convert procedure `$name` to method by adding `: Unit`.",
-        at = name
-      )
+    def warnProcedureDeprecation = {
+      val hint = s"Convert procedure `$name` to method by adding `: Unit =`."
+      if (dialect.allowProcedureSyntax)
+        deprecationWarning(
+          s"Procedure syntax is deprecated. $hint",
+          at = name
+        )
+      else
+        syntaxError(s"Procedure syntax is not supported. $hint", at = name)
+    }
     val tparams = typeParamClauseOpt(ownerIsType = false, ctxBoundsAllowed = true)
     val paramss = paramClauses(ownerIsType = false).require[List[List[Term.Param]]]
 

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -42,9 +42,11 @@ class SurfaceSuite extends FunSuite {
     .diff(tokens)
     .map(fullName => (fullName, wildcardImportStatics.contains(fullName)))
     .toMap
-  lazy val allSurface = explore.allSurface("scala.meta").filterNot(lsp4s)
+  lazy val extensionSurface = explore.extensionSurface("scala.meta").filterNot(lsp4s)
   lazy val coreSurface =
-    allSurface.filter(entry => !(tokens ++ trees).exists(noncore => entry.startsWith(noncore)))
+    extensionSurface.filter(entry =>
+      !(tokens ++ trees).exists(noncore => entry.startsWith(noncore))
+    )
 
   test("statics (core)") {
     val diagnostic = core.keys.toList.sorted

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -969,4 +969,14 @@ class MinorDottySuite extends BaseDottySuite {
       )
     )
   }
+
+  test("procedure-syntax") {
+
+    runTestError[Stat](
+      """|def hello(){
+         |  println("Hello!")
+         |}""".stripMargin,
+      "Procedure syntax is not supported. Convert procedure `hello` to method by adding `: Unit =`"
+    )
+  }
 }


### PR DESCRIPTION
It was also needed to fix the macro used in tests, since it started generating method that was too large, but we haven't actually used most of that, so no test was harmed. This should also be covered by MiMa.