### PR TITLE
ast: allow replacing old fields with new ones

### DIFF
--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/metadata.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/metadata.scala
@@ -12,6 +12,7 @@ object Metadata {
   class branch extends StaticAnnotation
   class astClass extends StaticAnnotation
   class newField(since: String) extends StaticAnnotation
+  class replacedField(until: String) extends StaticAnnotation
   class astCompanion extends StaticAnnotation
   @getter class astField extends StaticAnnotation
   @getter class auxiliary extends StaticAnnotation


### PR DESCRIPTION
As an alternative to existing `newFields` which are appended at the end of the list of existing params, let's have the ability to remove a field as long as it's replaced with another.

Current implementation supports cases when the new field value can be determined from the old one via an implicit conversion, similar to how quasiquotes define implicit Lift/Unlift conversions.

This change is backwards-binary-compatible and hence will not trigger MIMA-verification alerts.