### PR TITLE
Use Files.deleteIfExists

### DIFF
--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/RemoveOrphanSemanticdbFiles.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/RemoveOrphanSemanticdbFiles.scala
@@ -25,7 +25,7 @@ object RemoveOrphanSemanticdbFiles {
           if (PathIO.extension(file.getFileName) == SemanticdbPaths.semanticdbExtension) {
             val scalafile = SemanticdbPaths.toScala(AbsolutePath(file), sourceroot, targetroot)
             if (!scalafile.isFile || !config.fileFilter.matches(scalafile.toString)) {
-              Files.delete(file)
+              Files.deleteIfExists(file)
             }
           }
           FileVisitResult.CONTINUE


### PR DESCRIPTION
We had a failing test case in mdoc with this stack trace
```
java.nio.file.NoSuchFileException: /home/runner/work/mdoc/mdoc/tests/unit/target/scala-2.12/meta/META-INF/semanticdb/hello.sc.semanticdb
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixFileSystemProvider.implDelete(UnixFileSystemProvider.java:249)
	at java.base/sun.nio.fs.AbstractFileSystemProvider.delete(AbstractFileSystemProvider.java:105)
	at java.base/java.nio.file.Files.delete(Files.java:1152)
	at scala.meta.internal.semanticdb.scalac.RemoveOrphanSemanticdbFiles$$anon$1.visitFile(RemoveOrphanSemanticdbFiles.scala:28)
	at scala.meta.internal.semanticdb.scalac.RemoveOrphanSemanticdbFiles$$anon$1.visitFile(RemoveOrphanSemanticdbFiles.scala:23)
	at java.base/java.nio.file.Files.walkFileTree(Files.java:2811)
	at java.base/java.nio.file.Files.walkFileTree(Files.java:2882)
	at scala.meta.internal.semanticdb.scalac.RemoveOrphanSemanticdbFiles$.process(RemoveOrphanSemanticdbFiles.scala:23)
```

There's no point in making this codepath a fatal error.