### PR TITLE
Adding a Scala212Pre16 dialect

### DIFF
--- a/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
@@ -707,7 +707,9 @@ object Dialect extends InternalDialect {
     Scala211,
     Scala212,
     Scala213,
+    Scala213Pre9,
     Scala213Source3,
+    Scala212Pre16,
     Scala212Source3,
     Typelevel211,
     Typelevel212

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -55,6 +55,12 @@ package object dialects {
     .withAllowQuestionMarkPlaceholder(true)
 
   /**
+   * Dialect ending with Scala 2.13.9 for legacy F[_] syntax instead of F[?]
+   */
+  implicit val Scala213Pre9 = Scala213
+    .withAllowQuestionMarkPlaceholder(false)
+
+  /**
    * Dialect starting with Scala 2.13.6 for `-Xsource:3` option
    */
   implicit val Scala213Source3 = Scala213

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -79,6 +79,12 @@ package object dialects {
     .withAllowPlusMinusUnderscoreAsIdent(true)
     .withAllowGivenImports(true)
 
+  /**
+   * Dialect ending with Scala 2.12.15 for legacy F[_] syntax instead of F[?]
+   */
+  implicit val Scala212Pre16 = Scala212
+    .withAllowQuestionMarkPlaceholder(false)
+
   implicit val Scala = Scala213 // alias for latest Scala dialect.
 
   implicit val Sbt0136 = Scala210


### PR DESCRIPTION
Resolves #2751 

In preparation for #2757, to aide consumers who desire a seamless transition during the shakeout, introduce a new dialect that disallows the new `?` placeholder syntax for both 2.12 and 2.13:

```scala
Scala212Pre16
Scala213Pre9
```