### PR TITLE
Show correct error when secondary constructor has no parenthesis

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -4740,8 +4740,12 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
     rejectMod[Mod.Sealed](mods, Messages.InvalidSealed)
     val name = atPos(in.tokenPos, in.tokenPos)(Name.Anonymous())
     accept[KwThis]
-    val paramss = paramClauses(ownerIsType = true)
-    secondaryCtorRest(mods, name, paramss)
+    if (token.isNot[LeftParen]) {
+      syntaxError("auxiliary constructor needs non-implicit parameter list", at = token.pos)
+    } else {
+      val paramss = paramClauses(ownerIsType = true)
+      secondaryCtorRest(mods, name, paramss)
+    }
   }
 
   def quasiquoteCtor(): Ctor = autoPos {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -203,6 +203,15 @@ class MinorDottySuite extends BaseDottySuite {
     )
   }
 
+  test("no-params") {
+    runTestError[Stat](
+      """|class A
+         |class B extends A:
+         |  def this = this.f()""".stripMargin,
+      "auxiliary constructor needs non-implicit parameter list"
+    )
+  }
+
   test("trait-parameters-generic") {
     runTestAssert[Stat]("trait Foo[T](bar: T)")(
       Defn.Trait(Nil, pname("Foo"), List(pparam("T")), ctorp(List(tparam("bar", "T"))), tpl(Nil))


### PR DESCRIPTION
Fixes https://github.com/scalameta/scalameta/issues/2531