### PR TITLE
[Scala3] Significant indentation - handle comments properly

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -2038,4 +2038,130 @@ class SignificantIndentationSuite extends BaseDottySuite {
     )
   }
 
+  test("colon-eol-comment1") {
+    runTestAssert[Stat](
+      """|object Foo:
+         |  /*inline*/ def foo: Int = ???
+         |  def bar: Int = ???
+         |""".stripMargin,
+      assertLayout = None
+    )(
+      Defn.Object(
+        Nil,
+        Term.Name("Foo"),
+        Template(
+          Nil,
+          Nil,
+          Self(Name(""), None),
+          List(
+            Defn.Def(Nil, Term.Name("foo"), Nil, Nil, Some(Type.Name("Int")), Term.Name("???")),
+            Defn.Def(Nil, Term.Name("bar"), Nil, Nil, Some(Type.Name("Int")), Term.Name("???"))
+          ),
+          Nil
+        )
+      )
+    )
+  }
+
+  test("colon-eol-comment2") {
+    runTestAssert[Stat](
+      """|object Foo: /* comment*/
+         |  def foo: Int = ???
+         |""".stripMargin,
+      assertLayout = None
+    )(
+      Defn.Object(
+        Nil,
+        Term.Name("Foo"),
+        Template(
+          Nil,
+          Nil,
+          Self(Name(""), None),
+          List(Defn.Def(Nil, Term.Name("foo"), Nil, Nil, Some(Type.Name("Int")), Term.Name("???"))),
+          Nil
+        )
+      )
+    )
+  }
+
+  test("colon-eol-multiline-comment") {
+    runTestAssert[Stat](
+      """|object Foo:/* multi
+         |  line
+         |   comment */ def foo: Int = ???
+         |   def bar: Int = ???
+         |""".stripMargin,
+      assertLayout = None
+    )(
+      Defn.Object(
+        Nil,
+        Term.Name("Foo"),
+        Template(
+          Nil,
+          Nil,
+          Self(Name(""), None),
+          List(
+            Defn.Def(Nil, Term.Name("foo"), Nil, Nil, Some(Type.Name("Int")), Term.Name("???")),
+            Defn.Def(Nil, Term.Name("bar"), Nil, Nil, Some(Type.Name("Int")), Term.Name("???"))
+          ),
+          Nil
+        )
+      )
+    )
+  }
+
+  test("given-with-comment") {
+    runTestAssert[Stat](
+      """|given Foo with
+         |   /* comment */  def foo: Int = ???
+         |   def bar: Int = ???
+         |""".stripMargin,
+      assertLayout = None
+    )(
+      Defn.Given(
+        Nil,
+        Name(""),
+        Nil,
+        Nil,
+        Template(
+          Nil,
+          List(Init(Type.Name("Foo"), Name(""), Nil)),
+          Self(Name(""), None),
+          List(
+            Defn.Def(Nil, Term.Name("foo"), Nil, Nil, Some(Type.Name("Int")), Term.Name("???")),
+            Defn.Def(Nil, Term.Name("bar"), Nil, Nil, Some(Type.Name("Int")), Term.Name("???"))
+          ),
+          Nil
+        )
+      )
+    )
+  }
+
+  test("given-with-miltiline-comment") {
+    runTestAssert[Stat](
+      """|given Foo with /* multi
+         |   line
+         |   comment */  def foo: Int = ???
+         |   def bar: Int = ???
+         |""".stripMargin,
+      assertLayout = None
+    )(
+      Defn.Given(
+        Nil,
+        Name(""),
+        Nil,
+        Nil,
+        Template(
+          Nil,
+          List(Init(Type.Name("Foo"), Name(""), Nil)),
+          Self(Name(""), None),
+          List(
+            Defn.Def(Nil, Term.Name("foo"), Nil, Nil, Some(Type.Name("Int")), Term.Name("???")),
+            Defn.Def(Nil, Term.Name("bar"), Nil, Nil, Some(Type.Name("Int")), Term.Name("???"))
+          ),
+          Nil
+        )
+      )
+    )
+  }
 }


### PR DESCRIPTION
Indentation calculation rules:
- for single-line comment, spaces between newline and the start of comment
  ```scala
  object Foo:
     /* comment */ def foo: Int = ??? // <- indent = 3
- for multiline, spaces between newline and firts non-whitespace character
  ```scala
  object Foo: /* multi
   line
     comment */ def foo: Int = ??? // <- indent = 3
  ```
  
Fixes #2424 