### PR TITLE
Don't publish testkit JS and Native for 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -332,6 +332,8 @@ lazy val testkit = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       "org.scala-lang" % "scala-compiler" % scalaVersion.value % Test
     )
   )
+  .jsSettings(commonJsSettings)
+  .nativeSettings(nativeSettings)
 
 lazy val tests = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .in(file("tests"))


### PR DESCRIPTION
This fixes the release, since scalameta is not released for Native or JS on 2.11.