### PR TITLE
ScalametaParser: in param, pass Mod tree, not flag

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2862,33 +2862,28 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
   }
 
   def paramClauses(ownerIsType: Boolean, ownerIsCase: Boolean = false): List[List[Term.Param]] = {
-    var parsedImplicits = false
+    var modImplicit: Option[Mod.Implicit] = None
     def paramClause(first: Boolean): List[Term.Param] = inParensOnOpenOr(token match {
       case t @ Ellipsis(2) =>
         List(ellipsis[Term.Param](t))
-      case _ =>
-        var parsedUsing = false
-        if (acceptOpt[KwImplicit]) {
-          parsedImplicits = true
-        } else if (acceptOpt[soft.KwUsing]) {
-          parsedUsing = true
+      case t =>
+        var modUsing: Option[Mod.Using] = None
+        t match {
+          case _: KwImplicit => modImplicit = Some(atCurPosNext(Mod.Implicit()))
+          case soft.KwUsing() => modUsing = Some(atCurPosNext(Mod.Using()))
+          case _ =>
         }
         commaSeparated(token match {
           case t: Ellipsis => ellipsis[Term.Param](t)
           case _ =>
-            param(
-              ownerIsCase && first,
-              ownerIsType,
-              isImplicit = parsedImplicits,
-              isUsing = parsedUsing
-            )
+            param(ownerIsCase && first, ownerIsType, modImplicit = modImplicit, modUsing = modUsing)
         })
     })(Nil)
     if (!isAfterOptNewLine[LeftParen]) Nil
     else
       listBy[List[Term.Param]] { paramss =>
         paramss += paramClause(true)
-        while (isAfterOptNewLine[LeftParen] && !parsedImplicits) {
+        while (isAfterOptNewLine[LeftParen] && modImplicit.isEmpty) {
           paramss += paramClause(false)
         }
       }
@@ -2923,13 +2918,13 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
   def param(
       ownerIsCase: Boolean,
       ownerIsType: Boolean,
-      isImplicit: Boolean,
-      isUsing: Boolean
+      modImplicit: Option[Mod.Implicit] = None,
+      modUsing: Option[Mod.Using] = None
   ): Term.Param = autoPos {
     val mods = new ListBuffer[Mod]
     annotsBuf(mods, skipNewLines = false)
-    if (isImplicit) mods += autoPos(Mod.Implicit())
-    if (isUsing) mods += autoPos(Mod.Using())
+    modImplicit.foreach(mods += _)
+    modUsing.foreach(mods += _)
     rejectMod[Mod.Open](mods, "Open modifier only applied to classes")
     if (ownerIsType) {
       modifiersBuf(mods, isParams = true)
@@ -2959,7 +2954,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
         q.become[Term.Param.Quasi]
       case _ =>
         var anonymousUsing = false
-        val name = if (isUsing && ahead(!token.is[Colon])) { // anonymous using
+        val name = if (modUsing.isDefined && ahead(!token.is[Colon])) { // anonymous using
           anonymousUsing = true
           autoPos(Name.Anonymous())
         } else {
@@ -2993,7 +2988,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
                       mayNotBeByName("`var'")
                     else
                       mayNotBeByName("`val'")
-                  } else if (isImplicit && !dialect.allowImplicitByNameParameters)
+                  } else if (modImplicit.isDefined && !dialect.allowImplicitByNameParameters)
                     mayNotBeByName("implicit")
                 }
                 Some(tpt)
@@ -3007,7 +3002,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
   def quasiquoteTermParam(): Term.Param = entrypointTermParam()
 
   def entrypointTermParam(): Term.Param =
-    param(ownerIsCase = false, ownerIsType = true, isImplicit = false, isUsing = false)
+    param(ownerIsCase = false, ownerIsType = true)
 
   def typeParamClauseOpt(
       ownerIsType: Boolean,
@@ -3403,10 +3398,10 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
     val paramss = ListBuffer[List[Term.Param]]()
 
     def collectUparams(): Unit = {
-      while (isAfterOptNewLine[LeftParen] && tryAhead[soft.KwUsing]) {
-        next()
-        paramss += inParensAfterOpen(commaSeparated {
-          param(ownerIsCase = false, ownerIsType = true, isImplicit = false, isUsing = true)
+      while (isAfterOptNewLine[LeftParen] && tryAhead[soft.KwUsing]) paramss += {
+        val mod = atCurPos(Mod.Using())
+        inParensOnOpen(commaSeparated {
+          param(ownerIsCase = false, ownerIsType = true, modUsing = Some(mod))
         })
       }
     }
@@ -3414,7 +3409,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
     collectUparams()
 
     paramss += inParens(
-      List(param(ownerIsCase = false, ownerIsType = false, isImplicit = false, isUsing = false))
+      List(param(ownerIsCase = false, ownerIsType = false))
     )
 
     collectUparams()

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -34,10 +34,8 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
     """|Type.Bounds extension [A@@, B](i: A)(using a: F[A], G[B]) def isZero = i == 0
        |Type.Bounds extension [A, B@@](i: A)(using a: F[A], G[B]) def isZero = i == 0
        |Term.Param a: F[A]
-       |Mod.Using extension [A, B](i: A)(using @@a: F[A], G[B]) def isZero = i == 0
        |Type.Apply F[A]
        |Term.Param G[B]
-       |Mod.Using extension [A, B](i: A)(using a: F[A], @@G[B]) def isZero = i == 0
        |Type.Apply G[B]
        |Defn.Def def isZero = i == 0
        |Term.ApplyInfix i == 0
@@ -65,9 +63,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
   checkPositions[Stat](
     "def foo(implicit a: A, b: B): Unit",
     """|Term.Param a: A
-       |Mod.Implicit def foo(implicit @@a: A, b: B): Unit
        |Term.Param b: B
-       |Mod.Implicit def foo(implicit a: A, @@b: B): Unit
        |""".stripMargin
   )
 


### PR DESCRIPTION
Currently, we indicate whether we saw a `using` or `implicit` token in parameter parsing, and generate a new Mod tree that doesn't necessarily point to that keyword but to the current position.

Instead, let's generate the Mod tree over the keyword and pass it along.