### PR TITLE
[Scala3] Allow context bounds in trait type parameters

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -4462,7 +4462,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
       traitName,
       typeParamClauseOpt(
         ownerIsType = true,
-        ctxBoundsAllowed = false,
+        ctxBoundsAllowed = dialect.allowTraitParameters,
         allowUnderscore = dialect.allowTypeParamUnderscore
       ),
       primaryCtor(OwnedByTrait),

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -195,6 +195,20 @@ class MinorDottySuite extends BaseDottySuite {
     )
   }
 
+  test("trait-parameters-context-bounds") {
+    runTestAssert[Stat]("trait Foo[T: Eq]")(
+      Defn.Trait(
+        Nil,
+        Type.Name("Foo"),
+        List(
+          Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, List(Type.Name("Eq")))
+        ),
+        Ctor.Primary(Nil, Name(""), Nil),
+        Template(Nil, Nil, Self(Name(""), None), Nil, Nil)
+      )
+    )
+  }
+
   test("class-parameters-using") {
     runTestAssert[Stat]("trait A(using String)")(
       Defn.Trait(Nil, pname("A"), Nil, ctorp(List(tparamUsing("", "String"))), tpl(Nil))


### PR DESCRIPTION
Originally was reported here - https://github.com/scalameta/metals/issues/2874