### PR TITLE
Allow first statement inside for to be on the same line as the keyword

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -224,7 +224,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
       extends SepRegion {
     override def isIndented: Boolean = true
   }
-  case object RegionParen extends SepRegion
+  case class RegionParen(canProduceLF: Boolean = false) extends SepRegion
   case object RegionBracket extends SepRegion
   case class RegionBrace(override val indent: Int, override val indentOnArrow: Boolean)
       extends SepRegion
@@ -334,7 +334,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
       observeIndented0 { (i, prev) =>
         val undoRegionChange =
           prev.headOption match {
-            case Some(RegionParen) if token.is[LeftParen] => prev.tail
+            case Some(RegionParen(_)) if token.is[LeftParen] => prev.tail
             case Some(RegionEnumArtificialMark) if token.is[KwEnum] => prev.tail
             case Some(_: RegionBrace) if token.is[LeftBrace] => prev.tail
             case _ => prev
@@ -426,18 +426,19 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
 
       def currRef: TokenRef = TokenRef(curr, currPos, currPos + 1, currPos)
 
-      def indentationWithinParenRegion: Boolean = sepRegions.headOption.exists(_ != RegionParen) &&
-        sepRegions
-          .collectFirst {
-            case RegionParen => true
-            case other if !other.isIndented => false
-          }
-          .getOrElse(false)
+      def indentationWithinParenRegion: Boolean =
+        sepRegions.headOption.exists(!_.isInstanceOf[RegionParen]) &&
+          sepRegions
+            .collectFirst {
+              case RegionParen(_) => true
+              case other if !other.isIndented => false
+            }
+            .getOrElse(false)
 
       if (isTrailingComma) {
         nextToken(currPos, currPos + 1, sepRegions)
       } else if (curr.isNot[Trivia]) {
-        if (curr.is[LeftParen]) (RegionParen :: sepRegions, currRef)
+        if (curr.is[LeftParen]) (RegionParen(false) :: sepRegions, currRef)
         else if (curr.is[LeftBracket]) (RegionBracket :: sepRegions, currRef)
         else if (curr.is[Comma] && indentationWithinParenRegion) {
           (sepRegions.tail, mkOutdent(prevPos))
@@ -519,7 +520,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
         } else if (curr.is[RightParen]) {
           sepRegions match {
             case x :: xs if x.isIndented => (xs, mkOutdent(prevPos))
-            case x :: xs if x == RegionParen => (xs, currRef)
+            case RegionParen(_) :: xs => (xs, currRef)
             case _ => (sepRegions, currRef)
           }
         } else if (curr.is[LeftArrow]) {
@@ -543,7 +544,15 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
                 newRegions
             } else sepRegions
           (nextRegions, currRef)
-        } else (sepRegions, currRef)
+        } else if (dialect.allowSignificantIndentation && curr.is[KwFor]) {
+          val updatedSepRegions =
+            if (sepRegions.nonEmpty && sepRegions.head.isInstanceOf[RegionParen])
+              RegionParen(true) :: sepRegions.tail
+            else sepRegions
+          (updatedSepRegions, currRef)
+        } else {
+          (sepRegions, currRef)
+        }
       } else {
         var i = prevPos + 1
         var lastNewlinePos = -1
@@ -578,7 +587,11 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
             sepRegions.head.isInstanceOf[RegionCase] ||
             sepRegions.head.isInstanceOf[RegionEnum] ||
             sepRegions.head.isInstanceOf[RegionIndent] ||
-            sepRegions.head.isInstanceOf[RegionIndentEnum])
+            sepRegions.head.isInstanceOf[RegionIndentEnum] ||
+            (
+              sepRegions.head.isInstanceOf[RegionParen] &&
+                sepRegions.head.asInstanceOf[RegionParen].canProduceLF
+            ))
         }
 
         if (dialect.allowSignificantIndentation) {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -1129,6 +1129,43 @@ class SignificantIndentationSuite extends BaseDottySuite {
     )
   }
 
+  test("for-in-parens") {
+    val code = """|def foo =
+                  |  (for a <- List(1)
+                  |       b <- List(2)
+                  |   yield a + b).toSet.size
+                  |""".stripMargin
+    val output = "def foo = (for (a <- List(1); b <- List(2)) yield a + b).toSet.size"
+    runTestAssert[Stat](code, assertLayout = Some(output))(
+      Defn.Def(
+        Nil,
+        Term.Name("foo"),
+        Nil,
+        Nil,
+        None,
+        Term.Select(
+          Term.Select(
+            Term.ForYield(
+              List(
+                Enumerator.Generator(
+                  Pat.Var(Term.Name("a")),
+                  Term.Apply(Term.Name("List"), List(Lit.Int(1)))
+                ),
+                Enumerator.Generator(
+                  Pat.Var(Term.Name("b")),
+                  Term.Apply(Term.Name("List"), List(Lit.Int(2)))
+                )
+              ),
+              Term.ApplyInfix(Term.Name("a"), Term.Name("+"), Nil, List(Term.Name("b")))
+            ),
+            Term.Name("toSet")
+          ),
+          Term.Name("size")
+        )
+      )
+    )
+  }
+
   test("match-chained-same-indent") {
     runTestAssert[Stat](
       """|val hello = xs match


### PR DESCRIPTION
Fixes https://github.com/scalameta/scalameta/issues/2546

I don't think there is a way to make it simpler yet :thinking: 