### PR TITLE
Remove invalid "default" JSExportTopLevel

### DIFF
--- a/scalameta/parsers/js/src/main/scala/scala/meta/parsers/JSFacade.scala
+++ b/scalameta/parsers/js/src/main/scala/scala/meta/parsers/JSFacade.scala
@@ -108,13 +108,11 @@ object JSFacade {
         }
     }
 
-  @JSExportTopLevel("default")
   @JSExportTopLevel("parseSource")
   def parseSource(
       code: String
   ): js.Dictionary[Any] = parse[Source](code, defaultSettings)
 
-  @JSExportTopLevel("default")
   @JSExportTopLevel("parseSource")
   def parseSource(
       code: String,


### PR DESCRIPTION
This causes linking errors in a Scala 3 / Scala.js 1 project

> Invalid top level export for name 'default' in class scala.meta.parsers.JSFacade$ when emitting a Script (NoModule) because it is not a valid JavaScript identifier (did you want to emit a module instead?)

The default export was also never used in practice, and it's better to access the single exported elements instead.