### PR TITLE
Token macros: create common abstract base class

### DIFF
--- a/scalameta/common/shared/src/main/scala/org/scalameta/adt/Adt.scala
+++ b/scalameta/common/shared/src/main/scala/org/scalameta/adt/Adt.scala
@@ -73,7 +73,13 @@ class AdtNamerMacros(val c: Context) extends MacroHelpers {
 
   def branch(annottees: Tree*): Tree =
     annottees.transformAnnottees(new ImplTransformer {
-      override def transformTrait(cdef: ClassDef, mdef: ModuleDef): List[ImplDef] = {
+      override def transformTrait(cdef: ClassDef, mdef: ModuleDef): List[ImplDef] =
+        transformImpl(cdef, mdef)
+
+      override def transformClass(cdef: ClassDef, mdef: ModuleDef): List[ImplDef] =
+        transformImpl(cdef, mdef)
+
+      private def transformImpl(cdef: ClassDef, mdef: ModuleDef): List[ImplDef] = {
         val ClassDef(
           mods @ Modifiers(flags, privateWithin, anns),
           name,

--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/tokens/TokenNamerMacroHelpers.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/tokens/TokenNamerMacroHelpers.scala
@@ -1,0 +1,38 @@
+package scala.meta.internal.tokens
+
+import org.scalameta.internal.MacroHelpers
+import scala.language.experimental.macros
+
+trait TokenNamerMacroHelpers extends MacroHelpers {
+  import c.universe._
+
+  protected val Token = tq"_root_.scala.meta.tokens.Token"
+  protected val Classifier = tq"_root_.scala.meta.classifiers.Classifier"
+
+  protected def getClassifierBoilerplateRoot() = {
+    val q"..$classifierBoilerplate" = q"""
+        private object sharedClassifier extends $Classifier[$Token, $Token] {
+          def apply(x: $Token): _root_.scala.Boolean = true
+        }
+        implicit def classifier[T <: $Token]: $Classifier[T, $Token] = {
+          sharedClassifier.asInstanceOf[$Classifier[T, $Token]]
+        }
+      """
+    classifierBoilerplate
+  }
+
+  protected def getClassifierBoilerplate(cdef: ClassDef, unapplyToo: Boolean = false) = {
+    val tpe = typeRef(cdef, false, true)
+    val q"..$classifierBoilerplate" = q"""
+        private object sharedClassifier extends $Classifier[$Token, $tpe] {
+          def apply(x: $Token): _root_.scala.Boolean = x.isInstanceOf[$tpe]
+        }
+        implicit def classifier[T <: $Token]: $Classifier[T, $tpe] = {
+          sharedClassifier.asInstanceOf[$Classifier[T, $tpe]]
+        }
+      """
+    val unapplies = if (unapplyToo) List(q"def unapply(x: $tpe): Boolean = true") else Nil
+    classifierBoilerplate ++ unapplies
+  }
+
+}

--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/tokens/branch.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/tokens/branch.scala
@@ -1,0 +1,34 @@
+package scala.meta.internal.tokens
+
+import scala.annotation.StaticAnnotation
+import scala.language.experimental.macros
+import scala.reflect.macros.whitebox.Context
+
+class branch extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro BranchNamerMacros.impl
+}
+
+class BranchNamerMacros(val c: Context) extends TokenNamerMacroHelpers {
+  import c.universe._
+
+  def impl(annottees: Tree*): Tree =
+    annottees.transformAnnottees(new ImplTransformer {
+      override def transformTrait(cdef: ClassDef, mdef: ModuleDef): List[ImplDef] =
+        transformImpl(cdef, mdef)
+      override def transformClass(cdef: ClassDef, mdef: ModuleDef): List[ImplDef] =
+        transformImpl(cdef, mdef)
+
+      private def transformImpl(cdef: ClassDef, mdef: ModuleDef): List[ImplDef] = {
+        val ClassDef(mods, name, tparams, template) = cdef
+        val mods1 =
+          mods.mapAnnotations(_ :+ q"new $TokenMetadataModule.branch" :+ q"new $AdtPackage.branch")
+        val cdef1 = ClassDef(mods1, name, tparams, template)
+
+        val ModuleDef(mmods, mname, Template(mparents, mself, mstats)) = mdef
+        val mstats1 = mstats ++ getClassifierBoilerplate(cdef, true)
+        val mdef1 = ModuleDef(mmods, mname, Template(mparents, mself, mstats1))
+
+        List(cdef1, mdef1)
+      }
+    })
+}

--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/tokens/metadata.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/tokens/metadata.scala
@@ -8,6 +8,7 @@ import org.scalameta.adt.Metadata.Adt
 object Metadata {
   trait Token extends Adt
   class root extends StaticAnnotation
+  class branch extends StaticAnnotation
   class tokenClass(name: String, freeform: Boolean) extends StaticAnnotation
   class tokenCompanion extends StaticAnnotation
 }

--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/tokens/root.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/tokens/root.scala
@@ -5,53 +5,29 @@ package tokens
 import scala.language.experimental.macros
 import scala.annotation.StaticAnnotation
 import scala.reflect.macros.whitebox.Context
-import org.scalameta.internal.MacroHelpers
 
 // @root is a specialized version of @org.scalameta.adt.root for scala.meta tokens.
 class root extends StaticAnnotation {
   def macroTransform(annottees: Any*): Any = macro RootNamerMacros.impl
 }
 
-class RootNamerMacros(val c: Context) extends MacroHelpers {
+class RootNamerMacros(val c: Context) extends TokenNamerMacroHelpers {
   import c.universe._
-
-  val Token = tq"_root_.scala.meta.tokens.Token"
-  val Classifier = tq"_root_.scala.meta.classifiers.Classifier"
 
   def impl(annottees: Tree*): Tree =
     annottees.transformAnnottees(new ImplTransformer {
       override def transformTrait(cdef: ClassDef, mdef: ModuleDef): List[ImplDef] = {
-        val ClassDef(
-          mods @ Modifiers(flags, privateWithin, anns),
-          name,
-          tparams,
-          Template(parents, self, stats)
-        ) = cdef
-        val q"$mmods object $mname extends { ..$mearlydefns } with ..$mparents { $mself => ..$mstats }" =
-          mdef
-        val anns1 = q"new $TokenMetadataModule.root" +: q"new $AdtPackage.root" +: anns
-        val mstats1 = scala.collection.mutable.ListBuffer[Tree]() ++ mstats
-
-        val q"..$classifierBoilerplate" = q"""
-        private object sharedClassifier extends $Classifier[$Token, $Token] {
-          def apply(x: $Token): _root_.scala.Boolean = true
-        }
-        implicit def classifier[T <: $Token]: $Classifier[T, $Token] = {
-          sharedClassifier.asInstanceOf[$Classifier[T, $Token]]
-        }
-      """
-        mstats1 ++= classifierBoilerplate
-
+        val ClassDef(mods, name, tparams, Template(parents, self, stats)) = cdef
+        val mods1 =
+          mods.mapAnnotations(_ :+ q"new $TokenMetadataModule.root" :+ q"new $AdtPackage.root")
         val parents1 =
           parents :+ tq"$TokenMetadataModule.Token" :+ tq"_root_.scala.Product" :+ tq"_root_.scala.Serializable"
-        val cdef1 = ClassDef(
-          Modifiers(flags, privateWithin, anns1),
-          name,
-          tparams,
-          Template(parents1, self, stats)
-        )
-        val mdef1 =
-          q"$mmods object $mname extends { ..$mearlydefns } with ..$mparents { $mself => ..$mstats1 }"
+        val cdef1 = ClassDef(mods1, name, tparams, Template(parents1, self, stats))
+
+        val ModuleDef(mmods, mname, Template(mparents, mself, mstats)) = mdef
+        val mstats1 = mstats ++ getClassifierBoilerplateRoot()
+        val mdef1 = ModuleDef(mmods, mname, Template(mparents, mself, mstats1))
+
         List(cdef1, mdef1)
       }
     })


### PR DESCRIPTION
Also:
- simplify the root macro, matching only the needed fields
- define the branch macro, by copying root, removing custom parents and
  replacing root annotations with branch annotations.