### PR TITLE
bugfix: Don't allow multiple infix operators after newline

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/Scala213Suite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/Scala213Suite.scala
@@ -128,6 +128,38 @@ class Scala213Suite extends ParseSuite {
     )(dialects.Scala213Source3)
   }
 
+  test("issue-2880") {
+    runAssert(
+      """|Flow {
+         |    b.add()
+         |    input_< ~> filtering ~> removeItems.in0
+         |}
+         |""".stripMargin
+    )(
+      Term.Apply(
+        Term.Name("Flow"),
+        List(
+          Term.Block(
+            List(
+              Term.Apply(Term.Select(Term.Name("b"), Term.Name("add")), Nil),
+              Term.ApplyInfix(
+                Term.ApplyInfix(
+                  Term.Name("input_<"),
+                  Term.Name("~>"),
+                  Nil,
+                  List(Term.Name("filtering"))
+                ),
+                Term.Name("~>"),
+                Nil,
+                List(Term.Select(Term.Name("removeItems"), Term.Name("in0")))
+              )
+            )
+          )
+        )
+      )
+    )(dialects.Scala213Source3)
+  }
+
   private def runAssert(code: String)(expected: Tree)(implicit d: Dialect): Unit = {
     assertTree(templStat(code)(d))(expected)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -1383,20 +1383,6 @@ class TermSuite extends ParseSuite {
     )
   }
 
-  test("using-call-site in scala2") {
-    checkStat("val a = f()(using a)(using 3, true)")(
-      Defn.Val(
-        Nil,
-        List(Pat.Var(Term.Name("a"))),
-        None,
-        Term.ApplyUsing(
-          Term.ApplyUsing(Term.Apply(Term.Name("f"), Nil), List(Term.Name("a"))),
-          List(Lit.Int(3), Lit.Boolean(true))
-        )
-      )
-    )
-  }
-
   test("scala3-syntax") {
 
     runTestError[Term](


### PR DESCRIPTION
Previously, if we had two infix operators after newline they would be treated as whole expression together with the previous line. That, however, is not allowed by the parser. Now, we don't continue the expression if there are two infix operators after newline.

Fixes https://github.com/scalameta/scalameta/issues/2880