### PR TITLE
Only print `?` for Scala 2 dialect if explicitly used

### DIFF
--- a/tests/jvm/src/test/scala/scala/meta/tests/prettyprinters/RegressionSyntaxSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/prettyprinters/RegressionSyntaxSuite.scala
@@ -1,0 +1,58 @@
+package scala.meta.tests.prettyprinters
+
+import scala.meta.tests.parsers.ParseSuite
+
+import scala.meta._
+import munit.TestOptions
+
+class RegressionSyntaxSuite extends ParseSuite {
+
+  def check(
+      testOpts: TestOptions,
+      code: String,
+      expected: String,
+      newDialect: Option[Dialect] = None
+  )(implicit dialect: Dialect) = test(testOpts) {
+    val obtained = code.parse[Stat].get
+    val reprintedCode =
+      scala.meta.internal.prettyprinters.TreeSyntax
+        .reprint(obtained)(newDialect.getOrElse(dialects.Scala213))
+        .toString
+    assertEquals(reprintedCode, expected)
+  }
+
+  check("question-mark", "type T = List[?]", "type T = List[?]")
+  check("underscore", "type T = List[_]", "type T = List[_]")
+  check(
+    "new-dialect-scala3",
+    "type T = List[_]",
+    "type T = List[?]",
+    newDialect = Some(dialects.Scala3)
+  )(
+    dialects.Scala211
+  )
+
+  check(
+    "new-dialect-scala213",
+    "type T = List[_]",
+    "type T = List[_]",
+    newDialect = Some(dialects.Scala213)
+  )(
+    dialects.Scala211
+  )
+  check(
+    "new-dialect-scala213-from-scala3",
+    "type T = List[?]",
+    "type T = List[?]",
+    newDialect = Some(dialects.Scala213)
+  )(
+    dialects.Scala3
+  )
+
+  test("no-origin") {
+    assertEquals(
+      Type.Placeholder(Type.Bounds(None, None)).toString(),
+      "_"
+    )
+  }
+}


### PR DESCRIPTION
Previously, we would always print `?` for the placeholder even if the Scala version wouldn't allow it. Now, we only print `?` if it was explicitely used in the code.

Fixes https://github.com/scalameta/scalameta/issues/2751

The other solution would be introducing another dialect, but that would require a lot of people having to also change that, so it would require a lot more effort in the long run.