### PR TITLE
[Scala 3] Allow catch-case expressions without indentation

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -618,7 +618,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
                 } else
                   // always add indent for indented `match` block
                   // check the previous token to avoid infinity loop
-                  (!prev.prev.is[soft.KwEnd] && prev.is[KwMatch]) &&
+                  (!prev.prev.is[soft.KwEnd] && (prev.is[KwMatch] || prev.is[KwCatch])) &&
                   next.is[KwCase] && token.isNot[Indentation.Indent]
               } else false
             }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -1841,4 +1841,89 @@ class ControlSyntaxSuite extends BaseDottySuite {
       )
     )
   }
+
+  test("no-real-indentation") {
+    runTestAssert[Stat](
+      """|object Test:
+         |  try List(1, 2, 3) match
+         |  case x :: xs => println(x)
+         |  case Nil => println("Nil")
+         |  catch
+         |  case ex: java.io.IOException => println(ex)
+         |  case ex: Throwable => throw ex
+         |  end try
+         |""".stripMargin,
+      assertLayout = Some(
+        """|object Test {
+           |  try List(1, 2, 3) match {
+           |    case x :: xs =>
+           |      println(x)
+           |    case Nil =>
+           |      println("Nil")
+           |  } catch {
+           |    case ex: java.io.IOException =>
+           |      println(ex)
+           |    case ex: Throwable =>
+           |      throw ex
+           |      end try
+           |  }
+           |}
+           |""".stripMargin
+      )
+    )(
+      Defn.Object(
+        Nil,
+        Term.Name("Test"),
+        Template(
+          Nil,
+          Nil,
+          Self(Name(""), None),
+          List(
+            Term.Try(
+              Term.Match(
+                Term.Apply(Term.Name("List"), List(Lit.Int(1), Lit.Int(2), Lit.Int(3))),
+                List(
+                  Case(
+                    Pat.ExtractInfix(
+                      Pat.Var(Term.Name("x")),
+                      Term.Name("::"),
+                      List(Pat.Var(Term.Name("xs")))
+                    ),
+                    None,
+                    Term.Apply(Term.Name("println"), List(Term.Name("x")))
+                  ),
+                  Case(
+                    Term.Name("Nil"),
+                    None,
+                    Term.Apply(Term.Name("println"), List(Lit.String("Nil")))
+                  )
+                ),
+                Nil
+              ),
+              List(
+                Case(
+                  Pat.Typed(
+                    Pat.Var(Term.Name("ex")),
+                    Type.Select(
+                      Term.Select(Term.Name("java"), Term.Name("io")),
+                      Type.Name("IOException")
+                    )
+                  ),
+                  None,
+                  Term.Apply(Term.Name("println"), List(Term.Name("ex")))
+                ),
+                Case(
+                  Pat.Typed(Pat.Var(Term.Name("ex")), Type.Name("Throwable")),
+                  None,
+                  Term.Block(List(Term.Throw(Term.Name("ex")), Term.EndMarker(Term.Name("try"))))
+                )
+              ),
+              None
+            )
+          ),
+          Nil
+        )
+      )
+    )
+  }
 }


### PR DESCRIPTION
The same as with match expressions