### PR TITLE
ScaladocParser: fix check for table delim line

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
@@ -40,7 +40,6 @@ object ScaladocParser {
 
   private def escape[_: P] = P("\\")
   private def tableSep[_: P] = P("|")
-  private def tableSpaceSep[_: P] = P(hspaces0 ~ tableSep)
 
   private def codePrefix[_: P] = P("{{{")
   private def codeSuffix[_: P] = P(hspaces0 ~ "}}}" ~~ !"}")
@@ -191,12 +190,13 @@ object ScaladocParser {
     def cell = P((escape ~ AnyChar | !(nl | escape | tableSep) ~ AnyChar).rep)
     def row = P((cell.! ~ tableSep).rep(1))
 
+    def lineEnd = nl ~ hspaces0
     // non-standard but frequently used delimiter line, e.g.: +-----+-------+
-    def delimLine = hspaces0 ~ plusMinus
-    def nlDelimLine = P(nl ~ delimLine)
+    def delimLineNL = P(plusMinus ~ lineEnd)
+    def nlDelimLine = P(lineEnd ~ plusMinus)
 
-    def sep = nl ~ (delimLine ~ nl).rep ~ tableSpaceSep
-    def tableBeg = P((delimLine ~ nl).? ~ tableSpaceSep)
+    def sep = P(lineEnd ~ delimLineNL.rep ~ tableSep)
+    def tableBeg = P(hspaces0 ~ delimLineNL.? ~ tableSep)
     def tableEnd = P(nlDelimLine.?)
 
     // according to spec, the table must contain at least two rows

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
@@ -1294,7 +1294,59 @@ class ScaladocParserSuite extends FunSuite {
            |   */
            |""".stripMargin
       )
-    val expected = None
+    val expected = Option(
+      Scaladoc(
+        Seq(
+          Paragraph(
+            Seq(
+              ListBlock(
+                "1.",
+                Seq(
+                  ListItem(
+                    Text(Seq(Word("foo"))),
+                    Seq(
+                      CodeBlock(Seq("         embedded code")),
+                      ListBlock(
+                        "-",
+                        Seq(
+                          ListItem(
+                            Text(Seq(Word("foo1"))),
+                            Seq(
+                              Table(
+                                Table.Row(Seq("hdr1", "hdr22")),
+                                Seq(Table.Left, Table.Right),
+                                Seq(Table.Row(Seq("r1 1", "r1 2")))
+                              ),
+                              ListBlock(
+                                "-",
+                                Seq(
+                                  ListItem(
+                                    Text(Seq(Word("foo2"))),
+                                    Seq(
+                                      CodeBlock(Seq("         embedded code")),
+                                      MdCodeBlock(Nil, Seq("code foo2"), "```")
+                                    )
+                                  )
+                                )
+                              ),
+                              MdCodeBlock(Nil, Seq(" code foo1"), "```")
+                            )
+                          )
+                        )
+                      ),
+                      MdCodeBlock(Nil, Seq("   code foo"), "```")
+                    )
+                  ),
+                  ListItem(
+                    Text(Seq(Word("bar")))
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
     assertEquals(result, expected)
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
@@ -1177,6 +1177,127 @@ class ScaladocParserSuite extends FunSuite {
     assertEquals(result, expected)
   }
 
+  test("list 9, complex embedded elements 1") {
+    // table ends in a delim line
+    val result =
+      parseString(
+        s"""
+           |  /** 1. foo
+           |   *      {{{
+           |   *         embedded code
+           |   *      }}}
+           |   *      - foo1
+           |   *  | hdr1   |  hdr22 |
+           |   *   |:-------|-------:|
+           |   *    | r1 1   |   r1 2 |
+           |   *    +--------+--------+
+           |   *        - foo2
+           |   *   {{{
+           |   *         embedded code
+           |   *   }}}
+           |   *           ```
+           |   *         code foo2
+           |   *           ```
+           |   *        ```
+           |   *         code foo1
+           |   *        ```
+           |   *      ```
+           |   *         code foo
+           |   *      ```
+           |   * 1. bar
+           |   */
+           |""".stripMargin
+      )
+    val expected = Option(
+      Scaladoc(
+        Seq(
+          Paragraph(
+            Seq(
+              ListBlock(
+                "1.",
+                Seq(
+                  ListItem(
+                    Text(Seq(Word("foo"))),
+                    Seq(
+                      CodeBlock(Seq("         embedded code")),
+                      ListBlock(
+                        "-",
+                        Seq(
+                          ListItem(
+                            Text(Seq(Word("foo1"))),
+                            Seq(
+                              Table(
+                                Table.Row(Seq("hdr1", "hdr22")),
+                                Seq(Table.Left, Table.Right),
+                                Seq(Table.Row(Seq("r1 1", "r1 2")))
+                              ),
+                              ListBlock(
+                                "-",
+                                Seq(
+                                  ListItem(
+                                    Text(Seq(Word("foo2"))),
+                                    Seq(
+                                      CodeBlock(Seq("         embedded code")),
+                                      MdCodeBlock(Nil, Seq("code foo2"), "```")
+                                    )
+                                  )
+                                )
+                              ),
+                              MdCodeBlock(Nil, Seq(" code foo1"), "```")
+                            )
+                          )
+                        )
+                      ),
+                      MdCodeBlock(Nil, Seq("   code foo"), "```")
+                    )
+                  ),
+                  ListItem(
+                    Text(Seq(Word("bar")))
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    assertEquals(result, expected)
+  }
+
+  test("list 9, complex embedded elements 2") {
+    // table doesn't end in a delim line, followed by "-" list
+    val result =
+      parseString(
+        s"""
+           |  /** 1. foo
+           |   *      {{{
+           |   *         embedded code
+           |   *      }}}
+           |   *      - foo1
+           |   *  | hdr1   |  hdr22 |
+           |   *   |:-------|-------:|
+           |   *    | r1 1   |   r1 2 |
+           |   *        - foo2
+           |   *   {{{
+           |   *         embedded code
+           |   *   }}}
+           |   *           ```
+           |   *         code foo2
+           |   *           ```
+           |   *        ```
+           |   *         code foo1
+           |   *        ```
+           |   *      ```
+           |   *         code foo
+           |   *      ```
+           |   * 1. bar
+           |   */
+           |""".stripMargin
+      )
+    val expected = None
+    assertEquals(result, expected)
+  }
+
   test("label parsing/merging") {
     val testStringToMerge = "Test DocText"
     implicit val sb = new StringBuilder


### PR DESCRIPTION
The existing one was getting confused by a "-" list following the table.
