### PR TITLE
[Scala 3] Fix indented partial functions after `=>`

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2519,7 +2519,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
               }
               val params = convertToParams(t)
               val trm =
-                if (token.is[Indentation.Indent]) block()
+                if (token.is[Indentation.Indent]) blockExpr()
                 else if (location != BlockStat) expr()
                 else block()
               if (contextFunction)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -989,4 +989,42 @@ class MinorDottySuite extends BaseDottySuite {
       "error: do {...} while (...) syntax is no longer supported"
     )
   }
+
+  test("partial-function-function") {
+    runTestAssert[Stat](
+      """|val f : String => PartialFunction[String, Int] = s =>
+         |    case "Hello" =>
+         |        5
+         |    case "Goodbye" =>
+         |        0
+         |""".stripMargin,
+      assertLayout = Some(
+        """|val f: String => PartialFunction[String, Int] = s => {
+           |  case "Hello" => 5
+           |  case "Goodbye" => 0
+           |}
+           |""".stripMargin
+      )
+    )(
+      Defn.Val(
+        Nil,
+        List(Pat.Var(Term.Name("f"))),
+        Some(
+          Type.Function(
+            List(Type.Name("String")),
+            Type.Apply(Type.Name("PartialFunction"), List(Type.Name("String"), Type.Name("Int")))
+          )
+        ),
+        Term.Function(
+          List(Term.Param(Nil, Term.Name("s"), None, None)),
+          Term.PartialFunction(
+            List(
+              Case(Lit.String("Hello"), None, Lit.Int(5)),
+              Case(Lit.String("Goodbye"), None, Lit.Int(0))
+            )
+          )
+        )
+      )
+    )
+  }
 }


### PR DESCRIPTION
Connected to https://github.com/scalameta/scalafmt/issues/2480