### PR TITLE
ScalametaParser: Avoid stack overflow when annotation comes after modifier

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -4553,6 +4553,8 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
         val casePos = in.tokenPos
         next()
         objectDef(mods :+ atPos(casePos, casePos)(Mod.Case()))
+      case Token.At() =>
+        syntaxError("Annotations must precede keyword modifiers", at = token)
       case DefIntro() if dialect.allowToplevelStatements =>
         defOrDclOrSecondaryCtor(mods)
       case _ =>

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
@@ -479,4 +479,8 @@ class ModSuite extends ParseSuite {
     ) =
       templStat("protected[foo] private def foo = ???")
   }
+
+  test("Annotation after modifier") {
+    interceptParseErrors("implicit @foo def foo(a: Int): Int")
+  }
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -442,6 +442,18 @@ class MinorDottySuite extends BaseDottySuite {
     )
   }
 
+  test("annotation after modifier") {
+    runTestError[Stat](
+      "implicit @foo def foo(): Int",
+      "Annotations must precede keyword modifiers"
+    )
+
+    runTestError[Stat](
+      "{ inline @foo def foo(): Int }",
+      "; expected but @ found"
+    )
+  }
+
   test("unchecked-annotation") {
     runTestAssert[Stat]("val a :: Nil:  @unchecked = args")(
       Defn.Val(


### PR DESCRIPTION
Before this PR, parsing ```implicit @foo def foo(): Int``` would stack overflow. This is because `tmplDef` is happy to accept modifiers, even though in all cases it's been used, modifiers have already been parsed. This seems to only be a problem for dotty, but I added a test for both anyways. 