### PR TITLE
Use `java.nio.file.Files.write` to write SemanticDB files

### DIFF
--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/package.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/package.scala
@@ -16,12 +16,8 @@ package object scalac {
       if (!Files.exists(out.toNIO.getParent)) {
         Files.createDirectories(out.toNIO.getParent)
       }
-      val fos = Files.newOutputStream(out.toNIO, StandardOpenOption.CREATE, openOption)
-      try {
-        s.TextDocuments(sdocument :: Nil).writeTo(fos)
-      } finally {
-        fos.close()
-      }
+      val bytes = s.TextDocuments(sdocument :: Nil).toByteArray
+      Files.write(out.toNIO, bytes, StandardOpenOption.CREATE, openOption)
     }
     def save(targetroot: AbsolutePath): Unit =
       write(targetroot, append = false)


### PR DESCRIPTION
Related to https://github.com/scalameta/scalameta/issues/2561

Previously, the SemanticDB compiler plugin streamed bytes into the file
increasing the risk that the plugin would be interrupted mid-way. Now,
the plugin writes the payload into a byte array and then writes that
byte array to disk.

There's still a small risk that `Files.write` gets interrupted. We could
minimize that risk even further by writing to a temporary file first and
then moving that file. We can consider using that approach if the
problem persists, this change along should already significantly
minimize the risk of half-complete SemanticDB files.