### PR TITLE
Document how to run website locally and refine document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,3 +79,38 @@ In case of any questions, don't hesitate to ask on our
 (these guidelines have been adapted from
 https://github.com/lihaoyi/ammonite#contribution-guidelines)
 
+
+### Running the site locally
+
+The website is built using [Docusaurus](https://docusaurus.io/).
+
+For running the website locally, you'll need:
+
+- `yarn` (https://yarnpkg.com/lang/en/docs/install-ci/)
+- `sbt` (https://www.scala-sbt.org/1.0/docs/Setup.html)
+
+In addition to Docusaurus, we preprocess the markdown files using:
+
+- [mdoc](https://github.com/scalameta/mdoc), to type-check, interpret Scala
+  code fences, and to generate the site using its [built-in Docusaurus support](https://scalameta.org/mdoc/docs/docusaurus.html).
+
+The first step is to then preprocess the markdown files. You can do it with:
+
+```sh
+sbt
+docs/mdoc -w
+```
+
+This command will watch for new changes for Markdown files in the `docs/`
+directory and regenerate the files when they change.
+
+You can now build and launch the website using these commands:
+
+```sh
+cd website
+yarn install # only the first time, to install the dependencies
+yarn start
+```
+
+Now visit http://localhost:3000 and you should see a local version of the
+website. New changes should trigger a reload in the browser.

--- a/docs/semanticdb/specification.md
+++ b/docs/semanticdb/specification.md
@@ -797,7 +797,6 @@ languages map onto these properties.
   <tr>
     <td><code>0x10000</code></td>
     <td><code>GIVEN</code></td>
-    <td>Is a given instance?</td>
     <td>Is a <code>given instance</code> (e.g. <code>given x: Int = ...</code> or <code>using x: Int</code>)?</td>
   </tr>
   <tr>


### PR DESCRIPTION
- Document how to run the website locally
  - https://github.com/scalameta/scalameta/commit/426c3dcf33cf445a2ce2c5183f7dbb2eecfb4fc0
  - Realized there's no documentation on how to run the website locally, and I added the docs for it (basically copied from https://scalameta.org/metals/docs/contributors/updating-website)
- Remove redundant column from properties table
  - Sorry, I introduced a redundant column to the doc before 😅 

### before
<img width="866" alt="Screen Shot 2021-09-05 at 16 52 12" src="https://user-images.githubusercontent.com/9353584/132119797-7f0a4675-f760-4c50-b746-4fb94dde65f5.png">

### after
<img width="866" alt="Screen Shot 2021-09-05 at 16 54 01" src="https://user-images.githubusercontent.com/9353584/132119804-39a9f87a-aa55-49c6-bba9-f9183ed4eda5.png">
