### PR TITLE
ScalametaParser: param ellipses in extension group

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/TreeSuiteBase.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/TreeSuiteBase.scala
@@ -9,6 +9,13 @@ abstract class TreeSuiteBase extends FunSuite {
   protected def assertTree(obtained: Tree)(expected: Tree)(implicit loc: munit.Location): Unit =
     assertNoDiff(obtained.structure, expected.structure)
 
+  protected def assertTrees(
+      obtained: Tree*
+  )(expected: Tree*)(implicit loc: munit.Location): Unit = {
+    assertEquals(obtained.length, expected.length)
+    obtained.zip(expected).foreach { case (o, e) => assertTree(o)(e) }
+  }
+
   protected def assertTree(obtained: Option[Tree])(expected: Option[Tree])(
       implicit loc: munit.Location
   ): Unit =


### PR DESCRIPTION
Currently, quasiquote ellipses are not supported when parsing parameters of extension groups.

Instead, let's move the rank-1 ellipsis parsing into the param() method and add the rank-2 parsing into the extension group invocation.