### PR TITLE
Tests: don't use println, pass clue to asserts

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/inputs/FormatMessageSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/inputs/FormatMessageSuite.scala
@@ -13,8 +13,7 @@ class FormatMessageSuite extends FunSuite {
       val content = Input.String(s)
       val points = 0.to(content.chars.length).map(i => Position.Range(content, i, i))
       val actual = points.map(p => s"${p.formatMessage("error", "foo")}").mkString(EOL)
-      if (actual != expected) Console.err.println(actual)
-      assert(actual == expected)
+      assertNoDiff(actual, expected)
     }
   }
 


### PR DESCRIPTION
The output of println is not co-located with the test title which makes these somewhat hard to use to track down the issue. On the other hand, the assert clue is printed in the right location.