### PR TITLE
Dialect: add scala version, remove `allowPlusMinusUnderscoreAsIdent`

### DIFF
--- a/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
@@ -74,6 +74,11 @@ final class Dialect private (
     // What kind of separator is necessary to split top-level statements?
     // Normally none is required, but scripts may have their own rules.
     val toplevelSeparator: String,
+    // New fields should be added below this line, for backwards compat
+    // scala version parts
+    val scalaMajor: Int,
+    val scalaMinor: Int,
+    val scalaPatch: Int,
     // Are numeric literal underscore separators, i.e. `1_000_000` legal or not?
     val allowNumericLiteralUnderscoreSeparators: Boolean,
     // Can try body contain any expression? (2.13.1 https://github.com/scala/scala/pull/8071)
@@ -227,6 +232,9 @@ final class Dialect private (
       allowWithTypes,
       allowXmlLiterals,
       toplevelSeparator,
+      scalaMajor = 0,
+      scalaMinor = 0,
+      scalaPatch = 0,
       allowNumericLiteralUnderscoreSeparators = false,
       allowTryWithAnyExpr = false,
       allowGivenUsing = false,
@@ -271,6 +279,10 @@ final class Dialect private (
 
   // Are unquotes ($x) and splices (..$xs, ...$xss) allowed?
   def allowUnquotes: Boolean = allowTermUnquotes || allowPatUnquotes
+
+  def withScalaVersion(major: Int, minor: Int, patch: Int): Dialect = {
+    privateCopy(scalaMajor = major, scalaMinor = minor, scalaPatch = patch)
+  }
 
   def withAllowAndTypes(newValue: Boolean): Dialect = {
     privateCopy(allowAndTypes = newValue)
@@ -503,6 +515,10 @@ final class Dialect private (
       allowWithTypes: Boolean = this.allowWithTypes,
       allowXmlLiterals: Boolean = this.allowXmlLiterals,
       toplevelSeparator: String = this.toplevelSeparator,
+      // new parameters below this line
+      scalaMajor: Int = this.scalaMajor,
+      scalaMinor: Int = this.scalaMinor,
+      scalaPatch: Int = this.scalaPatch,
       allowNumericLiteralUnderscoreSeparators: Boolean =
         this.allowNumericLiteralUnderscoreSeparators,
       allowTryWithAnyExpr: Boolean = this.allowTryWithAnyExpr,
@@ -569,6 +585,9 @@ final class Dialect private (
       allowWithTypes,
       allowXmlLiterals,
       toplevelSeparator,
+      scalaMajor,
+      scalaMinor,
+      scalaPatch,
       allowNumericLiteralUnderscoreSeparators,
       allowTryWithAnyExpr,
       allowGivenUsing,

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
@@ -165,12 +165,9 @@ final class Dialect private (
     // Scala 3 no longer allows `do {...} while(...)`
     val allowDoWhile: Boolean,
     /* Kind-project support
-     * works under -Xsource3 flag
+     * scala2: works under -Xsource3 flag
      * https://github.com/scala/scala/pull/9605
-     */
-    val allowPlusMinusUnderscoreAsIdent: Boolean,
-    /* The same as previous but for Scala3
-     * works under -Ykind-projector:underscores
+     * scala3: works under -Ykind-projector:underscores
      */
     val allowPlusMinusUnderscoreAsPlaceholder: Boolean
 ) extends Product with Serializable {
@@ -271,7 +268,6 @@ final class Dialect private (
       allowStarWildcardImport = false,
       allowProcedureSyntax = true,
       allowDoWhile = true,
-      allowPlusMinusUnderscoreAsIdent = false,
       allowPlusMinusUnderscoreAsPlaceholder = false
       // NOTE(olafur): declare the default value for new fields above this comment.
     )
@@ -479,10 +475,6 @@ final class Dialect private (
     privateCopy(allowDoWhile = newValue)
   }
 
-  def withAllowPlusMinusUnderscoreAsIdent(newValue: Boolean): Dialect = {
-    privateCopy(allowPlusMinusUnderscoreAsIdent = newValue)
-  }
-
   def withAllowPlusMinusUnderscoreAsPlaceholder(newValue: Boolean): Dialect = {
     privateCopy(allowPlusMinusUnderscoreAsPlaceholder = newValue)
   }
@@ -556,7 +548,6 @@ final class Dialect private (
       allowStarWildcardImport: Boolean = this.allowStarWildcardImport,
       allowProcedureSyntax: Boolean = this.allowProcedureSyntax,
       allowDoWhile: Boolean = this.allowDoWhile,
-      allowPlusMinusUnderscoreAsIdent: Boolean = this.allowPlusMinusUnderscoreAsIdent,
       allowPlusMinusUnderscoreAsPlaceholder: Boolean = this.allowPlusMinusUnderscoreAsPlaceholder
       // NOTE(olafur): add the next parameter above this comment.
   ): Dialect = {
@@ -624,7 +615,6 @@ final class Dialect private (
       allowStarWildcardImport,
       allowProcedureSyntax,
       allowDoWhile,
-      allowPlusMinusUnderscoreAsIdent,
       allowPlusMinusUnderscoreAsPlaceholder
       // NOTE(olafur): add the next argument above this comment.
     )

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -33,8 +33,10 @@ package object dialects {
     allowXmlLiterals = true, // Not even deprecated yet, so we need to support xml literals
     toplevelSeparator = ""
   )
+    .withScalaVersion(2, 1, 0)
 
   implicit val Scala211 = Scala210
+    .withScalaVersion(2, 1, 1)
     .withAllowCaseClassWithoutParameterList(false)
     .withAllowSpliceUnderscores(true) // SI-7715, only fixed in 2.11.0-M5
 
@@ -50,9 +52,11 @@ package object dialects {
     .withAllowInlineMods(true)
 
   implicit val Scala212 = Scala211
+    .withScalaVersion(2, 1, 2)
     .withAllowTrailingCommas(true)
 
   implicit val Scala213 = Scala212
+    .withScalaVersion(2, 1, 3)
     .withAllowImplicitByNameParameters(true)
     .withAllowLiteralTypes(true)
     .withAllowNumericLiteralUnderscoreSeparators(true)
@@ -111,6 +115,7 @@ package object dialects {
     .withAllowInlineMods(true)
 
   implicit val Scala3 = Scala213
+    .withScalaVersion(3, 0, 0)
     .withAllowAndTypes(true)
     // there 3 different ways to specify vargs, some will be removed in future Scala 3 versions
     .withAllowAtForExtractorVarargs(true) // both @ and : work currently for Scala 3

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -73,7 +73,7 @@ package object dialects {
     .withAllowInfixMods(true)
     .withAllowPostfixStarVarargSplices(true)
     .withAllowAndTypes(true)
-    .withAllowPlusMinusUnderscoreAsIdent(true)
+    .withAllowPlusMinusUnderscoreAsPlaceholder(true)
 
   /**
    *  Dialect starting with  Scala 2.12.14 for `-Xsource:3` option
@@ -86,7 +86,7 @@ package object dialects {
     .withAllowInfixMods(true)
     .withAllowPostfixStarVarargSplices(true)
     .withAllowAndTypes(true)
-    .withAllowPlusMinusUnderscoreAsIdent(true)
+    .withAllowPlusMinusUnderscoreAsPlaceholder(true)
 
   implicit val Scala = Scala213 // alias for latest Scala dialect.
 

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1719,9 +1719,6 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
       else Type.Annotate(t, annots)
     }
 
-    private def allowPlusMinusUnderscore: Boolean =
-      dialect.allowPlusMinusUnderscoreAsIdent || dialect.allowPlusMinusUnderscoreAsPlaceholder
-
     def simpleType(): Type = {
       simpleTypeRest(autoPos(token match {
         case LeftParen() => autoPos(makeTupleType(inParens(types())))
@@ -1735,11 +1732,11 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
         case ident: Ident
             if (ident.value == "+" || ident.value == "-") &&
               ahead(token.is[Underscore]) &&
-              allowPlusMinusUnderscore =>
+              dialect.allowPlusMinusUnderscoreAsPlaceholder =>
           autoPos {
             accept[Ident]
             accept[Underscore]
-            if (dialect.allowPlusMinusUnderscoreAsPlaceholder)
+            if (dialect.scalaMajor >= 3)
               Type.Placeholder(typeBounds())
             else
               Type.Name(s"${ident.value}_")


### PR DESCRIPTION
Instead, use a combination of `allowPlusMinusUnderscoreAsPlaceholder` with `scalaMajor`.