### PR TITLE
fix: Do not crash when scalameta hit BoundedWildcardType

### DIFF
--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TypeOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TypeOps.scala
@@ -76,6 +76,8 @@ trait TypeOps { self: SemanticdbOps =>
            */
           case g.WildcardType =>
             s.NoType
+          case _: g.BoundedWildcardType =>
+            s.NoType
           case gother =>
             sys.error(s"unsupported type ${gother}: ${g.showRaw(gother)}")
         }


### PR DESCRIPTION
fix https://github.com/scalameta/scalameta/issues/2750

Confirmed it fixes the issue in https://github.com/tanishiking/scalameta-2750

As commented by https://github.com/scala/scala/blob/a3e918a10d2ed1fad78457377244106e22685277/src/reflect/scala/reflect/api/Types.scala#L996-L1014 those types shouldn't be accessible after type inference, and it might be a bug of scalac.