### PR TITLE
Fix issue with braces after function arrow

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
@@ -19,6 +19,8 @@ class ParseSuite extends FunSuite with CommonTrees {
     val expectedLines = expected.linesIterator.toList
     assert(actualLines == expectedLines)
   }
+  def assertNoDiff(obtained: Tree, expected: Tree): Unit =
+    assertNoDiff(obtained.structure, expected.structure)
 
   def stat(code: String)(implicit dialect: Dialect) = code.applyRule(_.parseStat())
   def term(code: String)(implicit dialect: Dialect) = code.parseRule(_.expr())


### PR DESCRIPTION
Previosly, we would not parser correctly when braces would appear after function arrow and were not actually the function body. Now, we make sure to treat that situation differently so that the braces are not accepted greedily.