### PR TITLE
Don't fail on empty signature

### DIFF
--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SymbolInformationOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SymbolInformationOps.scala
@@ -149,6 +149,8 @@ trait SymbolInformationOps { self: SemanticdbOps =>
               val sparamss = Nil
               val sret = ssig.tpe
               s.MethodSignature(stparams, sparamss, sret)
+            case s.Signature.Empty =>
+              s.NoSignature
             case _ =>
               sys.error(s"unsupported signature: ${ssig.getClass} $ssig")
           }


### PR DESCRIPTION
In some cases empty signature might show up when semanticdb is generated in the presentation compiler. In that case it's normal that it can happen.

Fixes https://github.com/scalameta/scalameta/issues/2499