### PR TITLE
bugfix: Make sure that the macro ident is not just $

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -490,7 +490,8 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
   @classifier
   trait MacroSplicedIdent {
     def unapply(token: Token): Boolean = {
-      dialect.allowSpliceAndQuote && QuotedSpliceContext.isInside() && isIdentAnd(_.head == '$')
+      dialect.allowSpliceAndQuote && QuotedSpliceContext.isInside() &&
+      isIdentAnd(name => name.size > 1 && name.head == '$')
     }
   }
 
@@ -2113,9 +2114,9 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
     }
   }
 
-  def macroSplicedIdent(): Term = autoPos {
+  private def macroSplicedIdent(): Term = autoPos {
     token match {
-      case Ident(value) =>
+      case Ident(value) if value.length() > 1 && value.head == '$' =>
         val name = atCurPosNext(Term.Name(value.stripPrefix("$")))
         Term.SplicedMacroExpr(name)
       case _ =>

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
@@ -421,4 +421,15 @@ class MacroSuite extends BaseDottySuite {
       )
     )
   }
+  test("no-name") {
+    runTestAssert[Stat](
+      "'{ val x: Int = $ }"
+    )(
+      Term.QuotedMacroExpr(
+        Term.Block(
+          List(Defn.Val(Nil, List(Pat.Var(Term.Name("x"))), Some(Type.Name("Int")), Term.Name("$")))
+        )
+      )
+    )
+  }
 }


### PR DESCRIPTION
Previously, if user started to write the macro spliced identifier the parser would throw an invariant exception. Now we check that we can construct proper name out of the Ident.

Fixes https://github.com/scalameta/scalameta/issues/2777