### PR TITLE
[Scala3] Fix `given ... with` + `Indent` + `import`/`export`

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1214,7 +1214,12 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
       token.is[KwMatch] || token.is[KwDo] || token.is[KwFor] || token.is[KwThen] ||
       token.is[KwElse] || token.is[Equals] || token.is[KwWhile] || token.is[KwIf] ||
       token.is[RightArrow] || token.is[KwReturn] || token.is[LeftArrow] ||
-      token.is[ContextArrow] || (token.is[KwWith] && token.next.is[DefIntro])
+      token.is[ContextArrow] || (
+        token.is[KwWith] && {
+          val next = token.next
+          next.is[DefIntro] || next.is[KwImport] || next.is[KwExport]
+        }
+      )
     }
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
@@ -328,6 +328,72 @@ class GivenUsingSuite extends BaseDottySuite {
     )
   }
 
+  test("given-with-import") {
+    runTestAssert[Stat](
+      code = """|given intOrd: Ord[Int] with
+                |  import math.max as maxF
+                |  def f(): Int = 1
+                |""".stripMargin,
+      assertLayout = Some(
+        """|given intOrd: Ord[Int] with {
+           |  import math.max as maxF
+           |  def f(): Int = 1
+           |}""".stripMargin
+      )
+    )(
+      Defn.Given(
+        Nil,
+        Term.Name("intOrd"),
+        Nil,
+        Nil,
+        Template(
+          Nil,
+          List(Init(Type.Apply(Type.Name("Ord"), List(Type.Name("Int"))), Name(""), Nil)),
+          Self(Name(""), None),
+          List(
+            Import(
+              List(Importer(Term.Name("math"), List(Importee.Rename(Name("max"), Name("maxF")))))
+            ),
+            Defn.Def(Nil, Term.Name("f"), Nil, List(List()), Some(Type.Name("Int")), Lit.Int(1))
+          ),
+          Nil
+        )
+      )
+    )
+  }
+
+  test("given-with-export") {
+    runTestAssert[Stat](
+      code = """|given intOrd: Ord[Int] with
+                |  export math.max
+                |  def f(): Int = 1
+                |""".stripMargin,
+      assertLayout = Some(
+        """|given intOrd: Ord[Int] with {
+           |  export math.max
+           |  def f(): Int = 1
+           |}""".stripMargin
+      )
+    )(
+      Defn.Given(
+        Nil,
+        Term.Name("intOrd"),
+        Nil,
+        Nil,
+        Template(
+          Nil,
+          List(Init(Type.Apply(Type.Name("Ord"), List(Type.Name("Int"))), Name(""), Nil)),
+          Self(Name(""), None),
+          List(
+            Export(List(Importer(Term.Name("math"), List(Importee.Name(Name("max")))))),
+            Defn.Def(Nil, Term.Name("f"), Nil, List(List()), Some(Type.Name("Int")), Lit.Int(1))
+          ),
+          Nil
+        )
+      )
+    )
+  }
+
   // ---------------------------------
   // GIVEN ALIAS
   // ---------------------------------


### PR DESCRIPTION
Found this case by running community tests against [shapeless-3](https://github.com/typelevel/shapeless-3/blob/main/modules/deriving/src/test/scala/shapeless3/deriving/type-classes.scala#L225)