### PR TITLE
2.13.4+ requires explicit guidance around irrefutable unapply methods

### DIFF
--- a/scalameta/tokens/shared/src/main/scala/scala/meta/tokens/Tokens.scala
+++ b/scalameta/tokens/shared/src/main/scala/scala/meta/tokens/Tokens.scala
@@ -88,7 +88,7 @@ import scala.meta.internal.prettyprinters._
 object Tokens {
   private[meta] def apply(tokens: Array[Token], start: Int, end: Int): Tokens =
     new Tokens(tokens, start, end)
-  def unapplySeq(tokens: Tokens): Option[Seq[Token]] = Some(tokens)
+  def unapplySeq(tokens: Tokens): Some[Seq[Token]] = Some(tokens)
 
   implicit val tokensToInput: Convert[Tokens, Input] =
     Convert(tokens => Input.String(tokens.syntax))

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -35,7 +35,7 @@ object Tree extends InternalTreeXtensions {
 @branch trait Name extends Ref { def value: String }
 object Name {
   def apply(value: String): Name = if (value == "") Name.Anonymous() else Name.Indeterminate(value)
-  def unapply(name: Name): Option[String] = Some(name.value)
+  def unapply(name: Name): Some[String] = Some(name.value)
   @ast class Anonymous() extends Name {
     def value = ""
     checkParent(ParentChecks.NameAnonymous)
@@ -47,7 +47,7 @@ object Name {
   def value: Any
 }
 object Lit {
-  def unapply(arg: Lit): Option[Any] = Some(arg.value)
+  def unapply(arg: Lit): Some[Any] = Some(arg.value)
   @ast class Null() extends Lit { def value: Any = null }
   @ast class Int(value: scala.Int) extends Lit
   // NOTE: Lit.Double/Float are strings to work the same across JS/JVM. Example:


### PR DESCRIPTION
Context for this PR: https://github.com/scala/bug/issues/12232#issuecomment-734811470

This represents the majority of `match may not be exhaustive` warnings in my codebase.

Given this trivial program on 2.13.6:

```scala
import scala.meta._

object App extends App {
  val Name(name) = Term.Name("foo")
}
```

we get:

```
[info] compiling 11 Scala sources to .../target/scala-2.13/classes ...
[warn] .../src/main/scala/App.scala:16:29: match may not be exhaustive.
[warn]   val Term.Name(name) = Term.Name("foo")
[warn]                                  ^
```

The mechanical change is to identify places where `unapply` trivially returns a `Some` instead of an `Option` and constrain the result type.