### PR TITLE
Trees: split off Type.Wildcard from Placeholder

### DIFF
--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/NamerMacros.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/NamerMacros.scala
@@ -91,13 +91,12 @@ trait CommonNamerMacros extends MacroHelpers {
 
     paramss.foreach(_.foreach(x => addStubbedMemberWithName(x.name)))
     extraStubs.foreach(x => addStubbedMemberWithName(TermName(x)))
-    val qcopyParamss = paramss.map(_.map { case ValDef(mods, name, tpt, _) =>
-      q"val $name: $tpt = this.$name"
-    })
+    val qcopyParamss = paramss.map(_.map(t => q"val ${t.name}: ${t.tpt}"))
     qstats += q"def copy(...$qcopyParamss): $name = $stub"
 
     extraAbstractDefs.foreach {
-      case x: ValOrDefDefApi if x.mods.hasFlag(Flag.ABSTRACT) || x.rhs.isEmpty =>
+      case x: ValOrDefDefApi
+          if x.mods.hasFlag(Flag.ABSTRACT) || x.mods.hasFlag(Flag.OVERRIDE) || x.rhs.isEmpty =>
         addStubbedOverrideMember(x)
       case _ =>
     }

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -238,7 +238,23 @@ object Type {
   @ast class Method(paramss: List[List[Term.Param]], tpe: Type) extends Type {
     checkParent(ParentChecks.TypeMethod)
   }
-  @ast class Placeholder(bounds: Bounds) extends Type
+  @deprecated("Placeholder replaced with AnonymousParam and Wildcard", ">4.5.13")
+  @branch trait Placeholder extends Type {
+    def bounds: Bounds
+    def copy(bounds: Bounds = this.bounds): Placeholder
+  }
+  @deprecated("Placeholder replaced with AnonymousParam and Wildcard", ">4.5.13")
+  object Placeholder {
+    @ast private[meta] class Impl(bounds: Bounds) extends Placeholder
+    @inline def apply(bounds: Bounds): Placeholder = Impl(bounds)
+    @inline final def unapply(tree: Placeholder): Option[Bounds] = Some(tree.bounds)
+  }
+  @ast class Wildcard(bounds: Bounds) extends Placeholder
+  @ast class AnonymousParam(variant: Option[Mod.Variant]) extends Placeholder {
+    @deprecated("Placeholder replaced with AnonymousParam and Wildcard", ">4.5.13")
+    override final def bounds: Bounds = Bounds(None, None)
+    override def copy(bounds: Bounds): Placeholder = Placeholder(bounds)
+  }
   @ast class Bounds(lo: Option[Type], hi: Option[Type]) extends Tree
   @ast class ByName(tpe: Type) extends Type {
     checkParent(ParentChecks.TypeByName)
@@ -304,7 +320,7 @@ object Pat {
   }
   @ast class Typed(lhs: Pat, rhs: Type) extends Pat {
     checkFields(rhs match {
-      case _: Type.Var | _: Type.Placeholder => false
+      case _: Type.Var | _: Type.Placeholder | _: Type.Wildcard | _: Type.AnonymousParam => false
       case _ => true
     })
   }

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -685,6 +685,19 @@ object TreeSyntax {
           Type,
           s(p(AnyInfixTyp, t.tpe), " ", kw("match"), " {", r(t.cases.map(i(_)), ""), n("}"))
         )
+      case t: Type.AnonymousParam =>
+        m(SimpleTyp, o(t.variant), "_")
+      case t: Type.Wildcard =>
+        /* In order not to break existing tools `.syntax` should still return
+         * `_` instead `?` unless specifically used.
+         */
+        def questionMarkUsed = t.origin match {
+          case o: Origin.Parsed => !o.tokens.headOption.exists(_.is[Token.Underscore])
+          case _ => false
+        }
+        val useQM = dialect.allowQuestionMarkAsTypeWildcard &&
+          (dialect.allowUnderscoreAsTypePlaceholder || questionMarkUsed)
+        m(SimpleTyp, s(kw(if (useQM) "?" else "_")), t.bounds)
       case t: Type.Placeholder =>
         /* In order not to break existing tools `.syntax` should still return
          * `_` instead `?` unless specifically used.

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -395,6 +395,7 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.Type.And
       |scala.meta.Type.Annotate
       |scala.meta.Type.AnonymousName
+      |scala.meta.Type.AnonymousParam
       |scala.meta.Type.Apply
       |scala.meta.Type.ApplyInfix
       |scala.meta.Type.Bounds
@@ -412,6 +413,7 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.Type.Or
       |scala.meta.Type.Param
       |scala.meta.Type.Placeholder
+      |scala.meta.Type.Placeholder.Impl
       |scala.meta.Type.PolyFunction
       |scala.meta.Type.Project
       |scala.meta.Type.Ref
@@ -422,6 +424,7 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.Type.Tuple
       |scala.meta.Type.TypedParam
       |scala.meta.Type.Var
+      |scala.meta.Type.Wildcard
       |scala.meta.Type.With
       |scala.meta.TypeCase
     """.trim.stripMargin.split('\n').mkString(EOL)

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
@@ -24,7 +24,7 @@ class ReflectionSuite extends FunSuite {
     val sym = symbolOf[scala.meta.Tree]
     assert(sym.isRoot)
     val root = sym.asRoot
-    assertEquals((root.allBranches.length, root.allLeafs.length), (25, 353))
+    assertEquals((root.allBranches.length, root.allLeafs.length), (26, 358))
   }
 
   test("If") {
@@ -86,6 +86,7 @@ class ReflectionSuite extends FunSuite {
       |List[scala.meta.TypeCase]
       |List[scala.meta.Type]
       |Long
+      |Option[scala.meta.Mod.Variant]
       |Option[scala.meta.Term]
       |Option[scala.meta.Type]
       |Short

--- a/tests/jvm/src/test/scala/scala/meta/tests/prettyprinters/RegressionSyntaxSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/prettyprinters/RegressionSyntaxSuite.scala
@@ -32,7 +32,7 @@ class RegressionSyntaxSuite extends ParseSuite {
 
   test("no-origin") {
     assertEquals(
-      Type.Placeholder(Type.Bounds(None, None)).toString(),
+      Type.AnonymousParam(None).toString(),
       "_"
     )
   }

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -148,7 +148,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
     """|Importer Instances.{ im, given Ordering[?] }
        |Importee.Given given Ordering[?]
        |Type.Apply Ordering[?]
-       |Type.Placeholder ?
+       |Type.Wildcard ?
        |Type.Bounds import Instances.{ im, given Ordering[?@@] }
        |""".stripMargin
   )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/PatSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/PatSuite.scala
@@ -59,7 +59,7 @@ class PatSuite extends ParseSuite {
     assertPat("_: F[_]") {
       Typed(
         Wildcard(),
-        Type.Apply(Type.Name("F"), Type.Placeholder(Type.Bounds(None, None)) :: Nil)
+        Type.Apply(Type.Name("F"), List(Type.Wildcard(Type.Bounds(None, None))))
       )
     }
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -884,7 +884,7 @@ class TermSuite extends ParseSuite {
                   Term.ApplyType(
                     Term.Name("sizeof"),
                     List(
-                      Type.Apply(Type.Name("Ptr"), List(Type.Placeholder(Type.Bounds(None, None))))
+                      Type.Apply(Type.Name("Ptr"), List(Type.Wildcard(Type.Bounds(None, None))))
                     )
                   )
                 )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TypeSuite.scala
@@ -127,26 +127,26 @@ class TypeSuite extends ParseSuite {
     assertTpe("F[_ >: lo <: hi]") {
       Apply(
         TypeName("F"),
-        Type.Placeholder(Type.Bounds(Some(TypeName("lo")), Some(TypeName("hi")))) :: Nil
+        List(Wildcard(Bounds(Some(TypeName("lo")), Some(TypeName("hi")))))
       )
     }
   }
 
   test("F[_ >: lo") {
     assertTpe("F[_ >: lo]") {
-      Apply(TypeName("F"), Type.Placeholder(Type.Bounds(Some(TypeName("lo")), None)) :: Nil)
+      Apply(TypeName("F"), List(Wildcard(Bounds(Some(TypeName("lo")), None))))
     }
   }
 
   test("F[_ <: hi]") {
     assertTpe("F[_ <: hi]") {
-      Apply(TypeName("F"), Type.Placeholder(Type.Bounds(None, Some(TypeName("hi")))) :: Nil)
+      Apply(TypeName("F"), List(Wildcard(Bounds(None, Some(TypeName("hi"))))))
     }
   }
 
   test("F[_]") {
     assertTpe("F[_]") {
-      Apply(TypeName("F"), Type.Placeholder(Type.Bounds(None, None)) :: Nil)
+      Apply(TypeName("F"), List(Wildcard(Bounds(None, None))))
     }
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
@@ -1129,7 +1129,7 @@ class GivenUsingSuite extends BaseDottySuite {
             List(
               Importee.Name(Name("im")),
               Importee.Given(
-                Type.Apply(Type.Name("Ordering"), List(Type.Placeholder(Type.Bounds(None, None))))
+                Type.Apply(Type.Name("Ordering"), List(Type.Wildcard(Type.Bounds(None, None))))
               )
             )
           )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MatchTypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MatchTypeSuite.scala
@@ -82,7 +82,7 @@ class MatchTypeSuite extends BaseDottySuite {
           List(
             TypeCase(
               Type.Tuple(
-                List(Type.Name("x1"), Type.Placeholder(Type.Bounds(None, None)))
+                List(Type.Name("x1"), Type.Wildcard(Type.Bounds(None, None)))
               ),
               Type.Name("x1")
             )
@@ -222,7 +222,7 @@ class MatchTypeSuite extends BaseDottySuite {
                 Type.Name("Left"),
                 List(
                   TypeCase(Type.Name("Unit"), Type.Name("Right")),
-                  TypeCase(Type.Placeholder(Type.Bounds(None, None)), Type.Name("Left"))
+                  TypeCase(Type.Wildcard(Type.Bounds(None, None)), Type.Name("Left"))
                 )
               ),
               Type.Bounds(None, None)
@@ -243,13 +243,12 @@ class MatchTypeSuite extends BaseDottySuite {
          |    case _ => R
          |    case ? => L
          |""".stripMargin,
-      // "case ? => R" is a bug
       assertLayout = Some(
         """|object match_types {
            |  type Combine[L, R] = L match {
-           |    case Foo[?] => L
+           |    case Foo[_] => L
            |    case Bar[?] => L
-           |    case ? => R
+           |    case _ => R
            |    case ? => L
            |  }
            |}
@@ -277,23 +276,23 @@ class MatchTypeSuite extends BaseDottySuite {
                   TypeCase(
                     Type.Apply(
                       Type.Name("Foo"),
-                      List(Type.Placeholder(Type.Bounds(None, None)))
+                      List(Type.AnonymousParam(None))
                     ),
                     Type.Name("L")
                   ),
                   TypeCase(
                     Type.Apply(
                       Type.Name("Bar"),
-                      List(Type.Placeholder(Type.Bounds(None, None)))
+                      List(Type.Wildcard(Type.Bounds(None, None)))
                     ),
                     Type.Name("L")
                   ),
                   TypeCase(
-                    Type.Placeholder(Type.Bounds(None, None)),
+                    Type.AnonymousParam(None),
                     Type.Name("R")
                   ),
                   TypeCase(
-                    Type.Placeholder(Type.Bounds(None, None)),
+                    Type.Wildcard(Type.Bounds(None, None)),
                     Type.Name("L")
                   )
                 )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -2,8 +2,6 @@ package scala.meta.tests.parsers.dotty
 
 import scala.meta.tests.parsers._
 import scala.meta._
-import scala.meta.Type.Apply
-import scala.meta.Type.Placeholder
 
 class MinorDottySuite extends BaseDottySuite {
 
@@ -351,7 +349,7 @@ class MinorDottySuite extends BaseDottySuite {
         List(Pat.Var(Term.Name("stat"))),
         Type.Apply(
           Type.Name("Tree"),
-          List(Type.Placeholder(Type.Bounds(Some(Type.Name("Untyped")), None)))
+          List(Type.Wildcard(Type.Bounds(Some(Type.Name("Untyped")), None)))
         )
       )
     )
@@ -476,7 +474,7 @@ class MinorDottySuite extends BaseDottySuite {
       Defn.Val(
         Nil,
         List(Pat.Var(Term.Name("x"))),
-        Some(Type.Apply(Type.Name("List"), List(Type.Placeholder(Type.Bounds(None, None))))),
+        Some(Type.Apply(Type.Name("List"), List(Type.Wildcard(Type.Bounds(None, None))))),
         Term.Apply(Term.Name("List"), List(Lit.Int(1)))
       )
     )
@@ -491,7 +489,7 @@ class MinorDottySuite extends BaseDottySuite {
             Term.Param(
               Nil,
               Term.Name("a"),
-              Some(Type.Apply(Type.Name("List"), List(Type.Placeholder(Type.Bounds(None, None))))),
+              Some(Type.Apply(Type.Name("List"), List(Type.Wildcard(Type.Bounds(None, None))))),
               None
             )
           )
@@ -1162,9 +1160,9 @@ class MinorDottySuite extends BaseDottySuite {
          |""".stripMargin,
       assertLayout = Some(
         """|object A {
-           |  type X = ? => Int
-           |  type Y = ? => Int
-           |  type Z = ? => Int
+           |  type X = +_ => Int
+           |  type Y = -_ => Int
+           |  type Z = _ => Int
            |}
            |""".stripMargin
       )
@@ -1181,21 +1179,21 @@ class MinorDottySuite extends BaseDottySuite {
               Nil,
               Type.Name("X"),
               Nil,
-              Type.Function(List(Type.Placeholder(Type.Bounds(None, None))), Type.Name("Int")),
+              Type.Function(List(Type.AnonymousParam(Some(Mod.Covariant()))), Type.Name("Int")),
               Type.Bounds(None, None)
             ),
             Defn.Type(
               Nil,
               Type.Name("Y"),
               Nil,
-              Type.Function(List(Type.Placeholder(Type.Bounds(None, None))), Type.Name("Int")),
+              Type.Function(List(Type.AnonymousParam(Some(Mod.Contravariant()))), Type.Name("Int")),
               Type.Bounds(None, None)
             ),
             Defn.Type(
               Nil,
               Type.Name("Z"),
               Nil,
-              Type.Function(List(Type.Placeholder(Type.Bounds(None, None))), Type.Name("Int")),
+              Type.Function(List(Type.AnonymousParam(None)), Type.Name("Int")),
               Type.Bounds(None, None)
             )
           ),

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NewFunctionsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NewFunctionsSuite.scala
@@ -626,7 +626,7 @@ class NewFunctionsSuite extends BaseDottySuite {
               Type.Name("o"),
               Type.Apply(
                 Type.Name("Other"),
-                List(Type.Placeholder(Type.Bounds(None, Some(Type.Name("P")))))
+                List(Type.Wildcard(Type.Bounds(None, Some(Type.Name("P")))))
               )
             )
           ),

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/PatSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/PatSuite.scala
@@ -54,7 +54,7 @@ class PatSuite extends ParseSuite {
     assertPat("_: F[_]") {
       Typed(
         Wildcard(),
-        Type.Apply(Type.Name("F"), Type.Placeholder(Type.Bounds(None, None)) :: Nil)
+        Type.Apply(Type.Name("F"), List(Type.AnonymousParam(None)))
       )
     }
   }
@@ -64,7 +64,7 @@ class PatSuite extends ParseSuite {
     assertPat("_: F[_]") {
       Pat.Typed(
         Pat.Wildcard(),
-        Type.Apply(Type.Name("F"), Type.Placeholder(Type.Bounds(None, None)) :: Nil)
+        Type.Apply(Type.Name("F"), List(Type.Wildcard(Type.Bounds(None, None))))
       )
     }
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
@@ -281,43 +281,49 @@ class TypeSuite extends BaseDottySuite {
   }
 
   test("F[_ >: lo <: hi]") {
-    assertTpe("F[_ >: lo <: hi]") {
+    implicit val Scala3: Dialect = scala.meta.dialects.Scala31
+    val expected =
       Apply(
         TypeName("F"),
-        Type.Placeholder(Type.Bounds(Some(TypeName("lo")), Some(TypeName("hi")))) :: Nil
+        Wildcard(Bounds(Some(TypeName("lo")), Some(TypeName("hi")))) :: Nil
       )
-    }
+    assertTpe("F[_ >: lo <: hi]") { expected }
+    assertTpe("F[? >: lo <: hi]") { expected }
   }
 
   test("F[_ >: lo") {
-    assertTpe("F[_ >: lo]") {
-      Apply(TypeName("F"), Type.Placeholder(Type.Bounds(Some(TypeName("lo")), None)) :: Nil)
-    }
+    implicit val Scala3: Dialect = scala.meta.dialects.Scala31
+    val expected =
+      Apply(TypeName("F"), Wildcard(Bounds(Some(TypeName("lo")), None)) :: Nil)
+    assertTpe("F[_ >: lo]") { expected }
+    assertTpe("F[? >: lo]") { expected }
   }
 
   test("F[_ <: hi]") {
-    assertTpe("F[_ <: hi]") {
-      Apply(TypeName("F"), Type.Placeholder(Type.Bounds(None, Some(TypeName("hi")))) :: Nil)
-    }
+    implicit val Scala3: Dialect = scala.meta.dialects.Scala31
+    val expected =
+      Apply(TypeName("F"), Wildcard(Bounds(None, Some(TypeName("hi")))) :: Nil)
+    assertTpe("F[_ <: hi]") { expected }
+    assertTpe("F[? <: hi]") { expected }
   }
 
   test("F[?]") {
     implicit val Scala3: Dialect = scala.meta.dialects.Scala31
     val expected =
-      Apply(TypeName("F"), Type.Placeholder(Type.Bounds(None, None)) :: Nil)
+      Apply(TypeName("F"), List(Wildcard(Bounds(None, None))))
     assertTpe("F[?]") { expected }
     assertTpe("F[_]") { expected }
   }
 
   test("F[_]") {
     assertTpe("F[_]") {
-      Apply(TypeName("F"), Type.Placeholder(Type.Bounds(None, None)) :: Nil)
+      Apply(TypeName("F"), AnonymousParam(None) :: Nil)
     }
     assertTpe("F[+_]") {
-      Apply(TypeName("F"), Type.Placeholder(Type.Bounds(None, None)) :: Nil)
+      Apply(TypeName("F"), AnonymousParam(Some(Mod.Covariant())) :: Nil)
     }
     assertTpe("F[-_]") {
-      Apply(TypeName("F"), Type.Placeholder(Type.Bounds(None, None)) :: Nil)
+      Apply(TypeName("F"), AnonymousParam(Some(Mod.Contravariant())) :: Nil)
     }
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -732,7 +732,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     val tree = pat("List[_](xs @ _*)")
     assertTree(tree)(
       Pat.Extract(
-        Term.ApplyType(Term.Name("List"), List(Type.Placeholder(Type.Bounds(None, None)))),
+        Term.ApplyType(Term.Name("List"), List(Type.Wildcard(Type.Bounds(None, None)))),
         List(Pat.Bind(Pat.Var(Term.Name("xs")), Pat.SeqWildcard()))
       )
     )
@@ -744,7 +744,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     val tree = pat("List[_](xs @ _*)")
     assertTree(tree)(
       Pat.Extract(
-        Term.ApplyType(Term.Name("List"), List(Type.Placeholder(Type.Bounds(None, None)))),
+        Term.ApplyType(Term.Name("List"), List(Type.Wildcard(Type.Bounds(None, None)))),
         List(Pat.Bind(Pat.Var(Term.Name("xs")), Pat.SeqWildcard()))
       )
     )
@@ -756,11 +756,11 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     val tree = pat("List[_](xs @ _*)")
     assertTree(tree)(
       Pat.Extract(
-        Term.ApplyType(Term.Name("List"), List(Type.Placeholder(Type.Bounds(None, None)))),
+        Term.ApplyType(Term.Name("List"), List(Type.AnonymousParam(None))),
         List(Pat.Bind(Pat.Var(Term.Name("xs")), Pat.SeqWildcard()))
       )
     )
-    assertEquals(tree.syntax, "List[?](xs @ _*)")
+    assertEquals(tree.syntax, "List[_](xs @ _*)")
   }
 
   test("package foo; class C; package baz { class D }") {

--- a/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -1161,7 +1161,7 @@ class SuccessSuite extends TreeSuiteBase {
     val tpe1 = t"X"
     val tpe2 = t"Y"
     assertTree(t"_ >: $tpe1 <: $tpe2")(
-      Type.Placeholder(Type.Bounds(Some(Type.Name("X")), Some(Type.Name("Y"))))
+      Type.Wildcard(Type.Bounds(Some(Type.Name("X")), Some(Type.Name("Y"))))
     )
   }
 


### PR DESCRIPTION
The `Placeholder` type (with bounds) we used earlier will be replaced with:

- `AnonymousParam`, with invariant/covariant/contravariant prefix indicator (for `"_"`, `"+_"` and `"-_"`)
- `Wildcard`, with bounds

Helps with #2807.