### PR TITLE
ScalametaParser: fix paren positions in infix expr

### DIFF
--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
@@ -37,7 +37,7 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Case](
     "case _ op (a | b) =>",
     """|Pat.ExtractInfix _ op (a | b)
-       |Pat.Alternative (a | b)
+       |Pat.Alternative a | b
        |Term.Block case _ op (a | b) =>@@
        |""".stripMargin
   )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/BasicPositionSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/BasicPositionSuite.scala
@@ -9,19 +9,19 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Term](
     "1 + (2 / 3) * 4",
     """|Term.ApplyInfix (2 / 3) * 4
-       |Term.ApplyInfix (2 / 3)
+       |Term.ApplyInfix 2 / 3
        |""".stripMargin
   )
 
   checkPositions[Term](
     "1 + (()) * 4",
-    """|Term.ApplyInfix ()) * 4
+    """|Term.ApplyInfix (()) * 4
        |""".stripMargin
   )
 
   checkPositions[Term](
     "1 + ((1, 2, 3)) * 4",
-    """|Term.ApplyInfix (1, 2, 3)) * 4
+    """|Term.ApplyInfix ((1, 2, 3)) * 4
        |Term.Tuple (1, 2, 3)
        |""".stripMargin
   )
@@ -31,9 +31,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
   )
 
   checkPositions[Term](
-    "a f (123)",
-    """|Lit.Int (123)
-       |""".stripMargin
+    "a f (123)"
   )
 
   checkPositions[Term](
@@ -53,14 +51,12 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Term](
     "a f (()).foo",
     """|Term.Select (()).foo
-       |Lit.Unit (())
        |""".stripMargin
   )
 
   checkPositions[Term](
     "a f (())(b)",
     """|Term.Apply (())(b)
-       |Lit.Unit (())
        |""".stripMargin
   )
 


### PR DESCRIPTION
- do not include parens in rhs args
- do include them in full infix when parens are part of lhs.

Supersedes #2744.