### PR TITLE
LegacyScanner: don't use BACKQUOTED_IDENT

### DIFF
--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
@@ -118,8 +118,8 @@ class LegacyScanner(input: Input, dialect: Dialect) {
   protected def emitIdentifierDeprecationWarnings = true
 
   /** Clear buffer and set name and token */
-  private def finishNamed(idtoken: LegacyToken = IDENTIFIER): Unit = {
-    curr.setIdentifier(cbuf, idtoken, dialect) { x =>
+  private def finishNamed(isBackquoted: Boolean = false): Unit = {
+    curr.setIdentifier(cbuf, dialect, check = !isBackquoted) { x =>
       if (x.token == IDENTIFIER && emitIdentifierDeprecationWarnings)
         deprecationWarning(
           s"${x.name} is now a reserved word; usage as an identifier is deprecated",
@@ -506,7 +506,7 @@ class LegacyScanner(input: Input, dialect: Dialect) {
     nextChar()
     if (getLitChars('`')) {
       nextChar()
-      finishNamed(BACKQUOTED_IDENT)
+      finishNamed(isBackquoted = true)
       if (name.isEmpty) syntaxError("empty quoted identifier", at = offset)
     } else if (ch == '$') {
       syntaxError("can't unquote into quoted identifiers", at = charOffset - 1)
@@ -642,7 +642,7 @@ class LegacyScanner(input: Input, dialect: Dialect) {
         putChar(ch)
         nextRawChar()
       } while (ch != SU && Character.isUnicodeIdentifierPart(ch))
-      next.setIdentifier(cbuf, IDENTIFIER, dialect) { x =>
+      next.setIdentifier(cbuf, dialect) { x =>
         if (x.token != IDENTIFIER && x.token != THIS)
           syntaxError(
             "invalid unquote: `$'ident, `$'BlockExpr, `$'this or `$'_ expected",

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyToken.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyToken.scala
@@ -6,8 +6,7 @@ package tokenizers
 // type LegacyToken = Int
 
 object LegacyToken {
-  def isIdentifier(code: LegacyToken) =
-    code == IDENTIFIER || code == BACKQUOTED_IDENT // used by ide
+  def isIdentifier(code: LegacyToken) = code == IDENTIFIER // used by ide
   def isLiteral(code: LegacyToken) = code >= CHARLIT && code <= INTERPOLATIONID
 
   /** special tokens */
@@ -31,7 +30,6 @@ object LegacyToken {
 
   /** identifiers */
   final val IDENTIFIER = 10
-  final val BACKQUOTED_IDENT = 11
 
   /** keywords */
   final val NEW = 20

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyTokenData.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyTokenData.scala
@@ -108,13 +108,13 @@ trait LegacyTokenData {
   def floatVal: BigDecimal = floatingVal
   def doubleVal: BigDecimal = floatingVal
 
-  def setIdentifier(ident: StringBuilder, tokVal: Int, dialect: Dialect)(
+  def setIdentifier(ident: StringBuilder, dialect: Dialect, check: Boolean = true)(
       fCheck: LegacyTokenData => Unit
   ): Unit = {
     name = ident.toString
     ident.clear()
-    token = tokVal
-    if (tokVal == IDENTIFIER)
+    token = IDENTIFIER
+    if (check)
       kw2legacytoken.get(name).foreach {
         case ENUM if !dialect.allowEnums =>
         case GIVEN if !dialect.allowGivenUsing =>

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
@@ -40,8 +40,6 @@ class ScalametaTokenizer(input: Input, dialect: Dialect) {
     def pushLegacyToken(curr: LegacyTokenData, next: => Option[LegacyTokenData]): Unit = {
       val token = (curr.token: @scala.annotation.switch) match {
         case IDENTIFIER => Token.Ident(input, dialect, curr.offset, curr.endOffset + 1, curr.name)
-        case BACKQUOTED_IDENT =>
-          Token.Ident(input, dialect, curr.offset, curr.endOffset + 1, curr.name)
         case INTLIT =>
           Token.Constant.Int(input, dialect, curr.offset, curr.endOffset + 1, curr.intVal)
         case LONGLIT =>


### PR DESCRIPTION
Its handling is identical to IDENTIFIER; use a simple boolean in the one place where there's a difference.