### PR TITLE
Add support for Scala 2.13.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,10 @@ jobs:
           - "++2.13.3 testsJVM/test"
           - "++2.13.4 testsJVM/test"
           - "++2.13.5 testsJVM/test"
-          - "++2.13.5 testsJS/test"
-          - "++2.13.5 testsNative/test"
-          - "++2.13.5 download-scala-library testsJVM/slow:test"
+          - "++2.13.6 testsJVM/test"
+          - "++2.13.6 testsJS/test"
+          - "++2.13.6 testsNative/test"
+          - "++2.13.6 download-scala-library testsJVM/slow:test"
           - "communitytest/test"
           - "mima"
     steps:
@@ -42,7 +43,7 @@ jobs:
       - uses: olafurpg/setup-scala@v10
         with:
           java-version: adopt@1.11
-      - run: sbt ++2.13.5 testsJVM/test
+      - run: sbt ++2.13.6 testsJVM/test
   windows:
     name: Windows tests
     runs-on: windows-latest

--- a/bin/test-release.sh
+++ b/bin/test-release.sh
@@ -12,6 +12,7 @@ coursier resolve \
   org.scalameta:metac_2.13.5:$version \
   org.scalameta:metac_2.12.13:$version \
   org.scalameta:metac_2.11.12:$version \
+  org.scalameta:semanticdb-scalac-core_2.13.6:$version \
   org.scalameta:semanticdb-scalac-core_2.13.5:$version \
   org.scalameta:semanticdb-scalac-core_2.13.4:$version \
   org.scalameta:semanticdb-scalac-core_2.13.3:$version \
@@ -19,6 +20,7 @@ coursier resolve \
   org.scalameta:semanticdb-scalac-core_2.13.1:$version \
   org.scalameta:semanticdb-scalac-core_2.12.13:$version \
   org.scalameta:semanticdb-scalac-core_2.11.12:$version \
+  org.scalameta:semanticdb-scalac_2.13.6:$version \
   org.scalameta:semanticdb-scalac_2.13.5:$version \
   org.scalameta:semanticdb-scalac_2.13.4:$version \
   org.scalameta:semanticdb-scalac_2.13.3:$version \

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -4,7 +4,7 @@ package build
 object Versions {
   val LatestScala211 = "2.11.12"
   val LatestScala212 = "2.12.13"
-  val LatestScala213 = "2.13.5"
+  val LatestScala213 = "2.13.6"
   val LegacyScalaVersions =
     List(
       "2.12.8",
@@ -16,6 +16,7 @@ object Versions {
       "2.13.1",
       "2.13.2",
       "2.13.3",
-      "2.13.4"
+      "2.13.4",
+      "2.13.5"
     )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,7 +19,7 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.0.0")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.5.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.5.1")
 
 addSbtPlugin("org.scala-debugger" % "sbt-jdi-tools" % "1.1.1")
 

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
@@ -737,6 +737,8 @@ object Dialect extends InternalDialect {
     "Scala211" -> Scala211,
     "Scala212" -> Scala212,
     "Scala213" -> Scala213,
+    "Scala213Source3" -> Scala213Source3,
+    "Scala212Source3" -> Scala212Source3,
     "Typelevel211" -> Typelevel211,
     "Typelevel212" -> Typelevel212
   )

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -58,6 +58,30 @@ package object dialects {
     .withAllowNumericLiteralUnderscoreSeparators(true)
     .withAllowTryWithAnyExpr(true)
 
+  /**
+   *  Dialect starting with Scala 2.13.6 for `-Xsource:3` option
+   */
+  implicit val Scala213Source3 = Scala213
+    .withAllowQuestionMarkPlaceholder(true)
+    .withAllowAsForImportRename(true)
+    .withAllowStarWildcardImport(true)
+    .withAllowOpenClass(true)
+    .withAllowInfixMods(true)
+    .withAllowPostfixStarVarargSplices(true)
+    .withAllowAndTypes(true)
+
+  /**
+   *  Dialect starting with  Scala 2.12.14 for `-Xsource:3` option
+   */
+  implicit val Scala212Source3 = Scala212
+    .withAllowQuestionMarkPlaceholder(true)
+    .withAllowAsForImportRename(true)
+    .withAllowStarWildcardImport(true)
+    .withAllowOpenClass(true)
+    .withAllowInfixMods(true)
+    .withAllowPostfixStarVarargSplices(true)
+    .withAllowAndTypes(true)
+
   implicit val Scala = Scala213 // alias for latest Scala dialect.
 
   implicit val Sbt0136 = Scala210

--- a/semanticdb/scalac/library/src/main/scala-2.13.6/scala/meta/internal/semanticdb/scalac/SemanticdbReporter.scala
+++ b/semanticdb/scalac/library/src/main/scala-2.13.6/scala/meta/internal/semanticdb/scalac/SemanticdbReporter.scala
@@ -1,0 +1,22 @@
+package scala.meta.internal.semanticdb.scalac
+
+import scala.reflect.internal.util.Position
+import scala.tools.nsc.reporters.{FilteringReporter, StoreReporter}
+
+class SemanticdbReporter(underlying: FilteringReporter) extends StoreReporter {
+  override def doReport(pos: Position, msg: String, severity: Severity): Unit = {
+    super.doReport(pos, msg, severity)
+    underlying.doReport(pos, msg, severity)
+  }
+
+  // overriding increment and filter is enough so make sure that error/warning
+  // counts are the same as in underlying reporter
+
+  override def increment(severity: Severity): Unit = {
+    super.increment(severity)
+    underlying.increment(severity)
+  }
+
+  override def filter(pos: Position, msg: String, severity: Severity): Int =
+    underlying.filter(pos, msg, severity)
+}

--- a/semanticdb/scalac/library/src/main/scala-2.13.6/scala/meta/internal/semanticdb/scalac/VersionCompilerOps.scala
+++ b/semanticdb/scalac/library/src/main/scala-2.13.6/scala/meta/internal/semanticdb/scalac/VersionCompilerOps.scala
@@ -1,0 +1,9 @@
+package scala.meta.internal.semanticdb.scalac
+
+import scala.tools.nsc.interactive.Global
+
+trait VersionCompilerOps {
+
+  def forceWarnings(global: Global) = {}
+
+}

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -86,7 +86,9 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.dialects.Scala210 *
       |scala.meta.dialects.Scala211 *
       |scala.meta.dialects.Scala212 *
+      |scala.meta.dialects.Scala212Source3 *
       |scala.meta.dialects.Scala213 *
+      |scala.meta.dialects.Scala213Source3 *
       |scala.meta.dialects.Scala3 *
       |scala.meta.dialects.Typelevel211 *
       |scala.meta.dialects.Typelevel212 *

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/InteractiveSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/InteractiveSuite.scala
@@ -112,6 +112,7 @@ class InteractiveSuite extends FunSuite {
     compat = List(
       "2.13.4" -> expectedLatest,
       "2.13.5" -> expectedLatest,
+      "2.13.6" -> expectedLatest,
       "2.13" -> expectedPrevious213
     )
   )

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/Issue2024Suite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/Issue2024Suite.scala
@@ -1,17 +1,11 @@
 package scala.meta.tests.semanticdb
 
 class Issue2024Suite extends SemanticdbSuite {
-  override def munitIgnore: Boolean = !isSupported(scala.util.Properties.versionNumberString)
-
-  private def isSupported(version: String): Boolean = {
-    val Array(major, minor, patch) =
-      version.replaceAll("(-|\\+).+$", "").split('.').map(_.toInt)
-    (major, minor) match {
-      case (2, 13) => patch >= 5
-      case (2, 12) => patch >= 14
-      case _ => false
-    }
-  }
+  override def munitIgnore: Boolean = !ScalaVersion.isSupported(
+    scala.util.Properties.versionNumberString,
+    minimal212 = 14,
+    minimal213 = 5
+  )
 
   // fixed in >=2.13.5 or >=2.12.14
   // https://github.com/scalameta/scalameta/issues/2024

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/ScalaVersion.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/ScalaVersion.scala
@@ -19,4 +19,13 @@ object ScalaVersion {
     }
   }
 
+  def isSupported(version: String, minimal212: Int, minimal213: Int): Boolean = {
+    val Array(major, minor, patch) =
+      version.replaceAll("(-|\\+).+$", "").split('.').map(_.toInt)
+    (major, minor) match {
+      case (2, 13) => patch >= minimal213
+      case (2, 12) => patch >= minimal212
+      case _ => false
+    }
+  }
 }

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/Source3Suite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/Source3Suite.scala
@@ -1,0 +1,87 @@
+package scala.meta.tests
+package semanticdb
+
+import org.scalameta.logger
+import munit.FunSuite
+import scala.meta.interactive.InteractiveSemanticdb._
+import scala.meta.internal.semanticdb.Print
+import scala.tools.nsc.interactive.Global
+import scala.util.Properties
+import scala.collection.SortedMap
+
+class Source3Suite extends FunSuite {
+
+  override def munitIgnore: Boolean = !ScalaVersion.isSupported(
+    scala.util.Properties.versionNumberString,
+    minimal212 = 14,
+    minimal213 = 6
+  )
+
+  val compiler: Global = newCompiler(scalacOptions = "-Xsource:3" :: Nil)
+  def check(
+      original: String,
+      expected: String,
+      compat: List[(String, String)] = List.empty
+  ): Unit = {
+    test(logger.revealWhitespace(original)) {
+      val options = List("-P:semanticdb:synthetics:on", "-P:semanticdb:text:on")
+      val document = toTextDocument(compiler, original, options)
+      val format = scala.meta.metap.Format.Detailed
+      val syntax = Print.document(format, document)
+      assertNoDiff(syntax, expected)
+    }
+  }
+
+  check(
+    """package b
+      |import scala.concurrent.Future as F
+      |object a {
+      |  def func(args: String*) = ???
+      |  val args = List.empty[String]
+      |  func(args*) 
+      |}
+    """.stripMargin,
+    """|interactive.scala
+       |-----------------
+       |
+       |Summary:
+       |Schema => SemanticDB v4
+       |Uri => interactive.scala
+       |Text => non-empty
+       |Language => Scala
+       |Symbols => 4 entries
+       |Occurrences => 16 entries
+       |
+       |Symbols:
+       |b/a. => final object a extends AnyRef { +2 decls }
+       |  AnyRef => scala/AnyRef#
+       |b/a.args. => val method args: List[String]
+       |  List => scala/collection/immutable/List#
+       |  String => scala/Predef.String#
+       |b/a.func(). => method func(args: String*): Nothing
+       |  args => b/a.func().(args)
+       |  String => scala/Predef.String#
+       |  Nothing => scala/Nothing#
+       |b/a.func().(args) => param args: String*
+       |  String => scala/Predef.String#
+       |
+       |Occurrences:
+       |[0:8..0:9): b <= b/
+       |[1:7..1:12): scala => scala/
+       |[1:13..1:23): concurrent => scala/concurrent/
+       |[1:24..1:30): Future => scala/concurrent/Future#
+       |[1:24..1:30): Future => scala/concurrent/Future.
+       |[2:7..2:8): a <= b/a.
+       |[3:6..3:10): func <= b/a.func().
+       |[3:11..3:15): args <= b/a.func().(args)
+       |[3:17..3:23): String => java/lang/String#
+       |[3:28..3:31): ??? => scala/Predef.`???`().
+       |[4:6..4:10): args <= b/a.args.
+       |[4:13..4:17): List => scala/package.List.
+       |[4:18..4:23): empty => scala/collection/immutable/List.empty().
+       |[4:24..4:30): String => scala/Predef.String#
+       |[5:2..5:6): func => b/a.func().
+       |[5:7..5:11): args => b/a.args.""".stripMargin
+  )
+
+}

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
@@ -137,8 +137,16 @@ class PublicSuite extends FunSuite {
     assertNoDiff(scala.meta.dialects.Scala212.toString, "Scala212")
   }
 
+  test("scala.meta.dialects.Scala212Source3.toString") {
+    assertNoDiff(scala.meta.dialects.Scala212Source3.toString, "Scala212Source3")
+  }
+
   test("scala.meta.dialects.Scala213.toString") {
     assertNoDiff(scala.meta.dialects.Scala213.toString, "Scala213")
+  }
+
+  test("scala.meta.dialects.Scala213Source3.toString") {
+    assertNoDiff(scala.meta.dialects.Scala213Source3.toString, "Scala213Source3")
   }
 
   test("scala.meta.dialects.Scala.toString") {


### PR DESCRIPTION
Also fixes https://github.com/scalameta/scalameta/issues/2323 by adding an additional dialect for use with source:3 option.

I don't think we can do much more on Scalameta side, since when parsing we don't have access to scalac options.
