### PR TITLE
Don't allow indentation on `=>` in enums

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -310,12 +310,23 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
       }
     }
 
+    /**
+     * Deals with different rules for indentation after self type arrow.
+     */
     def undoIndent(): Unit = {
-      sepRegions = sepRegions match {
+      sepRegions match {
         case region :: others if region.isIndented && curr.token.is[Indentation.Indent] =>
           next()
-          others
-        case regions => regions
+          sepRegions = sepRegions match {
+            // deal with  region added by `case` in enum after self type
+            case RegionArrow :: _ => others
+            // if no region was added
+            case `region` :: _ => others
+            // keep any added region in `next()`
+            case head :: _ => head :: others
+            case _ => sepRegions
+          }
+        case _ =>
       }
     }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EnumSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EnumSuite.scala
@@ -603,6 +603,51 @@ class EnumSuite extends BaseDottySuite {
     )
   }
 
+  test("enum-arrow-toplevel") {
+    val code =
+      """|enum T2Enum:
+         |  case Hmm
+         |  val a = () =>  
+         |    fx()
+         |    gx()
+    """.stripMargin
+    val expected =
+      """|enum T2Enum {
+         |  case Hmm
+         |  val a = () => {
+         |    fx()
+         |    gx()
+         |  }
+         |}
+         |""".stripMargin
+    runTestAssert[Stat](code, assertLayout = Some(expected))(
+      Defn.Enum(
+        Nil,
+        Type.Name("T2Enum"),
+        Nil,
+        Ctor.Primary(Nil, Name(""), Nil),
+        Template(
+          Nil,
+          Nil,
+          Self(Name(""), None),
+          List(
+            Defn.EnumCase(Nil, Term.Name("Hmm"), Nil, Ctor.Primary(Nil, Name(""), Nil), Nil),
+            Defn.Val(
+              Nil,
+              List(Pat.Var(Term.Name("a"))),
+              None,
+              Term.Function(
+                Nil,
+                Term.Block(List(Term.Apply(Term.Name("fx"), Nil), Term.Apply(Term.Name("gx"), Nil)))
+              )
+            )
+          ),
+          Nil
+        )
+      )
+    )
+  }
+
   private def enumWithCase(name: String, enumCase: Stat) = Defn.Enum(
     Nil,
     Type.Name(name),

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -2240,4 +2240,74 @@ class SignificantIndentationSuite extends BaseDottySuite {
     )
   }
 
+  test("i2505") {
+    runTestAssert[Source](
+      """|trait T2 { self: T =>
+         |  enum T2Enum:
+         |    case EnumCase
+         |  
+         |  extension (n: Int) def negate: Int = -n
+         |}""".stripMargin,
+      assertLayout = Some(
+        """|trait T2 { self: T =>
+           |  enum T2Enum { case EnumCase }
+           |  extension (n: Int) def negate: Int = -n
+           |}
+           |""".stripMargin
+      )
+    )(
+      Source(
+        List(
+          Defn.Trait(
+            Nil,
+            Type.Name("T2"),
+            Nil,
+            Ctor.Primary(Nil, Name(""), Nil),
+            Template(
+              Nil,
+              Nil,
+              Self(Term.Name("self"), Some(Type.Name("T"))),
+              List(
+                Defn.Enum(
+                  Nil,
+                  Type.Name("T2Enum"),
+                  Nil,
+                  Ctor.Primary(Nil, Name(""), Nil),
+                  Template(
+                    Nil,
+                    Nil,
+                    Self(Name(""), None),
+                    List(
+                      Defn.EnumCase(
+                        Nil,
+                        Term.Name("EnumCase"),
+                        Nil,
+                        Ctor.Primary(Nil, Name(""), Nil),
+                        Nil
+                      )
+                    ),
+                    Nil
+                  )
+                ),
+                Defn.ExtensionGroup(
+                  Nil,
+                  List(List(Term.Param(Nil, Term.Name("n"), Some(Type.Name("Int")), None))),
+                  Defn.Def(
+                    Nil,
+                    Term.Name("negate"),
+                    Nil,
+                    Nil,
+                    Some(Type.Name("Int")),
+                    Term.ApplyUnary(Term.Name("-"), Term.Name("n"))
+                  )
+                )
+              ),
+              Nil
+            )
+          )
+        )
+      )
+    )
+
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/scalameta/scalameta/issues/2505

PReviously, we would try to undo the indentation, but isntead we can just not introduce indentation on `=>` inside enums.