### PR TITLE
Support printing of literal types as type parameters

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -64,8 +64,8 @@ object TreeSyntax {
         @leaf class Pattern3(op: String) extends Pat { def precedence = 3 }
         @leaf object SimplePattern extends Pat { def precedence = 6 }
       }
-      @leaf object Literal extends Term with Pat {
-        override def categories = List("Term", "Pat"); def precedence = 6
+      @leaf object Literal extends Term with Pat with Type {
+        override def categories = List("Term", "Pat", "Type"); def precedence = 6
       }
       require(
         Literal.precedence == Term.SimpleExpr1.precedence && Literal.precedence == Pat.SimplePattern.precedence

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -300,6 +300,15 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     assertEquals(pat("_: false").syntax, "_: false")
   }
 
+  test("type with a literal type param (#2725)") {
+    val Scala211 = null
+    import dialects.Scala3
+    assertEquals(t"Foo[42]".syntax, "Foo[42]")
+    assertEquals(t"Foo @@ 42".syntax, "Foo @@ 42")
+    assertEquals(t"Foo[true]".syntax, "Foo[true]")
+    assertEquals(q"val x = new Foo[42]".syntax, "val x = new Foo[42]")
+  }
+
   test("packages") {
     assertEquals(source("package foo.bar; class C").syntax, s"package foo.bar${EOL}class C")
     assertEquals(


### PR DESCRIPTION
Fixes #2725 

This innocent-looking one-line change fixes my issue (by allowing literals to be treated as types by the printer), but I'm a little worried it might have some other impact I'm not aware of.