### PR TITLE
ScalametaParser: fix pattern infix type logic

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
@@ -25,6 +25,7 @@ class ParseSuite extends FunSuite with CommonTrees {
   def stat(code: String)(implicit dialect: Dialect) = code.applyRule(_.parseStat())
   def term(code: String)(implicit dialect: Dialect) = code.parseRule(_.expr())
   def pat(code: String)(implicit dialect: Dialect) = code.parseRule(_.pattern())
+  def patternTyp(code: String)(implicit dialect: Dialect) = code.parseRule(_.patternTyp())
   def tpe(code: String)(implicit dialect: Dialect) = code.parseRule(_.typ())
   def topStat(code: String)(implicit dialect: Dialect) =
     code.parseRule(p => p.statSeq(p.topStat).head)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/PatSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/PatSuite.scala
@@ -5,6 +5,15 @@ import scala.meta._, Pat._
 import scala.meta.dialects.Scala211
 
 class PatSuite extends ParseSuite {
+
+  private def assertPat(expr: String)(tree: Tree): Unit = {
+    assertEquals(pat(expr).structure, tree.structure)
+  }
+
+  private def assertPatTyp(expr: String)(tree: Tree): Unit = {
+    assertEquals(patternTyp(expr).structure, tree.structure)
+  }
+
   test("_") {
     val Wildcard() = pat("_")
   }
@@ -43,6 +52,40 @@ class PatSuite extends ParseSuite {
       Wildcard(),
       Type.Apply(Type.Name("F"), Type.Placeholder(Type.Bounds(None, None)) :: Nil)
     ) = pat("_: F[_]")
+  }
+
+  test("t Map u") {
+    assertPatTyp("t Map u") {
+      Type.ApplyInfix(Type.Name("t"), Type.Name("u"), Type.Name("Map"))
+    }
+  }
+
+  test("patTyp: t & u | v") {
+    assertPatTyp("t & u | v") {
+      Type.ApplyInfix(
+        Type.ApplyInfix(Type.Name("t"), Type.Name("u"), Type.Name("&")),
+        Type.Name("|"),
+        Type.Name("v")
+      )
+    }
+  }
+
+  test("pat: F[t & u | v]()") {
+    assertPat("F[t & u | v]()") {
+      Pat.Extract(
+        Term.ApplyType(
+          Term.Name("F"),
+          List(
+            Type.ApplyInfix(
+              Type.ApplyInfix(Type.Name("t"), Type.Name("u"), Type.Name("&")),
+              Type.Name("|"),
+              Type.Name("v")
+            )
+          )
+        ),
+        Nil
+      )
+    }
   }
 
   test("_: (t Map u)") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/PatSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/PatSuite.scala
@@ -56,14 +56,14 @@ class PatSuite extends ParseSuite {
 
   test("t Map u") {
     assertPatTyp("t Map u") {
-      Type.ApplyInfix(Type.Name("t"), Type.Name("u"), Type.Name("Map"))
+      Type.ApplyInfix(Type.Name("t"), Type.Name("Map"), Type.Name("u"))
     }
   }
 
   test("patTyp: t & u | v") {
     assertPatTyp("t & u | v") {
       Type.ApplyInfix(
-        Type.ApplyInfix(Type.Name("t"), Type.Name("u"), Type.Name("&")),
+        Type.ApplyInfix(Type.Name("t"), Type.Name("&"), Type.Name("u")),
         Type.Name("|"),
         Type.Name("v")
       )
@@ -77,7 +77,7 @@ class PatSuite extends ParseSuite {
           Term.Name("F"),
           List(
             Type.ApplyInfix(
-              Type.ApplyInfix(Type.Name("t"), Type.Name("u"), Type.Name("&")),
+              Type.ApplyInfix(Type.Name("t"), Type.Name("&"), Type.Name("u")),
               Type.Name("|"),
               Type.Name("v")
             )


### PR DESCRIPTION
It was duplicating code and inadvertently parsing the `op` after the `rhs`. Helps with #2315.
