### PR TITLE
Support LambdaType and MatchType for Scala3

### DIFF
--- a/semanticdb/semanticdb/semanticdb.proto
+++ b/semanticdb/semanticdb/semanticdb.proto
@@ -71,6 +71,8 @@ message Type {
     UniversalType universal_type = 10;
     ByNameType by_name_type = 13;
     RepeatedType repeated_type = 14;
+    LambdaType lambda_type = 24;
+    MatchType match_type = 25;
   }
 }
 
@@ -140,6 +142,20 @@ message ByNameType {
 
 message RepeatedType {
   Type tpe = 1;
+}
+
+message LambdaType {
+  Scope parameters = 1;
+  Type return_type = 2;
+}
+
+message MatchType {
+  message CaseType {
+    Type key = 1;
+    Type body = 2;
+  }
+  Type scrutinee = 1;
+  repeated CaseType cases = 2;
 }
 
 message Constant {


### PR DESCRIPTION
- Issue: https://github.com/scalameta/scalameta/issues/2403
- Here's a prototype implementation of Extracting Signature information for MatchType and TypeLambda from Scala3 
  - https://github.com/tanishiking/dotty/pull/1
  - https://github.com/tanishiking/semanticdb-for-scala3/pull/1/files


## LambdaType
```protobuf
message LambdaType {
  Scope parameters = 1;
  Type return_type = 2;
}
```

LambdaType represents the LambdaTypes for Scala3
http://dotty.epfl.ch/docs/reference/new-types/type-lambdas.html

for example `type Union = [A, B] =>> [C] =>> A | B | C`

```scala
LambdaType(
  parameters = Some(
    value = Scope(symlinks =
      List(
        "....Union#[A]"
        "....Union#[B]"
      ), hardlinks = List()
    )
  ),
  returnType = LambdaType(
    parameters = Some(
      value = Scope(symlinks = List("....Union#[C]"), hardlinks = List())
    ),
    returnType = UnionType(
      types = List(
        TypeRef(
          prefix = Empty,
          symbol = "....Union#[A]",
          typeArguments = List()
        ),
        TypeRef(
          prefix = Empty,
          symbol = "....Union#[B]",
          typeArguments = List()
        ),
        TypeRef(
          prefix = Empty,
          symbol = "....Union#[C]",
          typeArguments = List()
        )
      )
    )
  )
)
```

- As you can see, for the TypeLambda who has multiple type params like `[X] =>> [Y] =>> X | Y`, we will have nested LambdaType.
- The type parameters are represented as Scope and they should be symlinked.

## MatchType
```protobuf
message MatchType {
  message CaseType {
    Type key = 1;
    Type body = 2;
  }
  Type scrutinee = 1;
  repeated CaseType cases = 2;
}
```

MatchType represents the MatchType in Scala3
http://dotty.epfl.ch/docs/reference/new-types/match-types.html

Each case are represented as `CaseType` and they have key and value
types.

For example

```scala
type Elem[X] <: Any = X match
  case String => Char
  case Array[t] => t
```

The type signature of Elem looks like

```scala
TypeSignature(
  Some(Scope(List(matchtype/MatchType$package.Elem#[X]),List())),
  MatchType(
    TypeRef(Empty,matchtype/MatchType$package.Elem#[X],List()),
    List(
      CaseType(
        TypeRef(Empty,scala/Predef.String#,List()),
        TypeRef(Empty,scala/Char#,List())
      ),
      CaseType(
        TypeRef(Empty,scala/Array#,List(TypeRef(Empty,local0,List()))),
        TypeRef(Empty,local0,List())
      )
    )
  ),
  TypeRef(Empty,scala/Any#,List())
)
```

where `local0` means the local symbol for `t` in `Array[t]`.