### PR TITLE
ScaladocParser: add support for fenced code blocks

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/Scaladoc.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/Scaladoc.scala
@@ -42,6 +42,9 @@ object Scaladoc {
   /** A block of one or more lines of code */
   final case class CodeBlock(code: Seq[String]) extends Term
 
+  /** A markdown block of one or more lines of code */
+  final case class MdCodeBlock(info: Seq[String], code: Seq[String], fence: String) extends Term
+
   /** A heading */
   final case class Heading(level: Int, title: String) extends Term
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
@@ -206,6 +206,48 @@ class ScaladocParserSuite extends FunSuite {
     assertEquals(result, expectation)
   }
 
+  test("code blocks multiline") {
+    val complexCodeBlock = // keep all newlines and leading spaces
+      """|  ggmqwogmwogmqwomgq
+         |    val x = 1 // sdfdfh
+         |   // zzz
+         |   gmqwgoiqmgoqmwomw""".stripMargin.split("\n")
+    val complexCodeBlockAsComment = complexCodeBlock.mkString("\n *")
+
+    val result = parseString(
+      s"""
+          /**
+            * {{{
+            *$complexCodeBlockAsComment
+            *
+            * foo
+            * }}}
+            */
+       """.stripMargin
+    )
+
+    val expectation = Option(
+      Scaladoc(Seq(Paragraph(Seq(CodeBlock(complexCodeBlock ++ Seq("", " foo"))))))
+    )
+    assertEquals(result, expectation)
+  }
+
+  test("code blocks inline") {
+    val codeBlock2 = "\"HELLO SORAYA\""
+    val result = parseString(
+      s"""
+          /**
+            * {{{ $codeBlock2 }}}
+            */
+       """.stripMargin
+    )
+
+    val expectation = Option(
+      Scaladoc(Seq(Paragraph(Seq(Text(Seq(CodeExpr(codeBlock2, "")))))))
+    )
+    assertEquals(result, expectation)
+  }
+
   test("headings") {
     val level1HeadingBody = "Level 1"
     val level2HeadingBody = "Level 2"


### PR DESCRIPTION
Implements https://spec.commonmark.org/0.29/#fenced-code-blocks. Supersedes #2332.