### PR TITLE
ParentChecks: allow Repeated to be part of Tuple

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/ParentChecks.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/ParentChecks.scala
@@ -27,7 +27,10 @@ object ParentChecks {
   }
 
   def TermRepeated(tree: Term.Repeated, parent: Tree, destination: String): Boolean = {
-    termArgument(parent, destination)
+    parent match {
+      case _: Term.Tuple => destination == "args"
+      case _ => termArgument(parent, destination)
+    }
   }
 
   def PatVar(tree: Pat.Var, parent: Tree, destination: String): Boolean = parent match {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -1338,4 +1338,14 @@ class TermSuite extends ParseSuite {
     }
   }
 
+  test("#2720 infix with repeated arg last") {
+    import org.scalameta.invariants.InvariantFailedException
+    intercept[InvariantFailedException](term("a op (b, c: _*)"))
+  }
+
+  test("#2720 infix with repeated arg not last") {
+    import org.scalameta.invariants.InvariantFailedException
+    intercept[InvariantFailedException](term("a op (b: _*, c)"))
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -1339,13 +1339,23 @@ class TermSuite extends ParseSuite {
   }
 
   test("#2720 infix with repeated arg last") {
-    import org.scalameta.invariants.InvariantFailedException
-    intercept[InvariantFailedException](term("a op (b, c: _*)"))
+    assertTerm("a foo (b, c: _*)") {
+      Term.ApplyInfix(
+        Term.Name("a"),
+        Term.Name("foo"),
+        Nil,
+        List(Term.Name("b"), Term.Repeated(Term.Name("c")))
+      )
+    }
   }
 
   test("#2720 infix with repeated arg not last") {
-    import org.scalameta.invariants.InvariantFailedException
-    intercept[InvariantFailedException](term("a op (b: _*, c)"))
+    assertNoDiff(
+      intercept[ParseException](term("a op (b: _*, c)")).getMessage,
+      """|<input>:1: error: repeated argument not allowed here
+         |a op (b: _*, c)
+         |      ^""".stripMargin
+    )
   }
 
 }


### PR DESCRIPTION
But only as the last argument. This is for ApplyInfix to work. Fixes #2720.