### PR TITLE
Scaladoc: fix syntax for links with anchor text

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
@@ -109,7 +109,7 @@ object ScaladocParser {
     def end = space | linkSuffix
     def anchor = P((!end ~ AnyChar).rep(1).!.rep(1, sep = spaces1))
     def pattern = linkPrefix ~ (anchor ~ linkSuffix ~ punctParser.!)
-    pattern.map { case (x, y) => Link(x.head, x.tail.toSeq, y) }
+    pattern.map { case (x, y) => new Link(x, y) }
   }
 
   private def textParser[_: P]: P[Text] = P {

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
@@ -36,7 +36,7 @@ object ScaladocParser {
   private def nlHspaces1[_: P] = space ~ hspaces0
   private def leadHspaces0[_: P] = startOrNl ~ hspaces0
 
-  private def punctParser[_: P] = CharsWhileIn(".,:!?;", 0)
+  private def punctParser[_: P] = CharsWhileIn(".,:!?;)", 0)
   private def labelParser[_: P]: P[Unit] = (!space ~ AnyChar).rep(1)
   private def wordParser[_: P]: P[Word] = P(labelParser.!.map(Word.apply))
   private def trailWordParser[_: P] = nlHspaces1 ~ wordParser

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/Scaladoc.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/Scaladoc.scala
@@ -31,6 +31,7 @@ object Scaladoc {
 
   /** A reference to a symbol */
   final case class Link(ref: String, anchor: Seq[String], punct: String) extends TextPart {
+    def this(parts: Seq[String], punct: String) = this(parts.head, parts.tail, punct)
     override def syntax: String = anchor.mkString(s"[[$ref", " ", s"]]$punct")
   }
 

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/Scaladoc.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/Scaladoc.scala
@@ -32,7 +32,13 @@ object Scaladoc {
   /** A reference to a symbol */
   final case class Link(ref: String, anchor: Seq[String], punct: String) extends TextPart {
     def this(parts: Seq[String], punct: String) = this(parts.head, parts.tail, punct)
-    override def syntax: String = anchor.mkString(s"[[$ref", " ", s"]]$punct")
+    override def syntax: String = {
+      val sb = new StringBuilder
+      sb.append("[[").append(ref)
+      anchor.foreach { x => sb.append(' ').append(x) }
+      sb.append("]]").append(punct)
+      sb.result()
+    }
   }
 
   /** A single embedded code expression */

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
@@ -159,11 +159,11 @@ class ScaladocParserSuite extends FunSuite {
 
   test("paragraph parsing with complex references and parens") {
     val ref = "baz qux"
-    val link = new Link(ref.split("\\s+"), "")
-    assertEquals(link.syntax, "[[bazqux]]")
+    val link = new Link(ref.split("\\s+"), ")")
+    assertEquals(link.syntax, "[[bazqux]])")
 
-    val text1 = Seq(Word("(foo"), Word("bar"), link, Word(")"))
-    val text2 = Seq(Word("foo"), Word("bar"), link, Word(")"))
+    val text1 = Seq(Word("(foo"), Word("bar"), link)
+    val text2 = Seq(Word("foo"), Word("bar"), link)
 
     assertEquals(
       parseString(

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
@@ -157,6 +157,30 @@ class ScaladocParserSuite extends FunSuite {
     )
   }
 
+  test("paragraph parsing with complex references and parens") {
+    val ref = "baz qux"
+    val link = new Link(ref.split("\\s+"), "")
+    assertEquals(link.syntax, "[[bazqux]]")
+
+    val text1 = Seq(Word("(foo"), Word("bar"), link, Word(")"))
+    val text2 = Seq(Word("foo"), Word("bar"), link, Word(")"))
+
+    assertEquals(
+      parseString(
+        s"""
+         /**
+          * (foo bar
+          * [[$ref]])
+          *
+          * foo bar
+          * [[$ref]])
+          */
+         """
+      ),
+      Option(Scaladoc(Seq(Paragraph(Seq(Text(text1))), Paragraph(Seq(Text(text2))))))
+    )
+  }
+
   test("code blocks") {
 
     val testDescription = "This is a codeblock:"

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
@@ -160,7 +160,7 @@ class ScaladocParserSuite extends FunSuite {
   test("paragraph parsing with complex references and parens") {
     val ref = "baz qux"
     val link = new Link(ref.split("\\s+"), ")")
-    assertEquals(link.syntax, "[[bazqux]])")
+    assertEquals(link.syntax, "[[baz qux]])")
 
     val text1 = Seq(Word("(foo"), Word("bar"), link)
     val text2 = Seq(Word("foo"), Word("bar"), link)


### PR DESCRIPTION
Fixes #2349.