### PR TITLE
fix: allow export in extesion block

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -114,8 +114,7 @@ object Term {
     })
   }
   @ast class Block(stats: List[Stat]) extends Term {
-    // extension group block can have declarations without body too
-    checkFields(stats.forall(st => st.isBlockStat || st.is[Decl]))
+    checkParent(ParentChecks.TermBlock)
   }
   @ast class EndMarker(name: Term.Name) extends Term
   @ast class If(cond: Term, thenp: Term, elsep: Term) extends Term {

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/ParentChecks.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/ParentChecks.scala
@@ -107,4 +107,13 @@ object ParentChecks {
   def TypeMethod(tree: Type.Method, parent: Tree, destination: String): Boolean = {
     parent.is[Type] || parent.is[Defn.Type]
   }
+
+  def TermBlock(tree: Term.Block, parent: Tree, dest: String): Boolean = {
+    tree.stats.forall {
+      case _: Decl => true
+      case _: Export => parent.is[Defn.ExtensionGroup]
+      case x => x.isBlockStat
+    }
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExtensionMethodsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExtensionMethodsSuite.scala
@@ -399,6 +399,40 @@ class ExtensionMethodsSuite extends BaseDottySuite {
     )
   }
 
+  test("private-export") {
+    runTestAssert[Stat](
+      """|extension (i: Int)
+         |  private def richInt = RichInt(i)
+         |  export richInt.*
+         |""".stripMargin,
+      assertLayout = Some(
+        """|extension (i: Int){
+           |  private def richInt = RichInt(i)
+           |  export richInt.*
+           |}
+           |""".stripMargin
+      )
+    )(
+      Defn.ExtensionGroup(
+        Nil,
+        List(List(Term.Param(Nil, Term.Name("i"), Some(Type.Name("Int")), None))),
+        Term.Block(
+          List(
+            Defn.Def(
+              List(Mod.Private(Name(""))),
+              Term.Name("richInt"),
+              Nil,
+              Nil,
+              None,
+              Term.Apply(Term.Name("RichInt"), List(Term.Name("i")))
+            ),
+            Export(List(Importer(Term.Name("richInt"), List(Importee.Wildcard()))))
+          )
+        )
+      )
+    )
+  }
+
   final val defcrc = Defn.Def(Nil, tname("crc"), Nil, Nil, Some(pname("Int")), int(2))
 
   final val cparam = List(List(tparam("c", "Circle")))


### PR DESCRIPTION
Reported in Discord: https://discord.com/channels/632642981228314653/632652693013528589/1016780987658682398

Syntax added in 3.2.0: https://scala-lang.org/blog/2022/09/05/scala-3.2.0-released.html#exports-in-extension-clauses