### PR TITLE
ast: add a private `fullCopy` method

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1429,7 +1429,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
   def inlineMatchClause(inlineMods: List[Mod]) = {
     autoEndPos(inlineMods)(postfixExpr(allowRepeated = false)) match {
       case t: Term.Match =>
-        copyPos(t)(t.copy(mods = inlineMods))
+        copyPos(t)(t.fullCopy(mods = inlineMods))
       case other =>
         syntaxError("`inline` must be followed by an `if` or a `match`", at = other.pos)
     }


### PR DESCRIPTION
This method doesn't need to be binary-compatible and hence supports all current fields, unlike the primary copy method (the one with default parameter values) which, for backwards compatibility, must refer to the original order and types of parameters.