### PR TITLE
ScalametaParser: quasi() returns T with Quasi

### DIFF
--- a/scalameta/common/shared/src/main/scala/org/scalameta/internal/MacroHelpers.scala
+++ b/scalameta/common/shared/src/main/scala/org/scalameta/internal/MacroHelpers.scala
@@ -49,6 +49,7 @@ trait MacroHelpers extends DebugFinder with MacroCompat with FreeLocalFinder wit
   lazy val CommonTyperMacrosModule = hygienicRef(scala.meta.internal.trees.CommonTyperMacros)
   lazy val CommonTyperMacrosBundle = hygienicRef[scala.meta.internal.trees.CommonTyperMacrosBundle]
   lazy val AstInfoClass = tq"_root_.scala.meta.internal.trees.AstInfo"
+  lazy val QuasiClass = tq"_root_.scala.meta.internal.trees.Quasi"
   lazy val TokenMetadataModule = hygienicRef(scala.meta.internal.tokens.Metadata)
   lazy val BooleanClass = hygienicRef[scala.Boolean]
   lazy val IntClass = hygienicRef[scala.Int]

--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/transversers/transverser.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/transversers/transverser.scala
@@ -14,7 +14,6 @@ trait TransverserMacros extends MacroHelpers with AstReflection {
 
   lazy val TreeClass = tq"_root_.scala.meta.Tree"
   lazy val TreeAdt = TreeSymbol.asRoot
-  lazy val QuasiClass = tq"_root_.scala.meta.internal.trees.Quasi"
   lazy val QuasiAdt = QuasiSymbol.asAdt
   lazy val Hack1Class = hygienicRef[org.scalameta.overload.Hack1]
   lazy val Hack2Class = hygienicRef[org.scalameta.overload.Hack2]

--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/NamerMacros.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/NamerMacros.scala
@@ -15,7 +15,6 @@ trait CommonNamerMacros extends MacroHelpers {
   import c.universe._
 
   lazy val TreeClass = tq"_root_.scala.meta.Tree"
-  lazy val QuasiClass = tq"_root_.scala.meta.internal.trees.Quasi"
   lazy val ClassifierClass = tq"_root_.scala.meta.classifiers.Classifier"
   lazy val ArrayClassMethod = q"_root_.scala.meta.internal.trees.`package`.arrayClass"
   lazy val ClassOfMethod = q"_root_.scala.Predef.classOf"

--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/ast.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/ast.scala
@@ -439,17 +439,17 @@ class AstNamerMacros(val c: Context) extends Reflection with CommonNamerMacros {
         // step 15: finish codegen for Quasi
         if (isQuasi) {
           stats1 += q"""
-          def become[T <: $TreeClass](implicit ev: $AstInfoClass[T]): T = {
-            this match {
+          def become[T <: $TreeClass](implicit ev: $AstInfoClass[T]): T with $QuasiClass = {
+            (this match {
               case $mname(0, tree) =>
-                ev.quasi(0, tree).withOrigin(this.origin).asInstanceOf[T]
+                ev.quasi(0, tree)
               case $mname(1, nested @ $mname(0, tree)) =>
-                ev.quasi(1, nested.become[T]).withOrigin(this.origin).asInstanceOf[T]
+                ev.quasi(1, nested.become[T])
               case $mname(2, nested @ $mname(0, tree)) =>
-                ev.quasi(2, nested.become[T]).withOrigin(this.origin).asInstanceOf[T]
+                ev.quasi(2, nested.become[T])
               case _ =>
                 throw new Exception("complex ellipses are not supported yet")
-            }
+            }).withOrigin(this.origin): T with $QuasiClass
           }
         """
         } else {

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -614,7 +614,7 @@ package internal.trees {
     def rank: Int
     def tree: Tree
     def pt: Class[_]
-    def become[T <: Tree: AstInfo]: T
+    def become[T <: Tree: AstInfo]: T with Quasi
   }
 
   @registry object All

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/AstInfo.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/AstInfo.scala
@@ -12,7 +12,7 @@ import scala.meta.internal.trees.Metadata.Ast
 @implicitNotFound(msg = "${T} is not an ast class and can't be used here.")
 trait AstInfo[T <: Ast] extends ClassTag[T] {
   def runtimeClass: Class[T]
-  def quasi(rank: Int, tree: Tree): T
+  def quasi(rank: Int, tree: Tree): T with Quasi
 }
 object AstInfo {
   implicit def materialize[T <: Ast]: AstInfo[T] = macro AstInfoMacros.materialize[T]
@@ -32,7 +32,7 @@ class AstInfoMacros(val c: Context) extends MacroHelpers {
     q"""
       new $AstInfoClass[$T] {
         def runtimeClass: $ClassClass[$T] = implicitly[$ClassTagClass[$T]].runtimeClass.asInstanceOf[$ClassClass[$T]]
-        def quasi(rank: $IntClass, tree: $TreeSymbol): $T = $QuasiFactory.apply(rank, tree)
+        def quasi(rank: $IntClass, tree: $TreeSymbol): $T with $QuasiClass = $QuasiFactory.apply(rank, tree)
       }
     """
   }


### PR DESCRIPTION
Since it's now guaranteed that the returned type is a Quasi, it allows us to simplify the code a bit and remove some unnecessary checks and associated failure conditions.