### PR TITLE
ScalametaParser: constrain match type pattern

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -249,6 +249,7 @@ object Type {
     @inline def apply(bounds: Bounds): Placeholder = Impl(bounds)
     @inline final def unapply(tree: Placeholder): Option[Bounds] = Some(tree.bounds)
   }
+  @ast class PatWildcard extends Type
   @ast class Wildcard(bounds: Bounds) extends Placeholder
   @ast class AnonymousParam(variant: Option[Mod.Variant]) extends Placeholder {
     @deprecated("Placeholder replaced with AnonymousParam and Wildcard", ">4.5.13")

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -703,6 +703,8 @@ object TreeSyntax {
         val useQM = dialect.allowQuestionMarkAsTypeWildcard &&
           (dialect.allowUnderscoreAsTypePlaceholder || questionMarkUsed)
         m(SimpleTyp, s(kw(if (useQM) "?" else "_")), t.bounds)
+      case t: Type.PatWildcard =>
+        m(SimpleTyp, kw("_"))
       case t: Type.Placeholder =>
         /* In order not to break existing tools `.syntax` should still return
          * `_` instead `?` unless specifically used.

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -412,6 +412,7 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.Type.Name
       |scala.meta.Type.Or
       |scala.meta.Type.Param
+      |scala.meta.Type.PatWildcard
       |scala.meta.Type.Placeholder
       |scala.meta.Type.Placeholder.Impl
       |scala.meta.Type.PolyFunction

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
@@ -24,7 +24,7 @@ class ReflectionSuite extends FunSuite {
     val sym = symbolOf[scala.meta.Tree]
     assert(sym.isRoot)
     val root = sym.asRoot
-    assertEquals((root.allBranches.length, root.allLeafs.length), (26, 358))
+    assertEquals((root.allBranches.length, root.allLeafs.length), (26, 360))
   }
 
   test("If") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MatchTypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MatchTypeSuite.scala
@@ -222,7 +222,7 @@ class MatchTypeSuite extends BaseDottySuite {
                 Type.Name("Left"),
                 List(
                   TypeCase(Type.Name("Unit"), Type.Name("Right")),
-                  TypeCase(Type.Wildcard(Type.Bounds(None, None)), Type.Name("Left"))
+                  TypeCase(Type.Name("?"), Type.Name("Left"))
                 )
               ),
               Type.Bounds(None, None)
@@ -288,11 +288,11 @@ class MatchTypeSuite extends BaseDottySuite {
                     Type.Name("L")
                   ),
                   TypeCase(
-                    Type.AnonymousParam(None),
+                    Type.PatWildcard(),
                     Type.Name("R")
                   ),
                   TypeCase(
-                    Type.Wildcard(Type.Bounds(None, None)),
+                    Type.Name("?"),
                     Type.Name("L")
                   )
                 )


### PR DESCRIPTION
Currently, unlike pattern matching for Terms which follows a different parsing logic and produces Pat trees, pattern matching for Types uses exactly the same logic as regular Types.

This occasionally leads to incorrect parsing, and here we try to address the specific problem of parsing a wildcards and anonymous params which is different in a type pattern match context.

Helps with #2807.