### PR TITLE
replace binaryCompatVar with a field annotation and full unapply

### DIFF
--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -35,6 +35,11 @@ object Mima {
     ProblemFilters.exclude[A]("scala.meta." + metaType)
 
   val apiCompatibilityExceptions: Seq[ProblemFilter] = Seq(
+    // newField; these methods should have been package-private
+    exclude[DirectMissingMethodProblem]("Defn#Type.setBounds"),
+    exclude[DirectMissingMethodProblem]("Template.setDerives"),
+    exclude[DirectMissingMethodProblem]("Term#If.setMods"),
+    exclude[DirectMissingMethodProblem]("Term#Match.setMods"),
     // implicit classes
     exclude[IncompatibleResultTypeProblem]("package.XtensionDialectApply"),
     exclude[IncompatibleResultTypeProblem]("package.XtensionDialectTokenSyntax"),

--- a/scalameta/common/shared/src/main/scala/org/scalameta/adt/Liftables.scala
+++ b/scalameta/common/shared/src/main/scala/org/scalameta/adt/Liftables.scala
@@ -5,6 +5,8 @@ import scala.reflect.macros.blackbox.Context
 import org.scalameta.adt.Metadata.Adt
 import org.scalameta.adt.{Reflection => AdtReflection}
 
+import scala.meta.internal.trees.Metadata.newField
+
 // Implementation of the scala.reflect.api.Universe#Liftable interface for adts.
 trait Liftables {
   val u: scala.reflect.macros.Universe
@@ -66,7 +68,7 @@ class LiftableMacros(val c: Context) extends AdtReflection {
         val nameParts = adt.sym.fullName.split('.')
         val body = if (adt.sym.isClass) {
           val fields = adt match { case leaf: Leaf => leaf.fields; case _ => Nil }
-          val args = fields.map { f =>
+          val args = fields.filter(!_.sym.hasAnnotation[newField]).map { f =>
             q"_root_.scala.Predef.implicitly[$u.Liftable[${f.tpe}]].apply($localName.${f.name})"
           // NOTE: we can't really use AssignOrNamedArg here, sorry
           // Test.scala:10: warning: type-checking the invocation of method apply checks if the named argument expression 'stats = ...' is a valid assignment

--- a/scalameta/common/shared/src/main/scala/org/scalameta/adt/Reflection.scala
+++ b/scalameta/common/shared/src/main/scala/org/scalameta/adt/Reflection.scala
@@ -117,16 +117,11 @@ trait Reflection {
   class Leaf(sym: Symbol) extends Adt(sym) {
     if (!sym.isLeaf) sys.error(s"$sym is not a leaf")
     def fields: List[Field] = sym.fields.map(_.asField)
-    def binaryCompatFields: List[Field] = {
-      sym.info.decls.collect {
-        case s if s.hasAnnotation[AstMetadata.binaryCompatField] => s.asField
-      }.toList
-    }
     def allFields: List[Field] = sym.allFields.map(_.asField)
     override def toString = s"leaf $prefix"
   }
   class Field(val sym: Symbol) {
-    if (!sym.isField && !sym.hasAnnotation[AstMetadata.binaryCompatField])
+    if (!sym.isField)
       sys.error(s"$sym is not a field")
     def owner: Leaf = sym.owner.asLeaf
     def name: TermName = TermName(sym.name.toString.stripPrefix("_"))

--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/transversers/transformer.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/transversers/transformer.scala
@@ -90,25 +90,12 @@ class TransformerMacros(val c: Context) extends TransverserMacros {
     if (relevantFields.isEmpty) return q"$treeName"
     val transformedFields: List[ValDef] = relevantFields.map(transformField(treeName))
 
-    val binaryCompatFields = l.binaryCompatFields
-
-    val binaryCompatGetters = binaryCompatFields.map { field =>
-      q"val ${field.name} = $treeName.${field.name}"
-    }
-
-    val binaryCompatSetters = binaryCompatFields.map { field =>
-      val setter = TermName("set" + field.sym.name.toString.capitalize)
-      q"newTree.$setter(${TermName(field.name.toString + "1")})"
-    }
     q"""
       var same = true
-      ..$binaryCompatGetters
       ..$transformedFields
-      ..${binaryCompatFields.map(transformField(treeName))}
       if (same) $treeName
       else {
         val newTree = $constructor(..${transformedFields.map(_.name)})
-        ..$binaryCompatSetters
         newTree
       }
     """

--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/TyperMacros.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/TyperMacros.scala
@@ -110,7 +110,7 @@ class CommonTyperMacrosBundle(val c: Context) extends AdtReflection with MacroHe
       result
     }
     val leaf = T.tpe.typeSymbol.asLeaf
-    val allAnalyzedFields = leaf.fields ++ leaf.binaryCompatFields
+    val allAnalyzedFields = leaf.fields
     val acc = allAnalyzedFields.foldLeft(q"": Tree)((acc, f) =>
       f.tpe match {
         case TreeTpe() =>

--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/metadata.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/metadata.scala
@@ -11,7 +11,7 @@ object Metadata {
   class root extends StaticAnnotation
   class branch extends StaticAnnotation
   class astClass extends StaticAnnotation
-  class binaryCompatField(since: String) extends StaticAnnotation
+  class newField(since: String) extends StaticAnnotation
   class astCompanion extends StaticAnnotation
   @getter class astField extends StaticAnnotation
   @getter class auxiliary extends StaticAnnotation

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1429,8 +1429,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
   def inlineMatchClause(inlineMods: List[Mod]) = {
     autoEndPos(inlineMods)(postfixExpr(allowRepeated = false)) match {
       case t: Term.Match =>
-        t.setMods(inlineMods)
-        t
+        copyPos(t)(t.copy(mods = inlineMods))
       case other =>
         syntaxError("`inline` must be followed by an `if` or a `match`", at = other.pos)
     }

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -6,7 +6,7 @@ import scala.meta.inputs._
 import scala.meta.tokens._
 import scala.meta.prettyprinters._
 import scala.meta.internal.trees._
-import scala.meta.internal.trees.Metadata.binaryCompatField
+import scala.meta.internal.trees.Metadata.newField
 
 import scala.{meta => sm}
 
@@ -119,18 +119,21 @@ object Term {
     checkParent(ParentChecks.TermBlock)
   }
   @ast class EndMarker(name: Term.Name) extends Term
-  @ast class If(cond: Term, thenp: Term, elsep: Term) extends Term {
-    @binaryCompatField(since = "4.4.0")
-    private var _mods: List[Mod] = Nil
-  }
+  @ast class If(
+      cond: Term,
+      thenp: Term,
+      elsep: Term,
+      @newField(since = "4.4.0") mods: List[Mod] = Nil
+  ) extends Term
   @ast class QuotedMacroExpr(body: Term) extends Term
   @ast class QuotedMacroType(tpe: Type) extends Term
   @ast class SplicedMacroExpr(body: Term) extends Term
   @ast class SplicedMacroPat(pat: Pat) extends Term
-  @ast class Match(expr: Term, cases: List[Case] @nonEmpty) extends Term {
-    @binaryCompatField(since = "4.4.5")
-    private var _mods: List[Mod] = Nil
-  }
+  @ast class Match(
+      expr: Term,
+      cases: List[Case] @nonEmpty,
+      @newField(since = "4.4.5") mods: List[Mod] = Nil
+  ) extends Term
   @ast class Try(expr: Term, catchp: List[Case], finallyp: Option[Term]) extends Term
   @ast class TryWithHandler(expr: Term, catchp: Term, finallyp: Option[Term]) extends Term
 
@@ -458,11 +461,9 @@ object Defn {
       mods: List[Mod],
       name: sm.Type.Name,
       tparams: List[sm.Type.Param],
-      body: sm.Type
-  ) extends Defn with Member.Type with Stat.WithMods {
-    @binaryCompatField("4.4.0")
-    private var _bounds: sm.Type.Bounds = sm.Type.Bounds(None, None)
-  }
+      body: sm.Type,
+      @newField("4.4.0") bounds: sm.Type.Bounds = sm.Type.Bounds(None, None)
+  ) extends Defn with Member.Type with Stat.WithMods
   @ast class Class(
       mods: List[Mod],
       name: sm.Type.Name,
@@ -529,10 +530,9 @@ object Ctor {
     early: List[Stat],
     inits: List[Init],
     self: Self,
-    stats: List[Stat]
+    stats: List[Stat],
+    @newField("4.4.0") derives: List[Type] = Nil
 ) extends Tree {
-  @binaryCompatField("4.4.0")
-  private var _derives: List[Type] = Nil
   checkFields(early.forall(_.isEarlyStat && inits.nonEmpty))
   checkFields(stats.forall(_.isTemplateStat))
 }

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
@@ -29,14 +29,24 @@ class ReflectionSuite extends FunSuite {
 
   test("If") {
     val iff = symbolOf[scala.meta.Term.If].asLeaf
-    val List(f1, f2, f3) = iff.fields
-    assert(f1.toString == "field Term.If.cond: scala.meta.Term")
-    assert(f2.toString == "field Term.If.thenp: scala.meta.Term")
-    assert(f3.toString == "field Term.If.elsep: scala.meta.Term")
-    val List(a1, a2, a3) = iff.allFields
-    assert(a1.toString == "field Term.If.cond: scala.meta.Term")
-    assert(a2.toString == "field Term.If.thenp: scala.meta.Term")
-    assert(a3.toString == "field Term.If.elsep: scala.meta.Term")
+    assertEquals(
+      iff.fields.map(_.toString),
+      List(
+        "field Term.If.cond: scala.meta.Term",
+        "field Term.If.thenp: scala.meta.Term",
+        "field Term.If.elsep: scala.meta.Term",
+        "field Term.If.mods: List[scala.meta.Mod]"
+      )
+    )
+    assertEquals(
+      iff.allFields.map(_.toString),
+      List(
+        "field Term.If.cond: scala.meta.Term",
+        "field Term.If.thenp: scala.meta.Term",
+        "field Term.If.elsep: scala.meta.Term",
+        "field Term.If.mods: List[scala.meta.Mod]"
+      )
+    )
   }
 
   test("Term.Name") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -155,6 +155,19 @@ class MinorDottySuite extends BaseDottySuite {
     )
   }
 
+  test("opaque-type-bounded-alias-with-quasiquotes") {
+    import dialects.Scala3
+    checkTree(q"opaque type Foo <: String = String", "opaque type Foo = String")(
+      Defn.Type(
+        List(Mod.Opaque()),
+        pname("Foo"),
+        Nil,
+        pname("String"),
+        Type.Bounds(None, None)
+      )
+    )
+  }
+
   test("opaque-type-in-object") {
     runTestAssert[Source]("object X { opaque type IArray[+T] = Array }")(
       Source(

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -157,13 +157,13 @@ class MinorDottySuite extends BaseDottySuite {
 
   test("opaque-type-bounded-alias-with-quasiquotes") {
     import dialects.Scala3
-    checkTree(q"opaque type Foo <: String = String", "opaque type Foo = String")(
+    checkTree(q"opaque type Foo <: String = String", "opaque type Foo <: String = String")(
       Defn.Type(
         List(Mod.Opaque()),
         pname("Foo"),
         Nil,
         pname("String"),
-        Type.Bounds(None, None)
+        Type.Bounds(None, Some(pname("String")))
       )
     )
   }


### PR DESCRIPTION
Fixes #2881, by making private vars into "official" fields akin to other ones, and by introducing a full unapply (with all fields) and changing `Liftables` to use that instead.