### PR TITLE
ScalametaParser: keep `(())` as `Lit.Unit`

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -1431,4 +1431,180 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     )
   }
 
+  test("#2708 term lassoc") {
+    checkTree(q"""{
+            () == ()
+            (()) == (())
+            () == () == ()
+            (()) == (()) == (())
+          }""")(
+      Term.Block(
+        List(
+          Term.ApplyInfix(Lit.Unit(), Term.Name("=="), Nil, Nil),
+          Term.ApplyInfix(
+            Lit.Unit(),
+            Term.Name("=="),
+            Nil,
+            Nil
+          ),
+          Term.ApplyInfix(
+            Term.ApplyInfix(Lit.Unit(), Term.Name("=="), Nil, Nil),
+            Term.Name("=="),
+            Nil,
+            Nil
+          ),
+          Term.ApplyInfix(
+            Term.ApplyInfix(
+              Lit.Unit(),
+              Term.Name("=="),
+              Nil,
+              Nil
+            ),
+            Term.Name("=="),
+            Nil,
+            Nil
+          )
+        )
+      )
+    )
+  }
+
+  test("#2708 term rassoc") {
+    checkTree(q"""{
+            () :: ()
+            (()) :: (())
+            () :: () :: ()
+            (()) :: (()) :: (())
+          }""")(
+      Term.Block(
+        List(
+          Term.ApplyInfix(Lit.Unit(), Term.Name("::"), Nil, Nil),
+          Term.ApplyInfix(
+            Lit.Unit(),
+            Term.Name("::"),
+            Nil,
+            Nil
+          ),
+          Term.ApplyInfix(
+            Lit.Unit(),
+            Term.Name("::"),
+            Nil,
+            List(Term.ApplyInfix(Lit.Unit(), Term.Name("::"), Nil, Nil))
+          ),
+          Term.ApplyInfix(
+            Lit.Unit(),
+            Term.Name("::"),
+            Nil,
+            List(
+              Term.ApplyInfix(
+                Lit.Unit(),
+                Term.Name("::"),
+                Nil,
+                Nil
+              )
+            )
+          )
+        )
+      )
+    )
+  }
+
+  test("#2708 pat lassoc") {
+    checkTree(q"""foo match {
+            case () == () =>
+            case (()) == (()) =>
+            case () == () == () =>
+            case (()) == (()) == (()) =>
+          }""")(
+      Term.Match(
+        Term.Name("foo"),
+        List(
+          Case(Pat.ExtractInfix(Lit.Unit(), Term.Name("=="), Nil), None, Term.Block(Nil)),
+          Case(
+            Pat.ExtractInfix(
+              Lit.Unit(),
+              Term.Name("=="),
+              Nil
+            ),
+            None,
+            Term.Block(Nil)
+          ),
+          Case(
+            Pat.ExtractInfix(
+              Pat.ExtractInfix(Lit.Unit(), Term.Name("=="), Nil),
+              Term.Name("=="),
+              Nil
+            ),
+            None,
+            Term.Block(Nil)
+          ),
+          Case(
+            Pat.ExtractInfix(
+              Pat.ExtractInfix(
+                Lit.Unit(),
+                Term.Name("=="),
+                Nil
+              ),
+              Term.Name("=="),
+              Nil
+            ),
+            None,
+            Term.Block(Nil)
+          )
+        ),
+        Nil
+      )
+    )
+  }
+
+  test("#2708 pat rassoc") {
+    checkTree(q"""foo match {
+            case () :: () =>
+            case (()) :: (()) =>
+            case () :: () :: () =>
+            case (()) :: (()) :: (()) =>
+          }""")(
+      Term.Match(
+        Term.Name("foo"),
+        List(
+          Case(Pat.ExtractInfix(Lit.Unit(), Term.Name("::"), Nil), None, Term.Block(Nil)),
+          Case(
+            Pat.ExtractInfix(
+              Lit.Unit(),
+              Term.Name("::"),
+              Nil
+            ),
+            None,
+            Term.Block(Nil)
+          ),
+          Case(
+            Pat.ExtractInfix(
+              Lit.Unit(),
+              Term.Name("::"),
+              List(Pat.ExtractInfix(Lit.Unit(), Term.Name("::"), Nil))
+            ),
+            None,
+            Term.Block(Nil)
+          ),
+          Case(
+            Pat.ExtractInfix(
+              Lit.Unit(),
+              Term.Name("::"),
+              List(
+                Pat.ExtractInfix(
+                  Lit.Unit(),
+                  Term.Name("::"),
+                  Nil
+                )
+              )
+            ),
+            None,
+            Term.Block(Nil)
+          )
+        ),
+        Nil
+      )
+    )
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -1445,7 +1445,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
             Lit.Unit(),
             Term.Name("=="),
             Nil,
-            Nil
+            List(Lit.Unit())
           ),
           Term.ApplyInfix(
             Term.ApplyInfix(Lit.Unit(), Term.Name("=="), Nil, Nil),
@@ -1458,11 +1458,11 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
               Lit.Unit(),
               Term.Name("=="),
               Nil,
-              Nil
+              List(Lit.Unit())
             ),
             Term.Name("=="),
             Nil,
-            Nil
+            List(Lit.Unit())
           )
         )
       )
@@ -1483,7 +1483,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
             Lit.Unit(),
             Term.Name("::"),
             Nil,
-            Nil
+            List(Lit.Unit())
           ),
           Term.ApplyInfix(
             Lit.Unit(),
@@ -1500,7 +1500,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
                 Lit.Unit(),
                 Term.Name("::"),
                 Nil,
-                Nil
+                List(Lit.Unit())
               )
             )
           )
@@ -1524,7 +1524,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
             Pat.ExtractInfix(
               Lit.Unit(),
               Term.Name("=="),
-              Nil
+              List(Lit.Unit())
             ),
             None,
             Term.Block(Nil)
@@ -1543,10 +1543,10 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
               Pat.ExtractInfix(
                 Lit.Unit(),
                 Term.Name("=="),
-                Nil
+                List(Lit.Unit())
               ),
               Term.Name("=="),
-              Nil
+              List(Lit.Unit())
             ),
             None,
             Term.Block(Nil)
@@ -1572,7 +1572,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
             Pat.ExtractInfix(
               Lit.Unit(),
               Term.Name("::"),
-              Nil
+              List(Lit.Unit())
             ),
             None,
             Term.Block(Nil)
@@ -1594,7 +1594,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
                 Pat.ExtractInfix(
                   Lit.Unit(),
                   Term.Name("::"),
-                  Nil
+                  List(Lit.Unit())
                 )
               )
             ),


### PR DESCRIPTION
Fixes #2708.