### PR TITLE
Allow next apply after newline and indentation

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -247,6 +247,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
   trait TokenIterator extends Iterator[Token] {
     def prevTokenPos: Int
     def tokenPos: Int
+    def currentIndentation: Int
     def token: Token
     def fork: TokenIterator
     def observeIndented(): Boolean
@@ -336,6 +337,14 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
         }
         RegionIndentEnum(i) :: nextPrev
       })
+    }
+
+    def currentIndentation: Int = {
+      val foundIndentation = countIndent(curr.pointPos)
+      if (foundIndentation < 0)
+        sepRegions.headOption.fold(-1)(_.indent)
+      else
+        foundIndentation
     }
 
     def observeOutdented(): Boolean = {
@@ -679,6 +688,10 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
 
   private def countIndent(tokenPosition: Int): Int =
     countIndentAndNewlineIndex(tokenPosition)._1
+
+  private def currentIndentation: Int = {
+    in.currentIndentation
+  }
 
   @tailrec
   private def isAheadNewLine(currentPosition: Int): Boolean = {
@@ -2110,6 +2123,15 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
     if (token.is[LF] && ahead { token.is[T] }) newLineOpt()
   }
 
+  def newLineOptWhenFollowedBySignificantIndentationAnd(cond: Token => Boolean): Unit = {
+    def nextLineHasGreaterIndentation = {
+      val prev = currentIndentation
+      prev > 0 && ahead { cond(token) && currentIndentation > prev }
+    }
+    if (token.is[LF] && nextLineHasGreaterIndentation)
+      newLineOpt()
+  }
+
   def newLineOptWhenFollowing(p: Token => Boolean): Unit = {
     // note: next is defined here because current is token.LF
     if (token.is[LF] && ahead { p(token) }) newLineOpt()
@@ -2929,7 +2951,13 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
   }
 
   def simpleExprRest(t: Term, canApply: Boolean): Term = atPos(t, auto) {
-    if (canApply) newLineOptWhenFollowedBy[LeftBrace]
+    if (canApply) {
+      if (dialect.allowSignificantIndentation) {
+        newLineOptWhenFollowedBySignificantIndentationAnd(x => x.is[LeftBrace] || x.is[LeftParen])
+      } else {
+        newLineOptWhenFollowedBy[LeftBrace]
+      }
+    }
     token match {
       case Dot() =>
         next()


### PR DESCRIPTION
Related to https://github.com/lampepfl/dotty/issues/12554 and https://github.com/scalameta/scalafmt/issues/2522

It is now possible to have the next apply in curried functions to start in the next line if there is an indentation:

```scala
def f(s: String)(t: String) = s"$t: $s"

def g =
  f("Foo")
    ("Bar")
```