### PR TITLE
ScalametaParser: allow newline after pat infix op

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2504,6 +2504,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
             if (token.is[LeftBracket])
               syntaxError("infix patterns cannot have type arguments", at = token)
             ctx.push(ctx.UnfinishedInfix(lhs1, op))
+            newLineOpt()
             val rhs1 = simplePattern(badPattern3, isRhs = true)
             loop(rhs1)
           case None =>

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
@@ -327,16 +327,31 @@ class DefnSuite extends ParseSuite {
   }
 
   test("val with infix and break") {
-    def defn = templStat(
+    val defn = templStat(
       """|val foo :: bar ::
          |  baz :: Nil = qux
          |""".stripMargin
     )
-    val msg =
-      """|<input>:1: error: illegal start of simple pattern
-         |val foo :: bar ::
-         |                 ^""".stripMargin
-    interceptMessage[ParseException](msg)(defn)
+    assertTree(defn) {
+      Defn.Val(
+        Nil,
+        Pat.ExtractInfix(
+          Pat.Var(Term.Name("foo")),
+          Term.Name("::"),
+          Pat.ExtractInfix(
+            Pat.Var(Term.Name("bar")),
+            Term.Name("::"),
+            Pat.ExtractInfix(
+              Pat.Var(Term.Name("baz")),
+              Term.Name("::"),
+              List(Term.Name("Nil"))
+            ) :: Nil
+          ) :: Nil
+        ) :: Nil,
+        None,
+        Term.Name("qux")
+      )
+    }
   }
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
@@ -297,4 +297,46 @@ class DefnSuite extends ParseSuite {
       blockStat("infix def x = 42")
     }
   }
+
+  test("val with infix and no break") {
+    val defn = templStat(
+      """|val foo :: bar :: baz :: Nil =
+         |  qux
+         |""".stripMargin
+    )
+    assertTree(defn) {
+      Defn.Val(
+        Nil,
+        Pat.ExtractInfix(
+          Pat.Var(Term.Name("foo")),
+          Term.Name("::"),
+          Pat.ExtractInfix(
+            Pat.Var(Term.Name("bar")),
+            Term.Name("::"),
+            Pat.ExtractInfix(
+              Pat.Var(Term.Name("baz")),
+              Term.Name("::"),
+              List(Term.Name("Nil"))
+            ) :: Nil
+          ) :: Nil
+        ) :: Nil,
+        None,
+        Term.Name("qux")
+      )
+    }
+  }
+
+  test("val with infix and break") {
+    def defn = templStat(
+      """|val foo :: bar ::
+         |  baz :: Nil = qux
+         |""".stripMargin
+    )
+    val msg =
+      """|<input>:1: error: illegal start of simple pattern
+         |val foo :: bar ::
+         |                 ^""".stripMargin
+    interceptMessage[ParseException](msg)(defn)
+  }
+
 }


### PR DESCRIPTION
Helps with scalameta/scalafmt#3313.