### PR TITLE
Transverser: don't extract/bind fields via unapply

### DIFF
--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/transversers/transverser.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/transversers/transverser.scala
@@ -58,10 +58,7 @@ trait TransverserMacros extends MacroHelpers with AstReflection {
         if (idx != -1) idx else priority.length
       }
       .map { l =>
-        val extractor = hygienicRef(l.sym.companion)
-        val binders = l.fields.map(f => pq"${f.name}")
-        val handler = leafHandler(l, treeName)
-        cq"$treeName @ $extractor(..$binders) => $handler"
+        cq"$treeName: ${hygienicRef(l.sym)} => ${leafHandler(l, treeName)}"
       }
     val methodName = TermName(s"apply$prefix")
 

--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/transversers/traverser.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/transversers/traverser.scala
@@ -16,7 +16,7 @@ class TraverserMacros(val c: Context) extends TransverserMacros {
   def leafHandler(l: Leaf, treeName: TermName): Tree = {
     val relevantFields =
       l.fields.filter(f => !(f.tpe =:= typeOf[Any]) && !PrimitiveTpe.unapply(f.tpe))
-    val recursiveTraversals = relevantFields.map(f => q"this.apply(${f.name})")
+    val recursiveTraversals = relevantFields.map(f => q"this.apply($treeName.${f.name})")
     q"..$recursiveTraversals"
   }
 


### PR DESCRIPTION
Access the fields directly via the owner instance. Helps with #2881.