### PR TITLE
Remove option that breaks Metals&SBT on JDK 17

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -3,5 +3,4 @@
 -Xmx8G
 -XX:ReservedCodeCacheSize=1024m
 -XX:+TieredCompilation
--XX:+CMSClassUnloadingEnabled
 -Dsbt.server.autostart=false


### PR DESCRIPTION
- It breaks metals quietly on startup
- Breaks SBT loudly