### PR TITLE
TreeSyntax: handle Init argss explicitly

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -1018,7 +1018,11 @@ object TreeSyntax {
           )
 
       // Init
-      case t: Init => s(if (t.tpe.is[Type.Singleton]) kw("this") else p(RefineTyp, t.tpe), t.argss)
+      case t: Init =>
+        s(
+          if (t.tpe.is[Type.Singleton]) kw("this") else p(RefineTyp, t.tpe),
+          r(t.argss.map(x => s("(", r(x, ", "), ")")))
+        )
 
       // Self
       case t: Self => s(t.name, t.decltpe)
@@ -1168,7 +1172,7 @@ object TreeSyntax {
 
     // Multiples and optionals
     implicit def syntaxArgs: Syntax[List[Term]] = Syntax {
-      case (b: Term.Block) :: Nil if !b.parent.exists(_.is[Init]) => s(" ", b)
+      case (b: Term.Block) :: Nil => s(" ", b)
       case (f @ Term.Function(params, _)) :: Nil if !params.exists(_.decltpe.isEmpty) =>
         s(" { ", f, " }")
       case args => s("(", r(args, ", "), ")")

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -1215,4 +1215,17 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     )
   }
 
+  test("#2317 init block") {
+    checkTree(
+      q"new Foo({str => str.length})",
+      """new Foo({
+        |  str => str.length
+        |})""".stripMargin
+    )
+  }
+
+  test("#1917 init lambda") {
+    checkTree(q"new Foo((a: Int) => a + 1)", "new Foo((a: Int) => a + 1)")
+  }
+
 }


### PR DESCRIPTION
Fixes #1917. Follow on to #2325.