### PR TITLE
Update  parsers's JSFacade and publishing script

### DIFF
--- a/scalameta/parsers/js/npm/package.json
+++ b/scalameta/parsers/js/npm/package.json
@@ -1,12 +1,12 @@
 {
   "name": "scalameta-parsers",
-  "version": "4.2.1",
+  "version": "4.4.17",
   "main": "index.js",
   "files": [
     "index.js"
   ],
   "scripts": {
-    "prepublish": "export current=$PWD && cd ../../../.. && sbt parsersJS/fullOptJS && cd $current && cp ../target/scala-2.12/parsers-opt.js index.js"
+    "prepublishOnly": "export current=$PWD && cd ../../../.. && sbt parsersJS/fullOptJS && cd $current && cp ../target/scala-2.13/parsers-opt.js index.js"
   },
   "homepage": "https://scalameta.org/",
   "repository": {

--- a/scalameta/parsers/js/src/main/scala/scala/meta/parsers/JSFacade.scala
+++ b/scalameta/parsers/js/src/main/scala/scala/meta/parsers/JSFacade.scala
@@ -85,7 +85,7 @@ object JSFacade {
           case Some(dialect) => Right(dialect)
           case None => Left(s"'$dialectStr' is not a valid dialect.")
         }
-      case None => Right(dialects.Scala211)
+      case None => Right(dialects.Scala213)
     }
   }
 

--- a/tests/js/src/test/scala/scala/meta/tests/parsers/JSFacadeSuite.scala
+++ b/tests/js/src/test/scala/scala/meta/tests/parsers/JSFacadeSuite.scala
@@ -195,18 +195,36 @@ class JSFacadeSuite extends FunSuite {
     check(parsed, expected)
   }
 
-  test("default dialect is Scala 2.11") {
-    val code =
-      """|List(
-         |  1,
-         |  2,
-         |)""".stripMargin
+  test("default dialect is Scala 2.13") {
+    val code = "val x: 1 = 1"
     val parsedDefaultDialect = JSFacade.parseStat(code)
     val expected = d(
-      "error" -> "illegal start of simple expression",
-      "pos" -> pos(16, 17),
-      "lineNumber" -> 3,
-      "columnNumber" -> 0
+      "type" -> "Defn.Val",
+      "pos" -> pos(0, 12),
+      "mods" -> a(),
+      "pats" -> a(
+        d(
+          "type" -> "Pat.Var",
+          "pos" -> pos(4, 5),
+          "name" -> d(
+            "type" -> "Term.Name",
+            "pos" -> pos(4, 5),
+            "value" -> "x"
+          )
+        )
+      ),
+      "decltpe" -> d(
+        "type" -> "Lit.Int",
+        "pos" -> pos(7, 8),
+        "value" -> 1,
+        "syntax" -> "1"
+      ),
+      "rhs" -> d(
+        "type" -> "Lit.Int",
+        "pos" -> pos(11, 12),
+        "value" -> 1,
+        "syntax" -> "1"
+      )
     ).asInstanceOf[js.Dictionary[Any]]
     check(parsedDefaultDialect, expected)
   }


### PR DESCRIPTION
Minor tweaks to publish a new version of Scalameta parsers to npm (it's already published: https://www.npmjs.com/package/scalameta-parsers)