### PR TITLE
refactor: Rename Scala3x to Scala3Future

### DIFF
--- a/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
@@ -789,7 +789,7 @@ object Dialect extends InternalDialect {
   }
   private lazy val standardPairs = Seq[sourcecode.Text[Dialect]](
     Dotty,
-    Scala3x,
+    Scala3Future,
     Scala3,
     Scala30,
     Scala31,

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -152,7 +152,7 @@ package object dialects {
 
   implicit val Scala3 = Scala32
 
-  implicit val Scala3x = Scala3
+  implicit val Scala3Future = Scala3
     .withAllowUnderscoreAsTypePlaceholder(true)
 
   @deprecated("Use Scala3 instead", "4.4.2")

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -105,7 +105,7 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.dialects.Scala30 *
       |scala.meta.dialects.Scala31 *
       |scala.meta.dialects.Scala32 *
-      |scala.meta.dialects.Scala3x *
+      |scala.meta.dialects.Scala3Future *
       |scala.meta.dialects.Typelevel211 *
       |scala.meta.dialects.Typelevel212 *
       |scala.meta.inputs

--- a/tests/jvm/src/test/scala/scala/meta/tests/prettyprinters/RegressionSyntaxSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/prettyprinters/RegressionSyntaxSuite.scala
@@ -24,7 +24,7 @@ class RegressionSyntaxSuite extends ParseSuite {
   check("question-mark", "type T = List[?]", "type T = List[?]")
   check("underscore", "type T = List[_]", "type T = List[_]")
 
-  check("211->3x", "type T = List[_]", "type T = List[?]", dialects.Scala3x)(dialects.Scala211)
+  check("211->3x", "type T = List[_]", "type T = List[?]", dialects.Scala3Future)(dialects.Scala211)
   check("211->30", "type T = List[_]", "type T = List[_]", dialects.Scala30)(dialects.Scala211)
   check("211->213", "type T = List[_]", "type T = List[_]", dialects.Scala213)(dialects.Scala211)
   check("3->213", "type T = List[?]", "type T = List[?]", dialects.Scala213)(dialects.Scala3)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MatchTypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MatchTypeSuite.scala
@@ -305,6 +305,6 @@ class MatchTypeSuite extends BaseDottySuite {
           Nil
         )
       )
-    )(templStat(_)(dialects.Scala3x))
+    )(templStat(_)(dialects.Scala3Future))
   }
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -1200,7 +1200,7 @@ class MinorDottySuite extends BaseDottySuite {
           Nil
         )
       )
-    )(templStat(_)(dialects.Scala3x))
+    )(templStat(_)(dialects.Scala3Future))
   }
 
   test("type-param-last") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/PatSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/PatSuite.scala
@@ -51,7 +51,7 @@ class PatSuite extends ParseSuite {
   }
 
   test("_: F[_]") {
-    implicit val Scala3 = dialects.Scala3x
+    implicit val Scala3 = dialects.Scala3Future
     assertPat("_: F[_]") {
       Typed(
         Wildcard(),

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
@@ -316,7 +316,7 @@ class TypeSuite extends BaseDottySuite {
   }
 
   test("F[_]") {
-    implicit val Scala3: Dialect = scala.meta.dialects.Scala3x
+    implicit val Scala3: Dialect = scala.meta.dialects.Scala3Future
     assertTpe("F[_]") {
       AnonymousLambda(Apply(TypeName("F"), List(AnonymousParam(None))))
     }

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
@@ -109,8 +109,8 @@ class PublicSuite extends TreeSuiteBase {
     assertNoDiff(scala.meta.dialects.Scala32.toString, "Scala32")
   }
 
-  test("scala.meta.dialects.Scala3x.toString") {
-    assertNoDiff(scala.meta.dialects.Scala3x.toString.substring(0, 6), "Scala3")
+  test("scala.meta.dialects.Scala3Future.toString") {
+    assertNoDiff(scala.meta.dialects.Scala3Future.toString.substring(0, 6), "Scala3")
   }
 
   test("scala.meta.dialects.Dotty") {

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -752,7 +752,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
   }
 
   test("case List[_](xs @ _*): scala32") {
-    implicit val Scala211 = dialects.Scala3x
+    implicit val Scala211 = dialects.Scala3Future
     val tree = pat("List[_](xs @ _*)")
     assertTree(tree)(
       Pat.Extract(


### PR DESCRIPTION
This corresponds to the flag used by Scala 3