### PR TITLE
Properly parse patterns in splices inside quoted patterns

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -38,16 +38,23 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
 
   /* ------------- PARSER ENTRY POINTS -------------------------------------------- */
 
-  private object QuoteSpliceContext {
+  /** Utility for tracking a context, like whether we are inside a pattern or a quote. */
+  private trait NestedContextBase {
     private var nested = 0
-    def enter() = nested += 1
-    def exit() = nested -= 1
+    def within[T](body: => T): T = {
+      nested += 1
+      try {
+        body
+      } finally {
+        nested -= 1
+      }
+    }
     def isInside() = nested > 0
   }
 
-  private object QuotedPatternContext {
-    var inPattern: Boolean = false
-  }
+  private object QuoteSpliceContext extends NestedContextBase
+
+  private object QuotedPatternContext extends NestedContextBase
 
   def parseRule[T <: Tree](rule: this.type => T): T = {
     // NOTE: can't require in.tokenPos to be at -1, because TokIterator auto-rewinds when created
@@ -3032,29 +3039,26 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
 
   def macroSplice(): Term = autoPos {
     accept[MacroSplice]
-    QuoteSpliceContext.enter()
-    val splice =
-      if (QuotedPatternContext.inPattern)
+    QuoteSpliceContext.within {
+      if (QuotedPatternContext.isInside())
         Term.SplicedMacroPat(autoPos(inBraces(pattern())))
       else
         Term.SplicedMacroExpr(autoPos(Term.Block(inBraces(blockStatSeq()))))
 
-    QuoteSpliceContext.exit()
-    splice
+    }
   }
 
   def macroQuote(): Term = autoPos {
     accept[MacroQuote]
-    QuoteSpliceContext.enter()
-    val quote = if (token.is[LeftBrace]) {
-      Term.QuotedMacroExpr(autoPos(Term.Block(inBraces(blockStatSeq()))))
-    } else if (token.is[LeftBracket]) {
-      Term.QuotedMacroType(inBrackets(typ()))
-    } else {
-      syntaxError("Quotation only works for expressions and types", at = token)
+    QuoteSpliceContext.within {
+      if (token.is[LeftBrace]) {
+        Term.QuotedMacroExpr(autoPos(Term.Block(inBraces(blockStatSeq()))))
+      } else if (token.is[LeftBracket]) {
+        Term.QuotedMacroType(inBrackets(typ()))
+      } else {
+        syntaxError("Quotation only works for expressions and types", at = token)
+      }
     }
-    QuoteSpliceContext.exit()
-    quote
   }
 
   def macroQuotedIdent(): Term = autoPos {
@@ -3576,11 +3580,9 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
           val patterns = inParens(if (token.is[RightParen]) Nil else noSeq.patterns())
           makeTuple[Pat](patterns, () => Lit.Unit(), Pat.Tuple(_))
         case MacroQuote() =>
-          val oldInPattern = QuotedPatternContext.inPattern
-          QuotedPatternContext.inPattern = true
-          val res = Pat.Macro(macroQuote())
-          QuotedPatternContext.inPattern = oldInPattern
-          res
+          QuotedPatternContext.within {
+            Pat.Macro(macroQuote())
+          }
         case MacroQuotedIdent() =>
           Pat.Macro(macroQuotedIdent())
         case KwGiven() =>

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -117,6 +117,7 @@ object Term {
   @ast class QuotedMacroExpr(body: Term) extends Term
   @ast class QuotedMacroType(tpe: Type) extends Term
   @ast class SplicedMacroExpr(body: Term) extends Term
+  @ast class SplicedMacroPat(pat: Pat) extends Term
   @ast class Match(expr: Term, cases: List[Case] @nonEmpty) extends Term {
     @binaryCompatField(since = "4.4.5")
     private var _mods: List[Mod] = Nil

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -399,7 +399,8 @@ object TreeSyntax {
                   case _ => false
                 }
               case _: Lit | _: Term.Ref | _: Term.Function | _: Term.If | _: Term.Match |
-                  _: Term.ApplyInfix | _: Term.QuotedMacroExpr | _: Term.SplicedMacroExpr =>
+                  _: Term.ApplyInfix | _: Term.QuotedMacroExpr | _: Term.SplicedMacroExpr |
+                  _: Term.SplicedMacroPat =>
                 false
               case _ =>
                 true
@@ -604,6 +605,8 @@ object TreeSyntax {
           case head :: Nil => s("${ ", head, " }")
           case other => s("${", r(other.map(i(_)), ""), n("}"))
         }
+      case Term.SplicedMacroPat(pat) =>
+        s("${ ", pat, " }")
       case t: Term.SplicedMacroExpr =>
         m(SimpleExpr, s("$", p(Expr, t.body)))
       case t: Pat.Macro => m(SimplePattern, s(t.body))

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -358,6 +358,7 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.Term.Return
       |scala.meta.Term.Select
       |scala.meta.Term.SplicedMacroExpr
+      |scala.meta.Term.SplicedMacroPat
       |scala.meta.Term.Super
       |scala.meta.Term.This
       |scala.meta.Term.Throw

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
@@ -21,7 +21,7 @@ class ReflectionSuite extends FunSuite {
   test("root") {
     assert(symbolOf[scala.meta.Tree].isRoot)
     assertEquals(symbolOf[scala.meta.Tree].asRoot.allBranches.length, 23)
-    assertEquals(symbolOf[scala.meta.Tree].asRoot.allLeafs.length, 345)
+    assertEquals(symbolOf[scala.meta.Tree].asRoot.allLeafs.length, 347)
   }
 
   test("If") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
@@ -110,6 +110,36 @@ class MacroSuite extends BaseDottySuite {
         List(Case(Pat.Macro(Term.QuotedMacroExpr(Term.Block(List(tname("a"))))), None, Lit.Int(1)))
       )
     )
+
+    val layoutMatchWithSplice = s"x match {\n  case '{ $${ bind @ '{ a } } } => 1\n}"
+    runTestAssert[Stat](
+      s"x match { case '{ $${bind@'{a}} } => 1 }",
+      assertLayout = Some(layoutMatchWithSplice)
+    )(
+      Term.Match(
+        tname("x"),
+        List(
+          Case(
+            Pat.Macro(
+              Term.QuotedMacroExpr(
+                Term.Block(
+                  List(
+                    Term.SplicedMacroPat(
+                      Pat.Bind(
+                        Pat.Var(tname("bind")),
+                        Pat.Macro(Term.QuotedMacroExpr(Term.Block(List(tname("a")))))
+                      )
+                    )
+                  )
+                )
+              )
+            ),
+            None,
+            Lit.Int(1)
+          )
+        )
+      )
+    )
   }
 
   test("macro-brackets") {


### PR DESCRIPTION
Discussion [here](https://contributors.scala-lang.org/t/bind-in-splices-in-quoted-patterns/5533) and Dotty PR [here](https://github.com/lampepfl/dotty/pull/14277). Previously, splices inside quoted patterns (like the `...` in `case '{foo(${...})`) were parsed as blocks instead of patterns, even though the typer treats such splices as patterns. This means that arbitrary blocks were syntactically permitted, even though they would never compile, and some patterns (like those containing bindings like `${y@...}` were not syntactically permitted, even though the typer would accept them. 

This requires a change in the API to add a Term than can wrap a spliced pattern. Let me know if there's anything better I can do here. 