### PR TITLE
Revert "Allow `?` as placeholder as default in Scala213 and Scala212 dialects"

### DIFF
--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -45,19 +45,18 @@ package object dialects {
 
   implicit val Scala212 = Scala211
     .withAllowTrailingCommas(true)
-    .withAllowQuestionMarkPlaceholder(true)
 
   implicit val Scala213 = Scala212
     .withAllowImplicitByNameParameters(true)
     .withAllowLiteralTypes(true)
     .withAllowNumericLiteralUnderscoreSeparators(true)
     .withAllowTryWithAnyExpr(true)
-    .withAllowQuestionMarkPlaceholder(true)
 
   /**
    * Dialect starting with Scala 2.13.6 for `-Xsource:3` option
    */
   implicit val Scala213Source3 = Scala213
+    .withAllowQuestionMarkPlaceholder(true)
     .withAllowAsForImportRename(true)
     .withAllowStarWildcardImport(true)
     .withAllowOpenClass(true)
@@ -71,6 +70,7 @@ package object dialects {
    * Dialect starting with Scala 2.12.14 for `-Xsource:3` option
    */
   implicit val Scala212Source3 = Scala212
+    .withAllowQuestionMarkPlaceholder(true)
     .withAllowAsForImportRename(true)
     .withAllowStarWildcardImport(true)
     .withAllowOpenClass(true)


### PR DESCRIPTION
Fixes #2751 

This reverts commit 817b016b656a683378187d8937bea7c1526e53f5.

This is the first of two PRs, first to temporarily revert this breaking change to 2.12 and 2.13 dialects, the second will be to re-establish the new defaults, intended to be merged once 2.12.16 and 2.13.9 are released.