### PR TITLE
Enable xml and symbol literals in the Scala3 dialect

### DIFF
--- a/community-test/src/test/scala/CommunityDottySuite.scala
+++ b/community-test/src/test/scala/CommunityDottySuite.scala
@@ -159,10 +159,7 @@ class CommunityDottySuite extends FunSuite {
 
   final def dottyExclusionList = List()
 
-  final def munitExclusionList = List(
-    // xml literals are longer valid in Scala 3
-    "main/scala/docs/MUnitModifier.scala"
-  )
+  final def munitExclusionList = List()
 
   final val ignoreParts = List(
     "/tests/",

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -124,7 +124,6 @@ package object dialects {
     .withAllowTraitParameters(true)
     .withAllowTypeLambdas(true)
     .withAllowViewBounds(false) // View bounds have been removed in Dotty
-    .withAllowXmlLiterals(false) // Scala 3: parser doesn't support xml
     .withAllowGivenUsing(true)
     .withAllowExtensionMethods(true)
     .withAllowOpenClass(true)
@@ -147,7 +146,6 @@ package object dialects {
     .withAllowMatchAsOperator(true)
     .withAllowTypeMatch(true)
     .withAllowInfixMods(true)
-    .withAllowSymbolLiterals(false)
     .withAllowDependentFunctionTypes(true)
     .withAllowAllTypedPatterns(true)
     .withAllowAsForImportRename(true)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
@@ -16,7 +16,6 @@ class MacroSuite extends BaseDottySuite {
    *  '{ ... } OR 'ident - QuotedMacroExpr
    *  '[ ... ] - QuotedMacroType
    *  ${ ... } OR $ident - SplicedMacroExpr
-   *  symbols 'ident are not supported in dotty
    */
   test("parse-single-quote-character") {
     runTestAssert[Stat]("val a = 'c'")(
@@ -90,7 +89,13 @@ class MacroSuite extends BaseDottySuite {
       )
     )
     val layoutMatchSimple = "x match {\n  case 'c => 1\n}"
-    runTestError[Stat]("x match { case 'c => 1 }", "Symbol literals are no longer allowed")
+    runTestAssert[Stat]("x match { case 'c => 1 }", assertLayout = Some(layoutMatchSimple))(
+      Term.Match(
+        tname("x"),
+        List(Case(Lit.Symbol('c), None, Lit.Int(1))),
+        Nil
+      )
+    )
     val layoutMatchComplex = "x match {\n  case '{ a } => 1\n}"
     runTestAssert[Stat]("x match { case '{ a } => 1 }", assertLayout = Some(layoutMatchComplex))(
       Term.Match(

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -69,7 +69,7 @@ class MinorDottySuite extends BaseDottySuite {
   }
 
   test("xml-literals") {
-    intercept[TokenizeException] { term("<foo>{bar}</foo>")(dialects.Dotty) }
+    term("<foo>{bar}</foo>")(dialects.Dotty)
   }
 
   test("opaque-type-alias") {


### PR DESCRIPTION
- xml literals can be parsed by Scala 3 when scala-xml is on the
  classpath, just like in Scala 2.
- Symbol literals can still be used with
  `import scala.language.deprecated.symbolLiterals`