### PR TITLE
Do not escape symbols in multiline string interpolation

### DIFF
--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
@@ -695,10 +695,13 @@ class LegacyScanner(input: Input, dialect: Dialect) {
         setStrVal()
         token = STRINGLIT
       }
-    } else if (ch == '\\') {
-      nextRawChar()
+    } else if (ch == '\\' && !multiLine) {
       putChar(ch)
       nextRawChar()
+      if (ch == '"' || ch == '\\') {
+        putChar(ch)
+        nextRawChar()
+      }
       getStringPart(multiLine)
     } else if (ch == '$' && !isUnicodeEscape) {
       if (!getDollar()) {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -806,7 +806,7 @@ class TermSuite extends ParseSuite {
   test("fstring-interpolation") {
     val Term.Interpolate(
       Term.Name("f"),
-      List(Lit.String("\\u"), Lit.String("%04x")),
+      List(Lit.String("\\\\u"), Lit.String("%04x")),
       List(Term.Name("oct"))
     ) = term("""f"\\u$oct%04x"""")
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
@@ -1008,7 +1008,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
       BOF(),
       Interpolation.Id("s"),
       Interpolation.Start(),
-      Interpolation.Part("\"Hello\", "),
+      Interpolation.Part("\\\"Hello\\\", "),
       Interpolation.SpliceStart(),
       Ident("person"),
       Interpolation.SpliceEnd(),
@@ -1021,6 +1021,27 @@ class TokenizerSuite extends BaseTokenizerSuite {
     assert(
       ("""s"\\"Hello"""").tokenize.isInstanceOf[Tokenized.Error]
     )
+
+  }
+
+  test("Multiline interpolated string - ignore escape") {
+    val Tokens(
+      BOF(),
+      Interpolation.Id("raw"),
+      Interpolation.Start(),
+      Interpolation.Part("\\"),
+      Interpolation.SpliceStart(),
+      Ident("host"),
+      Interpolation.SpliceEnd(),
+      Interpolation.Part("\\"),
+      Interpolation.SpliceStart(),
+      Ident("share"),
+      Interpolation.SpliceEnd(),
+      Interpolation.Part("\\"),
+      Interpolation.End(),
+      EOF()
+    ) =
+      ("raw\"\"\"\\$host\\$share\\\"\"\"").tokenize.get
 
   }
 }


### PR DESCRIPTION
Fixes #2467.
Aligned with [implementation in compiler](https://github.com/lampepfl/dotty/blob/adefa482667f8a3bfed9951c522677b2418d9610/compiler/src/dotty/tools/dotc/parsing/Scanners.scala#L1141-L1148)