### PR TITLE
Show a clear message when using secondary constructors in a wrong place

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -189,6 +189,20 @@ class MinorDottySuite extends BaseDottySuite {
     )
   }
 
+  test("secondary-trait-constructors") {
+    runTestError[Stat](
+      "trait Foo{ def this(i: Int) = this() }",
+      "Illegal secondary constructor"
+    )
+  }
+
+  test("secondary-object-constructors") {
+    runTestError[Stat](
+      "object Foo{ def this(i: Int) = this() }",
+      "Illegal secondary constructor"
+    )
+  }
+
   test("trait-parameters-generic") {
     runTestAssert[Stat]("trait Foo[T](bar: T)")(
       Defn.Trait(Nil, pname("Foo"), List(pparam("T")), ctorp(List(tparam("bar", "T"))), tpl(Nil))

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -499,46 +499,78 @@ class SignificantIndentationSuite extends BaseDottySuite {
   }
 
   test("this-constructor") {
-    val code = """|def this(msg: String) =
-                  |  this(message, false)
+    val code = """|class A:
+                  |  def this(msg: String) =
+                  |    this(message, false)
                   |""".stripMargin
-    val output = "def this(msg: String) = this(message, false)"
+    val output = "class A { def this(msg: String) = this(message, false) }"
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Ctor.Secondary(
+      Defn.Class(
         Nil,
-        Name(""),
-        List(List(Term.Param(Nil, Term.Name("msg"), Some(Type.Name("String")), None))),
-        Init(
-          Type.Singleton(Term.This(Name(""))),
-          Name(""),
-          List(List(Term.Name("message"), Lit.Boolean(false)))
-        ),
-        Nil
+        Type.Name("A"),
+        Nil,
+        Ctor.Primary(Nil, Name(""), Nil),
+        Template(
+          Nil,
+          Nil,
+          Self(Name(""), None),
+          List(
+            Ctor.Secondary(
+              Nil,
+              Name(""),
+              List(List(Term.Param(Nil, Term.Name("msg"), Some(Type.Name("String")), None))),
+              Init(
+                Type.Singleton(Term.This(Name(""))),
+                Name(""),
+                List(List(Term.Name("message"), Lit.Boolean(false)))
+              ),
+              Nil
+            )
+          ),
+          Nil
+        )
       )
     )
   }
 
   test("this-constructor-indented-block") {
-    val code = """|def this(msg: String) =
-                  |  this(message, false)
-                  |  otherStat
+    val code = """|class A:
+                  |  def this(msg: String) =
+                  |    this(message, false)
+                  |    otherStat
                   |""".stripMargin
-    val output = """|def this(msg: String) {
-                    |  this(message, false)
-                    |  otherStat
+    val output = """|class A {
+                    |  def this(msg: String) {
+                    |    this(message, false)
+                    |    otherStat
+                    |  }
                     |}
                     |""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Ctor.Secondary(
+      Defn.Class(
         Nil,
-        Name(""),
-        List(List(Term.Param(Nil, Term.Name("msg"), Some(Type.Name("String")), None))),
-        Init(
-          Type.Singleton(Term.This(Name(""))),
-          Name(""),
-          List(List(Term.Name("message"), Lit.Boolean(false)))
-        ),
-        List(Term.Name("otherStat"))
+        Type.Name("A"),
+        Nil,
+        Ctor.Primary(Nil, Name(""), Nil),
+        Template(
+          Nil,
+          Nil,
+          Self(Name(""), None),
+          List(
+            Ctor.Secondary(
+              Nil,
+              Name(""),
+              List(List(Term.Param(Nil, Term.Name("msg"), Some(Type.Name("String")), None))),
+              Init(
+                Type.Singleton(Term.This(Name(""))),
+                Name(""),
+                List(List(Term.Name("message"), Lit.Boolean(false)))
+              ),
+              List(Term.Name("otherStat"))
+            )
+          ),
+          Nil
+        )
       )
     )
   }


### PR DESCRIPTION
Fixes https://github.com/scalameta/scalameta/issues/2529

Ideally, we would make the invariant messages have an additional message parameter so that this never happens again, but this is more involved.