### PR TITLE
Allow refinement in type position of given definition

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -4297,7 +4297,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
           (anonymousName, List.empty, List.empty)
       }
 
-    val decltype = startModType()
+    val decltype = if (token.is[LeftBrace]) refinement(None) else startModType()
 
     def parents() = {
       val parents = ListBuffer[Init](

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -1046,7 +1046,7 @@ object TreeSyntax {
           )
 
       // Init
-      case t: Init => s(if (t.tpe.is[Type.Singleton]) kw("this") else p(AnnotTyp, t.tpe), t.argss)
+      case t: Init => s(if (t.tpe.is[Type.Singleton]) kw("this") else p(RefineTyp, t.tpe), t.argss)
 
       // Self
       case t: Self => s(t.name, t.decltpe)

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/package.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/package.scala
@@ -117,6 +117,7 @@ package object trees {
       case _: Type.Annotate => true
       case _: Type.Apply => true
       case _: Type.ApplyInfix => true
+      case _: Type.Refine => true
       case Type.Singleton(Term.This(Name.Anonymous())) => true
       case _ => false
     }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
@@ -540,6 +540,37 @@ class GivenUsingSuite extends BaseDottySuite {
     )
   }
 
+  test("given-with-empty-refinement") {
+    runTestAssert[Stat](
+      code = """|given {} with
+                |  extension [T](t: T) def hello = ""
+                |""".stripMargin,
+      assertLayout = Some(
+        """given {} with { extension [T](t: T) def hello = "" }"""
+      )
+    )(
+      Defn.Given(
+        Nil,
+        Name(""),
+        Nil,
+        Nil,
+        Template(
+          Nil,
+          List(Init(Type.Refine(None, Nil), Name(""), Nil)),
+          Self(Name(""), None),
+          List(
+            Defn.ExtensionGroup(
+              List(Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, Nil)),
+              List(List(Term.Param(Nil, Term.Name("t"), Some(Type.Name("T")), None))),
+              Defn.Def(Nil, Term.Name("hello"), Nil, Nil, None, Lit.String(""))
+            )
+          ),
+          Nil
+        )
+      )
+    )
+  }
+
   // ---------------------------------
   // GIVEN ALIAS
   // ---------------------------------


### PR DESCRIPTION
Fixes https://github.com/scalameta/scalameta/issues/2483

@bishabosha is this the only place where you can have refinement?

Nothing along the lines of:
```scala
given {def a = "" } with { def b = 123 } with
  extension [T](t: T) def hello: String = s"hello, I am $t"
```
?

The above doesn't seem to compile. :thinking: 
