### PR TITLE
Remove not needed libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -321,8 +321,6 @@ lazy val testkit = project
       "org.scalameta" %% "munit" % munitVersion,
       // These are used to download and extract a corpus tar.gz
       "org.rauschig" % "jarchivelib" % "1.1.0",
-      "commons-io" % "commons-io" % "2.8.0",
-      "com.googlecode.java-diff-utils" % "diffutils" % "1.3.0",
       "com.lihaoyi" %% "geny" % "0.6.10"
     ),
     libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value % Test,

--- a/scalameta/testkit/src/main/scala/scala/meta/testkit/Corpus.scala
+++ b/scalameta/testkit/src/main/scala/scala/meta/testkit/Corpus.scala
@@ -4,7 +4,10 @@ import java.io.File
 import java.net.URL
 
 import geny.Generator
-import org.apache.commons.io.FileUtils
+
+import sys.process._
+import java.net.URL
+import java.io.File
 import org.rauschig.jarchivelib.ArchiverFactory
 
 /**
@@ -94,7 +97,7 @@ object Corpus {
 
   private def downloadReposTar(corpus: Corpus, destination: File): Unit = {
     Phase.run(s"download ${corpus.url}") {
-      FileUtils.copyURLToFile(new URL(corpus.url), destination)
+      new URL(corpus.url).#>(destination).!!
     }
   }
 

--- a/tests/jvm/src/test/scala-2.12/scala/meta/tests/semanticdb/ExpectSuite.scala
+++ b/tests/jvm/src/test/scala-2.12/scala/meta/tests/semanticdb/ExpectSuite.scala
@@ -17,6 +17,7 @@ import scala.meta.io.Classpath
 import scala.meta.io.AbsolutePath
 import scala.meta.tests.cli._
 import munit.FunSuite
+import munit.internal.difflib.DiffUtils
 import scala.meta.tests.metacp.Library
 import scala.meta.tests.metacp.MetacpOps
 
@@ -96,12 +97,12 @@ trait ExpectHelpers extends munit.Assertions {
     val revisedLines = revised.split("\n").toSeq.asJava
     val OnlyCurlyBrace = "\\s+}".r
     val diff = {
-      val lines = difflib.DiffUtils
+      val lines = DiffUtils
         .generateUnifiedDiff(
           originalTitle,
           revisedTitle,
           originalLines,
-          difflib.DiffUtils.diff(originalLines, revisedLines),
+          DiffUtils.diff(originalLines, revisedLines),
           3
         )
         .asScala


### PR DESCRIPTION
I started looking into this in order to start running Scalafmt tests on Native, but it seems I can instead just copy the small class that is needed for the tests. However, I think it's an improvement to remove two libraries here.

