### PR TITLE
Support MatchType in metacp

### DIFF
--- a/tests/jvm/src/test/scala/scala/meta/tests/metacp/MetacpOps.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/metacp/MetacpOps.scala
@@ -74,6 +74,12 @@ object MetacpOps {
         visitType(tpe)
       case s.RepeatedType(tpe) =>
         visitType(tpe)
+      case s.MatchType(scrutinee, cases) =>
+        visitType(scrutinee)
+        cases.foreach { kase =>
+          visitType(kase.key)
+          visitType(kase.body)
+        }
       case s.NoType =>
     }
     def visitSignature(signature: s.Signature): Unit = signature match {


### PR DESCRIPTION
Follow-up for https://github.com/scalameta/scalameta/pull/2681

This commit changes anything, as there are no MatchType included test files, and we don't invoke compilation using scala3 in the scalameta test at this moment :)