### PR TITLE
ScalametaParser: implement ammonite script parser

### DIFF
--- a/scalameta/inputs/shared/src/main/scala/scala/meta/inputs/Api.scala
+++ b/scalameta/inputs/shared/src/main/scala/scala/meta/inputs/Api.scala
@@ -21,6 +21,9 @@ private[meta] trait Aliases {
 
     type Slice = scala.meta.inputs.Input.Slice
     val Slice = scala.meta.inputs.Input.Slice
+
+    type Ammonite = scala.meta.inputs.Input.Ammonite
+    val Ammonite = scala.meta.inputs.Input.Ammonite
   }
 
   type Position = scala.meta.inputs.Position

--- a/scalameta/inputs/shared/src/main/scala/scala/meta/inputs/Input.scala
+++ b/scalameta/inputs/shared/src/main/scala/scala/meta/inputs/Input.scala
@@ -92,6 +92,12 @@ object Input {
     override def toString = s"Input.Slice($input, $start, $end)"
   }
 
+  final case class Ammonite(input: Input) extends Input {
+    override def chars = input.chars
+    override def text = input.text
+    override def toString = s"Input.Ammonite($input)"
+  }
+
   implicit val charsToInput: Convert[Array[Char], Input] =
     Convert(chars => Input.String(new scala.Predef.String(chars)))
   implicit val stringToInput: Convert[scala.Predef.String, Input] = Convert(Input.String(_))

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/parsers/Parse.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/parsers/Parse.scala
@@ -27,6 +27,7 @@ object Parse {
   implicit lazy val parseImporter: Parse[Importer] = toParse(_.parseImporter())
   implicit lazy val parseImportee: Parse[Importee] = toParse(_.parseImportee())
   implicit lazy val parseSource: Parse[Source] = toParse(_.parseSource())
+  implicit lazy val parseAmmonite: Parse[MultiSource] = toParse(_.parseAmmonite())
 
   private def toParse[T](fn: ScalametaParser => T): Parse[T] = new Parse[T] {
     def apply(input: Input, dialect: Dialect): Parsed[T] = {

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -571,6 +571,8 @@ object Importee {
   // checkFields(stats.forall(_.isTopLevelStat))
 }
 
+@ast class MultiSource(sources: List[Source]) extends Tree
+
 package internal.trees {
   // NOTE: Quasi is a base trait for a whole bunch of classes.
   // Every root, branch and ast trait/class among scala.meta trees (except for quasis themselves)

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -1179,6 +1179,7 @@ object TreeSyntax {
         s("case ", t.pat, " ", kw("=>"), " ", t.body)
       // Source
       case t: Source => r(t.stats, EOL)
+      case t: MultiSource => r(t.sources, s"$EOL$EOL@$EOL$EOL")
     }
 
     private def givenName(

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -301,6 +301,7 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.Mod.Using
       |scala.meta.Mod.ValParam
       |scala.meta.Mod.VarParam
+      |scala.meta.MultiSource
       |scala.meta.Name
       |scala.meta.Name.Anonymous
       |scala.meta.Name.Indeterminate

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -97,6 +97,7 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.dialects.Typelevel212 *
       |scala.meta.inputs
       |scala.meta.inputs.Input
+      |scala.meta.inputs.Input.Ammonite *
       |scala.meta.inputs.Input.File *
       |scala.meta.inputs.Input.None *
       |scala.meta.inputs.Input.Slice *

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
@@ -23,7 +23,7 @@ class ReflectionSuite extends FunSuite {
   test("root") {
     assert(symbolOf[scala.meta.Tree].isRoot)
     assertEquals(symbolOf[scala.meta.Tree].asRoot.allBranches.length, 23)
-    assertEquals(symbolOf[scala.meta.Tree].asRoot.allLeafs.length, 347)
+    assertEquals(symbolOf[scala.meta.Tree].asRoot.allLeafs.length, 349)
   }
 
   test("If") {
@@ -76,6 +76,7 @@ class ReflectionSuite extends FunSuite {
       |List[scala.meta.Mod.Annot]
       |List[scala.meta.Mod]
       |List[scala.meta.Pat]
+      |List[scala.meta.Source]
       |List[scala.meta.Stat]
       |List[scala.meta.Term.Name]
       |List[scala.meta.Term.Param]

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
@@ -32,6 +32,8 @@ class ParseSuite extends FunSuite with CommonTrees {
   def blockStat(code: String)(implicit dialect: Dialect) = code.parseRule(_.blockStatSeq().head)
   def caseClause(code: String)(implicit dialect: Dialect) = code.parseRule(_.caseClause())
   def source(code: String)(implicit dialect: Dialect) = code.parseRule(_.source())
+  def ammonite(code: String)(implicit dialect: Dialect) =
+    code.asAmmoniteInput.parseRule(_.entryPointAmmonite())
   def interceptParseErrors(stats: String*)(implicit loc: munit.Location) = {
     stats.foreach { stat =>
       try {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
@@ -69,6 +69,7 @@ object MoreHelpers {
   }
   implicit class XtensionCode(code: String) {
     def asInput: Input = Input.String(code)
+    def asAmmoniteInput: Input = Input.Ammonite(asInput)
     def applyRule[T <: Tree](rule: ScalametaParser => T)(implicit dialect: Dialect): T = {
       asInput.applyRule(rule)
     }

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
@@ -233,6 +233,12 @@ class PublicSuite extends FunSuite {
     assert(input.toString == s"""Input.VirtualFile("foo.scala", "foo")""")
   }
 
+  test("scala.meta.inputs.Input.Ammonite.toString") {
+    val input = Input.Ammonite(Input.None)
+    input match { case _: Input.Ammonite => }
+    assert(input.toString == s"""Input.Ammonite(Input.None)""")
+  }
+
   test("scala.meta.inputs.Position.toString") {
     // covered below
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -723,6 +723,39 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     assertEquals(tree.syntax, s"package foo${EOL}class C${EOL}package baz {$EOL  class D${EOL}}")
   }
 
+  test("ammonite: package foo; class C; package baz { class D }") {
+    val code = """
+                 |package foo1; class C1; package baz1 { class D1 }
+                 |@
+                 |package foo2; class C2; package baz2 { class D2 }
+                 |""".stripMargin
+    val tree = ammonite(code)
+    assertNoDiff(
+      tree.structure,
+      """MultiSource(List(
+        |Source(List(Pkg(Term.Name("foo1"), List(Defn.Class(Nil, Type.Name("C1"), Nil, Ctor.Primary(Nil, Name(""), Nil), Template(Nil, Nil, Self(Name(""), None), Nil, Nil)), Pkg(Term.Name("baz1"), List(Defn.Class(Nil, Type.Name("D1"), Nil, Ctor.Primary(Nil, Name(""), Nil), Template(Nil, Nil, Self(Name(""), None), Nil, Nil)))))))),
+        | Source(List(Pkg(Term.Name("foo2"), List(Defn.Class(Nil, Type.Name("C2"), Nil, Ctor.Primary(Nil, Name(""), Nil), Template(Nil, Nil, Self(Name(""), None), Nil, Nil)), Pkg(Term.Name("baz2"), List(Defn.Class(Nil, Type.Name("D2"), Nil, Ctor.Primary(Nil, Name(""), Nil), Template(Nil, Nil, Self(Name(""), None), Nil, Nil))))))))
+        |))""".stripMargin.replace("\n", "")
+    )
+    assertEquals(tree.syntax, code)
+    assertEquals(
+      tree.resetAllOrigins.syntax,
+      s"""package foo1
+         |class C1
+         |package baz1 {
+         |  class D1
+         |}
+         |
+         |@
+         |
+         |package foo2
+         |class C2
+         |package baz2 {
+         |  class D2
+         |}""".stripMargin.replace("\n", EOL)
+    )
+  }
+
   test("case `x`") {
     val tree1 = pat("`x`")
     assertEquals(tree1.structure, "Term.Name(\"x\")")


### PR DESCRIPTION
Adds a new MultiSource tree, and a new Input.Ammonite wrapper which is used as an indication that multi-source tokenization is needed.

Fixes #2155.