### PR TITLE
fix: exclude parens tokens in Term.ApplyInfix.args

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2204,11 +2204,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
           // For `a f (b)`, autoPos include `(b)` for ApplyInfix.args position.
           // https://github.com/scalacenter/scalafix/issues/1594
           case _: Term.Ref =>
-            val (start, end) = body.origin match {
-              case Origin.None => (lpPos, rpPos)
-              case origin: Origin.Parsed => (origin.pos.start, origin.pos.end - 1)
-            }
-            atPosWithBody(start, body, end)
+            body
           case _ =>
             atPosWithBody(lpPos, body, rpPos)
         }

--- a/semanticdb/integration/src/main/scala/example/Infix.scala
+++ b/semanticdb/integration/src/main/scala/example/Infix.scala
@@ -1,0 +1,7 @@
+package example
+
+trait SymbolTest {
+  def shouldBe(right: Any): Unit
+  def arg = 1
+  this shouldBe (arg) // see: https://github.com/scalacenter/scalafix/issues/1594
+}

--- a/tests/jvm/src/test/resources/example/Infix.scala
+++ b/tests/jvm/src/test/resources/example/Infix.scala
@@ -1,0 +1,7 @@
+package example
+
+trait SymbolTest/*<=example.SymbolTest#*/ {
+  def shouldBe/*<=example.SymbolTest#shouldBe().*/(right/*<=example.SymbolTest#shouldBe().(right)*/: Any/*=>scala.Any#*/): Unit/*=>scala.Unit#*/
+  def arg/*<=example.SymbolTest#arg().*/ = 1
+  this shouldBe/*=>example.SymbolTest#shouldBe().*/ (arg/*=>example.SymbolTest#arg().*/) // see: https://github.com/scalacenter/scalafix/issues/1594
+}

--- a/tests/jvm/src/test/resources/metac.expect
+++ b/tests/jvm/src/test/resources/metac.expect
@@ -1834,6 +1834,40 @@ Occurrences:
 Diagnostics:
 [0:26..0:34) [warning] Unused import
 
+semanticdb/integration/src/main/scala/example/Infix.scala
+---------------------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => semanticdb/integration/src/main/scala/example/Infix.scala
+Text => non-empty
+Language => Scala
+Symbols => 4 entries
+Occurrences => 9 entries
+
+Symbols:
+example/SymbolTest# => trait SymbolTest extends AnyRef { +2 decls }
+  AnyRef => scala/AnyRef#
+example/SymbolTest#arg(). => method arg: Int
+  Int => scala/Int#
+example/SymbolTest#shouldBe(). => abstract method shouldBe(right: Any): Unit
+  right => example/SymbolTest#shouldBe().(right)
+  Any => scala/Any#
+  Unit => scala/Unit#
+example/SymbolTest#shouldBe().(right) => param right: Any
+  Any => scala/Any#
+
+Occurrences:
+[0:8..0:15): example <= example/
+[2:6..2:16): SymbolTest <= example/SymbolTest#
+[3:6..3:14): shouldBe <= example/SymbolTest#shouldBe().
+[3:15..3:20): right <= example/SymbolTest#shouldBe().(right)
+[3:22..3:25): Any => scala/Any#
+[3:28..3:32): Unit => scala/Unit#
+[4:6..4:9): arg <= example/SymbolTest#arg().
+[5:7..5:15): shouldBe => example/SymbolTest#shouldBe().
+[5:17..5:20): arg => example/SymbolTest#arg().
+
 semanticdb/integration/src/main/scala/example/InstrumentTyper.scala
 -------------------------------------------------------------------
 

--- a/tests/jvm/src/test/resources/metacp.expect
+++ b/tests/jvm/src/test/resources/metacp.expect
@@ -2607,6 +2607,28 @@ example/NamedArguments#User.unapply().(x$0) => param x$0: User
   User => example/NamedArguments#User#
 example/NamedArguments#`<init>`(). => primary ctor <init>()
 
+example/SymbolTest.class
+------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => example/SymbolTest.class
+Text => empty
+Language => Scala
+Symbols => 4 entries
+
+Symbols:
+example/SymbolTest# => trait SymbolTest extends AnyRef { +2 decls }
+  AnyRef => scala/AnyRef#
+example/SymbolTest#arg(). => method arg: Int
+  Int => scala/Int#
+example/SymbolTest#shouldBe(). => abstract method shouldBe(right: Any): Unit
+  right => example/SymbolTest#shouldBe().(right)
+  Any => scala/Any#
+  Unit => scala/Unit#
+example/SymbolTest#shouldBe().(right) => param right: Any
+  Any => scala/Any#
+
 example/Synthetic.class
 -----------------------
 

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
@@ -171,7 +171,6 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Stat](
     "(a) op (b)",
     """|Term.Name (a)
-       |Term.Name (b)
        |""".stripMargin
   )
   checkPositions[Stat](
@@ -188,9 +187,7 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Stat]("1 + 1")
   checkPositions[Stat]("a f ()")
   checkPositions[Stat](
-    "a f (b)",
-    """|Term.Name (b)
-       |""".stripMargin
+    "a f (b)"
   )
   checkPositions[Stat](
     "(f) [A,B]",

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/BasicPositionSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/BasicPositionSuite.scala
@@ -12,6 +12,11 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
        |Term.ApplyInfix (2 / 3)
        |""".stripMargin
   )
+
+  checkPositions[Term](
+    "a f (b)"
+  )
+
   checkPositions[Term](
     "(1 + 2).foo",
     """|Term.ApplyInfix (1 + 2)

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
@@ -1089,9 +1089,4 @@ class TokenizerSuite extends BaseTokenizerSuite {
       ("raw\"\"\"\\$host\\$share\\\"\"\"").tokenize.get
 
   }
-
-  test("wrapped-identifiers-ApplyInfix") {
-    val Term.ApplyInfix(_, _, _, List(arg)) = "a f (b)".parse[Term].get
-    assert(arg.tokens.toString == "b")
-  }
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
@@ -1089,4 +1089,9 @@ class TokenizerSuite extends BaseTokenizerSuite {
       ("raw\"\"\"\\$host\\$share\\\"\"\"").tokenize.get
 
   }
+
+  test("wrapped-identifiers-ApplyInfix") {
+    val Term.ApplyInfix(_, _, _, List(arg)) = "a f (b)".parse[Term].get
+    assert(arg.tokens.toString == "b")
+  }
 }


### PR DESCRIPTION
fix: https://github.com/scalacenter/scalafix/issues/1594
related: https://github.com/scalameta/scalameta/pull/1489

Previously, for the following code

```scala
trait SymbolTest {
  def shouldBe(right: Any): Unit
  def arg = 1
  this shouldBe (arg)
}
```

Scala2 (semanticdb-scalac) generates:

```scala
trait SymbolTest/*<=_empty_.SymbolTest#*/ { 
  ...
  this shouldBe/*=>_empty_.SymbolTest#shouldBe().*/ (arg)/*=>_empty_.SymbolTest#arg().*/ 
} 
```

`[3:16..3:21): (arg) => _empty_/SymbolTest#arg().`

parens tokens are included in the `Term.ApplyInfix.args`.

This PR exclude the parens tokens from `args` and now scalameta generates:

```scala
trait SymbolTest/*<=_empty_.SymbolTest#*/ { 
  ...
  this shouldBe/*=>_empty_.SymbolTest#shouldBe().*/ (arg/*=>_empty_.SymbolTest#arg().*/)
} 
```
`[3:17..3:20): arg -> _empty_/SymbolTest#arg().`

which is consistent with Scala3 semanticdb-generator, see: https://github.com/scalacenter/scalafix/issues/1594#issuecomment-1106146379