### PR TITLE
bugfix: Allow refinement after with in type

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/LazyTokenIterator.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/LazyTokenIterator.scala
@@ -133,6 +133,10 @@ private[parsers] class LazyTokenIterator private (
       foundIndentation
   }
 
+  def previousIndentation: Int = {
+    sepRegions.lift(1).fold(0)(_.indent)
+  }
+
   def observeOutdented(): Boolean = {
     if (!dialect.allowSignificantIndentation) false
     else {

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/TokenIterator.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/TokenIterator.scala
@@ -8,6 +8,7 @@ trait TokenIterator {
   def prevTokenPos: Int
   def tokenPos: Int
   def currentIndentation: Int
+  def previousIndentation: Int
   def token: Token
   def fork: TokenIterator
   def observeIndented(): Boolean

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
@@ -123,6 +123,58 @@ class TypeSuite extends BaseDottySuite {
     )
   }
 
+  test("with-followed-by-brace-indent") {
+    runTestAssert[Stat](
+      """|type AA = String with Int with
+         |    type T>: Null
+         |      {
+         |        type T>: Int
+         |      }
+         |""".stripMargin,
+      assertLayout = Some("type AA = String with Int { type T >: Null { type T >: Int } }")
+    )(
+      Defn.Type(
+        Nil,
+        Type.Name("AA"),
+        Nil,
+        Type.Refine(
+          Some(Type.With(Type.Name("String"), Type.Name("Int"))),
+          List(
+            Decl.Type(
+              Nil,
+              Type.Name("T"),
+              Nil,
+              Type.Bounds(
+                Some(
+                  Type.Refine(
+                    Some(Type.Name("Null")),
+                    List(
+                      Decl.Type(Nil, Type.Name("T"), Nil, Type.Bounds(Some(Type.Name("Int")), None))
+                    )
+                  )
+                ),
+                None
+              )
+            )
+          )
+        ),
+        Type.Bounds(None, None)
+      )
+    )
+  }
+
+  test("with-followed-by-brace") {
+    runTestError[Stat](
+      """|type AA = String with Int with
+         |    type T>: Null
+         |{
+         |  type T>: Int
+         |}
+         |""".stripMargin,
+      "; expected but { found"
+    )
+  }
+
   test("T") {
     val TypeName("T") = tpe("T")
   }


### PR DESCRIPTION
Fixes https://github.com/scalameta/scalameta/issues/2853

Previously, we would not accept `type T = AnyRef with<Indentation>`. Now, we accept the statements in after indentation as refinements.