### PR TITLE
Use Term.Block in functions when {} are added explicitely.

### DIFF
--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -452,6 +452,9 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |    42
        |  }
        |Term.Param err
+       |Term.Block {
+       |    42
+       |  }
        |""".stripMargin
   )
 
@@ -517,6 +520,23 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |Pat.Typed _: Enum
        |Case case _: Singleton => xs
        |Pat.Typed _: Singleton
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """|val f: Int => Int = (x: Int) => {
+       |  x * x
+       |}
+       |""".stripMargin,
+    """|Type.Function Int => Int
+       |Term.Function (x: Int) => {
+       |  x * x
+       |}
+       |Term.Param (x: Int)
+       |Term.Block {
+       |  x * x
+       |}
+       |Term.ApplyInfix x * x
        |""".stripMargin
   )
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/StructureSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/StructureSuite.scala
@@ -7,26 +7,44 @@ import scala.meta.parsers.Parse
 
 class StructureSuite extends ParseSuite {
 
-  def checkStructure[T: Parse: Structure](code: String, expected: String): Unit = {
+  def checkStructure[T: Parse: Structure](code: String, expected: Tree): Unit = {
 
     test(logger.revealWhitespace(code)) {
       val obtained: String = code.parse[T].get.structure
-      assert(obtained == expected)
+      assertNoDiff(obtained, expected.structure)
     }
   }
 
   checkStructure[Case](
     "case _ => _ => false",
-    """Case(Pat.Wildcard(), None, Term.Function(List(Term.Param(Nil, Name(""), None, None)), Lit.Boolean(false)))"""
+    Case(
+      Pat.Wildcard(),
+      None,
+      Term.Function(List(Term.Param(Nil, Name(""), None, None)), Lit.Boolean(false))
+    )
   )
 
   checkStructure[Case](
     "case _ => _ => {false}",
-    """Case(Pat.Wildcard(), None, Term.Function(List(Term.Param(Nil, Name(""), None, None)), Term.Block(List(Lit.Boolean(false)))))"""
+    Case(
+      Pat.Wildcard(),
+      None,
+      Term.Function(
+        List(Term.Param(Nil, Name(""), None, None)),
+        Term.Block(List(Lit.Boolean(false)))
+      )
+    )
   )
 
   checkStructure[Case](
     "case _ => _ => false; a",
-    """Case(Pat.Wildcard(), None, Term.Function(List(Term.Param(Nil, Name(""), None, None)), Term.Block(List(Lit.Boolean(false), Term.Name("a")))))"""
+    Case(
+      Pat.Wildcard(),
+      None,
+      Term.Function(
+        List(Term.Param(Nil, Name(""), None, None)),
+        Term.Block(List(Lit.Boolean(false), Term.Name("a")))
+      )
+    )
   )
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -330,7 +330,7 @@ class TermSuite extends ParseSuite {
     val Block(
       Function(
         Term.Param(Mod.Implicit() :: Nil, TermName("x"), None, None) :: Nil,
-        Block(Lit(()) :: Nil)
+        Lit(())
       ) :: Nil
     ) = term("{ implicit x => () }")
   }
@@ -558,7 +558,7 @@ class TermSuite extends ParseSuite {
                   None
                 )
               ),
-              Term.Block(List(Term.Name("Ok")))
+              Term.Name("Ok")
             )
           )
         )


### PR DESCRIPTION
Previously, we would always remove the outer most {} and not report a Block even in:
```
List("").map{
s => {
    s + s
  }
}
```