### PR TITLE
Trees: use Term.ParamClause, not List[Term.Param]

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/package.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/package.scala
@@ -225,9 +225,8 @@ package object trees {
     else arrayClass(ScalaRunTime.arrayClass(clazz), rank - 1)
   }
 
-  def onlyLastParamCanBeRepeated(params: List[Term.Param]): Boolean = {
-    params.iterator
-      .take(params.length - 1)
-      .forall(p => p.is[Term.Param.Quasi] || !p.decltpe.exists(_.is[Type.Repeated]))
-  }
+  def onlyLastParamCanBeRepeated(clause: Term.ParamClause): Boolean =
+    clause.is[Quasi] || clause.values.view.dropRight(1).forall { p =>
+      p.is[Quasi] || !p.decltpe.exists(_.is[Type.Repeated])
+    }
 }

--- a/scalameta/trees/shared/src/main/scala/scala/meta/trees/Api.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/trees/Api.scala
@@ -1,11 +1,18 @@
 package scala.meta
 package trees
 
+import scala.collection.mutable
 import scala.language.implicitConversions
 
 private[meta] trait Api {
   implicit def typeParamClauseToValues(v: Type.ParamClause): List[Type.Param] = v.values
   implicit def typeValuesToParamClause(v: List[Type.Param]): Type.ParamClause = Type.ParamClause(v)
+
+  implicit def termParamClauseToValues(v: Term.ParamClause): List[Term.Param] = v.values
+  implicit def termValuesToParamClause(v: List[Term.Param]): Term.ParamClause =
+    Term.ParamClause(v, v.flatMap(_.mods).collectFirst { case x: Mod.ParamsType => x })
+  implicit def termListValuesToListParamClause(v: List[List[Term.Param]]): List[Term.ParamClause] =
+    v.map(termValuesToParamClause)
 }
 
 private[meta] trait Aliases {

--- a/tests/js/src/test/scala/scala/meta/tests/parsers/JSFacadeSuite.scala
+++ b/tests/js/src/test/scala/scala/meta/tests/parsers/JSFacadeSuite.scala
@@ -68,34 +68,39 @@ class JSFacadeSuite extends FunSuite {
                   "pos" -> pos(24, 24),
                   "values" -> a()
                 ),
-                "paramss" -> a(
-                  a(
-                    d(
-                      "type" -> "Term.Param",
-                      "pos" -> pos(25, 44),
-                      "mods" -> a(),
-                      "name" -> d(
-                        "type" -> "Term.Name",
-                        "pos" -> pos(25, 29),
-                        "value" -> "args"
-                      ),
-                      "decltpe" -> d(
-                        "type" -> "Type.Apply",
-                        "pos" -> pos(31, 44),
-                        "tpe" -> d(
-                          "type" -> "Type.Name",
-                          "pos" -> pos(31, 36),
-                          "value" -> "Array"
+                "paramClauses" -> a(
+                  d(
+                    "type" -> "Term.ParamClause",
+                    "pos" -> pos(24, 45),
+                    "values" -> a(
+                      d(
+                        "type" -> "Term.Param",
+                        "pos" -> pos(25, 44),
+                        "mods" -> a(),
+                        "name" -> d(
+                          "type" -> "Term.Name",
+                          "pos" -> pos(25, 29),
+                          "value" -> "args"
                         ),
-                        "args" -> a(
-                          d(
+                        "decltpe" -> d(
+                          "type" -> "Type.Apply",
+                          "pos" -> pos(31, 44),
+                          "tpe" -> d(
                             "type" -> "Type.Name",
-                            "pos" -> pos(37, 43),
-                            "value" -> "String"
+                            "pos" -> pos(31, 36),
+                            "value" -> "Array"
+                          ),
+                          "args" -> a(
+                            d(
+                              "type" -> "Type.Name",
+                              "pos" -> pos(37, 43),
+                              "value" -> "String"
+                            )
                           )
                         )
                       )
-                    )
+                    ),
+                    "mods" -> a()
                   )
                 ),
                 "decltpe" -> d(

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -376,6 +376,7 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.Term.New
       |scala.meta.Term.NewAnonymous
       |scala.meta.Term.Param
+      |scala.meta.Term.ParamClause
       |scala.meta.Term.PartialFunction
       |scala.meta.Term.Placeholder
       |scala.meta.Term.PolyFunction

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
@@ -24,7 +24,7 @@ class ReflectionSuite extends FunSuite {
     val sym = symbolOf[scala.meta.Tree]
     assert(sym.isRoot)
     val root = sym.asRoot
-    assertEquals((root.allBranches.length, root.allLeafs.length), (29, 367))
+    assertEquals((root.allBranches.length, root.allLeafs.length), (29, 369))
   }
 
   test("If") {
@@ -76,7 +76,6 @@ class ReflectionSuite extends FunSuite {
       |Byte
       |Char
       |Int
-      |List[List[scala.meta.Term.Param]]
       |List[List[scala.meta.Term]]
       |List[scala.meta.Case]
       |List[scala.meta.Enumerator]
@@ -96,9 +95,11 @@ class ReflectionSuite extends FunSuite {
       |List[scala.meta.TypeCase]
       |List[scala.meta.Type]
       |Long
+      |Option[scala.meta.Mod.ParamsType]
       |Option[scala.meta.Mod.Variant]
       |Option[scala.meta.Term]
       |Option[scala.meta.Type]
+      |Seq[scala.meta.Term.ParamClause]
       |Short
       |String
       |Symbol

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -44,6 +44,8 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |Type.Bounds extension [A@@, B](i: A)(using a: F[A], G[B]) def isZero = i == 0
        |Type.ParamClause extension [A, B@@](i: A)(using a: F[A], G[B]) def isZero = i == 0
        |Type.Bounds extension [A, B@@](i: A)(using a: F[A], G[B]) def isZero = i == 0
+       |Term.ParamClause (i: A)
+       |Term.ParamClause (using a: F[A], G[B])
        |Term.Param a: F[A]
        |Type.Apply F[A]
        |Term.Param G[B]
@@ -60,6 +62,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |  def isOne = i == 1
        |}""".stripMargin,
     """|Type.ParamClause extension @@(i: A) {
+       |Term.ParamClause (i: A)
        |Term.Block {
        |  def isZero = i == 0
        |  def isOne = i == 1
@@ -78,6 +81,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
   checkPositions[Stat](
     "def foo(implicit a: A, b: B): Unit",
     """|Type.ParamClause def foo@@(implicit a: A, b: B): Unit
+       |Term.ParamClause (implicit a: A, b: B)
        |Term.Param a: A
        |Term.Param b: B
        |""".stripMargin
@@ -89,6 +93,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |Type.ParamClause enum Day[T@@](e: T) extends A with B { case Monday, Tuesday }
        |Type.Bounds enum Day[T@@](e: T) extends A with B { case Monday, Tuesday }
        |Ctor.Primary (e: T)
+       |Term.ParamClause (e: T)
        |Template extends A with B { case Monday, Tuesday }
        |Self enum Day[T](e: T) extends A with B { @@case Monday, Tuesday }
        |Defn.RepeatedEnumCase case Monday, Tuesday
@@ -100,6 +105,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |Type.ParamClause class Day[T@@](e: T) extends A with B { val Monday = 42 }
        |Type.Bounds class Day[T@@](e: T) extends A with B { val Monday = 42 }
        |Ctor.Primary (e: T)
+       |Term.ParamClause (e: T)
        |Template extends A with B { val Monday = 42 }
        |Self class Day[T](e: T) extends A with B { @@val Monday = 42 }
        |Defn.Val val Monday = 42
@@ -116,6 +122,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |Self inline given intOrd: Ord[Int] with Eq[Int] with { @@def f(): Int = 1 }
        |Defn.Def def f(): Int = 1
        |Type.ParamClause inline given intOrd: Ord[Int] with Eq[Int] with { def f@@(): Int = 1 }
+       |Term.ParamClause ()
        |""".stripMargin
   )
   checkPositions[Stat](
@@ -211,6 +218,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
   checkPositions[Stat](
     "infix def a(param: Int) = param",
     """|Type.ParamClause infix def a@@(param: Int) = param
+       |Term.ParamClause (param: Int)
        |""".stripMargin
   )
   checkPositions[Stat](

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
@@ -315,6 +315,7 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Stat](
     "def f(a: A = (da)): A",
     """|Type.ParamClause def f@@(a: A = (da)): A
+       |Term.ParamClause (a: A = (da))
        |Term.Param a: A = (da)
        |Term.Name (da)
        |""".stripMargin
@@ -484,6 +485,7 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
        |Self class A { @@def this(a: A) = this() }
        |Ctor.Secondary def this(a: A) = this()
        |Name.Anonymous this
+       |Term.ParamClause (a: A)
        |Init this()
        |Type.Singleton this
        |Term.This this
@@ -498,6 +500,7 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
     "class A private (b: B)",
     """|Type.ParamClause class A @@private (b: B)
        |Ctor.Primary private (b: B)
+       |Term.ParamClause (b: B)
        |Template class A private (b: B)@@
        |Self class A private (b: B)@@
        |""".stripMargin
@@ -614,6 +617,7 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
     "class A(val b: B)",
     """|Type.ParamClause class A@@(val b: B)
        |Ctor.Primary (val b: B)
+       |Term.ParamClause (val b: B)
        |Term.Param val b: B
        |Mod.ValParam val
        |Template class A(val b: B)@@
@@ -624,6 +628,7 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
     "class A(var b: B)",
     """|Type.ParamClause class A@@(var b: B)
        |Ctor.Primary (var b: B)
+       |Term.ParamClause (var b: B)
        |Term.Param var b: B
        |Mod.VarParam var
        |Template class A(var b: B)@@

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
@@ -233,46 +233,45 @@ class DefnSuite extends ParseSuite {
          |}""".stripMargin
     )
     assertTree(defn)(
-      Defn
-        .Def(
-          Nil,
-          Term.Name("f"),
-          Nil,
-          Nil,
-          None,
-          Term.Block(
-            List(
-              Term.Function(
-                List(Term.Param(Nil, Term.Name("n"), Some(Type.Name("Int")), None)),
-                Term.Apply(
-                  Term.Select(
-                    Term.Block(
-                      List(
-                        Term.ForYield(
-                          List(
-                            Enumerator.Generator(
-                              Pat.Wildcard(),
-                              Term.Apply(
-                                Term.Select(
-                                  Term.Select(Term.Name("scala"), Term.Name("util")),
-                                  Term.Name("Success")
-                                ),
-                                List(Lit.Int(123))
-                              )
+      Defn.Def(
+        Nil,
+        Term.Name("f"),
+        Type.ParamClause(Nil),
+        Nil,
+        None,
+        Term.Block(
+          List(
+            Term.Function(
+              List(Term.Param(Nil, Term.Name("n"), Some(Type.Name("Int")), None)),
+              Term.Apply(
+                Term.Select(
+                  Term.Block(
+                    List(
+                      Term.ForYield(
+                        List(
+                          Enumerator.Generator(
+                            Pat.Wildcard(),
+                            Term.Apply(
+                              Term.Select(
+                                Term.Select(Term.Name("scala"), Term.Name("util")),
+                                Term.Name("Success")
+                              ),
+                              List(Lit.Int(123))
                             )
-                          ),
-                          Lit.Int(42)
-                        )
+                          )
+                        ),
+                        Lit.Int(42)
                       )
-                    ),
-                    Term.Name("recover")
+                    )
                   ),
-                  List(Term.Name("???"))
-                )
+                  Term.Name("recover")
+                ),
+                List(Term.Name("???"))
               )
             )
           )
         )
+      )
     )
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExtensionMethodsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExtensionMethodsSuite.scala
@@ -8,7 +8,7 @@ class ExtensionMethodsSuite extends BaseDottySuite {
   implicit val parseBlock: String => Stat = code => blockStat(code)(dialects.Scala3)
 
   private final val cparam = tparam("c", "Circle")
-  private final val cparamss = List(List(cparam))
+  private final val cparamss: List[Term.ParamClause] = List(List(cparam))
 
   /**
    * For checking examples in repl declare:

--- a/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/ErrorSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/ErrorSuite.scala
@@ -803,23 +803,6 @@ class ErrorSuite extends FunSuite {
     )
   }
 
-  test("triple-dot mixes with something else in parameter lists") {
-    assertEquals(
-      typecheckError("""
-      import scala.meta._
-      import scala.meta.dialects.Scala211
-      val paramss = List(List(param"x: Int"))
-      q"def foo(...$paramss)(y: Int) = ???"
-    """).replace("\r", ""),
-      """
-      |<macro>:5: implementation restriction: can't mix ...$ with anything else in parameter lists.
-      |See https://github.com/scalameta/scalameta/issues/406 for details.
-      |      q"def foo(...$paramss)(y: Int) = ???"
-      |                ^
-    """.trim.stripMargin
-    )
-  }
-
   test("triple-dot in Term.ApplyInfix") {
     assertEquals(
       typecheckError("""

--- a/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -2,8 +2,6 @@ package scala.meta.tests
 package quasiquotes
 
 import munit._
-import org.scalameta.tests.typecheckError
-
 import scala.meta._
 import scala.meta.dialects.Scala211
 
@@ -1490,11 +1488,13 @@ class SuccessSuite extends TreeSuiteBase {
         Type.Param(Nil, Type.Name("W"), Type.ParamClause(Nil), Type.Bounds(None, None), Nil, Nil)
       )
     })
-    assertEquals(paramss.map(_.toString), List("List(x: X, y: Y)"))
-    assertTrees(paramss(0): _*)(
-      Term.Param(Nil, Term.Name("x"), Some(Type.Name("X")), None),
-      Term.Param(Nil, Term.Name("y"), Some(Type.Name("Y")), None)
-    )
+    assertEquals(paramss.lengthCompare(1), 0)
+    checkTreesWithSyntax(paramss: _*)("(x: X, y: Y)")(Term.ParamClause {
+      List(
+        Term.Param(Nil, Term.Name("x"), Some(Type.Name("X")), None),
+        Term.Param(Nil, Term.Name("y"), Some(Type.Name("Y")), None)
+      )
+    })
     assertTree(tpe)(Type.Name("R"))
   }
 
@@ -1622,11 +1622,12 @@ class SuccessSuite extends TreeSuiteBase {
         Type.Param(Nil, Type.Name("W"), Type.ParamClause(Nil), Type.Bounds(None, None), Nil, Nil)
       )
     })
-    assertEquals(paramss.map(_.toString), List("List(x: X, y: Y)"))
-    assertTrees(paramss(0): _*)(
-      Term.Param(Nil, Term.Name("x"), Some(Type.Name("X")), None),
-      Term.Param(Nil, Term.Name("y"), Some(Type.Name("Y")), None)
-    )
+    checkTreesWithSyntax(paramss: _*)("(x: X, y: Y)")(Term.ParamClause {
+      List(
+        Term.Param(Nil, Term.Name("x"), Some(Type.Name("X")), None),
+        Term.Param(Nil, Term.Name("y"), Some(Type.Name("Y")), None)
+      )
+    })
     assertTree(tpeopt)(Some(Type.Name("R")))
     assertTree(expr)(Term.Name("r"))
   }
@@ -1671,11 +1672,12 @@ class SuccessSuite extends TreeSuiteBase {
         Type.Param(Nil, Type.Name("W"), Type.ParamClause(Nil), Type.Bounds(None, None), Nil, Nil)
       )
     })
-    assertEquals(paramss.map(_.toString), List("List(x: X, y: Y)"))
-    assertTrees(paramss(0): _*)(
-      Term.Param(Nil, Term.Name("x"), Some(Type.Name("X")), None),
-      Term.Param(Nil, Term.Name("y"), Some(Type.Name("Y")), None)
-    )
+    checkTreesWithSyntax(paramss: _*)("(x: X, y: Y)")(Term.ParamClause {
+      List(
+        Term.Param(Nil, Term.Name("x"), Some(Type.Name("X")), None),
+        Term.Param(Nil, Term.Name("y"), Some(Type.Name("Y")), None)
+      )
+    })
     assertTree(tpeopt)(Some(Type.Name("R")))
     assertTree(expr)(Term.Name("r"))
   }
@@ -1755,11 +1757,12 @@ class SuccessSuite extends TreeSuiteBase {
       )
     })
     assertTree(mod)(Mod.Private(Name("")))
-    assertEquals(paramss.map(_.toString), List("List(x: X, y: Y)"))
-    assertTrees(paramss(0): _*)(
-      Term.Param(Nil, Term.Name("x"), Some(Type.Name("X")), None),
-      Term.Param(Nil, Term.Name("y"), Some(Type.Name("Y")), None)
-    )
+    checkTreesWithSyntax(paramss: _*)("(x: X, y: Y)")(Term.ParamClause {
+      List(
+        Term.Param(Nil, Term.Name("x"), Some(Type.Name("X")), None),
+        Term.Param(Nil, Term.Name("y"), Some(Type.Name("Y")), None)
+      )
+    })
     assertTree(template)(
       Template(Nil, List(Init(Type.Name("Y"), Name(""), Nil)), Self(Name(""), None), Nil, Nil)
     )
@@ -1779,11 +1782,12 @@ class SuccessSuite extends TreeSuiteBase {
       )
     })
     assertTree(mod)(Mod.Protected(Name("")))
-    assertEquals(paramss.map(_.toString), List("List(x: X, y: Y)"))
-    assertTrees(paramss(0): _*)(
-      Term.Param(Nil, Term.Name("x"), Some(Type.Name("X")), None),
-      Term.Param(Nil, Term.Name("y"), Some(Type.Name("Y")), None)
-    )
+    checkTreesWithSyntax(paramss: _*)("(x: X, y: Y)")(Term.ParamClause {
+      List(
+        Term.Param(Nil, Term.Name("x"), Some(Type.Name("X")), None),
+        Term.Param(Nil, Term.Name("y"), Some(Type.Name("Y")), None)
+      )
+    })
     assertTree(template)(
       Template(
         Nil,
@@ -2060,11 +2064,12 @@ class SuccessSuite extends TreeSuiteBase {
     val q"..$mods def this(...$paramss)" = q"private def this(x: X, y: Y)"
     assertEquals(mods.toString, "List(private)")
     assertTrees(mods: _*)(Mod.Private(Name("")))
-    assertEquals(paramss.map(_.toString), List("List(x: X, y: Y)"))
-    assertTrees(paramss(0): _*)(
-      Term.Param(Nil, Term.Name("x"), Some(Type.Name("X")), None),
-      Term.Param(Nil, Term.Name("y"), Some(Type.Name("Y")), None)
-    )
+    checkTreesWithSyntax(paramss: _*)("(x: X, y: Y)")(Term.ParamClause {
+      List(
+        Term.Param(Nil, Term.Name("x"), Some(Type.Name("X")), None),
+        Term.Param(Nil, Term.Name("y"), Some(Type.Name("Y")), None)
+      )
+    })
   }
 
   test("2 q\"..mods def this(...paramss)\"") {
@@ -2089,11 +2094,12 @@ class SuccessSuite extends TreeSuiteBase {
       q"private final def this(x: X, y: Y) = this(foo, bar)"
     assertEquals(mods.toString, "List(private, final)")
     assertTrees(mods: _*)(Mod.Private(Name("")), Mod.Final())
-    assertEquals(paramss.map(_.toString), List("List(x: X, y: Y)"))
-    assertTrees(paramss(0): _*)(
-      Term.Param(Nil, Term.Name("x"), Some(Type.Name("X")), None),
-      Term.Param(Nil, Term.Name("y"), Some(Type.Name("Y")), None)
-    )
+    checkTreesWithSyntax(paramss: _*)("(x: X, y: Y)")(Term.ParamClause {
+      List(
+        Term.Param(Nil, Term.Name("x"), Some(Type.Name("X")), None),
+        Term.Param(Nil, Term.Name("y"), Some(Type.Name("Y")), None)
+      )
+    })
     assertTree(init)(
       Init(
         Type.Singleton(Term.This(Name(""))),
@@ -2587,7 +2593,9 @@ class SuccessSuite extends TreeSuiteBase {
     val q"..$mods def $name[..$tparams](...$paramss): $tpe = $rhs" = q"def f(x: Int) = ???"
     assert(tparams.isEmpty)
     assertEquals(paramss.lengthCompare(1), 0)
-    assertTrees(paramss.head: _*)(Term.Param(Nil, Term.Name("x"), Some(Type.Name("Int")), None))
+    checkTreesWithSyntax(paramss: _*)("(x: Int)")(Term.ParamClause {
+      List(Term.Param(Nil, Term.Name("x"), Some(Type.Name("Int")), None))
+    })
     assertTree(q"..$mods def $name[..$tparams](...$paramss): $tpe = $rhs")(
       Defn.Def(
         Nil,
@@ -2607,8 +2615,9 @@ class SuccessSuite extends TreeSuiteBase {
         Type.Param(Nil, Type.Name("A"), Type.ParamClause(Nil), Type.Bounds(None, None), Nil, Nil)
       )
     })
-    assertEquals(paramss.lengthCompare(1), 0)
-    assertTrees(paramss.head: _*)(Term.Param(Nil, Term.Name("x"), Some(Type.Name("Int")), None))
+    checkTreesWithSyntax(paramss: _*)("(x: Int)")(Term.ParamClause {
+      List(Term.Param(Nil, Term.Name("x"), Some(Type.Name("Int")), None))
+    })
     assertTree(q"..$mods def $name[..$tparams](...$paramss): $tpe = $rhs")(
       Defn.Def(
         Nil,
@@ -2746,22 +2755,21 @@ class SuccessSuite extends TreeSuiteBase {
 
   test("#468 - primary constructor III") {
     val q"case class A(..$params)" = q"case class A(a: Int, b: String)"
-    assertEquals(params.length, 2)
-    checkTreesWithSyntax(params: _*)("a: Int", "b: String")(
-      Term.Param(Nil, Term.Name("a"), Some(Type.Name("Int")), None),
-      Term.Param(Nil, Term.Name("b"), Some(Type.Name("String")), None)
-    )
+    checkTreesWithSyntax(params)("(a: Int, b: String)")(Term.ParamClause {
+      List(
+        Term.Param(Nil, Term.Name("a"), Some(Type.Name("Int")), None),
+        Term.Param(Nil, Term.Name("b"), Some(Type.Name("String")), None)
+      )
+    })
   }
 
   test("#468 - primary constructor IV") {
     val q"case class A(...$paramss)" = q"case class A(a: Int)(b: String)"
     assertEquals(paramss.length, 2)
-    checkTreesWithSyntax(paramss(0): _*)("a: Int") {
-      Term.Param(Nil, Term.Name("a"), Some(Type.Name("Int")), None)
-    }
-    checkTreesWithSyntax(paramss(1): _*)("b: String") {
-      Term.Param(Nil, Term.Name("b"), Some(Type.Name("String")), None)
-    }
+    checkTreesWithSyntax(paramss: _*)("(a: Int)", "(b: String)")(
+      Term.ParamClause(List(Term.Param(Nil, Term.Name("a"), Some(Type.Name("Int")), None))),
+      Term.ParamClause(List(Term.Param(Nil, Term.Name("b"), Some(Type.Name("String")), None)))
+    )
   }
 
   test("#468 - function parameter list I") {
@@ -2777,50 +2785,37 @@ class SuccessSuite extends TreeSuiteBase {
 
   test("#468 - function parameter list III") {
     val q"def foo(..$params): Int = a" = q"def foo(a: Int, b: String): Int = a"
-    assertEquals(params.length, 2)
-    checkTreesWithSyntax(params: _*)("a: Int", "b: String")(
-      Term.Param(Nil, Term.Name("a"), Some(Type.Name("Int")), None),
-      Term.Param(Nil, Term.Name("b"), Some(Type.Name("String")), None)
-    )
+    checkTreesWithSyntax(params)("(a: Int, b: String)")(Term.ParamClause {
+      List(
+        Term.Param(Nil, Term.Name("a"), Some(Type.Name("Int")), None),
+        Term.Param(Nil, Term.Name("b"), Some(Type.Name("String")), None)
+      )
+    })
   }
 
   test("#468 - function parameter list IV") {
     val q"def foo(...$paramss): Int = a" = q"def foo(a: Int)(b: String): Int = a"
     assertEquals(paramss.length, 2)
-    checkTreesWithSyntax(paramss(0): _*)("a: Int") {
-      Term.Param(Nil, Term.Name("a"), Some(Type.Name("Int")), None)
-    }
-    checkTreesWithSyntax(paramss(1): _*)("b: String") {
-      Term.Param(Nil, Term.Name("b"), Some(Type.Name("String")), None)
-    }
-    paramss(0) match {
-      case (head: Tree) +: rest => // tests "+:"
-        checkTree(head, "a: Int") {
-          Term.Param(Nil, Term.Name("a"), Some(Type.Name("Int")), None)
-        }
-        assert(rest.isEmpty)
-      case x => fail(s"cannot match on `+:` pattern: $x")
-    }
-    paramss(1) match {
-      case (head: Tree) +: rest =>
-        checkTree(head, "b: String") {
-          Term.Param(Nil, Term.Name("b"), Some(Type.Name("String")), None)
-        }
-        assert(rest.isEmpty)
-      case x => fail(s"cannot match on `+:` pattern: $x")
-    }
+    checkTreesWithSyntax(paramss: _*)("(a: Int)", "(b: String)")(
+      Term.ParamClause(List(Term.Param(Nil, Term.Name("a"), Some(Type.Name("Int")), None))),
+      Term.ParamClause(List(Term.Param(Nil, Term.Name("b"), Some(Type.Name("String")), None)))
+    )
   }
 
   test("#468 - function parameter list V") {
-    assertEquals(
-      typecheckError(
-        """
-    val q"def foo(...$paramss)(..$params)($param): Int = a" = q"def foo(a: Int)(b: String)(c: Long): Int = a"
-        """
-      ).replace("\r", ""),
-      """|implementation restriction: can't mix ...$ with anything else in parameter lists.
-         |See https://github.com/scalameta/scalameta/issues/406 for details.""".stripMargin
-    )
+    val q"def foo(...$paramss)(..$params)($param): Int = a" =
+      q"def foo(a: Int)(b: String)(c: Long): Int = a"
+    assertEquals(paramss.length, 1)
+    assertEquals(params.length, 1)
+    checkTree(paramss(0), "(a: Int)")(Term.ParamClause {
+      List(Term.Param(Nil, Term.Name("a"), Some(Type.Name("Int")), None))
+    })
+    checkTree(params(0), "b: String") {
+      Term.Param(Nil, Term.Name("b"), Some(Type.Name("String")), None)
+    }
+    checkTree(param, "c: Long") {
+      Term.Param(Nil, Term.Name("c"), Some(Type.Name("Long")), None)
+    }
   }
 
   test("#230 - tparam extensions I") {

--- a/tests/shared/src/test/scala/scala/meta/tests/transversers/SimpleTraverserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/transversers/SimpleTraverserSuite.scala
@@ -29,9 +29,11 @@ class SimpleTraverserSuite extends FunSuite {
       |def foo(x: x)(x: Int) = x + x
       |foo
       |
+      |(x: x)
       |x: x
       |x
       |x
+      |(x: Int)
       |x: Int
       |x
       |Int
@@ -44,6 +46,7 @@ class SimpleTraverserSuite extends FunSuite {
       |
       |def this(x: x)
       |_
+      |(x: x)
       |x: x
       |x
       |x
@@ -53,6 +56,7 @@ class SimpleTraverserSuite extends FunSuite {
       |def bar(x: x) = ???
       |bar
       |
+      |(x: x)
       |x: x
       |x
       |x

--- a/tests/shared/src/test/scala/scala/meta/tests/transversers/TraverserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/transversers/TraverserSuite.scala
@@ -28,9 +28,11 @@ class TraverserSuite extends FunSuite {
       |def foo(x: x)(x: Int) = x + x
       |foo
       |
+      |(x: x)
       |x: x
       |x
       |x
+      |(x: Int)
       |x: Int
       |x
       |Int
@@ -43,6 +45,7 @@ class TraverserSuite extends FunSuite {
       |
       |def this(x: x)
       |_
+      |(x: x)
       |x: x
       |x
       |x
@@ -52,6 +55,7 @@ class TraverserSuite extends FunSuite {
       |def bar(x: x) = ???
       |bar
       |
+      |(x: x)
       |x: x
       |x
       |x


### PR DESCRIPTION
duplicate of #2919.