### PR TITLE
ScalametaParser: outdent after indented comments

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -389,11 +389,39 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
           case region :: tail if region.isIndented && canEndIndentation(curr.token) =>
             sepRegions = tail
             val outdent = mkOutdentToken(curr.token)
-            curr = TokenRef(outdent, curr.pos, curr.pos, prevPos)
+            val outdentPos = findOutdentPos(prevPos, curr.pos, region)
+            curr = TokenRef(outdent, curr.pos, curr.pos, outdentPos)
             true
           case _ => false
         }
       }
+    }
+
+    private def findOutdentPos(prevPos: Int, currPos: Int, region: SepRegion): Int = {
+      val outdent = region.indent
+      @tailrec
+      def iter(i: Int, pos: Int, indent: Int): Int = {
+        if (i >= currPos) {
+          if (pos < currPos) pos else currPos - 1
+        } else {
+          scannerTokens(i) match {
+            case _: LF | _: FF =>
+              iter(i + 1, if (pos == prevPos) i else pos, 0)
+            case _: Space | _: Tab if indent >= 0 =>
+              iter(i + 1, pos, indent + 1)
+            case Whitespace() =>
+              iter(i + 1, pos, indent)
+            case _: Comment if indent < 0 || outdent <= indent =>
+              iter(i + 1, i + 1, -1)
+            case _ => pos
+          }
+        }
+      }
+
+      val iterPos = 1 + prevPos
+      if (iterPos < currPos) iter(iterPos, prevPos, -1)
+      else if (scannerTokens(currPos).is[EOF]) currPos
+      else prevPos
     }
 
     @tailrec
@@ -421,27 +449,38 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
       def mkIndent(pointPos: Int): TokenRef =
         TokenRef(mkIndentToken(curr), prevPos, currPos, pointPos)
 
-      def mkOutdent(pointPos: Int): TokenRef =
+      def mkOutdent(region: SepRegion): TokenRef =
+        mkOutdentTo(region, currPos)
+
+      def mkOutdentTo(region: SepRegion, maxPointPos: Int): TokenRef = {
+        val pointPos = findOutdentPos(prevPos, maxPointPos, region)
         TokenRef(mkOutdentToken(curr), prevPos, currPos, pointPos)
+      }
 
       def currRef: TokenRef = TokenRef(curr, currPos, currPos + 1, currPos)
 
-      def indentationWithinParenRegion: Boolean =
-        sepRegions.headOption.exists(!_.isInstanceOf[RegionParen]) &&
-          sepRegions
+      def indentationWithinParenRegion: Option[SepRegion] = {
+        def isWithinParenRegion =
+          sepRegions.tail
             .collectFirst {
               case RegionParen(_) => true
               case other if !other.isIndented => false
             }
-            .getOrElse(false)
+            .contains(true)
+        sepRegions.headOption.filter(_.isIndented && isWithinParenRegion)
+      }
 
       if (isTrailingComma) {
         nextToken(currPos, currPos + 1, sepRegions)
       } else if (curr.isNot[Trivia]) {
         if (curr.is[LeftParen]) (RegionParen(false) :: sepRegions, currRef)
         else if (curr.is[LeftBracket]) (RegionBracket :: sepRegions, currRef)
-        else if (curr.is[Comma] && indentationWithinParenRegion) {
-          (sepRegions.tail, mkOutdent(prevPos))
+        else if (curr.is[Comma]) {
+          indentationWithinParenRegion.fold {
+            (sepRegions, currRef)
+          } { region =>
+            (sepRegions.tail, mkOutdent(region))
+          }
         } else if (curr.is[LeftBrace]) {
           val indentInBrace = if (isAheadNewLine(currPos)) countIndent(nextPos) else -1
           // After encountering keyword Enum we add artificial '{' on top of stack.
@@ -474,7 +513,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
               case (_: RegionBrace | _: RegionEnum) :: xs =>
                 (xs, currRef)
               case x :: xs if x.isIndented =>
-                (xs, mkOutdent(prevPos))
+                (xs, mkOutdent(x))
               case _ :: xs =>
                 nextRegions(xs)
               case Nil =>
@@ -489,15 +528,12 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
           (nextRegions, currRef)
         } else if (curr.is[EOF]) {
           sepRegions match {
-            case x :: xs if x.isIndented =>
-              // do no include trailing comment/whitespace tokens
-              val pointPos = prevPos + 1
-              (xs, mkOutdent(pointPos))
+            case x :: xs if x.isIndented => (xs, mkOutdent(x))
             case other => (other, currRef)
           }
         } else if (curr.is[RightParen]) {
           sepRegions match {
-            case x :: xs if x.isIndented => (xs, mkOutdent(prevPos))
+            case x :: xs if x.isIndented => (xs, mkOutdent(x))
             case RegionParen(_) :: xs => (xs, currRef)
             case _ => (sepRegions, currRef)
           }
@@ -586,15 +622,15 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
              *    foo()
              *    ```
              */
-            def needOutdent: Boolean = {
-              sepRegions.headOption.exists {
-                case r if r.isIndented =>
-                  // need to check prev.prev in case of `end match`
-                  if (nextIndent < r.indent)
-                    prev.isNot[CanContinueOnNextLine] || prev.prev.is[soft.KwEnd]
-                  else r.closeOnNonCase && next.isNot[KwCase] && nextIndent == r.indent
-                case _ => false
-              }
+            def getOutdentIfNeeded(): SepRegion = sepRegions.headOption match {
+              case Some(r) if r.isIndented && {
+                    // need to check prev.prev in case of `end match`
+                    if (nextIndent < r.indent)
+                      prev.isNot[CanContinueOnNextLine] || prev.prev.is[soft.KwEnd]
+                    else r.closeOnNonCase && next.isNot[KwCase] && nextIndent == r.indent
+                  } =>
+                r
+              case _ => null
             }
 
             /**
@@ -634,8 +670,9 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
               } else false
             }
 
-            if (needOutdent)
-              (sepRegions.tail, mkOutdent(lastNewlinePos))
+            val needOutdent = getOutdentIfNeeded()
+            if (needOutdent ne null)
+              (sepRegions.tail, mkOutdentTo(needOutdent, nextPos))
             else if (needIndent)
               (RegionIndent(nextIndent, prev.is[KwMatch]) :: sepRegions, mkIndent(lastNewlinePos))
             else if (canProduceLF) {

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -891,11 +891,12 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
     def skipBy(range: Range, f: Token => Boolean): Int =
       range.dropWhile(i => f(scannerTokens(i))).headOption.getOrElse(range.start)
     @inline def skipTrivia(range: Range): Int = skipBy(range, _.is[Trivia])
+    @inline def skipWhitespace(range: Range): Int = skipBy(range, _.is[Whitespace])
 
     val rangeFromStart = startTokenPos to endTokenPos
     val (start, end) =
       if (rangeFromStart.isEmpty) (startTokenPos, endTokenPos)
-      else (skipTrivia(rangeFromStart), skipTrivia(rangeFromStart.reverse))
+      else (skipTrivia(rangeFromStart), skipWhitespace(rangeFromStart.reverse))
 
     val endExcl = if (start == end && scannerTokens(start).is[Trivia]) end else end + 1
     val pos = TokenStreamPosition(start, endExcl)

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -905,6 +905,12 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
     def startTokenPos = in.tokenPos
     def endTokenPos = in.prevTokenPos
   }
+  case object StartPosPrev extends StartPos {
+    def startTokenPos = in.prevTokenPos
+  }
+  case object EndPosPreOutdent extends EndPos {
+    def endTokenPos = if (in.token.is[Indentation.Outdent]) in.tokenPos else in.prevTokenPos
+  }
   implicit def intToIndexPos(index: Int): IndexPos = IndexPos(index)
   implicit def tokenToTokenPos(token: Token): TokenPos = TokenPos(token)
   implicit def treeToTreePos(tree: Tree): TreePos = TreePos(tree)
@@ -3253,7 +3259,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
     }
   }
 
-  def caseClause(forceSingleExpr: Boolean = false): Case = atPos(in.prevTokenPos, auto) {
+  def caseClause(forceSingleExpr: Boolean = false): Case = atPos(StartPosPrev, EndPosPreOutdent) {
     if (token.isNot[KwCase]) {
       def caseBody() = {
         accept[RightArrow]

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -612,6 +612,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |      // c1
        |    else
        |      gx
+       |      // c2
        |Self   @@val a = 
        |Defn.Val val a = 
        |    if cond then
@@ -619,11 +620,17 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |      // c1
        |    else
        |      gx
+       |      // c2
        |Term.If if cond then
        |      fx
        |      // c1
        |    else
        |      gx
+       |      // c2
+       |Term.Name fx
+       |      // c1
+       |Term.Name gx
+       |      // c2
        |""".stripMargin
   )
 
@@ -644,6 +651,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |      // c1
        |    else
        |      gx
+       |    // c2
        |Self   @@val a =
        |Defn.Val val a =
        |    if cond then
@@ -651,11 +659,17 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |      // c1
        |    else
        |      gx
+       |    // c2
        |Term.If if cond then
        |      fx
        |      // c1
        |    else
        |      gx
+       |    // c2
+       |Term.Name fx
+       |      // c1
+       |Term.Name gx
+       |    // c2
        |""".stripMargin
   )
 
@@ -689,6 +703,8 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |      // c1
        |    else
        |      gx
+       |Term.Name fx
+       |      // c1
        |""".stripMargin
   )
 
@@ -722,6 +738,8 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |      // c1
        |    else
        |      gx
+       |Term.Name fx
+       |      // c1
        |""".stripMargin
   )
 
@@ -751,11 +769,17 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |      // c1
        |    else
        |      gx
+       |    // c2
        |Term.If if cond then
        |      fx
        |      // c1
        |    else
        |      gx
+       |    // c2
+       |Term.Name fx
+       |      // c1
+       |Term.Name gx
+       |    // c2
        |""".stripMargin
   )
 
@@ -788,6 +812,8 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |      // c1
        |    else
        |      gx
+       |Term.Name fx
+       |      // c1
        |""".stripMargin
   )
 
@@ -831,7 +857,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |""".stripMargin,
     """|Pat.Tuple (x, y)
        |Term.Match (foo, bar) match
-       |  case (false, false) => (baz, qux)
+       |  case (false, false) => (baz, qux) // c1
        |Term.Tuple (foo, bar)
        |Case case (false, false) => (baz, qux)
        |Pat.Tuple (false, false)
@@ -847,9 +873,9 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
     """|Pat.Tuple (x, y)
        |Term.Match (foo, bar) match
        |  case (true, false) => (baz, qux) // c1
-       |  case (false, true) => (baz, qux)
+       |  case (false, true) => (baz, qux) // c2
        |Term.Tuple (foo, bar)
-       |Case case (true, false) => (baz, qux)
+       |Case case (true, false) => (baz, qux) // c1
        |Pat.Tuple (true, false)
        |Term.Tuple (baz, qux)
        |Case case (false, true) => (baz, qux)
@@ -867,7 +893,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |  case (true, false) => (baz, qux) // c1
        |  case (false, true) => (baz, qux)
        |Term.Tuple (foo, bar)
-       |Case case (true, false) => (baz, qux)
+       |Case case (true, false) => (baz, qux) // c1
        |Pat.Tuple (true, false)
        |Term.Tuple (baz, qux)
        |Case case (false, true) => (baz, qux)
@@ -881,7 +907,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |  case (true, false) => (baz, qux) // c1
        |  case (false, true) => (baz, qux) // c2""".stripMargin,
     """|Term.Tuple (foo, bar)
-       |Case case (true, false) => (baz, qux)
+       |Case case (true, false) => (baz, qux) // c1
        |Pat.Tuple (true, false)
        |Term.Tuple (baz, qux)
        |Case case (false, true) => (baz, qux)
@@ -895,7 +921,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |case (true, false) => (baz, qux) // c1
        |case (false, true) => (baz, qux) // c2""".stripMargin,
     """|Term.Tuple (foo, bar)
-       |Case case (true, false) => (baz, qux)
+       |Case case (true, false) => (baz, qux) // c1
        |Pat.Tuple (true, false)
        |Term.Tuple (baz, qux)
        |Case case (false, true) => (baz, qux)
@@ -910,7 +936,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |case (false, true) => (baz, qux) // c2
        |""".stripMargin,
     """|Term.Tuple (foo, bar)
-       |Case case (true, false) => (baz, qux)
+       |Case case (true, false) => (baz, qux) // c1
        |Pat.Tuple (true, false)
        |Term.Tuple (baz, qux)
        |Case case (false, true) => (baz, qux)

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -519,9 +519,11 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
     """|Term.Function s =>
        |    fx
        |    gx(s)
+       |    /* c1 */
        |Term.Param s
        |Term.Block fx
        |    gx(s)
+       |    /* c1 */
        |Term.Apply gx(s)
        |Lit.String "yo"
        |""".stripMargin
@@ -668,8 +670,6 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |    // c2
        |Term.Name fx
        |      // c1
-       |Term.Name gx
-       |    // c2
        |""".stripMargin
   )
 
@@ -691,6 +691,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |      // c1
        |    else
        |      gx
+       |      // c2
        |Self   @@val a = 
        |Defn.Val val a = 
        |    if cond then
@@ -698,13 +699,17 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |      // c1
        |    else
        |      gx
+       |      // c2
        |Term.If if cond then
        |      fx
        |      // c1
        |    else
        |      gx
+       |      // c2
        |Term.Name fx
        |      // c1
+       |Term.Name gx
+       |      // c2
        |""".stripMargin
   )
 
@@ -726,6 +731,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |      // c1
        |    else
        |      gx
+       |    // c2
        |Self   @@val a =
        |Defn.Val val a =
        |    if cond then
@@ -733,11 +739,13 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |      // c1
        |    else
        |      gx
+       |    // c2
        |Term.If if cond then
        |      fx
        |      // c1
        |    else
        |      gx
+       |    // c2
        |Term.Name fx
        |      // c1
        |""".stripMargin
@@ -778,8 +786,6 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |    // c2
        |Term.Name fx
        |      // c1
-       |Term.Name gx
-       |    // c2
        |""".stripMargin
   )
 
@@ -807,11 +813,13 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |      // c1
        |    else
        |      gx
+       |    /* c2 */
        |Term.If if cond then
        |      fx
        |      // c1
        |    else
        |      gx
+       |    /* c2 */
        |Term.Name fx
        |      // c1
        |""".stripMargin
@@ -843,7 +851,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |  case (false, false) => (baz, qux) // c1""".stripMargin,
     """|Pat.Tuple (x, y)
        |Term.Match (foo, bar) match
-       |  case (false, false) => (baz, qux)
+       |  case (false, false) => (baz, qux) // c1
        |Term.Tuple (foo, bar)
        |Case case (false, false) => (baz, qux)
        |Pat.Tuple (false, false)
@@ -891,7 +899,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
     """|Pat.Tuple (x, y)
        |Term.Match (foo, bar) match
        |  case (true, false) => (baz, qux) // c1
-       |  case (false, true) => (baz, qux)
+       |  case (false, true) => (baz, qux) // c2
        |Term.Tuple (foo, bar)
        |Case case (true, false) => (baz, qux) // c1
        |Pat.Tuple (true, false)

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -853,7 +853,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |Term.Match (foo, bar) match
        |  case (false, false) => (baz, qux) // c1
        |Term.Tuple (foo, bar)
-       |Case case (false, false) => (baz, qux)
+       |Case case (false, false) => (baz, qux) // c1
        |Pat.Tuple (false, false)
        |Term.Tuple (baz, qux)
        |""".stripMargin
@@ -867,7 +867,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |Term.Match (foo, bar) match
        |  case (false, false) => (baz, qux) // c1
        |Term.Tuple (foo, bar)
-       |Case case (false, false) => (baz, qux)
+       |Case case (false, false) => (baz, qux) // c1
        |Pat.Tuple (false, false)
        |Term.Tuple (baz, qux)
        |""".stripMargin
@@ -886,7 +886,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |Case case (true, false) => (baz, qux) // c1
        |Pat.Tuple (true, false)
        |Term.Tuple (baz, qux)
-       |Case case (false, true) => (baz, qux)
+       |Case case (false, true) => (baz, qux) // c2
        |Pat.Tuple (false, true)
        |Term.Tuple (baz, qux)
        |""".stripMargin
@@ -904,7 +904,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |Case case (true, false) => (baz, qux) // c1
        |Pat.Tuple (true, false)
        |Term.Tuple (baz, qux)
-       |Case case (false, true) => (baz, qux)
+       |Case case (false, true) => (baz, qux) // c2
        |Pat.Tuple (false, true)
        |Term.Tuple (baz, qux)
        |""".stripMargin
@@ -918,7 +918,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |Case case (true, false) => (baz, qux) // c1
        |Pat.Tuple (true, false)
        |Term.Tuple (baz, qux)
-       |Case case (false, true) => (baz, qux)
+       |Case case (false, true) => (baz, qux) // c2
        |Pat.Tuple (false, true)
        |Term.Tuple (baz, qux)
        |""".stripMargin
@@ -932,7 +932,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |Case case (true, false) => (baz, qux) // c1
        |Pat.Tuple (true, false)
        |Term.Tuple (baz, qux)
-       |Case case (false, true) => (baz, qux)
+       |Case case (false, true) => (baz, qux) // c2
        |Pat.Tuple (false, true)
        |Term.Tuple (baz, qux)
        |""".stripMargin
@@ -947,7 +947,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |Case case (true, false) => (baz, qux) // c1
        |Pat.Tuple (true, false)
        |Term.Tuple (baz, qux)
-       |Case case (false, true) => (baz, qux)
+       |Case case (false, true) => (baz, qux) // c2
        |Pat.Tuple (false, true)
        |Term.Tuple (baz, qux)
        |""".stripMargin

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -508,6 +508,26 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
   )
 
   checkPositions[Stat](
+    """|foo(
+       |  s =>
+       |    fx
+       |    gx(s)
+       |    /* c1 */,
+       |  "yo"
+       |)
+       |""".stripMargin,
+    """|Term.Function s =>
+       |    fx
+       |    gx(s)
+       |Term.Param s
+       |Term.Block fx
+       |    gx(s)
+       |Term.Apply gx(s)
+       |Lit.String "yo"
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
     """|inline def encodeFlat =
        |    putInt
        |    inline erasedValue match
@@ -607,6 +627,38 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |""".stripMargin
   )
 
+  checkPositions[Stat](
+    """|object x:
+       |  val a =
+       |    if cond then
+       |      fx
+       |      // c1
+       |    else
+       |      gx
+       |    // c2
+       |""".stripMargin,
+    """|Template :
+       |  val a =
+       |    if cond then
+       |      fx
+       |      // c1
+       |    else
+       |      gx
+       |Self   @@val a =
+       |Defn.Val val a =
+       |    if cond then
+       |      fx
+       |      // c1
+       |    else
+       |      gx
+       |Term.If if cond then
+       |      fx
+       |      // c1
+       |    else
+       |      gx
+       |""".stripMargin
+  )
+
   // do not add LF to end of input
   // this test checks `..$comment$EOF` case
   checkPositions[Stat](
@@ -627,6 +679,105 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |      gx
        |Self   @@val a = 
        |Defn.Val val a = 
+       |    if cond then
+       |      fx
+       |      // c1
+       |    else
+       |      gx
+       |Term.If if cond then
+       |      fx
+       |      // c1
+       |    else
+       |      gx
+       |""".stripMargin
+  )
+
+  // do not add LF to end of input
+  // this test checks `..$comment$EOF` case
+  checkPositions[Stat](
+    """|object y:
+       |  val a =
+       |    if cond then
+       |      fx
+       |      // c1
+       |    else
+       |      gx
+       |    // c2""".stripMargin,
+    """|Template :
+       |  val a =
+       |    if cond then
+       |      fx
+       |      // c1
+       |    else
+       |      gx
+       |Self   @@val a =
+       |Defn.Val val a =
+       |    if cond then
+       |      fx
+       |      // c1
+       |    else
+       |      gx
+       |Term.If if cond then
+       |      fx
+       |      // c1
+       |    else
+       |      gx
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """|object y {
+       |  val a =
+       |    if cond then
+       |      fx
+       |      // c1
+       |    else
+       |      gx
+       |    // c2
+       |}""".stripMargin,
+    """|Template {
+       |  val a =
+       |    if cond then
+       |      fx
+       |      // c1
+       |    else
+       |      gx
+       |    // c2
+       |}
+       |Self   @@val a =
+       |Defn.Val val a =
+       |    if cond then
+       |      fx
+       |      // c1
+       |    else
+       |      gx
+       |Term.If if cond then
+       |      fx
+       |      // c1
+       |    else
+       |      gx
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """|object y {
+       |  val a =
+       |    if cond then
+       |      fx
+       |      // c1
+       |    else
+       |      gx
+       |    /* c2 */}""".stripMargin,
+    """|Template {
+       |  val a =
+       |    if cond then
+       |      fx
+       |      // c1
+       |    else
+       |      gx
+       |    /* c2 */}
+       |Self   @@val a =
+       |Defn.Val val a =
        |    if cond then
        |      fx
        |      // c1

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
@@ -688,9 +688,10 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
        |} // c4""".stripMargin,
     """|Ctor.Primary trait SampleTrait @@extends A {
        |Template extends A {
-       |  self: X with B with C =>
+       |  self: X with B with C => // c1
        |
-       |  def foo: Boolean = true
+       |  def foo: Boolean = true // c2
+       |  // c3
        |}
        |Self self: X with B with C
        |Type.With X with B with C

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
@@ -680,6 +680,26 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
   )
 
   checkPositions[Stat](
+    """|trait SampleTrait extends A {
+       |  self: X with B with C => // c1
+       |
+       |  def foo: Boolean = true // c2
+       |  // c3
+       |} // c4""".stripMargin,
+    """|Ctor.Primary trait SampleTrait @@extends A {
+       |Template extends A {
+       |  self: X with B with C =>
+       |
+       |  def foo: Boolean = true
+       |}
+       |Self self: X with B with C
+       |Type.With X with B with C
+       |Type.With X with B
+       |Defn.Def def foo: Boolean = true
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
     """|object A {
        |  private [this] def foo: Int = ???
        |}


### PR DESCRIPTION
Previously, we would outdent immediately after a non-trivial token while ignoring any trailing comments which followed.
Fixes #2516.