### PR TITLE
ScalametaParser: refactor macro ident matching

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
@@ -421,11 +421,21 @@ class MacroSuite extends BaseDottySuite {
       )
     )
   }
+
   test("no-name") {
     runTestAssert[Stat](
       "'{ val x: Int = $ }"
     )(
       Term.QuotedMacroExpr(
+        Term.Block(
+          List(Defn.Val(Nil, List(Pat.Var(Term.Name("x"))), Some(Type.Name("Int")), Term.Name("$")))
+        )
+      )
+    )
+    runTestAssert[Stat](
+      "${ val x: Int = $ }"
+    )(
+      Term.SplicedMacroExpr(
         Term.Block(
           List(Defn.Val(Nil, List(Pat.Var(Term.Name("x"))), Some(Type.Name("Int")), Term.Name("$")))
         )


### PR DESCRIPTION
Remove syntax error because it cannot currently occur. Follow up to #2779.