### PR TITLE
ScaladocParser: simplify, remove unnecessary parts

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
@@ -246,7 +246,8 @@ object ScaladocParser {
     paraSep.? ~ docParser ~ spacesMin(0) ~ End
   }
 
-  private val scaladocDelim = Pattern.compile("[ \t]*(?:$|\n[ \t]*\\**)")
+  private val ws = "[ \r\t]"
+  private val scaladocDelim = Pattern.compile(s"$ws*(?:$$|\n$ws*\\**)")
 
   /** Parses a scaladoc comment */
   def parse(comment: String): Option[Scaladoc] = {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
@@ -1012,8 +1012,7 @@ class ScaladocParserSuite extends FunSuite {
             * }}}
             * bar baz
             * {{{
-            *$complexCodeBlockAsComment
-            * }}}
+            *$complexCodeBlockAsComment }}}
             * baz qux
             */
        """.stripMargin
@@ -1328,9 +1327,13 @@ class ScaladocParserSuite extends FunSuite {
     val result = parseString(
       """
           /**
+
+            *
+
             * text1 text2
             * |hdr1  |hdr2   |hdr3|  hdr4||
             * text3 text4
+            *
             */
        """.stripMargin
     )


### PR DESCRIPTION
Since we have removed all trailing space in the scaladoc, remove all references to `hspaces0` before `nl`. Also, remove redundant parsers.