### PR TITLE
Allow QuotedMacroType to be used in pattern matches

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -281,7 +281,7 @@ object Pat {
     checkFields(!rhs.is[Type.Var] && !rhs.is[Type.Placeholder])
   }
   @ast class Macro(body: Term) extends Pat {
-    checkFields(body.is[Term.QuotedMacroExpr])
+    checkFields(body.is[Term.QuotedMacroExpr] || body.is[Term.QuotedMacroType])
   }
   @ast class Given(tpe: Type) extends Pat
   def fresh(): Pat.Var = Pat.Var(Term.fresh())

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
@@ -100,6 +100,28 @@ class MacroSuite extends BaseDottySuite {
     )
   }
 
+  test("macro-brackets") {
+    runTestAssert[Stat](
+      """|tpr.asType match {
+         |  case '[ t ] =>
+         |    getTypeTree[t]
+         |}""".stripMargin
+    )(
+      Term.Match(
+        Term.Select(Term.Name("tpr"), Term.Name("asType")),
+        List(
+          Case(
+            Pat.Macro(Term.QuotedMacroType(Type.Name("t"))),
+            None,
+            Term.ApplyType(Term.Name("getTypeTree"), List(Type.Name("t")))
+          )
+        ),
+        Nil
+      )
+    )
+
+  }
+
   test("macro-quote-multiline") {
     val code = """|'{
                   |  1 + 3


### PR DESCRIPTION
Connected to https://github.com/scalameta/scalafmt/issues/2512