### PR TITLE
[Scala 3] Recognize macro stats as block stats

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2959,7 +2959,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
   def macroSplice(): Term = autoPos {
     accept[MacroSplice]
     QuoteSpliceContext.enter()
-    val splice = Term.SplicedMacroExpr(autoPos(Term.Block(inBraces(templateStats()))))
+    val splice = Term.SplicedMacroExpr(autoPos(Term.Block(inBraces(blockStatSeq()))))
     QuoteSpliceContext.exit()
     splice
   }
@@ -2968,7 +2968,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
     accept[MacroQuote]
     QuoteSpliceContext.enter()
     val quote = if (token.is[LeftBrace]) {
-      Term.QuotedMacroExpr(autoPos(Term.Block(inBraces(templateStats()))))
+      Term.QuotedMacroExpr(autoPos(Term.Block(inBraces(blockStatSeq()))))
     } else if (token.is[LeftBracket]) {
       Term.QuotedMacroType(inBrackets(typ()))
     } else {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
@@ -352,4 +352,33 @@ class MacroSuite extends BaseDottySuite {
       )
     )
   }
+
+  test("simpler") {
+    runTestAssert[Stat](
+      "'{ val x: Int = ${ (q2) ?=> a } }",
+      assertLayout = Some("'{ val x: Int = ${ q2 ?=> a } }")
+    )(
+      Term.QuotedMacroExpr(
+        Term.Block(
+          List(
+            Defn.Val(
+              Nil,
+              List(Pat.Var(Term.Name("x"))),
+              Some(Type.Name("Int")),
+              Term.SplicedMacroExpr(
+                Term.Block(
+                  List(
+                    Term.ContextFunction(
+                      List(Term.Param(Nil, Term.Name("q2"), None, None)),
+                      Term.Name("a")
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  }
 }


### PR DESCRIPTION
Previously they were recognized as template blocks, which is not correct and breaks for example in case of lambdas.