### PR TITLE
[Scala 3] Deprecate do while syntax

### DIFF
--- a/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
@@ -156,7 +156,9 @@ final class Dialect private (
     // Scala 3 wildcard imports can be specified as `import a.b.*`
     val allowStarWildcardImport: Boolean,
     // Scala 3 no longer allows def hello(){} - `=` is always needed
-    val allowProcedureSyntax: Boolean
+    val allowProcedureSyntax: Boolean,
+    // Scala 3 no longer allows `do {...} while(...)`
+    val allowDoWhile: Boolean
 ) extends Product with Serializable {
 
   // NOTE(olafur) checklist for adding a new dialect field in a binary compatible way:
@@ -250,7 +252,8 @@ final class Dialect private (
       allowAllTypedPatterns = false,
       allowAsForImportRename = false,
       allowStarWildcardImport = false,
-      allowProcedureSyntax = true
+      allowProcedureSyntax = true,
+      allowDoWhile = true
       // NOTE(olafur): declare the default value for new fields above this comment.
     )
   }
@@ -449,6 +452,9 @@ final class Dialect private (
   def withAllowProcedureSyntax(newValue: Boolean): Dialect = {
     privateCopy(allowProcedureSyntax = newValue)
   }
+  def withAllowDoWhile(newValue: Boolean): Dialect = {
+    privateCopy(allowDoWhile = newValue)
+  }
   // NOTE(olafur): add the next `withX()` method above this comment. Please try
   // to use consistent formatting, use `newValue` as the parameter name and wrap
   // the body inside curly braces.
@@ -513,7 +519,8 @@ final class Dialect private (
       allowAllTypedPatterns: Boolean = this.allowAllTypedPatterns,
       allowAsRenames: Boolean = this.allowAsForImportRename,
       allowStarWildcardImport: Boolean = this.allowStarWildcardImport,
-      allowProcedureSyntax: Boolean = this.allowProcedureSyntax
+      allowProcedureSyntax: Boolean = this.allowProcedureSyntax,
+      allowDoWhile: Boolean = this.allowDoWhile
       // NOTE(olafur): add the next parameter above this comment.
   ): Dialect = {
     new Dialect(
@@ -575,7 +582,8 @@ final class Dialect private (
       allowAllTypedPatterns,
       allowAsRenames,
       allowStarWildcardImport,
-      allowProcedureSyntax
+      allowProcedureSyntax,
+      allowDoWhile
       // NOTE(olafur): add the next argument above this comment.
     )
   }

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -129,6 +129,7 @@ package object dialects {
     .withAllowAsForImportRename(true)
     .withAllowStarWildcardImport(true)
     .withAllowProcedureSyntax(false)
+    .withAllowDoWhile(false)
 
   @deprecated("Use Scala3 instead", "4.4.2")
   implicit val Dotty = Scala3

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2311,13 +2311,15 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
           accept[KwDo]
           Term.While(cond, exprMaybeIndented())
         }
-      case KwDo() =>
+      case KwDo() if dialect.allowDoWhile =>
         next()
         val body = expr()
         while (token.is[StatSep]) next()
         accept[KwWhile]
         val cond = condExpr()
         Term.Do(body, cond)
+      case KwDo() =>
+        syntaxError("do {...} while (...) syntax is no longer supported", at = token)
       case KwFor() =>
         next()
         val enums: List[Enumerator] =

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -971,12 +971,22 @@ class MinorDottySuite extends BaseDottySuite {
   }
 
   test("procedure-syntax") {
-
     runTestError[Stat](
       """|def hello(){
          |  println("Hello!")
          |}""".stripMargin,
       "Procedure syntax is not supported. Convert procedure `hello` to method by adding `: Unit =`"
+    )
+  }
+
+  test("do-while") {
+    runTestError[Stat](
+      """|def hello() = {
+         |  do {
+         |    i+= 1
+         |  } while (i < 10)
+         |}""".stripMargin,
+      "error: do {...} while (...) syntax is no longer supported"
     )
   }
 }


### PR DESCRIPTION
This already no longer works with Scala 3: https://dotty.epfl.ch/docs/reference/dropped-features/do-while.html