### PR TITLE
TreeSyntax: handle single trailing NL with dquotes

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -822,10 +822,9 @@ object TreeSyntax {
       case Lit.Char(value) => m(Literal, s(enquote(value.toString, SingleQuotes)))
       // Strings should be triple-quoted regardless of what newline style is used.
       case Lit.String(value) =>
-        m(
-          Literal,
-          s(enquote(value.toString, if (value.contains("\n")) TripleQuotes else DoubleQuotes))
-        )
+        val firstNL = value.indexOf('\n') + 1
+        val style = if (firstNL > 0 && firstNL < value.length) TripleQuotes else DoubleQuotes
+        m(Literal, s(enquote(value, style)))
       case Lit.Symbol(value) => m(Literal, s("'", value.name))
       case Lit.Null() => m(Literal, s(kw("null")))
       case Lit.Unit() => m(Literal, s("()"))

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -1320,16 +1320,14 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
   test("#2695 1") {
     checkTree(
       q"""s.split("\n")""",
-      s"""s.split(${"\"" * 3}
-         |${"\"" * 3})""".stripMargin
+      """s.split("\n")""".stripMargin
     )
   }
 
   test("#2695 2") {
     checkTree(
       q"""s.split("foo\n")""",
-      s"""s.split(${"\"" * 3}foo
-         |${"\"" * 3})""".stripMargin
+      """s.split("foo\n")""".stripMargin
     )
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -1317,4 +1317,28 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     )
   }
 
+  test("#2695 1") {
+    checkTree(
+      q"""s.split("\n")""",
+      s"""s.split(${"\"" * 3}
+         |${"\"" * 3})""".stripMargin
+    )
+  }
+
+  test("#2695 2") {
+    checkTree(
+      q"""s.split("foo\n")""",
+      s"""s.split(${"\"" * 3}foo
+         |${"\"" * 3})""".stripMargin
+    )
+  }
+
+  test("#2695 3") {
+    checkTree(
+      q"""s.split("\nfoo")""",
+      s"""s.split(${"\"" * 3}
+         |foo${"\"" * 3})""".stripMargin
+    )
+  }
+
 }


### PR DESCRIPTION
Fixes #2695.