### PR TITLE
ScalametaParser: fix bug, `match` allows 0 indent

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -613,8 +613,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
              *  It's produced manually on the parser level.
              */
             def needIndent: Boolean = {
-              val nextIndent = countIndent(nextPos)
-              if (nextIndent > 0) {
+              if (nextIndent >= 0) {
 
                 val (currIndent, indentOnArrow) =
                   sepRegions.headOption.fold((0, true))(r => (r.indent, r.indentOnArrow))

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -661,4 +661,111 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |""".stripMargin
   )
 
+  checkPositions[Stat](
+    """|val (x, y) = (foo, bar) match
+       |  case (false, false) => (baz, qux) // c1""".stripMargin,
+    """|Pat.Tuple (x, y)
+       |Term.Match (foo, bar) match
+       |  case (false, false) => (baz, qux)
+       |Term.Tuple (foo, bar)
+       |Case case (false, false) => (baz, qux)
+       |Pat.Tuple (false, false)
+       |Term.Tuple (baz, qux)
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """|val (x, y) = (foo, bar) match
+       |  case (false, false) => (baz, qux) // c1
+       |""".stripMargin,
+    """|Pat.Tuple (x, y)
+       |Term.Match (foo, bar) match
+       |  case (false, false) => (baz, qux)
+       |Term.Tuple (foo, bar)
+       |Case case (false, false) => (baz, qux)
+       |Pat.Tuple (false, false)
+       |Term.Tuple (baz, qux)
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """|val (x, y) = (foo, bar) match
+       |  case (true, false) => (baz, qux) // c1
+       |  case (false, true) => (baz, qux) // c2
+       |""".stripMargin,
+    """|Pat.Tuple (x, y)
+       |Term.Match (foo, bar) match
+       |  case (true, false) => (baz, qux) // c1
+       |  case (false, true) => (baz, qux)
+       |Term.Tuple (foo, bar)
+       |Case case (true, false) => (baz, qux)
+       |Pat.Tuple (true, false)
+       |Term.Tuple (baz, qux)
+       |Case case (false, true) => (baz, qux)
+       |Pat.Tuple (false, true)
+       |Term.Tuple (baz, qux)
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """|val (x, y) = (foo, bar) match
+       |  case (true, false) => (baz, qux) // c1
+       |  case (false, true) => (baz, qux) // c2""".stripMargin,
+    """|Pat.Tuple (x, y)
+       |Term.Match (foo, bar) match
+       |  case (true, false) => (baz, qux) // c1
+       |  case (false, true) => (baz, qux)
+       |Term.Tuple (foo, bar)
+       |Case case (true, false) => (baz, qux)
+       |Pat.Tuple (true, false)
+       |Term.Tuple (baz, qux)
+       |Case case (false, true) => (baz, qux)
+       |Pat.Tuple (false, true)
+       |Term.Tuple (baz, qux)
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """|(foo, bar) match
+       |  case (true, false) => (baz, qux) // c1
+       |  case (false, true) => (baz, qux) // c2""".stripMargin,
+    """|Term.Tuple (foo, bar)
+       |Case case (true, false) => (baz, qux)
+       |Pat.Tuple (true, false)
+       |Term.Tuple (baz, qux)
+       |Case case (false, true) => (baz, qux)
+       |Pat.Tuple (false, true)
+       |Term.Tuple (baz, qux)
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """|(foo, bar) match
+       |case (true, false) => (baz, qux) // c1
+       |case (false, true) => (baz, qux) // c2""".stripMargin,
+    """|Term.Tuple (foo, bar)
+       |Case case (true, false) => (baz, qux)
+       |Pat.Tuple (true, false)
+       |Term.Tuple (baz, qux)
+       |Case case (false, true) => (baz, qux)
+       |Pat.Tuple (false, true)
+       |Term.Tuple (baz, qux)
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """|(foo, bar) match
+       |case (true, false) => (baz, qux) // c1
+       |case (false, true) => (baz, qux) // c2
+       |""".stripMargin,
+    """|Term.Tuple (foo, bar)
+       |Case case (true, false) => (baz, qux)
+       |Pat.Tuple (true, false)
+       |Term.Tuple (baz, qux)
+       |Case case (false, true) => (baz, qux)
+       |Pat.Tuple (false, true)
+       |Term.Tuple (baz, qux)
+       |""".stripMargin
+  )
+
 }


### PR DESCRIPTION
Unindented tests were failing parsing before this fix.