### PR TITLE
ScalametaParser: allow `using` even in scala 2

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -1383,4 +1383,18 @@ class TermSuite extends ParseSuite {
     )
   }
 
+  test("using-call-site in scala2") {
+    checkStat("val a = f()(using a)(using 3, true)")(
+      Defn.Val(
+        Nil,
+        List(Pat.Var(Term.Name("a"))),
+        None,
+        Term.ApplyUsing(
+          Term.ApplyUsing(Term.Apply(Term.Name("f"), Nil), List(Term.Name("a"))),
+          List(Lit.Int(3), Lit.Boolean(true))
+        )
+      )
+    )
+  }
+
 }


### PR DESCRIPTION
Fixes #2785.