### PR TITLE
Allow using backquoted pattern vars in generators

### DIFF
--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
@@ -6,7 +6,8 @@ import scala.meta.tests.parsers.BasePositionSuite
 class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Enumerator](
     "`a` <- b",
-    """|Term.Name `a`
+    """|Pat.Var `a`
+       |Term.Name `a`
        |""".stripMargin
   )
   checkPositions[Enumerator]("a = 1")

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -1348,6 +1348,19 @@ class TermSuite extends ParseSuite {
       )
     }
   }
+  test("#2720-for-comp") {
+    assertTerm("for { `j`: Int <- Seq(4, 5, 6, 7)} yield `j`") {
+      Term.ForYield(
+        List(
+          Enumerator.Generator(
+            Pat.Typed(Pat.Var(Term.Name("j")), Type.Name("Int")),
+            Term.Apply(Term.Name("Seq"), List(Lit.Int(4), Lit.Int(5), Lit.Int(6), Lit.Int(7)))
+          )
+        ),
+        Term.Name("j")
+      )
+    }
+  }
 
   test("#2720 infix with repeated arg not last") {
     assertNoDiff(


### PR DESCRIPTION
This is not allowed in pattern matches but in generators backquoted identifiers are always treated as pattern variables, even with a `case` keyword

Fixes https://github.com/scalameta/scalameta/issues/2719