### PR TITLE
[Scala 3] Fix issues with mixed indented and braceless packages

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -5144,10 +5144,17 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
         val startPos = in.tokenPos
         accept[KwPackage]
         val qid = qualId()
-        if (token.is[LeftBrace]) {
-          val pkg = atPos(startPos, auto)(Pkg(qid, inBraces(topStatSeq())))
+        def inPackage(topStats: => List[Stat]) = {
+          val pkg = atPos(startPos, auto)(Pkg(qid, topStats))
           acceptStatSepOpt()
           pkg +: bracelessPackageStats()
+        }
+        if (token.is[LeftBrace]) {
+          inPackage(inBraces(topStatSeq()))
+        } else if (isColonEol(token)) {
+          next()
+          in.observeIndented()
+          inPackage(indented(topStatSeq()))
         } else {
           List(atPos(startPos, auto)(Pkg(qid, bracelessPackageStats())))
         }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -1932,4 +1932,53 @@ class SignificantIndentationSuite extends BaseDottySuite {
       )
     )
   }
+
+  test("package-mixed") {
+    runTestAssert[Source](
+      """|package tests.site
+         |
+         |package some.other:
+         |  class SomeOtherPackage
+         |
+         |class BrokenLink
+         |""".stripMargin,
+      assertLayout = Some(
+        """|package tests.site
+           |package some.other {
+           |  class SomeOtherPackage
+           |}
+           |class BrokenLink
+           |""".stripMargin
+      )
+    )(
+      Source(
+        List(
+          Pkg(
+            Term.Select(Term.Name("tests"), Term.Name("site")),
+            List(
+              Pkg(
+                Term.Select(Term.Name("some"), Term.Name("other")),
+                List(
+                  Defn.Class(
+                    Nil,
+                    Type.Name("SomeOtherPackage"),
+                    Nil,
+                    Ctor.Primary(Nil, Name(""), Nil),
+                    Template(Nil, Nil, Self(Name(""), None), Nil, Nil)
+                  )
+                )
+              ),
+              Defn.Class(
+                Nil,
+                Type.Name("BrokenLink"),
+                Nil,
+                Ctor.Primary(Nil, Name(""), Nil),
+                Template(Nil, Nil, Self(Name(""), None), Nil, Nil)
+              )
+            )
+          )
+        )
+      )
+    )
+  }
 }


### PR DESCRIPTION
It's another one that popped up within the dotty tests.