### PR TITLE
[Scala 3] Add the rest of possible inline matched expressions

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1097,9 +1097,13 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
   @classifier
   trait InlineMatchMod {
     def unapply(token: Token): Boolean = {
-      token.is[soft.KwInline] &&
-      (token.next.is[LeftParen] || token.next.is[LeftBrace] || token.next.is[KwNew] ||
-        token.next.is[Ident] || token.next.is[Literal])
+      token.is[soft.KwInline] && {
+        val nextToken = token.next
+        nextToken.is[LeftParen] || nextToken.is[LeftBrace] || nextToken.is[KwNew] ||
+        nextToken.is[Ident] || nextToken.is[Literal] || nextToken.is[Interpolation.Id] ||
+        nextToken.is[Xml.Start] || nextToken.is[KwSuper] || nextToken.is[KwThis] ||
+        nextToken.is[MacroSplice] || nextToken.is[MacroQuote]
+      }
     }
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InlineSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InlineSuite.scala
@@ -525,4 +525,38 @@ class InlineSuite extends BaseDottySuite {
       )
     )
   }
+
+  test("transparent-inline-with-this") {
+    runTestAssert[Stat](
+      """|transparent inline def nat =
+         |  inline this match
+         |    case Zero    => ()
+         |    case Succ(p) => ()
+         |      
+         |""".stripMargin,
+      assertLayout = Some(
+        """|transparent inline def nat = inline this match {
+           |  case Zero => ()
+           |  case Succ(p) => ()
+           |}
+           |""".stripMargin
+      )
+    )(
+      Defn.Def(
+        List(Mod.Transparent(), Mod.Inline()),
+        Term.Name("nat"),
+        Nil,
+        Nil,
+        None,
+        Term.Match(
+          Term.This(Name("")),
+          List(
+            Case(Term.Name("Zero"), None, Lit.Unit()),
+            Case(Pat.Extract(Term.Name("Succ"), List(Pat.Var(Term.Name("p")))), None, Lit.Unit())
+          ),
+          List(Mod.Inline())
+        )
+      )
+    )
+  }
 }


### PR DESCRIPTION
In the previous PR, I haven't added all possible cases, which inline can be followed by with a match. I went through all ExprIntro tokens and checked each one, so we should be good now. We could use `ExprIntro` classifier in theory, but it seems around half of the tokens defined there would be invalid after inline.

This issue came up when I was looking through the Dotty test cases and it seems we should try to parse as many as possible there, however it seems we do have some bugs still and I don't want to fix it all in one PR.