### PR TITLE
ScaladocParser: handle `@usecase` as special case

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/Scaladoc.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/Scaladoc.scala
@@ -164,7 +164,7 @@ object Scaladoc {
      * Provide a simplified method definition for when the full method definition is too complex
      * or noisy
      */
-    case object UseCase extends Base("@usecase")
+    case object UseCase extends Base("@usecase", hasLabel = true, optDesc = false)
 
     /* Member grouping tags */
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
@@ -1403,6 +1403,24 @@ class ScaladocParserSuite extends FunSuite {
     )
   }
 
+  test("parse usecase tags") {
+    assertEquals(
+      parseString(
+        s"""
+         /**
+          * @usecase foo bar
+          * baz qux
+          */
+         """
+      ),
+      Option {
+        val desc = Seq(Text(Seq(Word("foo"), Word("bar"), Word("baz"), Word("qux"))))
+        val rest = Nil
+        Scaladoc(Seq(Paragraph(Tag(TagType.UseCase, desc = desc) +: rest)))
+      }
+    )
+  }
+
   test("parse tag") {
     assertEquals(
       parseString(

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
@@ -1213,7 +1213,7 @@ class ScaladocParserSuite extends FunSuite {
     // Inherit doc does not merge
     parsedTags.foreach { // check label
       case Tag(t, label, _) if t.hasLabel =>
-        val expected = if (t.optDesc) "TestLabel" else "Test"
+        val expected = if (t.optDesc) "TestLabel" else "Test Label"
         assertEquals(label, Some(Word(expected)))
       case _ =>
     }
@@ -1360,8 +1360,7 @@ class ScaladocParserSuite extends FunSuite {
           Seq(
             Paragraph(
               Seq(
-                Tag(TagType.Version, Some(Word("1.0"))),
-                Text(Seq(Word("foo"), Word("bar"))),
+                Tag(TagType.Version, Some(Word("1.0 foo bar"))),
                 Tag(
                   TagType.Since,
                   Some(Word("1.0")),
@@ -1414,9 +1413,9 @@ class ScaladocParserSuite extends FunSuite {
          """
       ),
       Option {
-        val desc = Seq(Text(Seq(Word("foo"), Word("bar"), Word("baz"), Word("qux"))))
-        val rest = Nil
-        Scaladoc(Seq(Paragraph(Tag(TagType.UseCase, desc = desc) +: rest)))
+        val label = Some(Word("foo bar"))
+        val rest = Seq(Text(Seq(Word("baz"), Word("qux"))))
+        Scaladoc(Seq(Paragraph(Tag(TagType.UseCase, label = label) +: rest)))
       }
     )
   }


### PR DESCRIPTION
Let's handle cases where label is expected but description is not, by reading in the entire tag line as label. This adds required handling to @usecase which must be formatted all on one line.