### PR TITLE
Fix UnreachableError when printing a pattern match bind to a case object

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -239,7 +239,7 @@ object TreeSyntax {
           case p: Pat.Wildcard => unreachable
           case p: Pat.Var => false
           case p: Pat.Repeated => false
-          case p: Pat.Bind => unreachable
+          case p: Pat.Bind => true
           case p: Pat.Alternative => true
           case p: Pat.Tuple => true
           case p: Pat.Extract => p.args.exists(_ eq t)

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -1087,6 +1087,14 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     checkTree(Lit.String("ラーメン"), "\"ラーメン\"")
   }
 
+  test("#2447 Pat.Bind on Term.Name") {
+    checkTree(q"{ case x @ Y => x }", "{\n  case x @ Y => x\n}")
+  }
+
+  test("#2447 Pat.Bind on Term.Name backticks") {
+    checkTree(q"{ case x @ `y` => x }", "{\n  case x @ `y` => x\n}")
+  }
+
   def checkTree(original: Tree, expected: String)(implicit loc: munit.Location): Unit = {
     assertNoDiff(original.syntax, expected)
     assertNoDiff(original.structure, expected.parse[Stat].get.structure)


### PR DESCRIPTION
Fixes #2447

Please take a good look at if this is not breaking anything 🙏.

`{ case x => Y => () }` parses differently than `{ case x @ y => () }`. I'm assuming this is on purpose and for a very good reason.

This PR changes the `thisLocationAlsoAcceptsPatVars` to return true for a `Pat.Bind`. I'm _assuming_ this is correct, as in a pattern match a `Pat.Var` can also take the place of a `Pat.Bind` (like in `{ case x => () }`).

EDIT: I just noticed that the [documentation](https://scalameta.org/docs/trees/quasiquotes.html#patterns-metapat-and-cases-metacase) mentions a `Pat.Bind` always consisting of two `Pat`'s. Is this correct, and does it mean that `x @ Y` should be parsed differently? (now it is `Pat.Bind(Pat.Var(Term.Name("x")), Term.Name("Y")))`)