### PR TITLE
Support MatchType in `metap`

### DIFF
--- a/semanticdb/metap/src/main/scala/scala/meta/internal/metap/SymbolInformationPrinter.scala
+++ b/semanticdb/metap/src/main/scala/scala/meta/internal/metap/SymbolInformationPrinter.scala
@@ -227,6 +227,13 @@ trait SymbolInformationPrinter extends BasePrinter {
           case RepeatedType(utpe) =>
             opt(utpe)(normal)
             out.print("*")
+          case MatchType(scrutinee, cases) =>
+            opt(scrutinee)(normal)
+            rep(" match { ", cases, ", ", " }") { kase =>
+              opt(kase.key)(normal)
+              out.print(" => ")
+              opt(kase.body)(normal)
+            }
           case NoType =>
             out.print("<?>")
         }


### PR DESCRIPTION
Follow up for https://github.com/scalameta/scalameta/pull/2681

Confirmed locally, and looks good :+1:

```
Symbols:
example/MatchType$package.Concat# => type Concat[Xs <: Tuple, +Ys <: Tuple] = Xs match { EmptyTuple => Ys, *:[x, xs] => *:[x, Concat[xs, Ys]] }
...
example/MatchType$package.Elem# => type Elem[X] = X match { String => Char, Array[t] => t, Iterable[t] => t }
...
```


Here's how I confirmed the behavior

- `sbt publishLocal` (in scalameta/scalameta)
  - published, for example, 2.13, 4.5.0-SNAPSHOT
- Go `lampepfl/dotty` with the branch https://github.com/lampepfl/dotty/pull/14608
- `sbt scalac -Xsemanticdb tests/semanticdb/expect/MatchType.scala`
- `coursier launch --main-class scala.meta.cli.Metap org.scalameta:scalameta_2.13:4.5.0-SNAPSHOT -- META-INF/semanticdb/tests/semanticdb/expect/MatchType.scala.semanticdb`

