### PR TITLE
ScalametaParser: Make `allowToplevelTerms` accept package declarations

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -5030,7 +5030,8 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
   private val consumeStat: PartialFunction[Token, Stat] = {
     case KwImport() => importStmt()
     case KwExport() => exportStmt()
-    case KwPackage() if !dialect.allowToplevelTerms => packageOrPackageObjectDef()
+    case KwPackage() =>
+      packageOrPackageObjectDef(if (dialect.allowToplevelTerms) consumeStat else topStat)
     case DefIntro() => nonLocalDefOrDcl(secondaryConstructorAllowed = true)
     case EndMarkerIntro() => endMarker()
     case ExprIntro() => stat(expr(location = NoStat, allowRepeated = true))
@@ -5099,14 +5100,13 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
     stats.toList
   }
 
-  def topStatSeq(): List[Stat] = statSeq(topStat, errorMsg = "expected class or object definition")
   def topStat: PartialFunction[Token, Stat] = {
     case Ellipsis(_) =>
       ellipsis(1, astInfo[Stat])
     case Unquote() =>
       unquote[Stat]
     case KwPackage() =>
-      packageOrPackageObjectDef()
+      packageOrPackageObjectDef(topStat)
     case KwImport() =>
       importStmt()
     case KwExport() =>
@@ -5253,21 +5253,21 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
     stats.toList
   }
 
-  def packageOrPackageObjectDef(): Stat = autoPos {
+  def packageOrPackageObjectDef(statpf: PartialFunction[Token, Stat]): Stat = autoPos {
     require(token.is[KwPackage] && debug(token))
     if (ahead(token.is[KwObject])) packageObjectDef()
-    else packageDef()
+    else packageDef(statpf)
   }
 
-  def packageDef(): Pkg = autoPos {
+  def packageDef(statpf: PartialFunction[Token, Stat]): Pkg = autoPos {
     accept[KwPackage]
     def packageBody = {
       if (isColonEol(token)) {
         accept[Colon]
         in.observeIndented()
-        indented(topStatSeq())
+        indented(statSeq(statpf))
       } else {
-        inBracesOrNil(topStatSeq())
+        inBracesOrNil(statSeq(statpf))
       }
     }
     Pkg(qualId(), packageBody)
@@ -5280,25 +5280,14 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
   }
 
   def source(): Source = autoPos {
-    if (dialect.allowToplevelTerms) scriptSource()
-    else batchSource()
+    batchSource(if (dialect.allowToplevelTerms) consumeStat else topStat)
   }
 
   def quasiquoteSource(): Source = entrypointSource()
 
   def entrypointSource(): Source = source()
 
-  def scriptSource(): Source = autoPos {
-    // WONTFIX: https://github.com/scalameta/scalameta/issues/368
-    if (dialect.toplevelSeparator == "") {
-      Source(parser.statSeq(consumeStat))
-    } else {
-      require(dialect.toplevelSeparator == EOL)
-      Source(parser.statSeq(consumeStat))
-    }
-  }
-
-  def batchSource(): Source = autoPos {
+  def batchSource(statpf: PartialFunction[Token, Stat] = topStat): Source = autoPos {
     def inBracelessPackage(): Boolean = token.is[KwPackage] && !ahead(token.is[KwObject]) && ahead {
       qualId()
       if (token.is[LF]) { next() }
@@ -5314,24 +5303,24 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
         val startPos = in.tokenPos
         accept[KwPackage]
         val qid = qualId()
-        def inPackage(topStats: => List[Stat]) = {
-          val pkg = atPos(startPos, auto)(Pkg(qid, topStats))
+        def inPackage(stats: => List[Stat]) = {
+          val pkg = atPos(startPos, auto)(Pkg(qid, stats))
           acceptStatSepOpt()
           pkg +: bracelessPackageStats()
         }
         if (token.is[LeftBrace]) {
-          inPackage(inBraces(topStatSeq()))
+          inPackage(inBraces(statSeq(statpf)))
         } else if (isColonEol(token)) {
           next()
           in.observeIndented()
-          inPackage(indented(topStatSeq()))
+          inPackage(indented(statSeq(statpf)))
         } else {
           List(atPos(startPos, auto)(Pkg(qid, bracelessPackageStats())))
         }
       } else if (token.is[LeftBrace]) {
-        inBraces(topStatSeq())
+        inBraces(statSeq(statpf))
       } else {
-        topStatSeq()
+        statSeq(statpf)
       }
     }
     if (inBracelessPackage()) {
@@ -5339,7 +5328,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
       accept[KwPackage]
       Source(List(atPos(startPos, auto)(Pkg(qualId(), bracelessPackageStats()))))
     } else {
-      Source(topStatSeq())
+      Source(statSeq(statpf))
     }
   }
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
@@ -26,7 +26,8 @@ class ParseSuite extends FunSuite with CommonTrees {
   def term(code: String)(implicit dialect: Dialect) = code.parseRule(_.expr())
   def pat(code: String)(implicit dialect: Dialect) = code.parseRule(_.pattern())
   def tpe(code: String)(implicit dialect: Dialect) = code.parseRule(_.typ())
-  def topStat(code: String)(implicit dialect: Dialect) = code.parseRule(_.topStatSeq().head)
+  def topStat(code: String)(implicit dialect: Dialect) =
+    code.parseRule(p => p.statSeq(p.topStat).head)
   def templStat(code: String)(implicit dialect: Dialect) = code.parseRule(_.templateStats().head)
   def blockStat(code: String)(implicit dialect: Dialect) = code.parseRule(_.blockStatSeq().head)
   def caseClause(code: String)(implicit dialect: Dialect) = code.parseRule(_.caseClause())

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ToplevelTermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ToplevelTermSuite.scala
@@ -1,0 +1,92 @@
+package scala.meta.tests.parsers
+
+import scala.compat.Platform.EOL
+import scala.meta._
+
+import munit._
+
+class ToplevelTermSuite extends FunSuite {
+  implicit val dialect: Dialect = dialects.Scala3.withAllowToplevelTerms(true)
+  test("allowToplevelTerms simple") {
+
+    val sourceString = """def foo(x: Int): Int = x
+                          |foo(x)
+                          |""".trim.stripMargin
+
+    val tree = sourceString.parse[Source].get
+
+    assertEquals(tree.syntax, sourceString)
+    val expected =
+      Source(
+        List(
+          Defn.Def(
+            Nil,
+            Term.Name("foo"),
+            Nil,
+            List(List(Term.Param(Nil, Term.Name("x"), Some(Type.Name("Int")), None))),
+            Some(Type.Name("Int")),
+            Term.Name("x")
+          ),
+          Term.Apply(Term.Name("foo"), List(Term.Name("x")))
+        )
+      )
+    assertEquals(tree.structure, expected.structure)
+  }
+
+  test("allowToplevelTerms and allowPackageStatementsWithToplevelTerms with package") {
+
+    val sourceString = """package bar
+                         |def foo(x: Int): Int = x
+                         |foo(x)
+                         |""".trim.stripMargin
+
+    val tree = sourceString.parse[Source].get
+
+    assertEquals(tree.syntax, sourceString)
+    val expected =
+      Source(
+        List(
+          Pkg(
+            Term.Name("bar"),
+            List(
+              Defn.Def(
+                Nil,
+                Term.Name("foo"),
+                Nil,
+                List(List(Term.Param(Nil, Term.Name("x"), Some(Type.Name("Int")), None))),
+                Some(Type.Name("Int")),
+                Term.Name("x")
+              ),
+              Term.Apply(Term.Name("foo"), List(Term.Name("x")))
+            )
+          )
+        )
+      )
+    assertEquals(tree.structure, expected.structure)
+  }
+
+  test("allowToplevelTerms and allowPackageStatementsWithToplevelTerms no package") {
+    val sourceString = """def foo(x: Int): Int = x
+                         |foo(x)
+                         |""".trim.stripMargin
+
+    val tree = sourceString.parse[Source].get
+
+    assertEquals(tree.syntax, sourceString)
+    val expected = Source(
+      List(
+        Defn.Def(
+          Nil,
+          Term.Name("foo"),
+          Nil,
+          List(List(Term.Param(Nil, Term.Name("x"), Some(Type.Name("Int")), None))),
+          Some(Type.Name("Int")),
+          Term.Name("x")
+        ),
+        Term.Apply(Term.Name("foo"), List(Term.Name("x")))
+      )
+    )
+    assertEquals(tree.structure, expected.structure)
+  }
+
+}


### PR DESCRIPTION
Addresses https://github.com/scalameta/scalameta/issues/1940. A little more complicated than I thought. Comments welcome. I'm not sure if I put the test in the right place. 