### PR TITLE
Scaladoc: treat tag description as optional

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
@@ -39,7 +39,6 @@ object ScaladocParser {
   private def punctParser[_: P] = CharsWhileIn(".,:!?;)", 0)
   private def labelParser[_: P]: P[Unit] = (!space ~ AnyChar).rep(1)
   private def wordParser[_: P]: P[Word] = P(labelParser.!.map(Word.apply))
-  private def trailWordParser[_: P] = nlHspaces1 ~ wordParser
 
   private def listPrefix[_: P] = "-" | CharIn("1aiI") ~ "."
 
@@ -122,29 +121,32 @@ object ScaladocParser {
     text.map(x => Text(x.toSeq))
   }
 
-  private def trailTextParser[_: P]: P[Text] = P(nlHspaces1 ~ textParser)
   private def leadTextParser[_: P]: P[Text] = P((space | Start) ~ hspaces0 ~ textParser)
+
+  private def tagLabelParser[_: P]: P[Word] = nlHspaces1 ~ wordParser
+
+  private def tagDescParser[_: P]: P[Text] = P(nlHspaces1 ~ textParser)
 
   private def tagParser[_: P]: P[Tag] = P {
     def tagTypeMap = TagType.predefined.map(x => x.tag -> x).toMap
     def getParserByTag(tag: String): P[Tag] = {
       val tagTypeOpt = tagTypeMap.get(tag)
       tagTypeOpt.fold[P[Tag]] {
-        trailTextParser.map { desc => Tag(TagType.UnknownTag(tag), desc = desc) }
+        tagDescParser.map { desc => Tag(TagType.UnknownTag(tag), desc = desc) }
       } { tagType =>
         (tagType.hasLabel, tagType.hasDesc) match {
           case (false, false) => Pass(Tag(tagType))
-          case (false, true) => trailTextParser.map(x => Tag(tagType, desc = x))
-          case (true, false) => trailWordParser.map(x => Tag(tagType, label = x))
+          case (false, true) => tagDescParser.map(x => Tag(tagType, desc = x))
+          case (true, false) => tagLabelParser.map(x => Tag(tagType, label = x))
           case (true, true) =>
-            (trailWordParser ~ trailTextParser).map { case (label, desc) =>
+            (tagLabelParser ~ tagDescParser).map { case (label, desc) =>
               Tag(tagType, label, desc)
             }
         }
       }
     }
-    def tagLabelParser = P(("@" ~ labelParser).!)
-    leadHspaces0 ~ tagLabelParser.flatMap(getParserByTag)
+    def tagTypeParser = P(("@" ~ labelParser).!)
+    leadHspaces0 ~ tagTypeParser.flatMap(getParserByTag)
   }
 
   private def listBlockParser[_: P](minIndent: Int = 1): P[ListBlock] = P {

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
@@ -111,10 +111,14 @@ object ScaladocParser {
     pattern.map { case (x, y) => new Link(x, y) }
   }
 
-  private def textParser[_: P]: P[Text] = P {
+  private def nextPartParser[_: P]: P[Unit] = P {
     def mdCodeBlockPrefix = mdCodeBlockIndent ~ mdCodeBlockFence
     def anotherBeg = P(CharIn("@=") | (codePrefix ~ nl) | listPrefix | tableSep | "+-" | nl)
-    def end = P(End | nl ~/ (mdCodeBlockPrefix | hspaces0 ~/ anotherBeg))
+    nl ~/ (nl | mdCodeBlockPrefix | hspaces0 ~/ anotherBeg)
+  }
+
+  private def textParser[_: P]: P[Text] = P {
+    def end = P(End | nextPartParser)
     def part: P[TextPart] = P(!paraEnd ~ (codeExprParser | linkParser | wordParser))
     def sep = P(!end ~ nlHspaces0)
     def text = hspaces0 ~ part.rep(1, sep = sep)

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
@@ -127,9 +127,11 @@ object ScaladocParser {
 
   private def leadTextParser[_: P]: P[Text] = P((space | Start) ~ hspaces0 ~ textParser)
 
-  private def tagLabelParser[_: P]: P[Word] = nlHspaces1 ~ wordParser
+  private def tagLabelParser[_: P]: P[Word] = P(!nextPartParser ~ nlHspaces1 ~ wordParser)
 
-  private def tagDescParser[_: P]: P[Text] = P(nlHspaces1 ~ textParser)
+  private def tagDescParser[_: P]: P[Text] = P {
+    hspaces0 ~ (textParser | !nextPartParser ~ nl ~ textParser).?.map(_.orNull)
+  }
 
   private def tagParser[_: P]: P[Tag] = P {
     def tagTypeMap = TagType.predefined.map(x => x.tag -> x).toMap

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
@@ -699,7 +699,7 @@ class ScaladocParserSuite extends FunSuite {
           Paragraph(
             Seq(
               Tag(TagType.Param, Word("foo"), Text(Seq(Word("-"), Word("bar"), Word("baz")))),
-              Text(Seq(Word("@return")))
+              Tag(TagType.Return)
             )
           )
         )
@@ -721,7 +721,10 @@ class ScaladocParserSuite extends FunSuite {
       Scaladoc(
         Seq(
           Paragraph(
-            Seq(Tag(TagType.Param, Word("foo"), Text(Seq(Word("-"), Word("bar"), Word("baz")))))
+            Seq(
+              Tag(TagType.Param, Word("foo")),
+              ListBlock("-", Seq(ListItem(Text(Seq(Word("bar"), Word("baz"))))))
+            )
           )
         )
       )
@@ -743,7 +746,8 @@ class ScaladocParserSuite extends FunSuite {
         Seq(
           Paragraph(
             Seq(
-              Tag(TagType.UnknownTag("@foo"), null, Text(Seq(Word("-"), Word("bar"), Word("baz"))))
+              Tag(TagType.UnknownTag("@foo")),
+              ListBlock("-", Seq(ListItem(Text(Seq(Word("bar"), Word("baz"))))))
             )
           )
         )
@@ -884,7 +888,7 @@ class ScaladocParserSuite extends FunSuite {
           */
          """
       ),
-      Option(Scaladoc(Seq(Paragraph(Seq(Text(Seq(Word("@param"))), Text(Seq(Word("@return"))))))))
+      Option(Scaladoc(Seq(Paragraph(Seq(Text(Seq(Word("@param"))), Tag(TagType.Return))))))
     )
   }
 
@@ -944,14 +948,9 @@ class ScaladocParserSuite extends FunSuite {
           Paragraph(
             Seq(
               Text(Seq(Word("blah"))),
-              Tag(
-                TagType.Example,
-                desc = Text(
-                  Seq(Word("{{{")) ++
-                    complexCodeBlockWords ++
-                    Seq(Word("}}}"), Word("bar"), Word("baz"))
-                )
-              ),
+              Tag(TagType.Example),
+              CodeBlock(complexCodeBlock),
+              Text(Seq(Word("bar"), Word("baz"))),
               CodeBlock(complexCodeBlock),
               Text(Seq(Word("baz"), Word("qux")))
             )
@@ -994,14 +993,9 @@ class ScaladocParserSuite extends FunSuite {
           Paragraph(
             Seq(
               Text(Seq(Word("blah"))),
-              Tag(
-                TagType.Example,
-                desc = Text(
-                  Seq(Word("```info1"), Word("info2")) ++
-                    complexCodeBlockWords
-                )
-              ),
-              Text(Seq(Word("```"), Word("bar"), Word("baz"))),
+              Tag(TagType.Example),
+              MdCodeBlock(Seq("info1", "info2"), complexCodeBlock, "```"),
+              Text(Seq(Word("bar"), Word("baz"))),
               MdCodeBlock(Seq("info3", "info4"), complexCodeBlock, "```"),
               Text(Seq(Word("baz"), Word("qux")))
             )


### PR DESCRIPTION
Don't consume other elements (tags, code blocks, etc.) if description is expected but in reality missing.

Fixes #2444.