### PR TITLE
Trees: turn Type.{And, Or} into infix-like trees

### DIFF
--- a/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
@@ -9,6 +9,7 @@ import scala.collection.immutable.TreeMap
  */
 final class Dialect private (
     // Are `&` intersection types supported by this dialect?
+    @deprecated("allowAndTypes unneeded, infix types are supported", "4.5.1")
     val allowAndTypes: Boolean,
     // Are extractor varargs specified using ats, i.e. is `case Extractor(xs @ _*)` legal or not?
     val allowAtForExtractorVarargs: Boolean,
@@ -33,6 +34,7 @@ final class Dialect private (
     // Some quasiquotes only support single-line snippets.
     val allowMultilinePrograms: Boolean,
     // Are `|` (union types) supported by this dialect?
+    @deprecated("allowOrTypes unneeded, infix types are supported", "4.5.1")
     val allowOrTypes: Boolean,
     // Are unquotes ($x) and splices (..$xs, ...$xss) allowed?
     // If yes, they will be parsed as patterns.
@@ -242,6 +244,7 @@ final class Dialect private (
   // Are unquotes ($x) and splices (..$xs, ...$xss) allowed?
   def allowUnquotes: Boolean = allowTermUnquotes || allowPatUnquotes
 
+  @deprecated("allowAndTypes unneeded, infix types are supported", "4.5.1")
   def withAllowAndTypes(newValue: Boolean): Dialect = {
     privateCopy(allowAndTypes = newValue)
   }
@@ -274,6 +277,7 @@ final class Dialect private (
   def withAllowMultilinePrograms(newValue: Boolean): Dialect = {
     privateCopy(allowMultilinePrograms = newValue)
   }
+  @deprecated("allowOrTypes unneeded, infix types are supported", "4.5.1")
   def withAllowOrTypes(newValue: Boolean): Dialect = {
     privateCopy(allowOrTypes = newValue)
   }
@@ -620,6 +624,7 @@ final class Dialect private (
 
 object Dialect extends InternalDialect {
   def apply(
+      @deprecated("allowAndTypes unneeded, infix types are supported", "4.5.1")
       allowAndTypes: Boolean,
       allowAtForExtractorVarargs: Boolean,
       allowCaseClassWithoutParameterList: Boolean,
@@ -631,6 +636,7 @@ object Dialect extends InternalDialect {
       allowLiteralTypes: Boolean,
       allowMethodTypes: Boolean,
       allowMultilinePrograms: Boolean,
+      @deprecated("allowOrTypes unneeded, infix types are supported", "4.5.1")
       allowOrTypes: Boolean,
       allowPatUnquotes: Boolean,
       allowSpliceUnderscores: Boolean,

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -1,9 +1,6 @@
 package scala.meta
 
-import org.scalameta.data._
 import org.scalameta.invariants._
-import scala.meta.dialects._
-import scala.meta.internal.dialects._
 
 package object dialects {
   implicit val Scala210 = Dialect(
@@ -65,7 +62,6 @@ package object dialects {
     .withAllowOpenClass(true)
     .withAllowInfixMods(true)
     .withAllowPostfixStarVarargSplices(true)
-    .withAllowAndTypes(true)
     .withAllowPlusMinusUnderscoreAsIdent(true)
     .withAllowGivenImports(true)
 
@@ -79,7 +75,6 @@ package object dialects {
     .withAllowOpenClass(true)
     .withAllowInfixMods(true)
     .withAllowPostfixStarVarargSplices(true)
-    .withAllowAndTypes(true)
     .withAllowPlusMinusUnderscoreAsIdent(true)
     .withAllowGivenImports(true)
 
@@ -108,7 +103,6 @@ package object dialects {
     .withAllowInlineMods(true)
 
   implicit val Scala3 = Scala213
-    .withAllowAndTypes(true)
     // there 3 different ways to specify vargs, some will be removed in future Scala 3 versions
     .withAllowAtForExtractorVarargs(true) // both @ and : work currently for Scala 3
     .withAllowColonForExtractorVarargs(true) // both @ and : work currently for Scala 3
@@ -117,7 +111,6 @@ package object dialects {
     .withAllowImplicitByNameParameters(true)
     .withAllowInlineMods(true)
     .withAllowLiteralTypes(true)
-    .withAllowOrTypes(true) // Scala 3: `val a: A | B`
     .withAllowTrailingCommas(true)
     .withAllowTraitParameters(true)
     .withAllowTypeLambdas(true)

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -844,18 +844,6 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
               case _ => false
             }) => // we assume that this is a type specification for a vararg parameter
           t
-        case Ident("&") if dialect.allowAndTypes =>
-          next()
-          newLineOptWhenFollowedBy[TypeIntro]
-          val t1 = compoundType()
-          verifyLeftAssoc(t1)
-          infixTypeRest(atPos(startPos, t1)(Type.And(t, t1)), InfixMode.LeftOp, startPos)
-        case Ident("|") if dialect.allowOrTypes =>
-          next()
-          newLineOptWhenFollowedBy[TypeIntro]
-          val t1 = compoundType()
-          verifyLeftAssoc(t1)
-          infixTypeRest(atPos(startPos, t1)(Type.Or(t, t1)), InfixMode.LeftOp, startPos)
         case _: Ident | _: Unquote =>
           val op = typeName()
           val leftAssoc = op.isLeftAssoc
@@ -1014,14 +1002,6 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
           val lhs1 = loop(lhs, convertTypevars = false)
           val rhs1 = loop(rhs, convertTypevars = false)
           Type.With(lhs1, rhs1)
-        case Type.And(lhs, rhs) =>
-          val lhs1 = loop(lhs, convertTypevars = false)
-          val rhs1 = loop(rhs, convertTypevars = false)
-          Type.And(lhs1, rhs1)
-        case Type.Or(lhs, rhs) =>
-          val lhs1 = loop(lhs, convertTypevars = false)
-          val rhs1 = loop(rhs, convertTypevars = false)
-          Type.Or(lhs1, rhs1)
         case Type.Refine(tpe, stats) =>
           val tpe1 = tpe.map(loop(_, convertTypevars = false))
           val stats1 = stats

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -204,7 +204,9 @@ object Type {
     checkFields(args.length > 1 || (args.length == 1 && args.head.is[Type.Quasi]))
   }
   @ast class With(lhs: Type, rhs: Type) extends Type
+  @deprecated("And unused, replaced by ApplyInfix", "4.5.1")
   @ast class And(lhs: Type, rhs: Type) extends Type
+  @deprecated("Or unused, replaced by ApplyInfix", "4.5.1")
   @ast class Or(lhs: Type, rhs: Type) extends Type
   @ast class Refine(tpe: Option[Type], stats: List[Stat]) extends Type {
     checkFields(stats.forall(_.isRefineStat))

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
@@ -21,9 +21,10 @@ class ReflectionSuite extends FunSuite {
   // I understand that it's inconvenient to update these numbers every time something changes,
   // but please deal with that (or come up with a more effective way of testing TreeReflection)
   test("root") {
-    assert(symbolOf[scala.meta.Tree].isRoot)
-    assertEquals(symbolOf[scala.meta.Tree].asRoot.allBranches.length, 23)
-    assertEquals(symbolOf[scala.meta.Tree].asRoot.allLeafs.length, 351)
+    val sym = symbolOf[scala.meta.Tree]
+    assert(sym.isRoot)
+    val root = sym.asRoot
+    assertEquals((root.allBranches.length, root.allLeafs.length), (23, 351))
   }
 
   test("If") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/AndOrTypesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/AndOrTypesSuite.scala
@@ -1,7 +1,5 @@
 package scala.meta.tests.parsers.dotty
 
-import scala.meta.tests.parsers.ParseSuite
-
 import scala.meta._, Type._
 
 class AndOrTypesSuite extends BaseDottySuite {
@@ -25,19 +23,19 @@ class AndOrTypesSuite extends BaseDottySuite {
 
   test("A & B & C") {
     runTestAssert[Type]("A & B & C")(
-      And(And(Type.Name("A"), Type.Name("B")), Type.Name("C"))
+      ApplyInfix(ApplyInfix(pname("A"), pname("&"), pname("B")), pname("&"), pname("C"))
     )
   }
 
   test("A & B") {
     runTestAssert[Type]("A & B")(
-      And(Type.Name("A"), Type.Name("B"))
+      ApplyInfix(pname("A"), pname("&"), pname("B"))
     )
   }
 
   test("A | B") {
     runTestAssert[Type]("A | B")(
-      Or(Type.Name("A"), Type.Name("B"))
+      ApplyInfix(pname("A"), pname("|"), pname("B"))
     )
   }
 
@@ -49,7 +47,12 @@ class AndOrTypesSuite extends BaseDottySuite {
         Nil,
         List(
           List(
-            Term.Param(Nil, tname("id"), Some(Type.Or(pname("UserName"), pname("Password"))), None)
+            Term.Param(
+              Nil,
+              tname("id"),
+              Some(ApplyInfix(pname("UserName"), pname("|"), pname("Password"))),
+              None
+            )
           )
         ),
         pname("Unit")
@@ -57,7 +60,11 @@ class AndOrTypesSuite extends BaseDottySuite {
     )
 
     runTestAssert[Stat]("val either: Password | UserName")(
-      Decl.Val(Nil, List(Pat.Var(tname("either"))), Type.Or(pname("Password"), pname("UserName")))
+      Decl.Val(
+        Nil,
+        List(Pat.Var(tname("either"))),
+        ApplyInfix(pname("Password"), pname("|"), pname("UserName"))
+      )
     )
   }
 
@@ -66,7 +73,7 @@ class AndOrTypesSuite extends BaseDottySuite {
       Decl.Val(
         Nil,
         List(Pat.Var(tname("x"))),
-        Type.And(pname("Reset"), Type.Apply(Type.Name("Ord"), List(pname("Int"))))
+        ApplyInfix(pname("Reset"), pname("&"), Type.Apply(pname("Ord"), List(pname("Int"))))
       )
     )
     runTestAssert[Stat]("def fx(a: List[A & B]): Unit")(
@@ -79,7 +86,7 @@ class AndOrTypesSuite extends BaseDottySuite {
             Term.Param(
               Nil,
               tname("a"),
-              Some(Type.Apply(pname("List"), List(Type.And(Type.Name("A"), pname("B"))))),
+              Some(Type.Apply(pname("List"), List(ApplyInfix(pname("A"), pname("&"), pname("B"))))),
               None
             )
           )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
@@ -610,7 +610,7 @@ class GivenUsingSuite extends BaseDottySuite {
         Name(""),
         Nil,
         Nil,
-        Type.And(Type.Name("Cancelable"), Type.Name("Movable")),
+        Type.ApplyInfix(pname("Cancelable"), pname("&"), pname("Movable")),
         Term.Name("???")
       )
     )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -92,7 +92,7 @@ class MinorDottySuite extends BaseDottySuite {
         pname("F"),
         Nil,
         pname("AB"),
-        Type.Bounds(None, Some(Type.And(Type.Name("A"), Type.Name("B"))))
+        Type.Bounds(None, Some(Type.ApplyInfix(pname("A"), pname("&"), pname("B"))))
       )
     )
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -1908,7 +1908,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
               Term.Param(
                 List(Mod.ValParam()),
                 Term.Name("uri"),
-                Some(Type.Or(Type.Name("String"), Type.Name("Null"))),
+                Some(Type.ApplyInfix(pname("String"), pname("|"), pname("Null"))),
                 None
               )
             )


### PR DESCRIPTION
Otherwise we can't apply the complex infix formatting to them as the `|` and `&` tokens are not represented as separate children within the tree.

Needed by scalameta/scalafmt#3153.