### PR TITLE
TreeSyntax: don't print Name.Anonymous

### DIFF
--- a/scalameta/common/shared/src/main/scala/scala/meta/prettyprinters/Show.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/prettyprinters/Show.scala
@@ -117,8 +117,12 @@ private[meta] object Show {
   }
 
   def opt[T](x: Option[T])(implicit show: Show[T]): Result = x.fold[Result](None)(show(_))
-  def opt[T](x: Option[T], suffix: String)(implicit show: Show[T]): Result =
+  def opt[T](x: Option[T], suffix: Result)(implicit show: Show[T]): Result =
     x.fold[Result](None)(x => Sequence(show(x), suffix))
+  def opt[T](prefix: Result, x: Option[T])(implicit show: Show[T]): Result =
+    x.fold[Result](None)(x => Sequence(prefix, show(x)))
+  def opt[T](prefix: Result, x: Option[T], suffix: Result)(implicit show: Show[T]): Result =
+    x.fold[Result](None)(x => Sequence(prefix, show(x), suffix))
 
   def function(fn: StringBuilder => Result): Result = Function(fn)
 

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -311,18 +311,15 @@ object TreeSyntax {
         }
 
       // Name
-      case t: Name.Anonymous => s("_")
-      case t: Term.Anonymous => s("")
+      case _: Name.Anonymous => s()
+      case _: Term.Anonymous => s("")
       case t: Name.Indeterminate => w("`", t.value, "`", guessIsBackquoted(t))
 
       // Term
       case t: Term.This =>
-        val qual = if (t.qual.is[Name.Anonymous]) s() else s(t.qual, ".")
-        m(Path, qual, kw("this"))
+        m(Path, w(t.qual, "."), kw("this"))
       case t: Term.Super =>
-        val thisqual = if (t.thisp.is[Name.Anonymous]) s() else s(t.thisp, ".")
-        val superqual = if (t.superp.is[Name.Anonymous]) s() else s("[", t.superp, "]")
-        m(Path, s(thisqual, kw("super"), superqual))
+        m(Path, s(w(t.thisp, "."), kw("super"), w("[", t.superp, "]")))
       case t: Term.Name =>
         m(Path, w("`", t.value, "`", guessIsBackquoted(t)))
       case t: Term.Select =>
@@ -418,7 +415,7 @@ object TreeSyntax {
               )
             )
           case Block(
-                Function(Term.Param(mods, name: Term.Name, None, _) :: Nil, Block(stats)) :: Nil
+                Function(Term.Param(_, name: Name, None, _) :: Nil, Block(stats)) :: Nil
               ) =>
             m(SimpleExpr, s("{ ", name, " ", kw("=>"), " ", pstats(stats), n("}")))
           case Block(
@@ -740,6 +737,10 @@ object TreeSyntax {
         val mods = t.mods.filterNot(isVariant)
         require(t.mods.length - mods.length <= 1)
         val variance = o(t.mods.find(isVariant))
+        val name = t.name match {
+          case _: Name.Anonymous => s("_")
+          case n => s(n)
+        }
         val tbounds = s(t.tbounds)
         val vbounds = {
           if (t.vbounds.nonEmpty && !dialect.allowViewBounds)
@@ -747,7 +748,7 @@ object TreeSyntax {
           r(t.vbounds.map { s(" ", kw("<%"), " ", _) })
         }
         val cbounds = r(t.cbounds.map { s(kw(":"), " ", _) })
-        s(w(mods, " "), variance, t.name, t.tparamClause, tbounds, vbounds, cbounds)
+        s(w(mods, " "), variance, name, t.tparamClause, tbounds, vbounds, cbounds)
 
       // Pat
       case t: Pat.Var =>
@@ -1194,12 +1195,12 @@ object TreeSyntax {
     private def isUsingOrImplicit(m: Mod): Boolean = m.is[Mod.Implicit] || m.is[Mod.Using]
     private def printParam(t: Term.Param, keepImplicit: Boolean = false): Show.Result = {
       val mods = if (keepImplicit) t.mods else t.mods.filterNot(isUsingOrImplicit)
-      val nameType = if (t.mods.exists(_.is[Mod.Using]) && t.name.is[Name.Anonymous]) {
-        s(t.decltpe.get)
+      val nameType = if (t.name.is[Name.Anonymous]) {
+        o(t.decltpe)
       } else {
         s(t.name, t.decltpe)
       }
-      s(w(mods, " "), nameType, t.default.map(s(" ", kw("="), " ", _)).getOrElse(s()))
+      s(w(mods, " "), nameType, o(" = ", t.default))
     }
     implicit def syntaxAnnots: Syntax[Seq[Mod.Annot]] = Syntax { annots =>
       r(annots, " ")
@@ -1223,7 +1224,7 @@ object TreeSyntax {
       r(paramss)
     }
     implicit def syntaxTypeOpt: Syntax[Option[Type]] = Syntax {
-      _.map { t => s(kw(":"), " ", t) }.getOrElse(s())
+      o(kw(": "), _)
     }
     implicit def syntaxImportee: Syntax[Seq[Importee]] = Syntax {
       case Seq(t: Importee.Name) => s(t)

--- a/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -2246,7 +2246,7 @@ class SuccessSuite extends TreeSuiteBase {
 
   test("1 self\"this: tpeopt\"") {
     val self"$name: $tpeopt" = self"this: T"
-    assertEquals(name.toString, "_")
+    assertEquals(name.toString, "")
     assertTree(name)(Name(""))
     assertEquals(tpeopt.toString, "Some(T)")
     assertTree(tpeopt)(Some(Type.Name("T")))

--- a/tests/shared/src/test/scala/scala/meta/tests/transversers/SimpleTraverserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/transversers/SimpleTraverserSuite.scala
@@ -45,14 +45,14 @@ class SimpleTraverserSuite extends FunSuite {
       |C
       |
       |def this(x: x)
-      |_
+      |
       |(x: x)
       |x: x
       |x
       |x
       |{ def bar(x: x) = ??? }
-      |_
-      |_
+      |
+      |
       |def bar(x: x) = ???
       |bar
       |

--- a/tests/shared/src/test/scala/scala/meta/tests/transversers/TraverserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/transversers/TraverserSuite.scala
@@ -44,14 +44,14 @@ class TraverserSuite extends FunSuite {
       |C
       |
       |def this(x: x)
-      |_
+      |
       |(x: x)
       |x: x
       |x
       |x
       |{ def bar(x: x) = ??? }
-      |_
-      |_
+      |
+      |
       |def bar(x: x) = ???
       |bar
       |


### PR DESCRIPTION
Name.Anonymous was designed to be used when the name is not actually present; let's handle the few outlier cases when it stands for `_`.