### PR TITLE
Allow braceless package definitions

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -439,7 +439,6 @@ object Defn {
 
 @ast class Pkg(ref: Term.Ref, stats: List[Stat]) extends Member.Term with Stat {
   checkFields(ref.isQualId)
-  checkFields(stats.forall(_.isTopLevelStat))
   def name: Term.Name = ref match {
     case name: Term.Name => name
     case Term.Select(_, name: Term.Name) => name

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -31,6 +31,39 @@ class SignificantIndentationSuite extends BaseDottySuite {
     )
   }
 
+  test("package-comment") {
+    val code = """|package mysadpackage:
+                  |  def f: Int
+                  |package anotherpackage:
+                  |  def f: Int
+                  |""".stripMargin
+    runTestAssert[Source](
+      code,
+      assertLayout = Some(
+        """|package mysadpackage {
+           |  def f: Int
+           |}
+           |package anotherpackage {
+           |  def f: Int
+           |}
+           |""".stripMargin
+      )
+    )(
+      Source(
+        List(
+          Pkg(
+            Term.Name("mysadpackage"),
+            List(Decl.Def(Nil, Term.Name("f"), Nil, Nil, Type.Name("Int")))
+          ),
+          Pkg(
+            Term.Name("anotherpackage"),
+            List(Decl.Def(Nil, Term.Name("f"), Nil, Nil, Type.Name("Int")))
+          )
+        )
+      )
+    )
+  }
+
   test("multistat-example") {
     val code = """|trait A:
                   |  def f: Int

--- a/tests/shared/src/test/scala/scala/meta/tests/trees/InvariantSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/trees/InvariantSuite.scala
@@ -23,7 +23,6 @@ class InvariantSuite extends FunSuite {
       Defn.Trait(Nil, Type.Name("test"), Nil, primaryCtor, template)
     }
     intercept[InvariantFailedException] { Defn.Object(Nil, Term.Name("test"), template) }
-    intercept[InvariantFailedException] { Pkg(Term.Name("test"), stats) }
     intercept[InvariantFailedException] { Pkg.Object(Nil, Term.Name("test"), template) }
   }
 


### PR DESCRIPTION
It turns out we are still missing some syntax changes for optional braces. We can now also define packages with body using `:`, which is similar to previously available:
```
package a {
  object A
}
```

This commit fixes that.