### PR TITLE
[Scala 3] Recognize implicit closures only if next token is not a SoftModifier

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -5136,7 +5136,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
         if (token.is[KwImplicit]) {
           val implicitPos = in.tokenPos
           next()
-          if (token.is[Ident]) stats += implicitClosure(BlockStat)
+          if (token.is[Ident] && token.isNot[SoftModifier]) stats += implicitClosure(BlockStat)
           else stats += localDef(Some(atPos(implicitPos, implicitPos)(Mod.Implicit())))
         } else {
           stats += localDef(None)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InlineSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InlineSuite.scala
@@ -559,4 +559,39 @@ class InlineSuite extends BaseDottySuite {
       )
     )
   }
+
+  test("transparent-inline-with-this") {
+    runTestAssert[Stat](
+      """|"static meta" - {
+         |   implicit inline def qm = ???
+         |}
+         |""".stripMargin,
+      assertLayout = Some(
+        """|"static meta" - ({
+           |  implicit inline def qm = ???
+           |})
+           |""".stripMargin
+      )
+    )(
+      Term.ApplyInfix(
+        Lit.String("static meta"),
+        Term.Name("-"),
+        Nil,
+        List(
+          Term.Block(
+            List(
+              Defn.Def(
+                List(Mod.Implicit(), Mod.Inline()),
+                Term.Name("qm"),
+                Nil,
+                Nil,
+                None,
+                Term.Name("???")
+              )
+            )
+          )
+        )
+      )
+    )
+  }
 }


### PR DESCRIPTION
Previously, we would only check for Ident, which is not enough for Scala 3.

Causes https://github.com/scalameta/scalafmt/issues/2640