### PR TITLE
ScaladocParser - minor fix for linkParser

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
@@ -107,7 +107,7 @@ object ScaladocParser {
   private def linkParser[_: P]: P[Link] = P {
     def end = space | linkSuffix
     def anchor = P((!end ~ AnyChar).rep(1).!.rep(1, sep = spaces1))
-    def pattern = linkPrefix ~ (anchor ~ linkSuffix ~ punctParser.!)
+    def pattern = linkPrefix ~ (anchor ~ linkSuffix ~ labelParser.?.!)
     pattern.map { case (x, y) => new Link(x, y) }
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
@@ -133,7 +133,7 @@ class ScaladocParserSuite extends FunSuite {
     val words = descriptionBody.split("\\s+").toSeq.map(Word.apply)
     val refNone = Seq(Link("Description", Seq("Body"), ""))
     val refDots = Seq(Link("Description", Seq("Body"), "..."))
-    val refExcl = Seq(Link("Description", Seq("Body"), "!"))
+    val refWithSuffix = Seq(Link("Description", Seq("Body"), "'s"))
     assertEquals(
       parseString(
         s"""
@@ -144,10 +144,10 @@ class ScaladocParserSuite extends FunSuite {
           * $descriptionBody [[ $descriptionBody ]]
           * $descriptionBody
           *
-          * [[ $descriptionBody ]]!$descriptionBody
-          *
           * $descriptionBody
           * [[ $descriptionBody ]] $descriptionBody
+          * 
+          * [[ $descriptionBody ]]'s
           *
           */
          """
@@ -157,8 +157,8 @@ class ScaladocParserSuite extends FunSuite {
           Seq(
             Paragraph(Seq(Text(words ++ refDots))),
             Paragraph(Seq(Text(words ++ refNone ++ words))),
-            Paragraph(Seq(Text(refExcl ++ words))),
-            Paragraph(Seq(Text(words ++ refNone ++ words)))
+            Paragraph(Seq(Text(words ++ refNone ++ words))),
+            Paragraph(Seq(Text(refWithSuffix)))
           )
         )
       )


### PR DESCRIPTION
Link might have some symbols at the end and we need to consume in as punc.
Otherwise it parses as separate `Word` and scalafmt writes is with an
additional space.

Example:
```scala
// before
"[Link]'s" -> Seq(Link("Link"), Word("'s"))
//after
"[Link]'s" -> Seq("Link", Seq.empty, "'s")
```

Should fix [this sample](https://github.com/scalameta/scalameta/pull/2468#discussion_r703208311)