### PR TITLE
Dialect: add allowStarAsTypePlaceholder

### DIFF
--- a/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
@@ -145,6 +145,8 @@ final class Dialect private (
     val allowPlusMinusUnderscoreAsIdent: Boolean,
     // Dotty uses `_` for placeholder for types since 3.2
     val allowUnderscoreAsTypePlaceholder: Boolean,
+    // Dotty uses `*` for placeholder for types in 3.0-3.2
+    val allowStarAsTypePlaceholder: Boolean,
     // import a.b.c.{ given, _} used for -X:source3
     val allowGivenImports: Boolean,
     // Scala 3 uses proper precedence rules for infix types, unlike Scala 2
@@ -242,6 +244,7 @@ final class Dialect private (
       allowDoWhile = true,
       allowPlusMinusUnderscoreAsIdent = false,
       allowUnderscoreAsTypePlaceholder = false,
+      allowStarAsTypePlaceholder = false,
       allowGivenImports = false,
       useInfixTypePrecedence = false,
       allowInfixOperatorAfterNL = false,
@@ -435,6 +438,9 @@ final class Dialect private (
   def withAllowUnderscoreAsTypePlaceholder(newValue: Boolean): Dialect = {
     privateCopy(allowUnderscoreAsTypePlaceholder = newValue)
   }
+  def withAllowStarAsTypePlaceholder(newValue: Boolean): Dialect = {
+    privateCopy(allowStarAsTypePlaceholder = newValue)
+  }
   @deprecated("use withAllowUnderscoreAsTypePlaceholder", ">4.5.13")
   def withAllowPlusMinusUnderscoreAsPlaceholder(newValue: Boolean): Dialect = {
     withAllowUnderscoreAsTypePlaceholder(newValue)
@@ -521,6 +527,7 @@ final class Dialect private (
       allowDoWhile: Boolean = this.allowDoWhile,
       allowPlusMinusUnderscoreAsIdent: Boolean = this.allowPlusMinusUnderscoreAsIdent,
       allowUnderscoreAsTypePlaceholder: Boolean = this.allowUnderscoreAsTypePlaceholder,
+      allowStarAsTypePlaceholder: Boolean = this.allowStarAsTypePlaceholder,
       allowGivenImports: Boolean = this.allowGivenImports,
       useInfixTypePrecedence: Boolean = this.useInfixTypePrecedence,
       allowInfixOperatorAfterNL: Boolean = this.allowInfixOperatorAfterNL,
@@ -583,6 +590,7 @@ final class Dialect private (
       allowDoWhile,
       allowPlusMinusUnderscoreAsIdent,
       allowUnderscoreAsTypePlaceholder,
+      allowStarAsTypePlaceholder,
       allowGivenImports,
       useInfixTypePrecedence,
       allowInfixOperatorAfterNL,
@@ -665,6 +673,7 @@ final class Dialect private (
       && this.allowDoWhile == that.allowDoWhile
       && this.allowPlusMinusUnderscoreAsIdent == that.allowPlusMinusUnderscoreAsIdent
       && this.allowUnderscoreAsTypePlaceholder == that.allowUnderscoreAsTypePlaceholder
+      && this.allowStarAsTypePlaceholder == that.allowStarAsTypePlaceholder
       && this.allowGivenImports == that.allowGivenImports
       && this.useInfixTypePrecedence == that.useInfixTypePrecedence
       && this.allowInfixOperatorAfterNL == that.allowInfixOperatorAfterNL

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -142,6 +142,7 @@ package object dialects {
     .withAllowStarWildcardImport(true)
     .withAllowProcedureSyntax(false)
     .withAllowDoWhile(false)
+    .withAllowStarAsTypePlaceholder(true)
     .withUseInfixTypePrecedence(true)
     .withAllowInfixOperatorAfterNL(true)
 

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -945,6 +945,10 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
           wildcardType()
         case Ident("?") if dialect.allowQuestionMarkAsTypeWildcard =>
           wildcardType()
+        case Ident("*") if dialect.allowStarAsTypePlaceholder =>
+          next(); Type.AnonymousParam(None)
+        case Ident(value @ ("-*" | "+*")) if dialect.allowStarAsTypePlaceholder =>
+          next(); anonymousParamWithVariant(value)
         case Ident(value @ ("+" | "-"))
             if (dialect.allowPlusMinusUnderscoreAsIdent || dialect.allowUnderscoreAsTypePlaceholder) &&
               tryAhead[Underscore] =>

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -686,7 +686,12 @@ object TreeSyntax {
           s(p(AnyInfixTyp, t.tpe), " ", kw("match"), " {", r(t.cases.map(i(_)), ""), n("}"))
         )
       case t: Type.AnonymousParam =>
-        m(SimpleTyp, o(t.variant), "_")
+        val useStar = dialect.allowStarAsTypePlaceholder && (t.origin match {
+          case o: Origin.Parsed => !o.tokens.lastOption.exists(_.is[Token.Underscore])
+          case _ => false
+        })
+        val ph = if (useStar) "*" else "_"
+        m(SimpleTyp, o(t.variant), ph)
       case t: Type.Wildcard =>
         /* In order not to break existing tools `.syntax` should still return
          * `_` instead `?` unless specifically used.

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/PatSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/PatSuite.scala
@@ -69,6 +69,17 @@ class PatSuite extends ParseSuite {
     }
   }
 
+  test("_: F[*]") {
+    // might be deprecated later
+    implicit val Scala3: Dialect = scala.meta.dialects.Scala31
+    assertPat("_: F[*]") {
+      Typed(
+        Wildcard(),
+        Type.Apply(Type.Name("F"), Type.AnonymousParam(None) :: Nil)
+      )
+    }
+  }
+
   test("patTyp: t Map u") {
     assertPatTyp("t Map u") {
       Type.ApplyInfix(Type.Name("t"), Type.Name("Map"), Type.Name("u"))

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
@@ -327,6 +327,20 @@ class TypeSuite extends BaseDottySuite {
     }
   }
 
+  test("F[*]") {
+    // will be deprecated in later versions
+    implicit val Scala3: Dialect = scala.meta.dialects.Scala31
+    assertTpe("F[*]") {
+      Apply(TypeName("F"), List(AnonymousParam(None)))
+    }
+    assertTpe("F[+*]") {
+      Apply(TypeName("F"), List(AnonymousParam(Some(Mod.Covariant()))))
+    }
+    assertTpe("F[-*]") {
+      Apply(TypeName("F"), List(AnonymousParam(Some(Mod.Contravariant()))))
+    }
+  }
+
   test("F[T] forSome { type T }") {
     val Existential(
       Apply(TypeName("F"), TypeName("T") :: Nil),


### PR DESCRIPTION
This allows scala2->3 migration via kind-projector. Helps with #2807.