### PR TITLE
Remove LF when soft keywords are used

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -362,6 +362,7 @@ class ScannerTokens(tokens: Tokens, input: Input)(implicit dialect: Dialect) {
     @classifier
     trait CanEndStat {
       def unapply(token: Token): Boolean = token match {
+        case SoftModifier() => false
         case _: Ident | _: KwGiven | _: Literal | _: Interpolation.End | _: Xml.End | _: KwReturn |
             _: KwThis | _: KwType | _: RightParen | _: RightBracket | _: RightBrace |
             _: Underscore | _: Ellipsis | _: Unquote =>

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InlineSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InlineSuite.scala
@@ -477,6 +477,23 @@ class InlineSuite extends BaseDottySuite {
     )
   }
 
+  test("transparent-trait-newlines") {
+    runTestAssert[Stat](
+      """|transparent 
+         |
+         |trait S""".stripMargin,
+      assertLayout = Some("transparent trait S")
+    )(
+      Defn.Trait(
+        List(Mod.Transparent()),
+        Type.Name("S"),
+        Nil,
+        Ctor.Primary(Nil, Name(""), Nil),
+        Template(Nil, Nil, Self(Name(""), None), Nil, Nil)
+      )
+    )
+  }
+
   test("transparent-inline-with-constant") {
     runTestAssert[Stat](
       """|transparent inline def f: String =


### PR DESCRIPTION
Previously, we would not remove newliens between sof keyword and the next token, which would lead to issues with double newlines after transparent. Now, we properly check if an indent is a soft identifier and in that case remove the newlines in the scanner.