### PR TITLE
Allow type acription on partial functions

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2519,7 +2519,14 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
               val params = convertToParams(t)
               val trm =
                 if (location != BlockStat) expr()
-                else blockExpr()
+                else {
+                  blockExpr() match {
+                    case partial: Term.PartialFunction if token.is[Colon] =>
+                      accept[Colon]
+                      atPos(partial, auto)(Term.Ascribe(partial, typeOrInfixType(location)))
+                    case t => t
+                  }
+                }
 
               if (contextFunction)
                 Term.ContextFunction(params, trm)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -839,4 +839,52 @@ class TermSuite extends ParseSuite {
       )
     ) = res
   }
+
+  test("type-partial-function") {
+    val res =
+      stat("""|val dynamicStrategy = resharding(
+              |  { fakePartitionId: Int =>
+              |    {
+              |      case sendBox: SendBox.Args => 
+              |    }: PartialFunction[ThriftStructIface, Unit]
+              |  }
+              |)
+              |""".stripMargin)
+
+    val Defn.Val(
+      Nil,
+      List(Pat.Var(Term.Name("dynamicStrategy"))),
+      None,
+      Term.Apply(
+        Term.Name("resharding"),
+        List(
+          Term.Block(
+            List(
+              Term.Function(
+                List(Term.Param(Nil, Term.Name("fakePartitionId"), Some(Type.Name("Int")), None)),
+                Term.Ascribe(
+                  Term.PartialFunction(
+                    List(
+                      Case(
+                        Pat.Typed(
+                          Pat.Var(Term.Name("sendBox")),
+                          Type.Select(Term.Name("SendBox"), Type.Name("Args"))
+                        ),
+                        None,
+                        Term.Block(Nil)
+                      )
+                    )
+                  ),
+                  Type.Apply(
+                    Type.Name("PartialFunction"),
+                    List(Type.Name("ThriftStructIface"), Type.Name("Unit"))
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    ) = res
+  }
 }


### PR DESCRIPTION
Discovered in https://github.com/twitter/finagle/blob/5a926d0a486d65d6571731de22932029a9a91e38/finagle-thrift/src/test/scala/com/twitter/finagle/thrift/exp/partitioning/PartitionAwareClientEndtoEndTest.scala#L367