### PR TITLE
Trees: add an option to get original input syntax

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -1280,7 +1280,7 @@ object TreeSyntax {
         // NOTE: Options don't really matter,
         // because if we've parsed a tree, it's not gonna contain lazy seqs anyway.
         // case Origin.Parsed(_, originalDialect, _) if dialect == originalDialect && options == Options.Eager =>
-        case Origin.Parsed(_, originalDialect, _) if dialect == originalDialect => s(x.pos.text)
+        case Origin.Parsed(input, `dialect`, _) => s(x.pos.text)
         case _ => new SyntaxInstances(dialect).syntaxTree[T].apply(x)
       }
     }

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/InternalTrees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/InternalTrees.scala
@@ -73,6 +73,13 @@ trait InternalTree extends Product {
     }
   }
 
+  def inputSyntax(implicit dialect: Dialect): String = {
+    pos match {
+      case Position.None => this.syntax
+      case p => p.text
+    }
+  }
+
   // ==============================================================
   // Setters for pieces of internal state defined above.
   // Everyone except for scala.meta's core should be using "private"-less versions of these methods,

--- a/tests/jvm/src/test/scala/scala/meta/tests/prettyprinters/PlatformSyntacticSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/prettyprinters/PlatformSyntacticSuite.scala
@@ -12,4 +12,34 @@ class PlatformSyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     assert(Lit.Float("1.40").syntax == "1.40f")
     assert(Lit.Float("1.4").syntax == "1.4f")
   }
+
+  test("syntax vs inputSyntax: full") {
+    val code = "import     foo.{ bar as   baz,   *  }"
+    val tree = parsers.Parse.parseStat(Input.String(code), dialects.Scala3).get
+    assertEquals(tree.inputSyntax, code)
+    locally {
+      implicit val dialect = dialects.Scala213
+      assertEquals(tree.syntax, "import foo.{ bar => baz, _ }")
+    }
+    locally {
+      implicit val dialect = dialects.Scala3
+      assertEquals(tree.syntax, code)
+    }
+  }
+
+  test("syntax vs inputSyntax: partial") {
+    val importCode = "import     foo.{ bar as   baz,   *  }"
+    val code = s"object a { $importCode }"
+    val tree = parsers.Parse.parseStat(Input.String(code), dialects.Scala3).get
+    val importTree = tree.asInstanceOf[Defn.Object].templ.stats.head
+    assertEquals(importTree.inputSyntax, importCode)
+    locally {
+      implicit val dialect = dialects.Scala213
+      assertEquals(importTree.syntax, "import foo.{ bar => baz, _ }")
+    }
+    locally {
+      implicit val dialect = dialects.Scala3
+      assertEquals(importTree.syntax, importCode)
+    }
+  }
 }


### PR DESCRIPTION
Currently, the syntax is requested with an implicit dialect, and most of the time the dialect isn't set explicitly but uses whatever happened to be provided by default.

For this type of case, let's provide a way to obtain the original syntax as it was used when parsing the code.