### PR TITLE
bugfix: Show better error when no `{` is before case

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1393,7 +1393,9 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
     if (acceptOpt[Indentation.Indent]) {
       autoEndPos(t)(Term.Match(t, indentedAfterOpen(caseClauses())))
     } else {
-      autoEndPos(t)(Term.Match(t, inBracesOrNil(caseClauses())))
+      autoEndPos(t)(
+        Term.Match(t, inBracesOr(caseClauses(), syntaxErrorExpected[LeftBrace]))
+      )
     }
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
@@ -69,6 +69,21 @@ class ParseSuite extends TreeSuiteBase with CommonTrees {
   ): Unit =
     checkParsedTree(code, _.entrypointStat(), syntax)(tree)
 
+  protected def runTestError[T <: Tree](code: String, expected: String)(
+      implicit parser: String => T
+  ): Unit = {
+    val error = intercept[ParseException] {
+      val result = parser(code)
+      throw new ParseException(
+        Position.None,
+        s"Statement ${code} should not parse! Got result ${result.structure}"
+      )
+    }
+    assert(
+      error.getMessage.contains(expected),
+      s"Expected [${error.getMessage}] to contain [${expected}]."
+    )
+  }
 }
 
 object MoreHelpers {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -1397,4 +1397,13 @@ class TermSuite extends ParseSuite {
     )
   }
 
+  test("scala3-syntax") {
+
+    runTestError[Term](
+      """|() match
+         |  case _: Unit => ()""".stripMargin,
+      "error: { expected but case found"
+    )(term(_))
+
+  }
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/BaseDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/BaseDottySuite.scala
@@ -82,19 +82,4 @@ trait BaseDottySuite extends ParseSuite {
     assertLayout.foreach(assertNoDiff(reprintedCode, _, "Reprinted stat"))
   }
 
-  protected def runTestError[T <: Tree](code: String, expected: String)(
-      implicit parser: String => T
-  ): Unit = {
-    val error = intercept[ParseException] {
-      val result = parser(code)
-      throw new ParseException(
-        Position.None,
-        s"Statement ${code} should not parse! Got result ${result.structure}"
-      )
-    }
-    assert(
-      error.getMessage.contains(expected),
-      s"Expected [${error.getMessage}] to contain [${expected}]."
-    )
-  }
 }


### PR DESCRIPTION
Related to https://github.com/scalacenter/scastie/issues/636