### PR TITLE
Trees: add interleaved param groups to Def/Macro for parameter clause interleaving

### DIFF
--- a/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
@@ -153,6 +153,8 @@ final class Dialect private (
     val useInfixTypePrecedence: Boolean,
     // Scala213Source3 and Scala3 allow infix operator being placed after nl
     val allowInfixOperatorAfterNL: Boolean,
+    // Scala 3 allows `def f[X](x: X)[Y](y: Y)`
+    val allowParamClauseInterleaving: Boolean,
     /* Scala 3 allows dropping braces for block arguments such as `list.map: a =>`
      * It wasn't available in Scala 3.0 and got introduced later.
      */
@@ -248,6 +250,7 @@ final class Dialect private (
       allowGivenImports = false,
       useInfixTypePrecedence = false,
       allowInfixOperatorAfterNL = false,
+      allowParamClauseInterleaving = false,
       allowFewerBraces = false
       // NOTE(olafur): declare the default value for new fields above this comment.
     )
@@ -462,6 +465,10 @@ final class Dialect private (
     privateCopy(allowInfixOperatorAfterNL = newValue)
   }
 
+  def withAllowParamClauseInterleaving(newValue: Boolean): Dialect = {
+    privateCopy(allowParamClauseInterleaving = newValue)
+  }
+
   def withAllowFewerBraces(newValue: Boolean): Dialect = {
     privateCopy(allowFewerBraces = newValue)
   }
@@ -531,6 +538,7 @@ final class Dialect private (
       allowGivenImports: Boolean = this.allowGivenImports,
       useInfixTypePrecedence: Boolean = this.useInfixTypePrecedence,
       allowInfixOperatorAfterNL: Boolean = this.allowInfixOperatorAfterNL,
+      allowParamClauseInterleaving: Boolean = this.allowParamClauseInterleaving,
       allowFewerBraces: Boolean = this.allowFewerBraces
       // NOTE(olafur): add the next parameter above this comment.
   ): Dialect = {
@@ -594,6 +602,7 @@ final class Dialect private (
       allowGivenImports,
       useInfixTypePrecedence,
       allowInfixOperatorAfterNL,
+      allowParamClauseInterleaving,
       allowFewerBraces
       // NOTE(olafur): add the next argument above this comment.
     )
@@ -677,6 +686,8 @@ final class Dialect private (
       && this.allowGivenImports == that.allowGivenImports
       && this.useInfixTypePrecedence == that.useInfixTypePrecedence
       && this.allowInfixOperatorAfterNL == that.allowInfixOperatorAfterNL
+      && this.allowParamClauseInterleaving == that.allowParamClauseInterleaving
+      && this.allowFewerBraces == that.allowFewerBraces
   )
 
   @deprecated("Use withX method instead", "4.3.11")

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -150,7 +150,9 @@ package object dialects {
 
   implicit val Scala32 = Scala31
 
-  implicit val Scala33 = Scala32.withAllowFewerBraces(true)
+  implicit val Scala33 = Scala32
+    .withAllowFewerBraces(true)
+    .withAllowParamClauseInterleaving(true)
 
   implicit val Scala3 = Scala33
 

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -792,7 +792,7 @@ object TreeSyntax {
         s(w(t.mods, " "), kw("var"), " ", r(t.pats, ", "), kw(":"), " ", t.decltpe)
       case t: Decl.Type => s(w(t.mods, " "), kw("type"), " ", t.name, t.tparamClause, t.bounds)
       case t: Decl.Def =>
-        s(w(t.mods, " "), kw("def "), t.name, o(t.paramClauseGroup), kw(": "), t.decltpe)
+        s(w(t.mods, " "), kw("def "), t.name, t.paramClauseGroups, kw(": "), t.decltpe)
       case t: Decl.Given =>
         s(w(t.mods, " "), kw("given "), t.name, o(t.paramClauseGroup), kw(": "), t.decltpe)
       case t: Defn.Val =>
@@ -865,9 +865,9 @@ object TreeSyntax {
         s(kw("extension"), " ", o(t.paramClauseGroup), m)
       case t: Defn.Object => r(" ")(t.mods, kw("object"), t.name, t.templ)
       case t: Defn.Def =>
-        s(w(t.mods, " "), kw("def "), t.name, o(t.paramClauseGroup), t.decltpe, " = ", t.body)
+        s(w(t.mods, " "), kw("def "), t.name, t.paramClauseGroups, t.decltpe, " = ", t.body)
       case t: Defn.Macro =>
-        s(w(t.mods, " "), kw("def "), t.name, o(t.paramClauseGroup), t.decltpe, " = macro ", t.body)
+        s(w(t.mods, " "), kw("def "), t.name, t.paramClauseGroups, t.decltpe, " = macro ", t.body)
       case t: Pkg =>
         if (guessHasBraces(t)) s(kw("package"), " ", t.ref, " {", r(t.stats.map(i(_)), ""), n("}"))
         else s(kw("package"), " ", t.ref, r(t.stats.map(n(_))))
@@ -1044,6 +1044,7 @@ object TreeSyntax {
         case _ => s(args)
       }
 
+    implicit def syntaxParamClauseGroups: Syntax[Seq[Member.ParamClauseGroup]] = Syntax { r(_) }
     implicit def syntaxArgss: Syntax[Seq[Term.ArgClause]] = Syntax { r(_) }
     implicit def syntaxMods: Syntax[Seq[Mod]] = Syntax { r(_, " ") }
     private def isUsingOrImplicit(m: Mod): Boolean = m.is[Mod.ParamsType]

--- a/tests/js/src/test/scala/scala/meta/tests/parsers/JSFacadeSuite.scala
+++ b/tests/js/src/test/scala/scala/meta/tests/parsers/JSFacadeSuite.scala
@@ -63,7 +63,7 @@ class JSFacadeSuite extends FunSuite {
                   "pos" -> pos(20, 24),
                   "value" -> "main"
                 ),
-                "paramClauseGroup" -> {
+                "paramClauseGroups" -> a(
                   d(
                     "type" -> "Member.ParamClauseGroup",
                     "pos" -> pos(24, 45),
@@ -111,7 +111,7 @@ class JSFacadeSuite extends FunSuite {
                       )
                     )
                   )
-                },
+                ),
                 "decltpe" -> d(
                   "type" -> "Type.Name",
                   "pos" -> pos(47, 51),

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -419,6 +419,7 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.Tree.WithDeclTpeOpt
       |scala.meta.Tree.WithEnums
       |scala.meta.Tree.WithParamClauseGroup
+      |scala.meta.Tree.WithParamClauseGroups
       |scala.meta.Tree.WithParamClauses
       |scala.meta.Tree.WithTParamClause
       |scala.meta.Type

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
@@ -24,7 +24,7 @@ class ReflectionSuite extends FunSuite {
     val sym = symbolOf[scala.meta.Tree]
     assert(sym.isRoot)
     val root = sym.asRoot
-    assertEquals((root.allBranches.length, root.allLeafs.length), (46, 398))
+    assertEquals((root.allBranches.length, root.allLeafs.length), (47, 399))
   }
 
   test("If") {
@@ -83,6 +83,7 @@ class ReflectionSuite extends FunSuite {
       |List[scala.meta.Importer]
       |List[scala.meta.Init]
       |List[scala.meta.Lit]
+      |List[scala.meta.Member.ParamClauseGroup]
       |List[scala.meta.Mod.Annot]
       |List[scala.meta.Mod]
       |List[scala.meta.Pat]

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InterleavedDeclSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InterleavedDeclSuite.scala
@@ -1,0 +1,180 @@
+package scala.meta.tests.parsers.dotty
+
+import scala.meta._
+
+class InterleavedDeclSuite extends BaseDottySuite {
+
+  import dialects.Scala3Future
+
+  protected override val dialect: Dialect = Scala3Future
+
+  test("def f: Unit") {
+    checkTree(templStat("def f: Unit")) {
+      Decl.Def(Nil, Term.Name("f"), Nil, Nil, Type.Name("Unit"))
+    }
+  }
+
+  test("def f(x: Int): Unit") {
+    checkTree(templStat("def f(x: Int): Unit")) {
+      Decl.Def(
+        Nil,
+        Term.Name("f"),
+        Nil,
+        List(
+          Term.Param(Nil, Term.Name("x"), Some(Type.Name("Int")), None) :: Nil
+        ),
+        Type.Name("Unit")
+      )
+    }
+  }
+
+  test("def f(x: Int*): Unit") {
+    checkTree(templStat("def f(x: Int*): Unit")) {
+      Decl.Def(
+        Nil,
+        Term.Name("f"),
+        Nil,
+        List(
+          Term.Param(Nil, Term.Name("x"), Some(Type.Repeated(Type.Name("Int"))), None) :: Nil
+        ),
+        Type.Name("Unit")
+      )
+    }
+  }
+
+  test("def f(x: => Int): Unit") {
+    checkTree(templStat("def f(x: => Int): Unit")) {
+      Decl.Def(
+        Nil,
+        Term.Name("f"),
+        Nil,
+        List(
+          Term.Param(Nil, Term.Name("x"), Some(Type.ByName(Type.Name("Int"))), None) :: Nil
+        ),
+        Type.Name("Unit")
+      )
+    }
+  }
+
+  test("def f(implicit x: Int): Unit") {
+    checkTree(templStat("def f(implicit x: Int): Unit")) {
+      Decl.Def(
+        Nil,
+        Term.Name("f"),
+        Nil,
+        List(
+          Term.Param(Mod.Implicit() :: Nil, Term.Name("x"), Some(Type.Name("Int")), None) :: Nil
+        ),
+        Type.Name("Unit")
+      )
+    }
+  }
+
+  test("def f: X") {
+    checkTree(templStat("def f: X")) {
+      Decl.Def(Nil, Term.Name("f"), Nil, Nil, Type.Name("X"))
+    }
+  }
+
+  test("def f[T]: T") {
+    checkTree(templStat("def f[T]: T")) {
+      Decl.Def(
+        Nil,
+        Term.Name("f"),
+        Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, Nil) :: Nil,
+        Nil,
+        Type.Name("T")
+      )
+    }
+  }
+
+  test("def f[A][B]: A") {
+    runTestError[Stat](
+      "def f[A][B]: A",
+      """|error: = expected but [ found
+         |def f[A][B]: A
+         |        ^""".stripMargin
+    )
+  }
+
+  test("def f[A](a: A, as: A*)[B]: B") {
+    runTestError[Stat](
+      "def f[A](a: A, as: A*)[B]: B",
+      """|error: = expected but [ found
+         |def f[A](a: A, as: A*)[B]: B
+         |                      ^""".stripMargin
+    )
+  }
+
+  test("def f[A](implicit a: A)[B](implicit b: B): B") {
+    runTestError[Stat](
+      "def f[A](implicit a: A)[B](implicit b: B): B",
+      """|error: = expected but [ found
+         |def f[A](implicit a: A)[B](implicit b: B): B
+         |                       ^""".stripMargin
+    )
+  }
+
+  test("def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B") {
+    runTestError[Stat](
+      "def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B",
+      """|error: = expected but [ found
+         |def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B
+         |                      ^""".stripMargin
+    )
+  }
+
+  test("single ..., without tparams") {
+    val q"..$mods def $name(...$paramss): $tpe" = q"def f(x: Int)(y: Int): Unit"
+    val paramsExpected =
+      Term.ParamClause(
+        Term.Param(Nil, Term.Name("x"), Some(Type.Name("Int")), None) :: Nil,
+        None
+      ) :: Term.ParamClause(
+        Term.Param(Nil, Term.Name("y"), Some(Type.Name("Int")), None) :: Nil,
+        None
+      ) :: Nil
+
+    checkTreesWithSyntax(paramss: _*)("(x: Int)", "(y: Int)")(paramsExpected: _*)
+    assertTree(q"..$mods def $name(...$paramss): $tpe")(
+      Decl.Def(
+        Nil,
+        Term.Name("f"),
+        Nil,
+        paramsExpected.map(_.values),
+        Type.Name("Unit")
+      )
+    )
+  }
+
+  test("single ..., with tparams") {
+    val q"..$mods def $name[..$tparams](...$paramss): $tpe" = q"def f[A, B](x: Int)(y: Int): Unit"
+    val tparamsExpected = Type.ParamClause(
+      List(
+        Type.Param(Nil, Type.Name("A"), Type.ParamClause(Nil), Type.Bounds(None, None), Nil, Nil),
+        Type.Param(Nil, Type.Name("B"), Type.ParamClause(Nil), Type.Bounds(None, None), Nil, Nil)
+      )
+    )
+    val paramsExpected =
+      Term.ParamClause(
+        Term.Param(Nil, Term.Name("x"), Some(Type.Name("Int")), None) :: Nil,
+        None
+      ) :: Term.ParamClause(
+        Term.Param(Nil, Term.Name("y"), Some(Type.Name("Int")), None) :: Nil,
+        None
+      ) :: Nil
+
+    checkTree(tparams, "[A, B]")(tparamsExpected)
+    checkTreesWithSyntax(paramss: _*)("(x: Int)", "(y: Int)")(paramsExpected: _*)
+    assertTree(q"..$mods def $name[..$tparams](...$paramss): $tpe")(
+      Decl.Def(
+        Nil,
+        Term.Name("f"),
+        tparamsExpected.values,
+        paramsExpected.map(_.values),
+        Type.Name("Unit")
+      )
+    )
+  }
+
+}

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InterleavedDefnSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InterleavedDefnSuite.scala
@@ -10,7 +10,7 @@ class InterleavedDefnSuite extends BaseDottySuite {
 
   test("def x = 2") {
     checkTree(templStat("def x = 2")) {
-      Defn.Def(Nil, Term.Name("x"), Nil, Nil, None, Lit.Int(2))
+      Defn.Def(Nil, Term.Name("x"), Nil, None, Lit.Int(2))
     }
   }
 
@@ -111,7 +111,6 @@ class InterleavedDefnSuite extends BaseDottySuite {
         Nil,
         Term.Name("f"),
         Nil,
-        Nil,
         None,
         Term.Block(
           List(
@@ -159,12 +158,34 @@ class InterleavedDefnSuite extends BaseDottySuite {
   }
 
   test("def f[A](a: A, as: A*)[B]: B = ???") {
-    runTestError[Stat](
-      "def f[A](a: A, as: A*)[B]: B = ???",
-      """|error: = expected but [ found
-         |def f[A](a: A, as: A*)[B]: B = ???
-         |                      ^""".stripMargin
-    )
+    runTestAssert[Stat]("def f[A](a: A, as: A*)[B]: B = ???") {
+      Defn.Def(
+        Nil,
+        Term.Name("f"),
+        List(
+          Member.ParamClauseGroup(
+            Type.ParamClause(
+              Type.Param(Nil, Type.Name("A"), Nil, Type.Bounds(None, None), Nil, Nil) :: Nil
+            ),
+            Term.ParamClause(
+              List(
+                Term.Param(Nil, Term.Name("a"), Some(Type.Name("A")), None),
+                Term.Param(Nil, Term.Name("as"), Some(Type.Repeated(Type.Name("A"))), None)
+              ),
+              None
+            ) :: Nil
+          ),
+          Member.ParamClauseGroup(
+            Type.ParamClause(
+              Type.Param(Nil, Type.Name("B"), Nil, Type.Bounds(None, None), Nil, Nil) :: Nil
+            ),
+            Nil
+          )
+        ),
+        Some(Type.Name("B")),
+        Term.Name("???")
+      )
+    }
   }
 
   test("def f[A](implicit a: A)[B](implicit b: B): B = ???") {
@@ -177,12 +198,49 @@ class InterleavedDefnSuite extends BaseDottySuite {
   }
 
   test("def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???") {
-    runTestError[Stat](
-      "def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???",
-      """|error: = expected but [ found
-         |def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
-         |                      ^""".stripMargin
-    )
+    runTestAssert[Stat]("def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???") {
+      Defn.Def(
+        Nil,
+        Term.Name("f"),
+        List(
+          Member.ParamClauseGroup(
+            Type.ParamClause(
+              Type.Param(Nil, Type.Name("A"), Nil, Type.Bounds(None, None), Nil, Nil) :: Nil
+            ),
+            Term.ParamClause(
+              List(
+                Term.Param(Nil, Term.Name("a"), Some(Type.Name("A")), None),
+                Term.Param(Nil, Term.Name("as"), Some(Type.Repeated(Type.Name("A"))), None)
+              ),
+              None
+            ) :: Nil
+          ),
+          Member.ParamClauseGroup(
+            Type.ParamClause(
+              Type.Param(Nil, Type.Name("B"), Nil, Type.Bounds(None, None), Nil, Nil) :: Nil
+            ),
+            Term.ParamClause(
+              List(
+                Term.Param(Nil, Term.Name("b"), Some(Type.Name("B")), None),
+                Term.Param(Nil, Term.Name("bs"), Some(Type.Repeated(Type.Name("B"))), None)
+              ),
+              None
+            ) :: Nil
+          ),
+          Member.ParamClauseGroup(
+            Type.ParamClause(
+              Type.Param(Nil, Type.Name("C"), Nil, Type.Bounds(None, None), Nil, Nil) :: Nil
+            ),
+            Term.ParamClause(
+              List(Term.Param(List(Mod.Implicit()), Term.Name("c"), Some(Type.Name("C")), None)),
+              Some(Mod.Implicit())
+            ) :: Nil
+          )
+        ),
+        Some(Type.Name("B")),
+        Term.Name("???")
+      )
+    }
   }
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InterleavedDefnSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InterleavedDefnSuite.scala
@@ -1,0 +1,188 @@
+package scala.meta.tests.parsers.dotty
+
+import scala.meta._
+
+class InterleavedDefnSuite extends BaseDottySuite {
+
+  import dialects.Scala3Future
+
+  protected override val dialect: Dialect = Scala3Future
+
+  test("def x = 2") {
+    checkTree(templStat("def x = 2")) {
+      Defn.Def(Nil, Term.Name("x"), Nil, Nil, None, Lit.Int(2))
+    }
+  }
+
+  test("def x[A <: B] = 2") {
+    checkTree(templStat("def x[A <: B] = 2")) {
+      Defn.Def(
+        Nil,
+        Term.Name("x"),
+        Type.Param(
+          Nil,
+          Type.Name("A"),
+          Type.ParamClause(Nil),
+          Type.Bounds(None, Some(Type.Name("B"))),
+          Nil,
+          Nil
+        ) :: Nil,
+        Nil,
+        None,
+        Lit.Int(2)
+      )
+    }
+  }
+
+  test("def x[A: B] = 2") {
+    checkTree(templStat("def x[A: B] = 2")) {
+      Defn.Def(
+        Nil,
+        Term.Name("x"),
+        Type.Param(
+          Nil,
+          Type.Name("A"),
+          Type.ParamClause(Nil),
+          Type.Bounds(None, None),
+          Nil,
+          Type.Name("B") :: Nil
+        ) :: Nil,
+        Nil,
+        None,
+        Lit.Int(2)
+      )
+    }
+  }
+
+  test("def f(a: Int)(implicit b: Int) = a + b") {
+    checkTree(templStat("def f(a: Int)(implicit b: Int) = a + b")) {
+      Defn.Def(
+        Nil,
+        Term.Name("f"),
+        Nil,
+        List(
+          Term.Param(Nil, Term.Name("a"), Some(Type.Name("Int")), None) :: Nil,
+          Term.Param(Mod.Implicit() :: Nil, Term.Name("b"), Some(Type.Name("Int")), None) :: Nil
+        ),
+        None,
+        Term.ApplyInfix(Term.Name("a"), Term.Name("+"), Nil, Term.Name("b") :: Nil)
+      )
+    }
+  }
+
+  test("def f(x: Int) = macro impl") {
+    checkTree(templStat("def f(x: Int) = macro impl")) {
+      Defn.Macro(
+        Nil,
+        Term.Name("f"),
+        Nil,
+        List(Term.Param(List(), Term.Name("x"), Some(Type.Name("Int")), None) :: Nil),
+        None,
+        Term.Name("impl")
+      )
+    }
+  }
+
+  test("def f(x: Int): Int = macro impl") {
+    checkTree(templStat("def f(x: Int): Int = macro impl")) {
+      Defn.Macro(
+        Nil,
+        Term.Name("f"),
+        Nil,
+        List(Term.Param(List(), Term.Name("x"), Some(Type.Name("Int")), None) :: Nil),
+        Some(Type.Name("Int")),
+        Term.Name("impl")
+      )
+    }
+  }
+
+  test("braces-in-functions") {
+    val defn = templStat(
+      """|def f = { (n: Int) =>
+         |  {
+         |    for {
+         |      _ <- scala.util.Success(123)
+         |    } yield 42
+         |  }.recover(???)
+         |}""".stripMargin
+    )
+    checkTree(defn)(
+      Defn.Def(
+        Nil,
+        Term.Name("f"),
+        Nil,
+        Nil,
+        None,
+        Term.Block(
+          List(
+            Term.Function(
+              List(Term.Param(Nil, Term.Name("n"), Some(Type.Name("Int")), None)),
+              Term.Apply(
+                Term.Select(
+                  Term.Block(
+                    List(
+                      Term.ForYield(
+                        List(
+                          Enumerator.Generator(
+                            Pat.Wildcard(),
+                            Term.Apply(
+                              Term.Select(
+                                Term.Select(Term.Name("scala"), Term.Name("util")),
+                                Term.Name("Success")
+                              ),
+                              List(Lit.Int(123))
+                            )
+                          )
+                        ),
+                        Lit.Int(42)
+                      )
+                    )
+                  ),
+                  Term.Name("recover")
+                ),
+                List(Term.Name("???"))
+              )
+            )
+          )
+        )
+      )
+    )
+  }
+
+  test("def f[A][B]: A = ???") {
+    runTestError[Stat](
+      "def f[A][B]: A = ???",
+      """|error: = expected but [ found
+         |def f[A][B]: A = ???
+         |        ^""".stripMargin
+    )
+  }
+
+  test("def f[A](a: A, as: A*)[B]: B = ???") {
+    runTestError[Stat](
+      "def f[A](a: A, as: A*)[B]: B = ???",
+      """|error: = expected but [ found
+         |def f[A](a: A, as: A*)[B]: B = ???
+         |                      ^""".stripMargin
+    )
+  }
+
+  test("def f[A](implicit a: A)[B](implicit b: B): B = ???") {
+    runTestError[Stat](
+      "def f[A](implicit a: A)[B](implicit b: B): B = ???",
+      """|error: = expected but [ found
+         |def f[A](implicit a: A)[B](implicit b: B): B = ???
+         |                       ^""".stripMargin
+    )
+  }
+
+  test("def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???") {
+    runTestError[Stat](
+      "def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???",
+      """|error: = expected but [ found
+         |def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???
+         |                      ^""".stripMargin
+    )
+  }
+
+}


### PR DESCRIPTION
Also, add `Dialect.allowParamClauseInterleaving`. Based on #2820.
