### PR TITLE
exclude parens tokens in Lit Term.ApplyInfix.args

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2200,10 +2200,13 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
       val rpPos = auto.endTokenPos
       @inline def addPos(body: Term): Term = {
         body match {
-          // For `Term.Ref`, avoid using autoPos to exclude parens tokens in Term.ApplyInfix.args.
+          // For `Term.Ref` & `Lit` other than Unit, avoid using autoPos
+          // to exclude parens tokens in Term.ApplyInfix.args.
           // For `a f (b)`, autoPos include `(b)` for ApplyInfix.args position.
           // https://github.com/scalacenter/scalafix/issues/1594
           case _: Term.Ref =>
+            body
+          case l: Lit if l.value != () =>
             body
           case _ =>
             atPosWithBody(lpPos, body, rpPos)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/BasicPositionSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/BasicPositionSuite.scala
@@ -18,6 +18,14 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
   )
 
   checkPositions[Term](
+    "a f (123)"
+  )
+
+  checkPositions[Term](
+    "a f ()"
+  )
+
+  checkPositions[Term](
     "(1 + 2).foo",
     """|Term.ApplyInfix (1 + 2)
        |""".stripMargin


### PR DESCRIPTION
Follows https://github.com/scalameta/scalameta/pull/2736

This is not related to https://github.com/scalacenter/scalafix/issues/1594 as there is no reason to lookup literals in semanticdb, but for consistency, I thought it could be good to exclude parens as well for literals.