### PR TITLE
bugfix: Manually skip newlines after soft keywords

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -362,7 +362,6 @@ class ScannerTokens(tokens: Tokens, input: Input)(implicit dialect: Dialect) {
     @classifier
     trait CanEndStat {
       def unapply(token: Token): Boolean = token match {
-        case SoftModifier() => false
         case _: Ident | _: KwGiven | _: Literal | _: Interpolation.End | _: Xml.End | _: KwReturn |
             _: KwThis | _: KwType | _: RightParen | _: RightBracket | _: RightBrace |
             _: Underscore | _: Ellipsis | _: Unquote =>

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -43,6 +43,66 @@ class MinorDottySuite extends BaseDottySuite {
     stat("def open(open: open): open = ???").structure
   }
 
+  test("open-soft-modifier-case") {
+    runTestAssert[Source](
+      """|case class OHLCPrice(
+         |    val open: Int
+         |) {
+         |  val price = OHLCPrice(1)
+         |  val price1 = price.open
+         |  val price2 = 1
+         |}""".stripMargin,
+      assertLayout = Some(
+        """|case class OHLCPrice(val open: Int) {
+           |  val price = OHLCPrice(1)
+           |  val price1 = price.open
+           |  val price2 = 1
+           |}
+           |""".stripMargin
+      )
+    )(
+      Source(
+        List(
+          Defn.Class(
+            List(Mod.Case()),
+            Type.Name("OHLCPrice"),
+            Nil,
+            Ctor.Primary(
+              Nil,
+              Name(""),
+              List(
+                List(
+                  Term.Param(List(Mod.ValParam()), Term.Name("open"), Some(Type.Name("Int")), None)
+                )
+              )
+            ),
+            Template(
+              Nil,
+              Nil,
+              Self(Name(""), None),
+              List(
+                Defn.Val(
+                  Nil,
+                  List(Pat.Var(Term.Name("price"))),
+                  None,
+                  Term.Apply(Term.Name("OHLCPrice"), List(Lit.Int(1)))
+                ),
+                Defn.Val(
+                  Nil,
+                  List(Pat.Var(Term.Name("price1"))),
+                  None,
+                  Term.Select(Term.Name("price"), Term.Name("open"))
+                ),
+                Defn.Val(Nil, List(Pat.Var(Term.Name("price2"))), None, Lit.Int(1))
+              ),
+              Nil
+            )
+          )
+        )
+      )
+    )
+  }
+
   test("open-identifier") {
     runTestAssert[Stat]("def run(): Unit = { start; open(p); end }", assertLayout = None)(
       Defn.Def(


### PR DESCRIPTION
Previously, we would always skip newlines between `open` identifier and the next token if that could start a statement. This led to lossing info about newlines even if the open modifier was not used. Now, we skip newlines after we know a soft keyword is used.

Fixes https://github.com/scalameta/scalameta/issues/2786