### PR TITLE
Testkit - ignore KafkaConfig file as it can't be transformed in EqualProps test

### DIFF
--- a/scalameta/testkit/jvm/src/main/scala/scala/meta/testkit/Corpus.scala
+++ b/scalameta/testkit/jvm/src/main/scala/scala/meta/testkit/Corpus.scala
@@ -70,7 +70,9 @@ object Corpus {
         // Not sure why this is failing but it's new, and earlier version of Scalaparse fail too
         "target/repos/scala/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala",
         "target/repos/scala/src/scaladoc/scala/tools/nsc/doc/html/HtmlPage.scala",
-        "target/repos/scala/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala"
+        "target/repos/scala/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala",
+        // transformer fails with StackOverflow - https://github.com/scalameta/scalameta/issues/2509
+        "target/repos/kafka/core/src/main/scala/kafka/server/KafkaConfig.scala"
       ).exists(x.startsWith)
   )
 


### PR DESCRIPTION
I think it would be a challenge to fix #2509  so it's easier to ignore this file in test.