### PR TITLE
[Scala 3] Allow inline matches on literals

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1098,8 +1098,8 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
   trait InlineMatchMod {
     def unapply(token: Token): Boolean = {
       token.is[soft.KwInline] &&
-      (token.next.is[LeftParen] || token.next.is[LeftBrace] || token.next.is[KwNew] || token.next
-        .is[Ident])
+      (token.next.is[LeftParen] || token.next.is[LeftBrace] || token.next.is[KwNew] ||
+        token.next.is[Ident] || token.next.is[Literal])
     }
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InlineSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InlineSuite.scala
@@ -476,4 +476,53 @@ class InlineSuite extends BaseDottySuite {
       )
     )
   }
+
+  test("transparent-inline-with-constant") {
+    runTestAssert[Stat](
+      """|transparent inline def f: String =
+         |  inline 10 match
+         |    case _ =>
+         |      inline "foo" match
+         |        case x : String => x
+         |""".stripMargin,
+      assertLayout = Some(
+        """|transparent inline def f: String = inline 10 match {
+           |  case _ =>
+           |    inline "foo" match {
+           |      case x: String => x
+           |    }
+           |}
+           |""".stripMargin
+      )
+    )(
+      Defn.Def(
+        List(Mod.Transparent(), Mod.Inline()),
+        Term.Name("f"),
+        Nil,
+        Nil,
+        Some(Type.Name("String")),
+        Term.Match(
+          Lit.Int(10),
+          List(
+            Case(
+              Pat.Wildcard(),
+              None,
+              Term.Match(
+                Lit.String("foo"),
+                List(
+                  Case(
+                    Pat.Typed(Pat.Var(Term.Name("x")), Type.Name("String")),
+                    None,
+                    Term.Name("x")
+                  )
+                ),
+                List(Mod.Inline())
+              )
+            )
+          ),
+          List(Mod.Inline())
+        )
+      )
+    )
+  }
 }


### PR DESCRIPTION
Found while working on https://github.com/lampepfl/dotty/pull/12902