### PR TITLE
bugfix: Make AnonymousLambda contructable

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/package.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/package.scala
@@ -119,6 +119,7 @@ package object trees {
       case _: Type.Apply => true
       case _: Type.ApplyInfix => true
       case _: Type.Refine => true
+      case _: Type.AnonymousLambda => true
       case Type.Singleton(Term.This(Name.Anonymous())) => true
       case _ => false
     }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -1390,4 +1390,39 @@ class MinorDottySuite extends BaseDottySuite {
     )
   }
 
+  test("kleisli") {
+    runTestAssert[Stat](
+      "new (Kleisli[F, Span[F], *] ~> F) {}"
+    )(
+      Term.NewAnonymous(
+        Template(
+          Nil,
+          List(
+            Init(
+              Type.AnonymousLambda(
+                Type.ApplyInfix(
+                  Type.Apply(
+                    Type.Name("Kleisli"),
+                    List(
+                      Type.Name("F"),
+                      Type.Apply(Type.Name("Span"), List(Type.Name("F"))),
+                      Type.AnonymousParam(None)
+                    )
+                  ),
+                  Type.Name("~>"),
+                  Type.Name("F")
+                )
+              ),
+              Name(""),
+              Nil
+            )
+          ),
+          Self(Name(""), None),
+          Nil,
+          Nil
+        )
+      )
+    )
+  }
+
 }


### PR DESCRIPTION
Previously, AnonymousLambda could be used as a parent. Now, it can.