### PR TITLE
bugfix: Don't allow open for enum cases

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -3295,7 +3295,12 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
       case KwExtension() =>
         extensionGroupDecl(mods)
       case KwCase() if dialect.allowEnums && enumCaseAllowed && ahead(token.is[Ident]) =>
-        enumCaseDef(mods)
+        mods.find(mod => !mod.isAccessMod && !mod.is[Mod.Annot]) match {
+          case Some(mod) =>
+            syntaxError("Only access modifiers allowed on enum case", at = mod.pos)
+          case None =>
+            enumCaseDef(mods)
+        }
       case KwCase() if dialect.allowEnums && ahead(token.is[Ident]) =>
         syntaxError("Enum cases are only allowed in enums", at = token.pos)
       case KwIf() if mods.size == 1 && mods.head.is[Mod.Inline] =>

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
@@ -80,7 +80,7 @@ class ParseSuite extends TreeSuiteBase with CommonTrees {
       )
     }
     assert(
-      error.getMessage.contains(expected),
+      error.getMessage().contains(expected),
       s"Expected [${error.getMessage}] to contain [${expected}]."
     )
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EnumSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EnumSuite.scala
@@ -23,6 +23,56 @@ class EnumSuite extends BaseDottySuite {
     )
   }
 
+  test("enum-private-case") {
+    runTestAssert[Stat](
+      "enum Color { private case R; protected case G }",
+      assertLayout = Some(
+        """|enum Color {
+           |  private case R
+           |  protected case G
+           |}
+           |""".stripMargin
+      )
+    )(
+      Defn.Enum(
+        Nil,
+        Type.Name("Color"),
+        Nil,
+        Ctor.Primary(Nil, Name(""), Nil),
+        Template(
+          Nil,
+          Nil,
+          Self(Name(""), None),
+          List(
+            Defn.EnumCase(
+              List(Mod.Private(Name(""))),
+              Term.Name("R"),
+              Nil,
+              Ctor.Primary(Nil, Name(""), Nil),
+              Nil
+            ),
+            Defn.EnumCase(
+              List(Mod.Protected(Name(""))),
+              Term.Name("G"),
+              Nil,
+              Ctor.Primary(Nil, Name(""), Nil),
+              Nil
+            )
+          ),
+          Nil
+        )
+      )
+    )
+  }
+
+  test("enum-wrong-soft") {
+    runTestError[Stat](
+      """|enum Color:
+         | open case R, G """.stripMargin,
+      "error: Only access modifiers allowed on enum case"
+    )
+  }
+
   test("enum-parametrized") {
     runTestAssert[Stat]("enum C(i: Int) { case R, G }")(
       Defn.Enum(Nil, pname("C"), Nil, ctorp(List(tparam("i", "Int"))), tpl(List(RGCase)))


### PR DESCRIPTION
Follow up from https://github.com/lampepfl/dotty/pull/15961