### PR TITLE
Avoid ZipException when loading classpath

### DIFF
--- a/semanticdb/metacp/src/main/scala/scala/meta/internal/classpath/ClasspathIndex.scala
+++ b/semanticdb/metacp/src/main/scala/scala/meta/internal/classpath/ClasspathIndex.scala
@@ -165,7 +165,7 @@ object ClasspathIndex {
           jar.close()
         }
       } catch {
-        case zex: ZipException if zex.getMessage == "zip END header not found" => ()
+        case zex: ZipException => ()
       }
     }
 

--- a/tests/jvm/src/test/scala-2.12/scala/meta/tests/metacp/ClasspathIndexSuite.scala
+++ b/tests/jvm/src/test/scala-2.12/scala/meta/tests/metacp/ClasspathIndexSuite.scala
@@ -7,6 +7,7 @@ import scala.meta.io.AbsolutePath
 import scala.meta.io.Classpath
 import scala.meta.tests.BuildInfo
 import scala.meta.tests.semanticdb.ManifestMetacp
+import java.nio.file.Paths
 
 class ClasspathIndexSuite extends FunSuite {
   def classpath(path: AbsolutePath) =
@@ -51,4 +52,8 @@ class ClasspathIndexSuite extends FunSuite {
     val index = ClasspathIndex(classpath)
   }
 
+  test("ignore classpath entry for files that are not jar/zip") {
+    val classpath = Classpath(Paths.get(getClass().getResource("/unicode.txt").toURI()))
+    val index = ClasspathIndex(classpath)
+  }
 }


### PR DESCRIPTION
The default classpath behavior should load directories,
or file that are archives (jar or zip), or wildcards should
be ignored.

I'd like to implement this behaviour here: ignoring invalid files

But there are multiple ways at it:

* manual check of the file, it's existence, it's extension
* catching the ZipException and swallow it

Do you have a suggestion on which on I should take? The first one
is more brittle, and we could possibly ignore jar/zip if they don't
have the right extension. Where as the second one could swallow error
that are not related.

I'm coming from https://github.com/scalacenter/scalafix/pull/1646

Current exception

```
java.util.zip.ZipException: zip END header not found
    at java.util.zip.ZipFile$Source.findEND(ZipFile.java:1469)
    at java.util.zip.ZipFile$Source.initCEN(ZipFile.java:1477)
    at java.util.zip.ZipFile$Source.<init>(ZipFile.java:1315)
    at java.util.zip.ZipFile$Source.get(ZipFile.java:1277)
    at java.util.zip.ZipFile$CleanableResource.<init>(ZipFile.java:709)
    at java.util.zip.ZipFile.<init>(ZipFile.java:243)
    at java.util.zip.ZipFile.<init>(ZipFile.java:172)
    at java.util.jar.JarFile.<init>(JarFile.java:347)
    at java.util.jar.JarFile.<init>(JarFile.java:318)
    at java.util.jar.JarFile.<init>(JarFile.java:284)
    at scala.meta.internal.classpath.ClasspathIndex$Builder.scala$meta$internal$classpath$ClasspathIndex$Builder$$expandJarEntry(ClasspathIndex.scala:136)
    at scala.meta.internal.classpath.ClasspathIndex$Builder.expandEntry(ClasspathIndex.scala:102)
    at scala.meta.internal.classpath.ClasspathIndex$Builder.$anonfun$result$1(ClasspathIndex.scala:64)
    at scala.meta.internal.classpath.ClasspathIndex$Builder.$anonfun$result$1$adapted(ClasspathIndex.scala:64)
    at scala.collection.immutable.List.foreach(List.scala:431)
    at scala.meta.internal.classpath.ClasspathIndex$Builder.result(ClasspathIndex.scala:64)
    at scala.meta.internal.classpath.ClasspathIndex$.apply(ClasspathIndex.scala:51)
    at scala.meta.tests.metacp.ClasspathIndexSuite.$anonfun$new$38(ClasspathIndexSuite.scala:58)
```