### PR TITLE
Trees: use Type.Params, not List[Param]

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/trees/Api.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/trees/Api.scala
@@ -1,7 +1,12 @@
 package scala.meta
 package trees
 
-private[meta] trait Api {}
+import scala.language.implicitConversions
+
+private[meta] trait Api {
+  implicit def typeParamClauseToValues(v: Type.ParamClause): List[Type.Param] = v.values
+  implicit def typeValuesToParamClause(v: List[Type.Param]): Type.ParamClause = Type.ParamClause(v)
+}
 
 private[meta] trait Aliases {
   // NOTE: all trees are defined immediately in the scala.meta package,

--- a/tests/js/src/test/scala/scala/meta/tests/parsers/JSFacadeSuite.scala
+++ b/tests/js/src/test/scala/scala/meta/tests/parsers/JSFacadeSuite.scala
@@ -63,7 +63,11 @@ class JSFacadeSuite extends FunSuite {
                   "pos" -> pos(20, 24),
                   "value" -> "main"
                 ),
-                "tparams" -> a(),
+                "tparamClause" -> d(
+                  "type" -> "Type.ParamClause",
+                  "pos" -> pos(24, 24),
+                  "values" -> a()
+                ),
                 "paramss" -> a(
                   a(
                     d(

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -294,6 +294,8 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.Lit.Symbol
       |scala.meta.Lit.Unit
       |scala.meta.Member
+      |scala.meta.Member.Param
+      |scala.meta.Member.ParamClause
       |scala.meta.Member.Term
       |scala.meta.Member.Type
       |scala.meta.Mod
@@ -414,6 +416,7 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.Type.Name
       |scala.meta.Type.Or
       |scala.meta.Type.Param
+      |scala.meta.Type.ParamClause
       |scala.meta.Type.PatWildcard
       |scala.meta.Type.Placeholder
       |scala.meta.Type.Placeholder.Impl

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
@@ -24,7 +24,7 @@ class ReflectionSuite extends FunSuite {
     val sym = symbolOf[scala.meta.Tree]
     assert(sym.isRoot)
     val root = sym.asRoot
-    assertEquals((root.allBranches.length, root.allLeafs.length), (26, 362))
+    assertEquals((root.allBranches.length, root.allLeafs.length), (28, 366))
   }
 
   test("If") {
@@ -116,6 +116,7 @@ class ReflectionSuite extends FunSuite {
       |scala.meta.Type
       |scala.meta.Type.Bounds
       |scala.meta.Type.Name
+      |scala.meta.Type.ParamClause
     """.trim.stripMargin.split('\n').mkString(EOL)
     )
   }

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
@@ -76,17 +76,20 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Type](
     "A { def f: B }",
     """|Decl.Def def f: B
+       |Type.ParamClause A { def f@@: B }
        |""".stripMargin
   )
   checkPositions[Type]("A{}")
   checkPositions[Type](
     "{ def f: B }",
     """|Decl.Def def f: B
+       |Type.ParamClause { def f@@: B }
        |""".stripMargin
   )
   checkPositions[Type](
     "A forSome { type T }",
     """|Decl.Type type T
+       |Type.ParamClause A forSome { type T @@}
        |Type.Bounds A forSome { type T @@}
        |""".stripMargin
   )
@@ -119,20 +122,26 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Type]("Any*")
   checkPositions[Stat](
     "def f[A <% B[A]]: C",
-    """|Type.Param A <% B[A]
+    """|Type.ParamClause [A <% B[A]]
+       |Type.Param A <% B[A]
+       |Type.ParamClause def f[A @@<% B[A]]: C
        |Type.Bounds def f[A @@<% B[A]]: C
        |Type.Apply B[A]
        |""".stripMargin
   )
   checkPositions[Stat](
     "def f[A: B]: C",
-    """|Type.Param A: B
+    """|Type.ParamClause [A: B]
+       |Type.Param A: B
+       |Type.ParamClause def f[A@@: B]: C
        |Type.Bounds def f[A@@: B]: C
        |""".stripMargin
   )
   checkPositions[Stat](
     "def f[A : B : C]: D",
-    """|Type.Param A : B : C
+    """|Type.ParamClause [A : B : C]
+       |Type.Param A : B : C
+       |Type.ParamClause def f[A @@: B : C]: D
        |Type.Bounds def f[A @@: B : C]: D
        |""".stripMargin
   )
@@ -305,7 +314,8 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
   )
   checkPositions[Stat](
     "def f(a: A = (da)): A",
-    """|Term.Param a: A = (da)
+    """|Type.ParamClause def f@@(a: A = (da)): A
+       |Term.Param a: A = (da)
        |Term.Name (da)
        |""".stripMargin
   )
@@ -455,16 +465,21 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
   // Decl
   checkPositions[Stat]("val a: Int")
   checkPositions[Stat]("var b: Long")
-  checkPositions[Stat]("def f: String")
+  checkPositions[Stat](
+    "def f: String",
+    "Type.ParamClause def f@@: String"
+  )
   checkPositions[Stat](
     "type T",
-    """|Type.Bounds type T@@
+    """|Type.ParamClause type T@@
+       |Type.Bounds type T@@
        |""".stripMargin
   )
 
   checkPositions[Stat](
     "class A { def this(a: A) = this() }",
-    """|Ctor.Primary class A @@{ def this(a: A) = this() }
+    """|Type.ParamClause class A @@{ def this(a: A) = this() }
+       |Ctor.Primary class A @@{ def this(a: A) = this() }
        |Template { def this(a: A) = this() }
        |Self class A { @@def this(a: A) = this() }
        |Ctor.Secondary def this(a: A) = this()
@@ -475,10 +490,14 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
        |Name.Anonymous this
        |""".stripMargin
   )
-  checkPositions[Stat]("def f = macro m")
+  checkPositions[Stat](
+    "def f = macro m",
+    "Type.ParamClause def f @@= macro m"
+  )
   checkPositions[Stat](
     "class A private (b: B)",
-    """|Ctor.Primary private (b: B)
+    """|Type.ParamClause class A @@private (b: B)
+       |Ctor.Primary private (b: B)
        |Template class A private (b: B)@@
        |Self class A private (b: B)@@
        |""".stripMargin
@@ -487,22 +506,26 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Stat](
     "@tailrec def f = 1",
     """|Mod.Annot @tailrec
+       |Type.ParamClause @tailrec def f @@= 1
        |""".stripMargin
   )
   checkPositions[Stat](
     "@tailrec def f = 1",
     """|Mod.Annot @tailrec
+       |Type.ParamClause @tailrec def f @@= 1
        |""".stripMargin
   )
   checkPositions[Stat](
     "@a def b = 1",
     """|Mod.Annot @a
+       |Type.ParamClause @a def b @@= 1
        |""".stripMargin
   )
   checkPositions[Stat](
     "@a(1) def b = 1",
     """|Mod.Annot @a(1)
        |Init a(1)
+       |Type.ParamClause @a(1) def b @@= 1
        |""".stripMargin
   )
   checkPositions[Stat](
@@ -511,6 +534,7 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
        |Init (a @b)
        |Type.Annotate (a @b)
        |Mod.Annot @b
+       |Type.ParamClause @(a @b) def x @@= 1
        |""".stripMargin
   )
   checkPositions[Stat](
@@ -520,6 +544,7 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
        |Type.Annotate (a @b(1, 2)(3))
        |Mod.Annot @b(1, 2)(3)
        |Init b(1, 2)(3)
+       |Type.ParamClause @(a @b(1, 2)(3)) def x @@= 1
        |""".stripMargin
   )
   checkPositions[Stat](
@@ -536,12 +561,16 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Stat]("final val a = 1")
   checkPositions[Stat](
     "sealed trait a",
-    """|Ctor.Primary sealed trait a@@
+    """|Type.ParamClause sealed trait a@@
+       |Ctor.Primary sealed trait a@@
        |Template sealed trait a@@
        |Self sealed trait a@@
        |""".stripMargin
   )
-  checkPositions[Stat]("override def f = 1")
+  checkPositions[Stat](
+    "override def f = 1",
+    "Type.ParamClause override def f @@= 1"
+  )
   checkPositions[Stat](
     "case object B",
     """|Template case object B@@
@@ -550,15 +579,18 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
   )
   checkPositions[Stat](
     "abstract class A",
-    """|Ctor.Primary abstract class A@@
+    """|Type.ParamClause abstract class A@@
+       |Ctor.Primary abstract class A@@
        |Template abstract class A@@
        |Self abstract class A@@
        |""".stripMargin
   )
   checkPositions[Stat](
     "class A[+ T]",
-    """|Type.Param + T
+    """|Type.ParamClause [+ T]
+       |Type.Param + T
        |Mod.Covariant +
+       |Type.ParamClause class A[+ T@@]
        |Type.Bounds class A[+ T@@]
        |Ctor.Primary class A[+ T]@@
        |Template class A[+ T]@@
@@ -567,8 +599,10 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
   )
   checkPositions[Stat](
     "class A[- T]",
-    """|Type.Param - T
+    """|Type.ParamClause [- T]
+       |Type.Param - T
        |Mod.Contravariant -
+       |Type.ParamClause class A[- T@@]
        |Type.Bounds class A[- T@@]
        |Ctor.Primary class A[- T]@@
        |Template class A[- T]@@
@@ -578,7 +612,8 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Stat]("lazy val a = 1")
   checkPositions[Stat](
     "class A(val b: B)",
-    """|Ctor.Primary (val b: B)
+    """|Type.ParamClause class A@@(val b: B)
+       |Ctor.Primary (val b: B)
        |Term.Param val b: B
        |Mod.ValParam val
        |Template class A(val b: B)@@
@@ -587,7 +622,8 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
   )
   checkPositions[Stat](
     "class A(var b: B)",
-    """|Ctor.Primary (var b: B)
+    """|Type.ParamClause class A@@(var b: B)
+       |Ctor.Primary (var b: B)
        |Term.Param var b: B
        |Mod.VarParam var
        |Template class A(var b: B)@@
@@ -597,14 +633,16 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
 
   checkPositions[Stat](
     "trait A { self: B => }",
-    """|Ctor.Primary trait A @@{ self: B => }
+    """|Type.ParamClause trait A @@{ self: B => }
+       |Ctor.Primary trait A @@{ self: B => }
        |Template { self: B => }
        |Self self: B
        |""".stripMargin
   )
   checkPositions[Stat](
     "trait A { _: B => }",
-    """|Ctor.Primary trait A @@{ _: B => }
+    """|Type.ParamClause trait A @@{ _: B => }
+       |Ctor.Primary trait A @@{ _: B => }
        |Template { _: B => }
        |Self _: B
        |Name.Anonymous _
@@ -612,14 +650,16 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
   )
   checkPositions[Stat](
     "trait A { self => }",
-    """|Ctor.Primary trait A @@{ self => }
+    """|Type.ParamClause trait A @@{ self => }
+       |Ctor.Primary trait A @@{ self => }
        |Template { self => }
        |Self self
        |""".stripMargin
   )
   checkPositions[Stat](
     "trait A { this: B => }",
-    """|Ctor.Primary trait A @@{ this: B => }
+    """|Type.ParamClause trait A @@{ this: B => }
+       |Ctor.Primary trait A @@{ this: B => }
        |Template { this: B => }
        |Self this: B
        |Name.Anonymous this
@@ -664,7 +704,8 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
        |
        |  def foo: Boolean = true
        |}""".stripMargin,
-    """|Ctor.Primary trait SampleTrait @@extends A {
+    """|Type.ParamClause trait SampleTrait @@extends A {
+       |Ctor.Primary trait SampleTrait @@extends A {
        |Template extends A {
        |  self: X with B with C =>
        |
@@ -674,6 +715,7 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
        |Type.With X with B with C
        |Type.With X with B
        |Defn.Def def foo: Boolean = true
+       |Type.ParamClause   def foo@@: Boolean = true
        |""".stripMargin
   )
 
@@ -684,7 +726,8 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
        |  def foo: Boolean = true // c2
        |  // c3
        |} // c4""".stripMargin,
-    """|Ctor.Primary trait SampleTrait @@extends A {
+    """|Type.ParamClause trait SampleTrait @@extends A {
+       |Ctor.Primary trait SampleTrait @@extends A {
        |Template extends A {
        |  self: X with B with C => // c1
        |
@@ -695,6 +738,7 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
        |Type.With X with B with C
        |Type.With X with B
        |Defn.Def def foo: Boolean = true
+       |Type.ParamClause   def foo@@: Boolean = true // c2
        |""".stripMargin
   )
 
@@ -711,6 +755,7 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
        |Mod.Private private [this]
        |Term.This this
        |Name.Anonymous this
+       |Type.ParamClause   private [this] def foo@@: Int = ???
        |""".stripMargin
   )
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/BasicPositionSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/BasicPositionSuite.scala
@@ -90,7 +90,8 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Stat](
     // Issue #333
     """def shortInfo: String = s"created=$x"""",
-    """|Term.Interpolate s"created=$x"
+    """|Type.ParamClause def shortInfo@@: String = s"created=$x"
+       |Term.Interpolate s"created=$x"
        |""".stripMargin
   )
   checkPositions[Case](

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
@@ -27,6 +27,7 @@ trait CommonTrees {
   }
 
   object EmptyCtor {
+    def apply() = Ctor.Primary(Nil, Name.Anonymous(), Nil)
     def unapply(tree: Tree): Boolean = tree match {
       case Ctor.Primary(Nil, Name.Anonymous(), Nil) => true
       case _ => false

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/DeclSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/DeclSuite.scala
@@ -26,135 +26,221 @@ class DeclSuite extends ParseSuite {
   }
 
   test("type T") {
-    val t @ Decl.Type(Nil, Type.Name("T"), Nil, Type.Bounds(None, None)) = templStat("type T")
+    assertTree(templStat("type T")) {
+      Decl.Type(Nil, Type.Name("T"), Type.ParamClause(Nil), Type.Bounds(None, None))
+    }
   }
 
   test("type T <: hi") {
-    val t @ Decl.Type(Nil, Type.Name("T"), Nil, Type.Bounds(None, Some(Type.Name("hi")))) =
-      templStat("type T <: hi")
+    assertTree(templStat("type T <: hi")) {
+      Decl.Type(
+        Nil,
+        Type.Name("T"),
+        Type.ParamClause(Nil),
+        Type.Bounds(None, Some(Type.Name("hi")))
+      )
+    }
   }
 
   test("type T >: lo") {
-    val t @ Decl.Type(Nil, Type.Name("T"), Nil, Type.Bounds(Some(Type.Name("lo")), None)) =
-      templStat("type T >: lo")
+    assertTree(templStat("type T >: lo")) {
+      Decl.Type(
+        Nil,
+        Type.Name("T"),
+        Type.ParamClause(Nil),
+        Type.Bounds(Some(Type.Name("lo")), None)
+      )
+    }
   }
 
   test("type T >: lo <: hi") {
-    val t @ Decl.Type(
-      Nil,
-      Type.Name("T"),
-      Nil,
-      Type.Bounds(Some(Type.Name("lo")), Some(Type.Name("hi")))
-    ) = templStat("type T >: lo <: hi")
+    assertTree(templStat("type T >: lo <: hi")) {
+      Decl.Type(
+        Nil,
+        Type.Name("T"),
+        Type.ParamClause(Nil),
+        Type.Bounds(Some(Type.Name("lo")), Some(Type.Name("hi")))
+      )
+    }
   }
 
   test("type F[T]") {
-    val Decl.Type(
-      Nil,
-      Type.Name("F"),
-      Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, Nil) :: Nil,
-      Type.Bounds(None, None)
-    ) = templStat("type F[T]")
+    assertTree(templStat("type F[T]")) {
+      Decl.Type(
+        Nil,
+        Type.Name("F"),
+        Type.ParamClause(
+          Type.Param(
+            Nil,
+            Type.Name("T"),
+            Type.ParamClause(Nil),
+            Type.Bounds(None, None),
+            Nil,
+            Nil
+          ) :: Nil
+        ),
+        Type.Bounds(None, None)
+      )
+    }
   }
 
   test("type F[_]") {
-    val Decl.Type(
-      Nil,
-      Type.Name("F"),
-      Type.Param(Nil, Name.Anonymous(), Nil, Type.Bounds(None, None), Nil, Nil) :: Nil,
-      Type.Bounds(None, None)
-    ) = templStat("type F[_]")
+    assertTree(templStat("type F[_]")) {
+      Decl.Type(
+        Nil,
+        Type.Name("F"),
+        Type.ParamClause(
+          Type.Param(
+            Nil,
+            Name.Anonymous(),
+            Type.ParamClause(Nil),
+            Type.Bounds(None, None),
+            Nil,
+            Nil
+          ) :: Nil
+        ),
+        Type.Bounds(None, None)
+      )
+    }
   }
 
   test("type F[A <: B]") {
-    val Decl.Type(
-      Nil,
-      Type.Name("F"),
-      Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, Some(Type.Name("B"))), Nil, Nil)
-        :: Nil,
-      Type.Bounds(None, None)
-    ) = templStat("type F[T <: B]")
+    assertTree(templStat("type F[T <: B]")) {
+      Decl.Type(
+        Nil,
+        Type.Name("F"),
+        Type.ParamClause(
+          Type.Param(
+            Nil,
+            Type.Name("T"),
+            Type.ParamClause(Nil),
+            Type.Bounds(None, Some(Type.Name("B"))),
+            Nil,
+            Nil
+          ) :: Nil
+        ),
+        Type.Bounds(None, None)
+      )
+    }
   }
 
   test("type F[+T]") {
-    val Decl.Type(
-      Nil,
-      Type.Name("F"),
-      Type.Param(Mod.Covariant() :: Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, Nil)
-        :: Nil,
-      Type.Bounds(None, None)
-    ) = templStat("type F[+T]")
-    val Decl.Type(
-      Nil,
-      Type.Name("F"),
-      Type.Param(Mod.Contravariant() :: Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, Nil)
-        :: Nil,
-      Type.Bounds(None, None)
-    ) = templStat("type F[-T]")
+    assertTree(templStat("type F[+T]")) {
+      Decl.Type(
+        Nil,
+        Type.Name("F"),
+        Type.ParamClause(
+          Type.Param(
+            Mod.Covariant() :: Nil,
+            Type.Name("T"),
+            Type.ParamClause(Nil),
+            Type.Bounds(None, None),
+            Nil,
+            Nil
+          ) :: Nil
+        ),
+        Type.Bounds(None, None)
+      )
+    }
+    assertTree(templStat("type F[-T]")) {
+      Decl.Type(
+        Nil,
+        Type.Name("F"),
+        Type.ParamClause(
+          Type.Param(
+            Mod.Contravariant() :: Nil,
+            Type.Name("T"),
+            Type.ParamClause(Nil),
+            Type.Bounds(None, None),
+            Nil,
+            Nil
+          ) :: Nil
+        ),
+        Type.Bounds(None, None)
+      )
+    }
   }
 
   test("def f") {
-    val Decl.Def(Nil, Term.Name("f"), Nil, Nil, Type.Name("Unit")) = templStat("def f")
+    assertTree(templStat("def f")) {
+      Decl.Def(Nil, Term.Name("f"), Type.ParamClause(Nil), Nil, Type.Name("Unit"))
+    }
   }
 
   test("def f(x: Int)") {
-    val Decl.Def(
-      Nil,
-      Term.Name("f"),
-      Nil,
-      (Term.Param(Nil, Term.Name("x"), Some(Type.Name("Int")), None) :: Nil) :: Nil,
-      Type.Name("Unit")
-    ) =
-      templStat("def f(x: Int)")
+    assertTree(templStat("def f(x: Int)")) {
+      Decl.Def(
+        Nil,
+        Term.Name("f"),
+        Type.ParamClause(Nil),
+        (Term.Param(Nil, Term.Name("x"), Some(Type.Name("Int")), None) :: Nil) :: Nil,
+        Type.Name("Unit")
+      )
+    }
   }
 
   test("def f(x: Int*)") {
-    val Decl.Def(
-      Nil,
-      Term.Name("f"),
-      Nil,
-      (Term.Param(Nil, Term.Name("x"), Some(Type.Repeated(Type.Name("Int"))), None) :: Nil) :: Nil,
-      Type.Name("Unit")
-    ) =
-      templStat("def f(x: Int*)")
+    assertTree(templStat("def f(x: Int*)")) {
+      Decl.Def(
+        Nil,
+        Term.Name("f"),
+        Type.ParamClause(Nil),
+        (Term
+          .Param(Nil, Term.Name("x"), Some(Type.Repeated(Type.Name("Int"))), None) :: Nil) :: Nil,
+        Type.Name("Unit")
+      )
+    }
   }
 
   test("def f(x: => Int)") {
-    val Decl.Def(
-      Nil,
-      Term.Name("f"),
-      Nil,
-      (Term.Param(Nil, Term.Name("x"), Some(Type.ByName(Type.Name("Int"))), None) :: Nil) :: Nil,
-      Type.Name("Unit")
-    ) =
-      templStat("def f(x: => Int)")
+    assertTree(templStat("def f(x: => Int)")) {
+      Decl.Def(
+        Nil,
+        Term.Name("f"),
+        Type.ParamClause(Nil),
+        (Term.Param(Nil, Term.Name("x"), Some(Type.ByName(Type.Name("Int"))), None) :: Nil) :: Nil,
+        Type.Name("Unit")
+      )
+    }
   }
 
   test("def f(implicit x: Int)") {
-    val Decl.Def(
-      Nil,
-      Term.Name("f"),
-      Nil,
-      (Term.Param(Mod.Implicit() :: Nil, Term.Name("x"), Some(Type.Name("Int")), None) :: Nil)
-        :: Nil,
-      Type.Name("Unit")
-    ) =
-      templStat("def f(implicit x: Int)")
+    assertTree(templStat("def f(implicit x: Int)")) {
+      Decl.Def(
+        Nil,
+        Term.Name("f"),
+        Type.ParamClause(Nil),
+        (Term.Param(Mod.Implicit() :: Nil, Term.Name("x"), Some(Type.Name("Int")), None) :: Nil)
+          :: Nil,
+        Type.Name("Unit")
+      )
+    }
   }
 
   test("def f: X") {
-    val Decl.Def(Nil, Term.Name("f"), Nil, Nil, Type.Name("X")) =
-      templStat("def f: X")
+    assertTree(templStat("def f: X")) {
+      Decl.Def(Nil, Term.Name("f"), Type.ParamClause(Nil), Nil, Type.Name("X"))
+    }
   }
 
   test("def f[T]: T") {
-    val Decl.Def(
-      Nil,
-      Term.Name("f"),
-      Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, Nil) :: Nil,
-      Nil,
-      Type.Name("T")
-    ) =
-      templStat("def f[T]: T")
+    assertTree(templStat("def f[T]: T")) {
+      Decl.Def(
+        Nil,
+        Term.Name("f"),
+        Type.ParamClause(
+          Type.Param(
+            Nil,
+            Type.Name("T"),
+            Type.ParamClause(Nil),
+            Type.Bounds(None, None),
+            Nil,
+            Nil
+          ) :: Nil
+        ),
+        Nil,
+        Type.Name("T")
+      )
+    }
   }
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
@@ -71,105 +71,155 @@ class DefnSuite extends ParseSuite {
   }
 
   test("type A = B") {
-    val Defn.Type(Nil, Type.Name("A"), Nil, Type.Name("B")) =
-      templStat("type A = B")
+    assertTree(templStat("type A = B")) {
+      Defn.Type(Nil, Type.Name("A"), Type.ParamClause(Nil), Type.Name("B"))
+    }
   }
 
   test("type F[T] = List[T]") {
-    val Defn.Type(
-      Nil,
-      Type.Name("F"),
-      Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, Nil) :: Nil,
-      Type.Apply(Type.Name("List"), Type.Name("T") :: Nil)
-    ) = templStat("type F[T] = List[T]")
+    assertTree(templStat("type F[T] = List[T]")) {
+      Defn.Type(
+        Nil,
+        Type.Name("F"),
+        Type.ParamClause(
+          Type.Param(
+            Nil,
+            Type.Name("T"),
+            Type.ParamClause(Nil),
+            Type.Bounds(None, None),
+            Nil,
+            Nil
+          ) :: Nil
+        ),
+        Type.Apply(Type.Name("List"), Type.Name("T") :: Nil)
+      )
+    }
   }
 
   test("def x = 2") {
-    val Defn.Def(Nil, Term.Name("x"), Nil, Nil, None, Lit(2)) = templStat("def x = 2")
+    assertTree(templStat("def x = 2")) {
+      Defn.Def(Nil, Term.Name("x"), Nil, Nil, None, Lit.Int(2))
+    }
   }
 
   test("def x[A <: B] = 2") {
-    val Defn.Def(
-      Nil,
-      Term.Name("x"),
-      Type.Param(Nil, Type.Name("A"), Nil, Type.Bounds(None, Some(Type.Name("B"))), Nil, Nil)
-        :: Nil,
-      Nil,
-      None,
-      Lit(2)
-    ) = templStat("def x[A <: B] = 2")
+    assertTree(templStat("def x[A <: B] = 2")) {
+      Defn.Def(
+        Nil,
+        Term.Name("x"),
+        Type.ParamClause(
+          Type.Param(
+            Nil,
+            Type.Name("A"),
+            Type.ParamClause(Nil),
+            Type.Bounds(None, Some(Type.Name("B"))),
+            Nil,
+            Nil
+          ) :: Nil
+        ),
+        Nil,
+        None,
+        Lit.Int(2)
+      )
+    }
   }
 
   test("def x[A <% B] = 2") {
-    val Defn.Def(
-      Nil,
-      Term.Name("x"),
-      Type.Param(Nil, Type.Name("A"), Nil, Type.Bounds(None, None), Type.Name("B") :: Nil, Nil)
-        :: Nil,
-      Nil,
-      None,
-      Lit(2)
-    ) = templStat("def x[A <% B] = 2")
+    assertTree(templStat("def x[A <% B] = 2")) {
+      Defn.Def(
+        Nil,
+        Term.Name("x"),
+        Type.ParamClause(
+          Type.Param(
+            Nil,
+            Type.Name("A"),
+            Type.ParamClause(Nil),
+            Type.Bounds(None, None),
+            Type.Name("B") :: Nil,
+            Nil
+          ) :: Nil
+        ),
+        Nil,
+        None,
+        Lit.Int(2)
+      )
+    }
   }
 
   test("def x[A: B] = 2") {
-    val Defn.Def(
-      Nil,
-      Term.Name("x"),
-      Type.Param(Nil, Type.Name("A"), Nil, Type.Bounds(None, None), Nil, Type.Name("B") :: Nil)
-        :: Nil,
-      Nil,
-      None,
-      Lit(2)
-    ) = templStat("def x[A: B] = 2")
+    assertTree(templStat("def x[A: B] = 2")) {
+      Defn.Def(
+        Nil,
+        Term.Name("x"),
+        Type.ParamClause(
+          Type.Param(
+            Nil,
+            Type.Name("A"),
+            Type.ParamClause(Nil),
+            Type.Bounds(None, None),
+            Nil,
+            Type.Name("B") :: Nil
+          ) :: Nil
+        ),
+        Nil,
+        None,
+        Lit.Int(2)
+      )
+    }
   }
 
   test("def f(a: Int)(implicit b: Int) = a + b") {
-    val Defn.Def(
-      Nil,
-      Term.Name("f"),
-      Nil,
-      (Term.Param(Nil, Term.Name("a"), Some(Type.Name("Int")), None) :: Nil) ::
-        (Term.Param(Mod.Implicit() :: Nil, Term.Name("b"), Some(Type.Name("Int")), None) :: Nil)
-        :: Nil,
-      None,
-      Term.ApplyInfix(Term.Name("a"), Term.Name("+"), Nil, Term.Name("b") :: Nil)
-    ) =
-      templStat("def f(a: Int)(implicit b: Int) = a + b")
+    assertTree(templStat("def f(a: Int)(implicit b: Int) = a + b")) {
+      Defn.Def(
+        Nil,
+        Term.Name("f"),
+        Type.ParamClause(Nil),
+        (Term.Param(Nil, Term.Name("a"), Some(Type.Name("Int")), None) :: Nil) ::
+          (Term.Param(Mod.Implicit() :: Nil, Term.Name("b"), Some(Type.Name("Int")), None) :: Nil)
+          :: Nil,
+        None,
+        Term.ApplyInfix(Term.Name("a"), Term.Name("+"), Nil, Term.Name("b") :: Nil)
+      )
+    }
   }
 
   test("def proc { return 42 }") {
-    val Defn.Def(
-      Nil,
-      Term.Name("proc"),
-      Nil,
-      Nil,
-      Some(Type.Name("Unit")),
-      Term.Block((ret @ Term.Return(Lit(42))) :: Nil)
-    ) =
-      templStat("def proc { return 42 }")
+    assertTree(templStat("def proc { return 42 }")) {
+      Defn.Def(
+        Nil,
+        Term.Name("proc"),
+        Type.ParamClause(Nil),
+        Nil,
+        Some(Type.Name("Unit")),
+        Term.Block(Term.Return(Lit.Int(42)) :: Nil)
+      )
+    }
   }
 
   test("def f(x: Int) = macro impl") {
-    val Defn.Macro(
-      Nil,
-      Term.Name("f"),
-      Nil,
-      (Term.Param(List(), Term.Name(x), Some(Type.Name("Int")), None) :: Nil) :: Nil,
-      None,
-      Term.Name("impl")
-    ) = templStat("def f(x: Int) = macro impl")
+    assertTree(templStat("def f(x: Int) = macro impl")) {
+      Defn.Macro(
+        Nil,
+        Term.Name("f"),
+        Type.ParamClause(Nil),
+        (Term.Param(List(), Term.Name("x"), Some(Type.Name("Int")), None) :: Nil) :: Nil,
+        None,
+        Term.Name("impl")
+      )
+    }
   }
 
   test("def f(x: Int): Int = macro impl") {
-    val Defn.Macro(
-      Nil,
-      Term.Name("f"),
-      Nil,
-      (Term.Param(List(), Term.Name(x), Some(Type.Name("Int")), None) :: Nil) :: Nil,
-      Some(Type.Name("Int")),
-      Term.Name("impl")
-    ) = templStat("def f(x: Int): Int = macro impl")
+    assertTree(templStat("def f(x: Int): Int = macro impl")) {
+      Defn.Macro(
+        Nil,
+        Term.Name("f"),
+        Nil,
+        (Term.Param(List(), Term.Name("x"), Some(Type.Name("Int")), None) :: Nil) :: Nil,
+        Some(Type.Name("Int")),
+        Term.Name("impl")
+      )
+    }
   }
 
   test("braces-in-functions") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
@@ -282,31 +282,155 @@ class ModSuite extends ParseSuite {
     )
   }
 
-  test("covariant") {
-    val Defn.Class(_, _, List(Type.Param(List(Mod.Covariant()), _, _, _, _, _)), _, _) =
-      templStat("case class A[+T](t: T)")
+  test("covariant in case class") {
+    assertTree(templStat("case class A[+T](t: T)")) {
+      Defn.Class(
+        List(Mod.Case()),
+        Type.Name("A"),
+        Type.ParamClause(
+          Type.Param(
+            List(Mod.Covariant()),
+            Type.Name("T"),
+            Type.ParamClause(Nil),
+            Type.Bounds(None, None),
+            Nil,
+            Nil
+          ) :: Nil
+        ),
+        Ctor.Primary(
+          Nil,
+          Name(""),
+          List(List(Term.Param(Nil, Term.Name("t"), Some(Type.Name("T")), None)))
+        ),
+        Template(Nil, Nil, Self(Name(""), None), Nil, Nil)
+      )
+    }
+  }
 
-    val Defn.Class(_, _, List(Type.Param(List(Mod.Covariant()), _, _, _, _, _)), _, _) =
-      templStat("class A[+T](t: T)")
+  test("covariant in class") {
+    assertTree(templStat("class A[+T](t: T)")) {
+      Defn.Class(
+        Nil,
+        Type.Name("A"),
+        Type.ParamClause(
+          Type.Param(
+            List(Mod.Covariant()),
+            Type.Name("T"),
+            Type.ParamClause(Nil),
+            Type.Bounds(None, None),
+            Nil,
+            Nil
+          ) :: Nil
+        ),
+        Ctor.Primary(
+          Nil,
+          Name(""),
+          List(List(Term.Param(Nil, Term.Name("t"), Some(Type.Name("T")), None)))
+        ),
+        Template(Nil, Nil, Self(Name(""), None), Nil, Nil)
+      )
+    }
+  }
 
-    val Defn.Type(_, _, List(Type.Param(List(Mod.Covariant()), _, _, _, _, _)), _) =
-      templStat("type A[+T] = B[T]")
+  test("covariant in type") {
+    assertTree(templStat("type A[+T] = B[T]")) {
+      Defn.Type(
+        Nil,
+        Type.Name("A"),
+        Type.ParamClause(
+          Type.Param(
+            List(Mod.Covariant()),
+            Type.Name("T"),
+            Type.ParamClause(Nil),
+            Type.Bounds(None, None),
+            Nil,
+            Nil
+          ) :: Nil
+        ),
+        Type.Apply(Type.Name("B"), List(Type.Name("T"))),
+        Type.Bounds(None, None)
+      )
+    }
+  }
 
+  test("covariant in def") {
     interceptParseErrors(
       "def foo[+T](t: T): Int"
     )
   }
 
-  test("contravariant") {
-    val Defn.Class(_, _, List(Type.Param(List(Mod.Contravariant()), _, _, _, _, _)), _, _) =
-      templStat("case class A[-T](t: T)")
+  test("contravariant in case class") {
+    assertTree(templStat("case class A[-T](t: T)")) {
+      Defn.Class(
+        List(Mod.Case()),
+        Type.Name("A"),
+        Type.ParamClause(
+          Type.Param(
+            List(Mod.Contravariant()),
+            Type.Name("T"),
+            Type.ParamClause(Nil),
+            Type.Bounds(None, None),
+            Nil,
+            Nil
+          ) :: Nil
+        ),
+        Ctor.Primary(
+          Nil,
+          Name(""),
+          List(List(Term.Param(Nil, Term.Name("t"), Some(Type.Name("T")), None)))
+        ),
+        Template(Nil, Nil, Self(Name(""), None), Nil, Nil)
+      )
+    }
+  }
 
-    val Defn.Class(_, _, List(Type.Param(List(Mod.Contravariant()), _, _, _, _, _)), _, _) =
-      templStat("class A[-T](t: T)")
+  test("contravariant in class") {
+    assertTree(templStat("class A[-T](t: T)")) {
+      Defn.Class(
+        Nil,
+        Type.Name("A"),
+        Type.ParamClause(
+          Type.Param(
+            List(Mod.Contravariant()),
+            Type.Name("T"),
+            Type.ParamClause(Nil),
+            Type.Bounds(None, None),
+            Nil,
+            Nil
+          ) :: Nil
+        ),
+        Ctor.Primary(
+          Nil,
+          Name(""),
+          List(List(Term.Param(Nil, Term.Name("t"), Some(Type.Name("T")), None)))
+        ),
+        Template(Nil, Nil, Self(Name(""), None), Nil, Nil)
+      )
+    }
+  }
 
-    val Defn.Type(_, _, List(Type.Param(List(Mod.Contravariant()), _, _, _, _, _)), _) =
-      templStat("type A[-T] = B[T]")
+  test("contravariant in type") {
+    assertTree(templStat("type A[-T] = B[T]")) {
+      Defn.Type(
+        Nil,
+        Type.Name("A"),
+        Type.ParamClause(
+          Type.Param(
+            List(Mod.Contravariant()),
+            Type.Name("T"),
+            Type.ParamClause(Nil),
+            Type.Bounds(None, None),
+            Nil,
+            Nil
+          ) :: Nil
+        ),
+        Type.Apply(Type.Name("B"), List(Type.Name("T"))),
+        Type.Bounds(None, None)
+      )
+    }
+  }
 
+  test("contravariant in def") {
     interceptParseErrors(
       "def foo[-T](t: T): Int"
     )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/PackageSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/PackageSuite.scala
@@ -6,74 +6,87 @@ import scala.meta.dialects.Scala211
 
 class PackageSuite extends ParseSuite {
   test("class C") {
-    val Source(Class(Nil, Type.Name("C"), Nil, EmptyCtor(), EmptyTemplate()) :: Nil) =
-      source("class C")
+    assertTree(source("class C")) {
+      Source(Class(Nil, Type.Name("C"), Type.ParamClause(Nil), EmptyCtor(), EmptyTemplate()) :: Nil)
+    }
   }
 
   test("package foo; class C") {
-    val Source(
-      (pkgfoo @ Pkg(
-        Term.Name("foo"),
-        Class(Nil, Type.Name("C"), Nil, EmptyCtor(), EmptyTemplate()) :: Nil
-      )) :: Nil
-    ) =
-      source("package foo; class C")
+    assertTree(source("package foo; class C")) {
+      Source(
+        Pkg(
+          Term.Name("foo"),
+          Class(Nil, Type.Name("C"), Type.ParamClause(Nil), EmptyCtor(), EmptyTemplate()) :: Nil
+        ) :: Nil
+      )
+    }
+
   }
 
   test("package foo { class C }") {
-    val Source(
-      (pkgfoo @ Pkg(
-        Term.Name("foo"),
-        Class(Nil, Type.Name("C"), Nil, EmptyCtor(), EmptyTemplate()) :: Nil
-      )) :: Nil
-    ) =
-      source("package foo { class C }")
+    assertTree(source("package foo { class C }")) {
+      Source(
+        Pkg(
+          Term.Name("foo"),
+          Class(Nil, Type.Name("C"), Type.ParamClause(Nil), EmptyCtor(), EmptyTemplate()) :: Nil
+        ) :: Nil
+      )
+    }
+
   }
 
   test("package foo.bar; class C") {
-    val Source(
-      (pkgfoobar @ Pkg(
-        Term.Select(Term.Name("foo"), Term.Name("bar")),
-        Class(Nil, Type.Name("C"), Nil, EmptyCtor(), EmptyTemplate()) :: Nil
-      )) :: Nil
-    ) =
-      source("package foo.bar; class C")
+    assertTree(source("package foo.bar; class C")) {
+      Source(
+        Pkg(
+          Term.Select(Term.Name("foo"), Term.Name("bar")),
+          Class(Nil, Type.Name("C"), Type.ParamClause(Nil), EmptyCtor(), EmptyTemplate()) :: Nil
+        ) :: Nil
+      )
+    }
+
   }
 
   test("package foo.bar { class C }") {
-    val Source(
-      (pkgfoobar @ Pkg(
-        Term.Select(Term.Name("foo"), Term.Name("bar")),
-        Class(Nil, Type.Name("C"), Nil, EmptyCtor(), EmptyTemplate()) :: Nil
-      )) :: Nil
-    ) =
-      source("package foo.bar { class C }")
+    assertTree(source("package foo.bar { class C }")) {
+      Source(
+        Pkg(
+          Term.Select(Term.Name("foo"), Term.Name("bar")),
+          Class(Nil, Type.Name("C"), Type.ParamClause(Nil), EmptyCtor(), EmptyTemplate()) :: Nil
+        ) :: Nil
+      )
+    }
+
   }
 
   test("package foo; package bar; class C") {
-    val Source(
-      (pkgfoo @ Pkg(
-        Term.Name("foo"),
-        (pkgbar @ Pkg(
-          Term.Name("bar"),
-          Class(Nil, Type.Name("C"), Nil, EmptyCtor(), EmptyTemplate()) :: Nil
-        )) :: Nil
-      )) :: Nil
-    ) =
-      source("package foo; package bar; class C")
+    assertTree(source("package foo; package bar; class C")) {
+      Source(
+        Pkg(
+          Term.Name("foo"),
+          Pkg(
+            Term.Name("bar"),
+            Class(Nil, Type.Name("C"), Type.ParamClause(Nil), EmptyCtor(), EmptyTemplate()) :: Nil
+          ) :: Nil
+        ) :: Nil
+      )
+    }
+
   }
 
   test("package foo { package bar { class C } }") {
-    val Source(
-      (pkgfoo @ Pkg(
-        Term.Name("foo"),
-        (pkgbar @ Pkg(
-          Term.Name("bar"),
-          Class(Nil, Type.Name("C"), Nil, EmptyCtor(), EmptyTemplate()) :: Nil
-        )) :: Nil
-      )) :: Nil
-    ) =
-      source("package foo { package bar { class C } }")
+    assertTree(source("package foo { package bar { class C } }")) {
+      Source(
+        Pkg(
+          Term.Name("foo"),
+          Pkg(
+            Term.Name("bar"),
+            Class(Nil, Type.Name("C"), Type.ParamClause(Nil), EmptyCtor(), EmptyTemplate()) :: Nil
+          ) :: Nil
+        ) :: Nil
+      )
+    }
+
   }
 
   test("package foo {}; package bar {}") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TemplateSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TemplateSuite.scala
@@ -6,296 +6,333 @@ import scala.meta.dialects.Scala211
 
 class TemplateSuite extends ParseSuite {
   test("trait T") {
-    val Trait(Nil, Type.Name("T"), Nil, EmptyCtor(), EmptyTemplate()) = templStat("trait T")
+    assertTree(templStat("trait T")) {
+      Trait(Nil, Type.Name("T"), Type.ParamClause(Nil), EmptyCtor(), EmptyTemplate())
+    }
   }
 
   test("trait T {}") {
-    val Trait(Nil, Type.Name("T"), Nil, EmptyCtor(), EmptyTemplate()) = templStat("trait T {}")
+    assertTree(templStat("trait T {}")) {
+      Trait(Nil, Type.Name("T"), Type.ParamClause(Nil), EmptyCtor(), EmptyTemplate())
+    }
   }
 
   test("trait F[T]") {
-    val Trait(
-      Nil,
-      Type.Name("F"),
-      Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, Nil) :: Nil,
-      EmptyCtor(),
-      EmptyTemplate()
-    ) = templStat("trait F[T]")
+    assertTree(templStat("trait F[T]")) {
+      Trait(
+        Nil,
+        Type.Name("F"),
+        Type.ParamClause(
+          Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, Nil) :: Nil
+        ),
+        EmptyCtor(),
+        EmptyTemplate()
+      )
+    }
   }
 
   test("trait A extends B") {
-    val Trait(
-      Nil,
-      Type.Name("A"),
-      Nil,
-      EmptyCtor(),
-      Template(Nil, Init(Type.Name("B"), Name.Anonymous(), Nil) :: Nil, EmptySelf(), Nil)
-    ) =
-      templStat("trait A extends B")
+    assertTree(templStat("trait A extends B")) {
+      Trait(
+        Nil,
+        Type.Name("A"),
+        Type.ParamClause(Nil),
+        EmptyCtor(),
+        Template(Nil, Init(Type.Name("B"), Name.Anonymous(), Nil) :: Nil, EmptySelf(), Nil)
+      )
+    }
   }
 
   test("trait Inner <: { val x : Int = 3 }") {
-    val Trait(
-      Nil,
-      Type.Name("Inner"),
-      Nil,
-      EmptyCtor(),
-      Template(
+    assertTree(templStat("trait Inner <: { val x : Int = 3 }")) {
+      Trait(
         Nil,
-        Nil,
-        EmptySelf(),
-        List(Defn.Val(Nil, List(Pat.Var(Term.Name("x"))), Some(Type.Name("Int")), Lit(3)))
+        Type.Name("Inner"),
+        Type.ParamClause(Nil),
+        EmptyCtor(),
+        Template(
+          Nil,
+          Nil,
+          EmptySelf(),
+          List(Defn.Val(Nil, List(Pat.Var(Term.Name("x"))), Some(Type.Name("Int")), Lit.Int(3)))
+        )
       )
-    ) =
-      templStat("trait Inner <: { val x : Int = 3 }")
+    }
   }
 
   test("trait A extends { val x: Int } with B") {
-    val Trait(
-      Nil,
-      Type.Name("A"),
-      Nil,
-      EmptyCtor(),
-      Template(
-        Defn.Val(Nil, List(Pat.Var(Term.Name("x"))), Some(Type.Name("Int")), Lit(2)) :: Nil,
-        Init(Type.Name("B"), Name.Anonymous(), Nil) :: Nil,
-        EmptySelf(),
-        Nil
+    assertTree(templStat("trait A extends { val x: Int = 2 } with B")) {
+      Trait(
+        Nil,
+        Type.Name("A"),
+        Type.ParamClause(Nil),
+        EmptyCtor(),
+        Template(
+          Defn.Val(Nil, List(Pat.Var(Term.Name("x"))), Some(Type.Name("Int")), Lit.Int(2)) :: Nil,
+          Init(Type.Name("B"), Name.Anonymous(), Nil) :: Nil,
+          EmptySelf(),
+          Nil
+        )
       )
-    ) =
-      templStat("trait A extends { val x: Int = 2 } with B")
+    }
   }
 
   test("trait A extends { self: B => }") {
-    val Trait(
-      Nil,
-      Type.Name("A"),
-      Nil,
-      EmptyCtor(),
-      Template(Nil, Nil, Self(Term.Name("self"), Some(Type.Name("B"))), Nil)
-    ) =
-      templStat("trait A { self: B => }")
+    assertTree(templStat("trait A { self: B => }")) {
+      Trait(
+        Nil,
+        Type.Name("A"),
+        Type.ParamClause(Nil),
+        EmptyCtor(),
+        Template(Nil, Nil, Self(Term.Name("self"), Some(Type.Name("B"))), Nil)
+      )
+    }
   }
 
   test("trait T { def x: Int }") {
-    val Trait(
-      Nil,
-      Type.Name("T"),
-      Nil,
-      EmptyCtor(),
-      Template(
+    assertTree(templStat("trait T { def x: Int }")) {
+      Trait(
         Nil,
-        Nil,
-        EmptySelf(),
-        List(Decl.Def(Nil, Term.Name("x"), Nil, Nil, Type.Name("Int")))
+        Type.Name("T"),
+        Type.ParamClause(Nil),
+        EmptyCtor(),
+        Template(
+          Nil,
+          Nil,
+          EmptySelf(),
+          List(Decl.Def(Nil, Term.Name("x"), Nil, Nil, Type.Name("Int")))
+        )
       )
-    ) =
-      templStat("trait T { def x: Int }")
+    }
   }
 
   test("class C") {
-    val Class(Nil, Type.Name("C"), Nil, EmptyCtor(), EmptyTemplate()) = templStat("class C")
+    assertTree(templStat("class C")) {
+      Class(Nil, Type.Name("C"), Type.ParamClause(Nil), EmptyCtor(), EmptyTemplate())
+    }
   }
 
   test("class C[T]") {
-    val Class(
-      Nil,
-      Type.Name("C"),
-      Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, Nil) :: Nil,
-      EmptyCtor(),
-      EmptyTemplate()
-    ) = templStat("class C[T]")
+    assertTree(templStat("class C[T]")) {
+      Class(
+        Nil,
+        Type.Name("C"),
+        Type.ParamClause(
+          Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, Nil) :: Nil
+        ),
+        EmptyCtor(),
+        EmptyTemplate()
+      )
+    }
   }
 
   test("class A extends B") {
-    val Class(
-      Nil,
-      Type.Name("A"),
-      Nil,
-      EmptyCtor(),
-      Template(Nil, Init(Type.Name("B"), Name.Anonymous(), Nil) :: Nil, EmptySelf(), Nil)
-    ) =
-      templStat("class A extends B")
+    assertTree(templStat("class A extends B")) {
+      Class(
+        Nil,
+        Type.Name("A"),
+        Type.ParamClause(Nil),
+        EmptyCtor(),
+        Template(Nil, Init(Type.Name("B"), Name.Anonymous(), Nil) :: Nil, EmptySelf(), Nil)
+      )
+    }
   }
 
   test("class A extends { val x: Int } with B") {
-    val Class(
-      Nil,
-      Type.Name("A"),
-      Nil,
-      EmptyCtor(),
-      Template(
-        Defn.Val(Nil, List(Pat.Var(Term.Name("x"))), Some(Type.Name("Int")), Lit(2)) :: Nil,
-        Init(Type.Name("B"), Name.Anonymous(), Nil) :: Nil,
-        EmptySelf(),
-        Nil
+    assertTree(templStat("class A extends { val x: Int = 2 } with B")) {
+      Class(
+        Nil,
+        Type.Name("A"),
+        Type.ParamClause(Nil),
+        EmptyCtor(),
+        Template(
+          Defn.Val(Nil, List(Pat.Var(Term.Name("x"))), Some(Type.Name("Int")), Lit.Int(2)) :: Nil,
+          Init(Type.Name("B"), Name.Anonymous(), Nil) :: Nil,
+          EmptySelf(),
+          Nil
+        )
       )
-    ) =
-      templStat("class A extends { val x: Int = 2 } with B")
+    }
   }
 
   test("class A extends { self: B => }") {
-    val Class(
-      Nil,
-      Type.Name("A"),
-      Nil,
-      EmptyCtor(),
-      Template(Nil, Nil, Self(Term.Name("self"), Some(Type.Name("B"))), Nil)
-    ) =
-      templStat("class A { self: B => }")
+    assertTree(templStat("class A { self: B => }")) {
+      Class(
+        Nil,
+        Type.Name("A"),
+        Type.ParamClause(Nil),
+        EmptyCtor(),
+        Template(Nil, Nil, Self(Term.Name("self"), Some(Type.Name("B"))), Nil)
+      )
+    }
   }
 
   test("class A { this => }") {
-    val Class(
-      Nil,
-      Type.Name("A"),
-      Nil,
-      EmptyCtor(),
-      Template(Nil, Nil, self @ EmptySelf(), Nil)
-    ) =
-      templStat("class A { this => }")
+    assertTree(templStat("class A { this => }")) {
+      Class(
+        Nil,
+        Type.Name("A"),
+        Type.ParamClause(Nil),
+        EmptyCtor(),
+        Template(Nil, Nil, EmptySelf(), Nil)
+      )
+    }
   }
 
   test("class A { _ => }") {
-    val Class(
-      Nil,
-      Type.Name("A"),
-      Nil,
-      EmptyCtor(),
-      Template(Nil, Nil, self @ EmptySelf(), Nil)
-    ) =
-      templStat("class A { this => }")
+    assertTree(templStat("class A { this => }")) {
+      Class(
+        Nil,
+        Type.Name("A"),
+        Type.ParamClause(Nil),
+        EmptyCtor(),
+        Template(Nil, Nil, EmptySelf(), Nil)
+      )
+    }
   }
 
   test("class C { def x: Int }") {
-    val Class(
-      Nil,
-      Type.Name("C"),
-      Nil,
-      EmptyCtor(),
-      Template(
+    assertTree(templStat("class C { def x: Int }")) {
+      Class(
         Nil,
-        Nil,
-        EmptySelf(),
-        List(Decl.Def(Nil, Term.Name("x"), Nil, Nil, Type.Name("Int")))
+        Type.Name("C"),
+        Type.ParamClause(Nil),
+        EmptyCtor(),
+        Template(
+          Nil,
+          Nil,
+          EmptySelf(),
+          List(Decl.Def(Nil, Term.Name("x"), Nil, Nil, Type.Name("Int")))
+        )
       )
-    ) =
-      templStat("class C { def x: Int }")
+    }
   }
 
   test("class C(x: Int)") {
-    val Class(
-      Nil,
-      Type.Name("C"),
-      Nil,
-      Ctor.Primary(
+    assertTree(templStat("class C(x: Int)")) {
+      Class(
         Nil,
-        Name.Anonymous(),
-        (Term.Param(Nil, Term.Name("x"), Some(Type.Name("Int")), None) :: Nil) :: Nil
-      ),
-      EmptyTemplate()
-    ) =
-      templStat("class C(x: Int)")
+        Type.Name("C"),
+        Type.ParamClause(Nil),
+        Ctor.Primary(
+          Nil,
+          Name.Anonymous(),
+          (Term.Param(Nil, Term.Name("x"), Some(Type.Name("Int")), None) :: Nil) :: Nil
+        ),
+        EmptyTemplate()
+      )
+    }
+
   }
 
   test("class C private(x: Int)") {
-    val Class(
-      Nil,
-      Type.Name("C"),
-      Nil,
-      Ctor.Primary(
-        Mod.Private(Name.Anonymous()) :: Nil,
-        Name.Anonymous(),
-        (Term.Param(Nil, Term.Name("x"), Some(Type.Name("Int")), None) :: Nil) :: Nil
-      ),
-      EmptyTemplate()
-    ) =
-      templStat("class C private(x: Int)")
+    assertTree(templStat("class C private(x: Int)")) {
+      Class(
+        Nil,
+        Type.Name("C"),
+        Type.ParamClause(Nil),
+        Ctor.Primary(
+          Mod.Private(Name.Anonymous()) :: Nil,
+          Name.Anonymous(),
+          (Term.Param(Nil, Term.Name("x"), Some(Type.Name("Int")), None) :: Nil) :: Nil
+        ),
+        EmptyTemplate()
+      )
+    }
+
   }
 
   test("class C(val x: Int)") {
-    val Class(
-      Nil,
-      Type.Name("C"),
-      Nil,
-      Ctor.Primary(
+    assertTree(templStat("class C(val x: Int)")) {
+      Class(
         Nil,
-        Name.Anonymous(),
-        (Term.Param(Mod.ValParam() :: Nil, Term.Name("x"), Some(Type.Name("Int")), None) :: Nil)
-          :: Nil
-      ),
-      EmptyTemplate()
-    ) =
-      templStat("class C(val x: Int)")
+        Type.Name("C"),
+        Type.ParamClause(Nil),
+        Ctor.Primary(
+          Nil,
+          Name.Anonymous(),
+          (Term.Param(Mod.ValParam() :: Nil, Term.Name("x"), Some(Type.Name("Int")), None) :: Nil)
+            :: Nil
+        ),
+        EmptyTemplate()
+      )
+    }
+
   }
 
   test("class C(var x: Int)") {
-    val Class(
-      Nil,
-      Type.Name("C"),
-      Nil,
-      Ctor.Primary(
+    assertTree(templStat("class C(var x: Int)")) {
+      Class(
         Nil,
-        Name.Anonymous(),
-        (Term.Param(Mod.VarParam() :: Nil, Term.Name("x"), Some(Type.Name("Int")), None) :: Nil)
-          :: Nil
-      ),
-      EmptyTemplate()
-    ) =
-      templStat("class C(var x: Int)")
+        Type.Name("C"),
+        Type.ParamClause(Nil),
+        Ctor.Primary(
+          Nil,
+          Name.Anonymous(),
+          (Term.Param(Mod.VarParam() :: Nil, Term.Name("x"), Some(Type.Name("Int")), None) :: Nil)
+            :: Nil
+        ),
+        EmptyTemplate()
+      )
+    }
+
   }
 
   test("class C(implicit x: Int)") {
-    val Class(
-      Nil,
-      Type.Name("C"),
-      Nil,
-      Ctor.Primary(
+    assertTree(templStat("class C(implicit x: Int)")) {
+      Class(
         Nil,
-        Name.Anonymous(),
-        (Term.Param(Mod.Implicit() :: Nil, Term.Name("x"), Some(Type.Name("Int")), None) :: Nil)
-          :: Nil
-      ),
-      EmptyTemplate()
-    ) =
-      templStat("class C(implicit x: Int)")
+        Type.Name("C"),
+        Type.ParamClause(Nil),
+        Ctor.Primary(
+          Nil,
+          Name.Anonymous(),
+          (Term.Param(Mod.Implicit() :: Nil, Term.Name("x"), Some(Type.Name("Int")), None) :: Nil)
+            :: Nil
+        ),
+        EmptyTemplate()
+      )
+    }
+
   }
 
   test("class C(override val x: Int)") {
-    val Class(
-      Nil,
-      Type.Name("C"),
-      Nil,
-      Ctor.Primary(
+    assertTree(templStat("class C(override val x: Int)")) {
+      Class(
         Nil,
-        Name.Anonymous(),
-        (Term.Param(
-          List(Mod.Override(), Mod.ValParam()),
-          Term.Name("x"),
-          Some(Type.Name("Int")),
-          None
-        ) :: Nil) :: Nil
-      ),
-      EmptyTemplate()
-    ) =
-      templStat("class C(override val x: Int)")
+        Type.Name("C"),
+        Type.ParamClause(Nil),
+        Ctor.Primary(
+          Nil,
+          Name.Anonymous(),
+          (Term.Param(
+            List(Mod.Override(), Mod.ValParam()),
+            Term.Name("x"),
+            Some(Type.Name("Int")),
+            None
+          ) :: Nil) :: Nil
+        ),
+        EmptyTemplate()
+      )
+    }
   }
 
   test("case class C(x: Int)(y: => Int)") {
-    val Class(
-      Mod.Case() :: Nil,
-      Type.Name("C"),
-      Nil,
-      Ctor.Primary(
-        Nil,
-        Name.Anonymous(),
-        (Term.Param(Nil, Term.Name("x"), Some(Type.Name("Int")), None) :: Nil) ::
-          (Term.Param(Nil, Term.Name("y"), Some(Type.ByName(Type.Name("Int"))), None) :: Nil)
-          :: Nil
-      ),
-      EmptyTemplate()
-    ) =
-      templStat("case class C(x: Int)(y: => Int)")
+    assertTree(templStat("case class C(x: Int)(y: => Int)")) {
+      Class(
+        Mod.Case() :: Nil,
+        Type.Name("C"),
+        Type.ParamClause(Nil),
+        Ctor.Primary(
+          Nil,
+          Name.Anonymous(),
+          (Term.Param(Nil, Term.Name("x"), Some(Type.Name("Int")), None) :: Nil) ::
+            (Term.Param(Nil, Term.Name("y"), Some(Type.ByName(Type.Name("Int"))), None) :: Nil)
+            :: Nil
+        ),
+        EmptyTemplate()
+      )
+    }
   }
 
   test("object O") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TypeSuite.scala
@@ -114,13 +114,14 @@ class TypeSuite extends ParseSuite {
   }
 
   test("A { def x: A; val y: B; type C }") {
-    val Refine(
-      Some(TypeName("A")),
-      Decl.Def(Nil, TermName("x"), Nil, Nil, TypeName("Int")) ::
-        Decl.Val(Nil, List(Pat.Var(TermName("y"))), TypeName("B")) ::
-        Decl.Type(Nil, TypeName("C"), Nil, Type.Bounds(None, None)) :: Nil
-    ) =
-      tpe("A { def x: Int; val y: B; type C }")
+    assertTpe("A { def x: Int; val y: B; type C }") {
+      Refine(
+        Some(TypeName("A")),
+        Decl.Def(Nil, TermName("x"), Type.ParamClause(Nil), Nil, TypeName("Int")) ::
+          Decl.Val(Nil, List(Pat.Var(TermName("y"))), TypeName("B")) ::
+          Decl.Type(Nil, TypeName("C"), Type.ParamClause(Nil), Type.Bounds(None, None)) :: Nil
+      )
+    }
   }
 
   test("F[_ >: lo <: hi]") {
@@ -151,11 +152,12 @@ class TypeSuite extends ParseSuite {
   }
 
   test("F[T] forSome { type T }") {
-    val Existential(
-      Apply(TypeName("F"), TypeName("T") :: Nil),
-      Decl.Type(Nil, TypeName("T"), Nil, Type.Bounds(None, None)) :: Nil
-    ) =
-      tpe("F[T] forSome { type T }")
+    assertTpe("F[T] forSome { type T }") {
+      Existential(
+        Apply(TypeName("F"), TypeName("T") :: Nil),
+        Decl.Type(Nil, TypeName("T"), Type.ParamClause(Nil), Type.Bounds(None, None)) :: Nil
+      )
+    }
   }
 
   test("a.T forSome { val a: A }") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
@@ -310,8 +310,7 @@ class MacroSuite extends BaseDottySuite {
         Nil,
         Type.PolyFunction(
           List(Type.Param(Nil, Type.Name("$T"), Nil, Type.Bounds(None, None), Nil, Nil)),
-          Type
-            .Function(List(Type.Name("$T")), Type.Apply(Type.Name("Option"), List(Type.Name("$T"))))
+          Type.Function(List(pname("$T")), Type.Apply(pname("Option"), List(pname("$T"))))
         ),
         Type.Bounds(None, None)
       )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MatchTypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MatchTypeSuite.scala
@@ -74,8 +74,7 @@ class MatchTypeSuite extends BaseDottySuite {
         Nil,
         Type.Name("Head"),
         List(
-          Type
-            .Param(Nil, Type.Name("X"), Nil, Type.Bounds(None, Some(Type.Name("Tuple"))), Nil, Nil)
+          Type.Param(Nil, pname("X"), Nil, Type.Bounds(None, Some(pname("Tuple"))), Nil, Nil)
         ),
         Type.Match(
           Type.Name("X"),
@@ -131,10 +130,8 @@ class MatchTypeSuite extends BaseDottySuite {
         Nil,
         Type.Name("Concat"),
         List(
-          Type
-            .Param(Nil, Type.Name("X"), Nil, Type.Bounds(None, Some(Type.Name("Tuple"))), Nil, Nil),
-          Type
-            .Param(Nil, Type.Name("Y"), Nil, Type.Bounds(None, Some(Type.Name("Tuple"))), Nil, Nil)
+          Type.Param(Nil, pname("X"), Nil, Type.Bounds(None, Some(pname("Tuple"))), Nil, Nil),
+          Type.Param(Nil, pname("Y"), Nil, Type.Bounds(None, Some(pname("Tuple"))), Nil, Nil)
         ),
         Type.Match(
           Type.Name("X"),

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
@@ -271,13 +271,14 @@ class TypeSuite extends BaseDottySuite {
   }
 
   test("A { def x: A; val y: B; type C }") {
-    val Refine(
-      Some(TypeName("A")),
-      Decl.Def(Nil, TermName("x"), Nil, Nil, TypeName("Int")) ::
-        Decl.Val(Nil, List(Pat.Var(TermName("y"))), TypeName("B")) ::
-        Decl.Type(Nil, TypeName("C"), Nil, Type.Bounds(None, None)) :: Nil
-    ) =
-      tpe("A { def x: Int; val y: B; type C }")
+    assertTpe("A { def x: Int; val y: B; type C }") {
+      Refine(
+        Some(TypeName("A")),
+        Decl.Def(Nil, TermName("x"), Type.ParamClause(Nil), Nil, TypeName("Int")) ::
+          Decl.Val(Nil, List(Pat.Var(TermName("y"))), TypeName("B")) ::
+          Decl.Type(Nil, TypeName("C"), Type.ParamClause(Nil), Type.Bounds(None, None)) :: Nil
+      )
+    }
   }
 
   test("F[_ >: lo <: hi]") {
@@ -343,11 +344,12 @@ class TypeSuite extends BaseDottySuite {
   }
 
   test("F[T] forSome { type T }") {
-    val Existential(
-      Apply(TypeName("F"), TypeName("T") :: Nil),
-      Decl.Type(Nil, TypeName("T"), Nil, Type.Bounds(None, None)) :: Nil
-    ) =
-      tpe("F[T] forSome { type T }")
+    assertTpe("F[T] forSome { type T }") {
+      Existential(
+        Apply(TypeName("F"), TypeName("T") :: Nil),
+        Decl.Type(Nil, TypeName("T"), Type.ParamClause(Nil), Type.Bounds(None, None)) :: Nil
+      )
+    }
   }
 
   test("a.T forSome { val a: A }") {

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -1042,6 +1042,17 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, Some(Type.Name("Int"))), Nil, Nil)
     )
     assertEquals(tree.syntax, "T <: Int")
+
+    assertTree(templStat("def foo[T <: Int] = ???")) {
+      Defn.Def(
+        Nil,
+        Term.Name("foo"),
+        Type.ParamClause(tree :: Nil),
+        Nil,
+        None,
+        Term.Name("???")
+      )
+    }
   }
 
   test("Lit(()) - 1") {

--- a/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -1133,10 +1133,17 @@ class SuccessSuite extends TreeSuiteBase {
 
   test("1 t\"[..tparams] =>> tpe\"") {
     val t"[..$tparams] =>> $tpe" = t"[T] =>> (T, T)"
-    assertEquals(tparams.toString, "List(T)")
-    assertTrees(tparams: _*)(
-      Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, Nil)
-    )
+    assertEquals(tparams.toString, "[T]")
+    assertTree(tparams)(Type.ParamClause {
+      Type.Param(
+        Nil,
+        Type.Name("T"),
+        Type.ParamClause(Nil),
+        Type.Bounds(None, None),
+        Nil,
+        Nil
+      ) :: Nil
+    })
     assertEquals(tpe.toString, "(T, T)")
   }
 
@@ -1476,11 +1483,13 @@ class SuccessSuite extends TreeSuiteBase {
     assertEquals(mods.toString, "List(private, final)")
     assertTrees(mods: _*)(Mod.Private(Name("")), Mod.Final())
     assertTree(name)(Term.Name("m"))
-    assertEquals(tparams.toString, "List(T, W)")
-    assertTrees(tparams: _*)(
-      Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, Nil),
-      Type.Param(Nil, Type.Name("W"), Nil, Type.Bounds(None, None), Nil, Nil)
-    )
+    assertEquals(tparams.toString, "[T, W]")
+    assertTree(tparams)(Type.ParamClause {
+      List(
+        Type.Param(Nil, Type.Name("T"), Type.ParamClause(Nil), Type.Bounds(None, None), Nil, Nil),
+        Type.Param(Nil, Type.Name("W"), Type.ParamClause(Nil), Type.Bounds(None, None), Nil, Nil)
+      )
+    })
     assertEquals(paramss.map(_.toString), List("List(x: X, y: Y)"))
     assertTrees(paramss(0): _*)(
       Term.Param(Nil, Term.Name("x"), Some(Type.Name("X")), None),
@@ -1520,11 +1529,13 @@ class SuccessSuite extends TreeSuiteBase {
     assertEquals(mods.toString, "List(private, final)")
     assertTrees(mods: _*)(Mod.Private(Name("")), Mod.Final())
     assertTree(tname)(Type.Name("T"))
-    assertEquals(tparams.toString, "List(T, W)")
-    assertTrees(tparams: _*)(
-      Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, Nil),
-      Type.Param(Nil, Type.Name("W"), Nil, Type.Bounds(None, None), Nil, Nil)
-    )
+    assertEquals(tparams.toString, "[T, W]")
+    assertTree(tparams)(Type.ParamClause {
+      List(
+        Type.Param(Nil, Type.Name("T"), Type.ParamClause(Nil), Type.Bounds(None, None), Nil, Nil),
+        Type.Param(Nil, Type.Name("W"), Type.ParamClause(Nil), Type.Bounds(None, None), Nil, Nil)
+      )
+    })
     assertTree(tpeopt1)(Some(Type.Name("A")))
     assertTree(tpeopt2)(Some(Type.Name("B")))
   }
@@ -1604,11 +1615,13 @@ class SuccessSuite extends TreeSuiteBase {
     assertEquals(mods.toString, "List(private, final)")
     assertTrees(mods: _*)(Mod.Private(Name("")), Mod.Final())
     assertTree(name)(Term.Name("m"))
-    assertEquals(tparams.toString, "List(T, W)")
-    assertTrees(tparams: _*)(
-      Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, Nil),
-      Type.Param(Nil, Type.Name("W"), Nil, Type.Bounds(None, None), Nil, Nil)
-    )
+    assertEquals(tparams.toString, "[T, W]")
+    assertTree(tparams)(Type.ParamClause {
+      List(
+        Type.Param(Nil, Type.Name("T"), Type.ParamClause(Nil), Type.Bounds(None, None), Nil, Nil),
+        Type.Param(Nil, Type.Name("W"), Type.ParamClause(Nil), Type.Bounds(None, None), Nil, Nil)
+      )
+    })
     assertEquals(paramss.map(_.toString), List("List(x: X, y: Y)"))
     assertTrees(paramss(0): _*)(
       Term.Param(Nil, Term.Name("x"), Some(Type.Name("X")), None),
@@ -1651,11 +1664,13 @@ class SuccessSuite extends TreeSuiteBase {
     assertEquals(mods.toString, "List(private, final)")
     assertTrees(mods: _*)(Mod.Private(Name("")), Mod.Final())
     assertTree(name)(Term.Name("m"))
-    assertEquals(tparams.toString, "List(T, W)")
-    assertTrees(tparams: _*)(
-      Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, Nil),
-      Type.Param(Nil, Type.Name("W"), Nil, Type.Bounds(None, None), Nil, Nil)
-    )
+    assertEquals(tparams.toString, "[T, W]")
+    assertTree(tparams)(Type.ParamClause {
+      List(
+        Type.Param(Nil, Type.Name("T"), Type.ParamClause(Nil), Type.Bounds(None, None), Nil, Nil),
+        Type.Param(Nil, Type.Name("W"), Type.ParamClause(Nil), Type.Bounds(None, None), Nil, Nil)
+      )
+    })
     assertEquals(paramss.map(_.toString), List("List(x: X, y: Y)"))
     assertTrees(paramss(0): _*)(
       Term.Param(Nil, Term.Name("x"), Some(Type.Name("X")), None),
@@ -1697,11 +1712,13 @@ class SuccessSuite extends TreeSuiteBase {
     assertEquals(mods.toString, "List(private, final)")
     assertTrees(mods: _*)(Mod.Private(Name("")), Mod.Final())
     assertTree(tname)(Type.Name("Q"))
-    assertEquals(tparams.toString, "List(T, W)")
-    assertTrees(tparams: _*)(
-      Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, Nil),
-      Type.Param(Nil, Type.Name("W"), Nil, Type.Bounds(None, None), Nil, Nil)
-    )
+    assertEquals(tparams.toString, "[T, W]")
+    assertTree(tparams)(Type.ParamClause {
+      List(
+        Type.Param(Nil, Type.Name("T"), Type.ParamClause(Nil), Type.Bounds(None, None), Nil, Nil),
+        Type.Param(Nil, Type.Name("W"), Type.ParamClause(Nil), Type.Bounds(None, None), Nil, Nil)
+      )
+    })
     assertTree(tpe)(Type.Name("R"))
   }
 
@@ -1730,11 +1747,13 @@ class SuccessSuite extends TreeSuiteBase {
     assertEquals(mods.toString, "List(private, final)")
     assertTrees(mods: _*)(Mod.Private(Name("")), Mod.Final())
     assertTree(tname)(Type.Name("Q"))
-    assertEquals(tparams.toString, "List(T, W)")
-    assertTrees(tparams: _*)(
-      Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, Nil),
-      Type.Param(Nil, Type.Name("W"), Nil, Type.Bounds(None, None), Nil, Nil)
-    )
+    assertEquals(tparams.toString, "[T, W]")
+    assertTree(tparams)(Type.ParamClause {
+      List(
+        Type.Param(Nil, Type.Name("T"), Type.ParamClause(Nil), Type.Bounds(None, None), Nil, Nil),
+        Type.Param(Nil, Type.Name("W"), Type.ParamClause(Nil), Type.Bounds(None, None), Nil, Nil)
+      )
+    })
     assertTree(mod)(Mod.Private(Name("")))
     assertEquals(paramss.map(_.toString), List("List(x: X, y: Y)"))
     assertTrees(paramss(0): _*)(
@@ -1752,11 +1771,13 @@ class SuccessSuite extends TreeSuiteBase {
     assertEquals(mods.toString, "List(private, final)")
     assertTrees(mods: _*)(Mod.Private(Name("")), Mod.Final())
     assertTree(tname)(Type.Name("Q"))
-    assertEquals(tparams.toString, "List(T, W)")
-    assertTrees(tparams: _*)(
-      Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, Nil),
-      Type.Param(Nil, Type.Name("W"), Nil, Type.Bounds(None, None), Nil, Nil)
-    )
+    assertEquals(tparams.toString, "[T, W]")
+    assertTree(tparams)(Type.ParamClause {
+      List(
+        Type.Param(Nil, Type.Name("T"), Type.ParamClause(Nil), Type.Bounds(None, None), Nil, Nil),
+        Type.Param(Nil, Type.Name("W"), Type.ParamClause(Nil), Type.Bounds(None, None), Nil, Nil)
+      )
+    })
     assertTree(mod)(Mod.Protected(Name("")))
     assertEquals(paramss.map(_.toString), List("List(x: X, y: Y)"))
     assertTrees(paramss(0): _*)(
@@ -1819,11 +1840,13 @@ class SuccessSuite extends TreeSuiteBase {
     assertEquals(mods.toString, "List(private, sealed)")
     assertTrees(mods: _*)(Mod.Private(Name("")), Mod.Sealed())
     assertTree(tname)(Type.Name("Q"))
-    assertEquals(tparams.toString, "List(T, W)")
-    assertTrees(tparams: _*)(
-      Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, Nil),
-      Type.Param(Nil, Type.Name("W"), Nil, Type.Bounds(None, None), Nil, Nil)
-    )
+    assertEquals(tparams.toString, "[T, W]")
+    assertTree(tparams)(Type.ParamClause {
+      List(
+        Type.Param(Nil, Type.Name("T"), Type.ParamClause(Nil), Type.Bounds(None, None), Nil, Nil),
+        Type.Param(Nil, Type.Name("W"), Type.ParamClause(Nil), Type.Bounds(None, None), Nil, Nil)
+      )
+    })
     assertTree(template)(
       Template(Nil, List(Init(Type.Name("Y"), Name(""), Nil)), Self(Name(""), None), Nil, Nil)
     )
@@ -1835,11 +1858,13 @@ class SuccessSuite extends TreeSuiteBase {
     assertEquals(mods.toString, "List(private, sealed)")
     assertTrees(mods: _*)(Mod.Private(Name("")), Mod.Sealed())
     assertTree(tname)(Type.Name("Q"))
-    assertEquals(tparams.toString, "List(T, W)")
-    assertTrees(tparams: _*)(
-      Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, Nil),
-      Type.Param(Nil, Type.Name("W"), Nil, Type.Bounds(None, None), Nil, Nil)
-    )
+    assertEquals(tparams.toString, "[T, W]")
+    assertTree(tparams)(Type.ParamClause {
+      List(
+        Type.Param(Nil, Type.Name("T"), Type.ParamClause(Nil), Type.Bounds(None, None), Nil, Nil),
+        Type.Param(Nil, Type.Name("W"), Type.ParamClause(Nil), Type.Bounds(None, None), Nil, Nil)
+      )
+    })
     assertTree(template)(
       Template(
         Nil,
@@ -2128,11 +2153,13 @@ class SuccessSuite extends TreeSuiteBase {
     assertEquals(mods.toString, "List(+)")
     assertTrees(mods: _*)(Mod.Covariant())
     assertTree(tparamname)(Type.Name("Z"))
-    assertEquals(tparams.toString, "List(Q, W)")
-    assertTrees(tparams: _*)(
-      Type.Param(Nil, Type.Name("Q"), Nil, Type.Bounds(None, None), Nil, Nil),
-      Type.Param(Nil, Type.Name("W"), Nil, Type.Bounds(None, None), Nil, Nil)
-    )
+    assertEquals(tparams.toString, "[Q, W]")
+    assertTree(tparams)(Type.ParamClause {
+      List(
+        Type.Param(Nil, Type.Name("Q"), Type.ParamClause(Nil), Type.Bounds(None, None), Nil, Nil),
+        Type.Param(Nil, Type.Name("W"), Type.ParamClause(Nil), Type.Bounds(None, None), Nil, Nil)
+      )
+    })
     assertTree(tpeopt1)(Some(Type.Name("E")))
     assertTree(tpeopt2)(Some(Type.Name("R")))
     assertEquals(tpes1.toString, "List(T with Y)")
@@ -2575,7 +2602,11 @@ class SuccessSuite extends TreeSuiteBase {
 
   test("initial support for ..., with tparams") {
     val q"..$mods def $name[..$tparams](...$paramss): $tpe = $rhs" = q"def f[A](x: Int) = ???"
-    assert(tparams.nonEmpty)
+    assertTree(tparams)(Type.ParamClause {
+      List(
+        Type.Param(Nil, Type.Name("A"), Type.ParamClause(Nil), Type.Bounds(None, None), Nil, Nil)
+      )
+    })
     assertEquals(paramss.lengthCompare(1), 0)
     assertTrees(paramss.head: _*)(Term.Param(Nil, Term.Name("x"), Some(Type.Name("Int")), None))
     assertTree(q"..$mods def $name[..$tparams](...$paramss): $tpe = $rhs")(

--- a/tests/shared/src/test/scala/scala/meta/tests/transversers/SimpleTraverserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/transversers/SimpleTraverserSuite.scala
@@ -22,13 +22,13 @@ class SimpleTraverserSuite extends FunSuite {
       }
     }
     traverser(tree0)
-    assert(
-      log
-        .mkString("\n")
-        .replace("\r", "") == """
+    assertEquals(
+      log.mkString("\n").replace("\r", ""),
+      """
       |{   def foo(x: x)(x: Int) = x + x   class C(x: x) { def bar(x: x) = ??? } }
       |def foo(x: x)(x: Int) = x + x
       |foo
+      |
       |x: x
       |x
       |x
@@ -41,6 +41,7 @@ class SimpleTraverserSuite extends FunSuite {
       |x
       |class C(x: x) { def bar(x: x) = ??? }
       |C
+      |
       |def this(x: x)
       |_
       |x: x
@@ -51,6 +52,7 @@ class SimpleTraverserSuite extends FunSuite {
       |_
       |def bar(x: x) = ???
       |bar
+      |
       |x: x
       |x
       |x

--- a/tests/shared/src/test/scala/scala/meta/tests/transversers/TraverserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/transversers/TraverserSuite.scala
@@ -21,13 +21,13 @@ class TraverserSuite extends FunSuite {
       }
     }
     traverser(tree0)
-    assert(
-      log
-        .mkString("\n")
-        .replace("\r", "") == """
+    assertEquals(
+      log.mkString("\n").replace("\r", ""),
+      """
       |{   def foo(x: x)(x: Int) = x + x   class C(x: x) { def bar(x: x) = ??? } }
       |def foo(x: x)(x: Int) = x + x
       |foo
+      |
       |x: x
       |x
       |x
@@ -40,6 +40,7 @@ class TraverserSuite extends FunSuite {
       |x
       |class C(x: x) { def bar(x: x) = ??? }
       |C
+      |
       |def this(x: x)
       |_
       |x: x
@@ -50,6 +51,7 @@ class TraverserSuite extends FunSuite {
       |_
       |def bar(x: x) = ???
       |bar
+      |
       |x: x
       |x
       |x

--- a/tests/shared/src/test/scala/scala/meta/tests/trees/ChildrenSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/trees/ChildrenSuite.scala
@@ -13,10 +13,11 @@ class ChildrenSuite extends FunSuite {
         import bar.baz.two
       }
     """
-    assert(tree.children.length == 3)
-    assert(tree.children(0).productPrefix == "Type.Name")
-    assert(tree.children(1).productPrefix == "Ctor.Primary")
-    assert(tree.children(2).productPrefix == "Template")
+    assertEquals(tree.children.length, 4)
+    assertEquals(tree.children(0).productPrefix, "Type.Name")
+    assertEquals(tree.children(1).productPrefix, "Type.ParamClause")
+    assertEquals(tree.children(2).productPrefix, "Ctor.Primary")
+    assertEquals(tree.children(3).productPrefix, "Template")
   }
 
   test("derives-in-children") {

--- a/tests/shared/src/test/scala/scala/meta/tests/trees/InvariantSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/trees/InvariantSuite.scala
@@ -6,7 +6,7 @@ import org.scalameta.invariants._
 import scala.meta._
 import scala.meta.dialects.Scala211
 
-class InvariantSuite extends FunSuite {
+class InvariantSuite extends TreeSuiteBase {
   test("secondary constructors in templates") {
     val primaryCtor = Ctor.Primary(Nil, Name.Anonymous(), Nil)
     val secondaryCtor = Ctor.Secondary(

--- a/tests/shared/src/test/scala/scala/meta/tests/trees/TokensSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/trees/TokensSuite.scala
@@ -26,7 +26,7 @@ class TokensSuite extends TreeSuiteBase {
   }
 
   test("Tree.tokens: empty") {
-    val emptyTemplate = "class C".parse[Stat].get.children(2)
+    val emptyTemplate = "class C".parse[Stat].get.children(3)
     assertTree(emptyTemplate)(Template(Nil, Nil, Self(Name(""), None), Nil, Nil))
     assert(emptyTemplate.tokens.structure == "Tokens()")
   }


### PR DESCRIPTION
Step 1 for #2869.