### PR TITLE
ScalametaParser: remove broken branch in statSeq

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -4147,10 +4147,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
     val isIndented = acceptOpt[Indentation.Indent]
 
     while (!token.is[StatSeqEnd]) {
-      def isDefinedInEllipsis = {
-        if (token.is[LeftParen] || token.is[LeftBrace]) next(); statpf.isDefinedAt(token)
-      }
-      if (statpf.isDefinedAt(token) || (token.is[Ellipsis] && ahead(isDefinedInEllipsis)))
+      if (statpf.isDefinedAt(token))
         stats += statpf(token)
       else if (!token.is[StatSep])
         syntaxError(errorMsg + s" ${token.name}", at = token)


### PR DESCRIPTION
If we are calling a partial function on an argument, it will throw an exception unless it is defined for that argument.

Therefore, there's no need for the Ellipsis check as it will result in a failure anyway; let's issue a proper syntax error instead.