### PR TITLE
Allow _IDENT in string interpolation

### DIFF
--- a/bin/test-release.sh
+++ b/bin/test-release.sh
@@ -9,7 +9,7 @@ coursier resolve \
   org.scalameta:scalameta_2.11:$version \
   org.scalameta:scalameta_sjs1_2.13:$version \
   org.scalameta:scalameta_sjs1_2.12:$version \
-  org.scalameta:metac_2.13.6:$version \
+  org.scalameta:metac_2.13.8:$version \
   org.scalameta:metac_2.12.15:$version \
   org.scalameta:metac_2.11.12:$version \
   org.scalameta:semanticdb-scalac-core_2.13.8:$version \

--- a/community-test/src/test/scala/CommunityDottySuite.scala
+++ b/community-test/src/test/scala/CommunityDottySuite.scala
@@ -61,7 +61,7 @@ class CommunityDottySuite extends FunSuite {
     CommunityBuild(
       "https://github.com/lampepfl/dotty.git",
       //commit hash from 12.07.2021
-      "54b89b1cc07b712abb280d64d24b4c363c8bb488",
+      "c99f6caa74e74a67dd42e8df6ede53c29cd7fce9",
       "dotty",
       dottyExclusionList
     ),
@@ -164,8 +164,10 @@ class CommunityDottySuite extends FunSuite {
   final val ignoreParts = List(
     "/tests/",
     "/test-resources/scripting/",
+    "/test-resources/repl/",
     "/sbt-test/",
     "/out/",
-    "/language-server/src/dotty/"
+    "/language-server/src/dotty/",
+    "/library/src/scala/CanThrow.scala"
   )
 }

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
@@ -235,21 +235,21 @@ class ScalametaTokenizer(input: Input, dialect: Dialect) {
               legacyIndex = loop(legacyIndex, returnWhenBraceBalanceHitsZero = true)
               emitSpliceEnd(curr.offset)
               emitContents()
-            } else if (input.chars(dollarOffset + 1) == '_') {
-              emitSpliceStart(dollarOffset)
-              nextToken()
-              emitExpectedToken(USCORE)
-              nextToken()
-              emitSpliceEnd(curr.offset)
-              emitContents()
             } else {
               emitSpliceStart(dollarOffset)
               nextToken()
-              require(curr.token == IDENTIFIER || curr.token == THIS)
-              emitToken()
-              nextToken()
-              emitSpliceEnd(curr.offset)
-              emitContents()
+              if (input.chars(dollarOffset + 1) == '_' && curr.token == USCORE) {
+                emitExpectedToken(USCORE)
+                nextToken()
+                emitSpliceEnd(curr.offset)
+                emitContents()
+              } else {
+                require(curr.token == IDENTIFIER || curr.token == THIS)
+                emitToken()
+                nextToken()
+                emitSpliceEnd(curr.offset)
+                emitContents()
+              }
             }
           } else {
             curr.endOffset -= numQuotes

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
@@ -759,6 +759,23 @@ class TokenizerSuite extends BaseTokenizerSuite {
     """.trim.stripMargin)
   }
 
+  test("interpolation-underscore") {
+    assertNoDiff(
+      tokenize("""s"checking redundancy in $_match"""").map(_.structure).mkString("\n"),
+      """|BOF [0..0)
+         |s [0..1)
+         |" [1..2)
+         |checking redundancy in  [2..25)
+         |$ [25..26)
+         |_match [26..32)
+         | [32..32)
+         | [32..32)
+         |" [32..33)
+         |EOF [33..33)
+         |""".stripMargin
+    )
+  }
+
   test("$this") {
     assert(tokenize("q\"$this\"").map(_.structure).mkString("\n") == """
       |BOF [0..0)


### PR DESCRIPTION
This doesn't work in the Scala 2 parser, but it feels like a bug, so should be safe to fix in the Scalameta parser