### PR TITLE
Fix position for Name.Anonymous. 

### DIFF
--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -31,7 +31,6 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |Type.Apply F[A]
        |Term.Param G[B]
        |Mod.Using extension [A, B](i: A)(using a: F[A], @@G[B]) def isZero = i == 0
-       |Name.Anonymous G
        |Type.Apply G[B]
        |Defn.Def def isZero = i == 0
        |Term.ApplyInfix i == 0

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
@@ -609,7 +609,6 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
     """|Ctor.Primary trait A @@{ _: B => }
        |Template { _: B => }
        |Self _: B
-       |Name.Anonymous _
        |""".stripMargin
   )
   checkPositions[Stat](
@@ -624,7 +623,6 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
     """|Ctor.Primary trait A @@{ this: B => }
        |Template { this: B => }
        |Self this: B
-       |Name.Anonymous this
        |""".stripMargin
   )
 


### PR DESCRIPTION
Addresses [@kitbellew comment](https://github.com/scalameta/scalameta/pull/2319#discussion_r623135604).
There were more occurrences of improper `Name.Anonymous` creation.