### PR TITLE
[Actions] Release semanticdb-plugin for new Scala2 version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,24 @@ jobs:
       - run: git fetch --unshallow
       - name: Publish
         run: |
-          sbt ci-release
-          sbt docs/docusaurusPublishGhpages
+          COMMAND="ci-release"
+          UPDATE_DOCS=true
+          if [[ $GITHUB_REF == "refs/tags"* ]] && [[ $GITHUB_REF_NAME == "semanticdb_v"* ]]; then
+            VERSION=$(echo $GITHUB_REF_NAME | cut -d "_" -f2 | cut -c2-)
+            SCALA_VERSION=$(echo $GITHUB_REF_NAME | cut -d "_" -f3)
+            if [ ! -z $VERSION ] && [ ! -z $SCALA_VERSION ]; then
+              export CI_RELEASE="++$SCALA_VERSION semanticdbScalacCore/publishLocal; ++$SCALA_VERSION semanticdbScalacPlugin/publishLocal;"
+              UPDATE_DOCS=false
+              COMMAND="; set ThisBuild/version :=\"$VERSION\"; $COMMAND"
+            else
+              echo 'Invalid tag name. Expected: semanticdb_v${existing-release}_${scala-version}'
+              exit 1
+            fi
+          fi
+          sbt "$COMMAND"
+          if [ "$UPDATE_DOCS" = true ]; then
+            sbt docs/docusaurusPublishGhpages
+          fi
         env:
           GIT_USER: scalameta@scalameta.org
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}


### PR DESCRIPTION
This change is needed to allow Metals automatically catch new
scala2-compiler releases avoiding the full release process.
More details: scalameta/metals#3281