### PR TITLE
Support new Scala3 modifiers

### DIFF
--- a/docs/semanticdb/specification.md
+++ b/docs/semanticdb/specification.md
@@ -794,6 +794,37 @@ languages map onto these properties.
     <td><code>DEFAULT</code></td>
     <td>Is a default parameter or a default method?</td>
   </tr>
+  <tr>
+    <td><code>0x10000</code></td>
+    <td><code>GIVEN</code></td>
+    <td>Is a given instance?</td>
+    <td>Is a <code>given instance</code> (e.g. <code>given x: Int = ...</code> or <code>using x: Int</code>)?</td>
+  </tr>
+  <tr>
+    <td><code>0x20000</code></td>
+    <td><code>INLINE</code></td>
+    <td>Has an <code>inline</code> modifier?</td>
+  </tr>
+  <tr>
+    <td><code>0x40000</code></td>
+    <td><code>OPEN</code></td>
+    <td>Has an <code>open</code> modifier?</td>
+  </tr>
+  <tr>
+    <td><code>0x80000</code></td>
+    <td><code>TRANSPARENT</code></td>
+    <td>Has a <code>transparent</code> modifier?</td>
+  </tr>
+  <tr>
+    <td><code>0x100000</code></td>
+    <td><code>INFIX</code></td>
+    <td>Has a <code>infix</code> modifier?</td>
+  </tr>
+  <tr>
+    <td><code>0x200000</code></td>
+    <td><code>OPAQUE</code></td>
+    <td>Has an <code>opaque</code> modifier?</td>
+  </tr>
 </table>
 
 `display_name`. Display name of the definition, i.e. how this definition should

--- a/semanticdb/metap/src/main/scala/scala/meta/internal/metap/SymbolInformationPrinter.scala
+++ b/semanticdb/metap/src/main/scala/scala/meta/internal/metap/SymbolInformationPrinter.scala
@@ -56,6 +56,12 @@ trait SymbolInformationPrinter extends BasePrinter {
       if (info.isPrimary) out.print("primary ")
       if (info.isEnum) out.print("enum ")
       if (info.isDefault) out.print("default ")
+      if (info.isGiven) out.print("given ")
+      if (info.isInline) out.print("inline ")
+      if (info.isOpen) out.print("open ")
+      if (info.isTransparent) out.print("transparent ")
+      if (info.isInfix) out.print("infix ")
+      if (info.isOpaque) out.print("opaque ")
       info.kind match {
         case LOCAL => out.print("local ")
         case FIELD => out.print("field ")

--- a/semanticdb/semanticdb/semanticdb.proto
+++ b/semanticdb/semanticdb/semanticdb.proto
@@ -270,6 +270,12 @@ message SymbolInformation {
     PRIMARY = 0x2000;
     ENUM = 0x4000;
     DEFAULT = 0x8000;
+    GIVEN = 0x10000;
+    INLINE = 0x20000;
+    OPEN = 0x40000;
+    TRANSPARENT = 0x80000;
+    INFIX = 0x100000;
+    OPAQUE = 0x200000;
   }
   reserved 2, 6, 7, 8, 9, 10, 11, 12, 14, 15;
   string symbol = 1;

--- a/semanticdb/semanticdb/src/main/scala/scala/meta/internal/semanticdb/package.scala
+++ b/semanticdb/semanticdb/src/main/scala/scala/meta/internal/semanticdb/package.scala
@@ -44,6 +44,12 @@ package object semanticdb {
     def isPrimary: Boolean = (info.properties & p.PRIMARY.value) != 0
     def isEnum: Boolean = (info.properties & p.ENUM.value) != 0
     def isDefault: Boolean = (info.properties & p.DEFAULT.value) != 0
+    def isGiven: Boolean = (info.properties & p.GIVEN.value) != 0
+    def isInline: Boolean = (info.properties & p.INLINE.value) != 0
+    def isOpen: Boolean = (info.properties & p.OPEN.value) != 0
+    def isTransparent: Boolean = (info.properties & p.TRANSPARENT.value) != 0
+    def isInfix: Boolean = (info.properties & p.INFIX.value) != 0
+    def isOpaque: Boolean = (info.properties & p.OPAQUE.value) != 0
     def isPrivate: Boolean = info.access.isInstanceOf[PrivateAccess]
     def isPrivateThis: Boolean = info.access.isInstanceOf[PrivateThisAccess]
     def isPrivateWithin: Boolean = info.access.isInstanceOf[PrivateWithinAccess]


### PR DESCRIPTION
This PR adds the following new modifiers for Scala3 to SemanticDB specification.

- Given
  - https://docs.scala-lang.org/scala3/reference/contextual/givens.html
  - for `given x: Int`, `given Int`, `using ctx: Context` and `using Context`
- Inline
  - https://docs.scala-lang.org/scala3/reference/metaprogramming/inline.html
- Open
  - https://docs.scala-lang.org/scala3/reference/other-new-features/open-classes.html
- Transparent
  - https://docs.scala-lang.org/scala3/reference/other-new-features/transparent-traits.html
- Infix
  - https://docs.scala-lang.org/scala3/reference/changed-features/operators.html
- Opaque
  - https://docs.scala-lang.org/scala3/reference/other-new-features/opaques.html

FYI here's the generated code from this new SemanticDB schema https://github.com/tanishiking/semanticdb-for-scala3/pull/2

---

Maybe we should also support `extension` modifier in the future, but how to encode `extension` seems a bit complicated. Therefore let's start with simple modifiers first.

- https://github.com/lampepfl/dotty/issues/11690
- https://discord.com/channels/632642981228314653/632642981228314657/867097982860394526 

---

After this PR merged, we have to

- [ ] Support new modifiers in `metap`
- [ ] Extend `ExtracctSemanticDB` of Scala3

Or should we implement the Scala3 side first, before updating the schema?