### PR TITLE
ScalametaParser: use tuple for interim infix rhs

### DIFF
--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
@@ -181,7 +181,7 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Stat](
     "(a, b) op ((c, d))",
     """|Term.Tuple (a, b)
-       |Term.Tuple ((c, d))
+       |Term.Tuple (c, d)
        |""".stripMargin
   )
   checkPositions[Stat]("1 + 1")


### PR DESCRIPTION
Uses for `Term.ApplyInfix` the approach we took for `Pat.ExtractInfix`. Simplifies the code and sets positions for the RHS correctly.