### PR TITLE
Trees: add Name.Placeholder, use as appropriate

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1764,8 +1764,8 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
       case t: Name => Some(t)
       case t: Quasi => Some(t.become[Term.Name])
       case t: Term.Select => Some(t.name)
-      case t: Term.Placeholder => Some(copyPos(t)(Name.Anonymous()))
-      case t: Term.Eta => Some(atPos(t.endTokenPos)(Name.Anonymous()))
+      case t: Term.Placeholder => Some(copyPos(t)(Name.Placeholder()))
+      case t: Term.Eta => Some(atPos(t.endTokenPos)(Name.Placeholder()))
       case t: Term.Ascribe if nest == 0 => getName(t.expr, 1)
       case _ => None
     }
@@ -3150,7 +3150,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
           case _: Ident => typeName()
           case t: Unquote => unquote[Name](t)
           case _: Underscore if allowUnderscore =>
-            autoPos { next(); Name.Anonymous() }
+            autoPos { next(); Name.Placeholder() }
           case _ =>
             if (allowUnderscore) syntaxError("identifier or `_' expected", at = token)
             else syntaxError("identifier expected", at = token)

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -46,6 +46,10 @@ object Name {
     checkParent(ParentChecks.NameAnonymous)
   }
   @ast class Indeterminate(value: Predef.String @nonEmpty) extends Name
+  @ast class Placeholder() extends Name {
+    def value = "_"
+    checkParent(ParentChecks.NamePlaceholder)
+  }
 }
 
 @branch trait Lit extends Term with Pat with Type {

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/ParentChecks.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/ParentChecks.scala
@@ -79,6 +79,12 @@ object ParentChecks {
       case _ => false
     }
 
+  def NamePlaceholder(tree: Name.Placeholder, parent: Tree, destination: String): Boolean =
+    parent match {
+      case _: Term.Param | _: Type.Param => destination == "name"
+      case _ => false
+    }
+
   def TypeVar(tree: Type.Var, parent: Tree, destination: String): Boolean = {
     @tailrec
     def loop(tree: Option[Tree]): Boolean = tree match {

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
@@ -179,8 +179,6 @@ trait TextDocumentOps { self: SemanticdbOps =>
               case mtree @ m.Importee.Rename(mname, mrename) =>
                 indexName(mname)
                 return // NOTE: ignore mrename for now, we may decide to make it a binder
-              case mtree @ m.Name.Anonymous() =>
-                ()
               case mtree: m.Ctor =>
                 mctordefs(mtree.pos.start) = mtree.name
               case mtree: m.Term.New =>
@@ -188,6 +186,7 @@ trait TextDocumentOps { self: SemanticdbOps =>
               case mtree: m.Init =>
                 indexArgNames(mtree)
                 mctorrefs(mtree.pos.start) = mtree.name
+              case _: m.Name.Anonymous | _: m.Name.Placeholder =>
               case mtree: m.Name =>
                 indexName(mtree)
               case mtree: m.Defn.Val =>

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -328,6 +328,7 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.Name
       |scala.meta.Name.Anonymous
       |scala.meta.Name.Indeterminate
+      |scala.meta.Name.Placeholder
       |scala.meta.Pat
       |scala.meta.Pat.Alternative
       |scala.meta.Pat.Bind

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
@@ -24,7 +24,7 @@ class ReflectionSuite extends FunSuite {
     val sym = symbolOf[scala.meta.Tree]
     assert(sym.isRoot)
     val root = sym.asRoot
-    assertEquals((root.allBranches.length, root.allLeafs.length), (31, 373))
+    assertEquals((root.allBranches.length, root.allLeafs.length), (31, 375))
   }
 
   test("If") {

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -18,8 +18,6 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
   checkPositions[Type](
     "[_] =>> Unit",
     """|Type.ParamClause [_]
-       |Type.Param _
-       |Name.Anonymous _
        |Type.ParamClause [_@@] =>> Unit
        |Type.Bounds [_@@] =>> Unit
        |""".stripMargin
@@ -635,7 +633,6 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
     """|(using _: C) => ???
        |""".stripMargin,
     """|Term.Param using _: C
-       |Name.Anonymous _
        |""".stripMargin
   )
 

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
@@ -732,8 +732,6 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
 
   checkPositions[Stat](
     """|(_: X) => 42
-       |""".stripMargin,
-    """|Name.Anonymous _
        |""".stripMargin
   )
 
@@ -741,7 +739,6 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
     """|_ => 42
        |""".stripMargin,
     """|Term.Param _
-       |Name.Anonymous _
        |""".stripMargin
   )
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/DeclSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/DeclSuite.scala
@@ -92,7 +92,7 @@ class DeclSuite extends ParseSuite {
         Type.ParamClause(
           Type.Param(
             Nil,
-            Name.Anonymous(),
+            Name.Placeholder(),
             Type.ParamClause(Nil),
             Type.Bounds(None, None),
             Nil,

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/StructureSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/StructureSuite.scala
@@ -22,7 +22,7 @@ class StructureSuite extends ParseSuite {
     Case(
       Pat.Wildcard(),
       None,
-      Term.Function(List(Term.Param(Nil, Name(""), None, None)), Lit.Boolean(false))
+      Term.Function(List(Term.Param(Nil, Name.Placeholder(), None, None)), Lit.Boolean(false))
     )
   )
 
@@ -32,7 +32,7 @@ class StructureSuite extends ParseSuite {
       Pat.Wildcard(),
       None,
       Term.Function(
-        List(Term.Param(Nil, Name(""), None, None)),
+        List(Term.Param(Nil, Name.Placeholder(), None, None)),
         Term.Block(List(Lit.Boolean(false)))
       )
     )
@@ -44,7 +44,7 @@ class StructureSuite extends ParseSuite {
       Pat.Wildcard(),
       None,
       Term.Function(
-        List(Term.Param(Nil, Name(""), None, None)),
+        List(Term.Param(Nil, Name.Placeholder(), None, None)),
         Term.Block(List(Lit.Boolean(false), Term.Name("a")))
       )
     )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -321,18 +321,18 @@ class TermSuite extends ParseSuite {
 
   test("_ => x") {
     assertTerm("_ => x") {
-      Term.Function(List(Term.Param(Nil, Name.Anonymous(), None, None)), Term.Name("x"))
+      Term.Function(List(Term.Param(Nil, Name.Placeholder(), None, None)), Term.Name("x"))
     }
-    val Term.Function(List(Term.Param(Nil, Name.Anonymous(), None, None)), Term.Name("x")) =
+    val Term.Function(List(Term.Param(Nil, Name.Placeholder(), None, None)), Term.Name("x")) =
       blockStat("_ => x")
     intercept[ParseException] { templStat("_ => x") }
   }
 
   test("(_) => x") {
     assertTerm("(_) => x") {
-      Term.Function(List(Term.Param(Nil, Name.Anonymous(), None, None)), Term.Name("x"))
+      Term.Function(List(Term.Param(Nil, Name.Placeholder(), None, None)), Term.Name("x"))
     }
-    val Term.Function(List(Term.Param(Nil, Name.Anonymous(), None, None)), Term.Name("x")) =
+    val Term.Function(List(Term.Param(Nil, Name.Placeholder(), None, None)), Term.Name("x")) =
       blockStat("(_) => x")
     intercept[ParseException] { templStat("(_) => x") }
   }
@@ -371,7 +371,7 @@ class TermSuite extends ParseSuite {
       Ascribe(Placeholder(), Type.Function(List(Type.Name("Int")), Type.Name("x")))
     }
     val Term.Function(
-      List(Term.Param(Nil, Name.Anonymous(), Some(Type.Name("Int")), None)),
+      List(Term.Param(Nil, Name.Placeholder(), Some(Type.Name("Int")), None)),
       Term.Name("x")
     ) = blockStat("_: Int => x")
     intercept[ParseException] { templStat("_: Int => x") }
@@ -380,16 +380,16 @@ class TermSuite extends ParseSuite {
   test("(_: Int) => x") {
     assertTerm("(_: Int) => x") {
       Term.Function(
-        List(Term.Param(Nil, Name.Anonymous(), Some(Type.Name("Int")), None)),
+        List(Term.Param(Nil, Name.Placeholder(), Some(Type.Name("Int")), None)),
         Term.Name("x")
       )
     }
     val Term.Function(
-      List(Term.Param(Nil, Name.Anonymous(), Some(Type.Name("Int")), None)),
+      List(Term.Param(Nil, Name.Placeholder(), Some(Type.Name("Int")), None)),
       Term.Name("x")
     ) = blockStat("(_: Int) => x")
     val Term.Function(
-      List(Term.Param(Nil, Name.Anonymous(), Some(Type.Name("Int")), None)),
+      List(Term.Param(Nil, Name.Placeholder(), Some(Type.Name("Int")), None)),
       Term.Name("x")
     ) = templStat("(_: Int) => x")
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/BaseDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/BaseDottySuite.scala
@@ -12,6 +12,7 @@ trait BaseDottySuite extends ParseSuite {
   implicit def parseType(code: String, dialect: Dialect): Type = tpe(code)(dialect)
 
   final val anon = meta.Name.Anonymous()
+  final val phName = meta.Name.Placeholder()
   final val ctor = Ctor.Primary(Nil, anon, Nil)
   final def ctorp(lp: List[Term.Param] = Nil) = Ctor.Primary(Nil, anon, List(lp))
   final val slf = meta.Self(anon, None)
@@ -24,9 +25,15 @@ trait BaseDottySuite extends ParseSuite {
     Term.Param(Nil, Term.Name(name), Some(pname(tpe)), None)
   final def tparamInline(name: String, tpe: String) =
     Term.Param(List(Mod.Inline()), Term.Name(name), Some(pname(tpe)), None)
-  final def tparamUsing(name: String, tpe: String) =
-    if (name.nonEmpty) Term.Param(List(Mod.Using()), Term.Name(name), Some(pname(tpe)), None)
-    else Term.Param(List(Mod.Using()), anon, Some(pname(tpe)), None)
+
+  final def tparamUsing(name: String, tpe: String) = {
+    val nameTree = name match {
+      case "" => anon
+      case "_" => phName
+      case _ => Term.Name(name)
+    }
+    Term.Param(List(Mod.Using()), nameTree, Some(pname(tpe)), None)
+  }
 
   final def pname(name: String): Type.Name = Type.Name(name)
   final def pparam(s: String): Type.Param =

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
@@ -985,7 +985,7 @@ class GivenUsingSuite extends BaseDottySuite {
         List(Pat.Var(Term.Name("fun"))),
         None,
         Term.Function(
-          List(Term.Param(List(Mod.Using()), Name(""), Some(Type.Name("Context")), None)),
+          List(Term.Param(List(Mod.Using()), phName, Some(Type.Name("Context")), None)),
           Term.Select(Term.Name("ctx"), Term.Name("open"))
         )
       )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NewFunctionsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NewFunctionsSuite.scala
@@ -215,7 +215,7 @@ class NewFunctionsSuite extends BaseDottySuite {
             Type.Param(
               Nil,
               Type.Name("F"),
-              List(Type.Param(Nil, Name(""), Nil, Type.Bounds(None, None), Nil, Nil)),
+              List(Type.Param(Nil, phName, Nil, Type.Bounds(None, None), Nil, Nil)),
               Type.Bounds(None, None),
               Nil,
               Nil
@@ -223,7 +223,7 @@ class NewFunctionsSuite extends BaseDottySuite {
             Type.Param(
               Nil,
               Type.Name("G"),
-              List(Type.Param(Nil, Name(""), Nil, Type.Bounds(None, None), Nil, Nil)),
+              List(Type.Param(Nil, phName, Nil, Type.Bounds(None, None), Nil, Nil)),
               Type.Bounds(None, None),
               Nil,
               Nil
@@ -376,7 +376,7 @@ class NewFunctionsSuite extends BaseDottySuite {
             Type.Param(
               Nil,
               Type.Name("F"),
-              List(Type.Param(Nil, Name(""), Nil, Type.Bounds(None, None), Nil, Nil)),
+              List(Type.Param(Nil, phName, Nil, Type.Bounds(None, None), Nil, Nil)),
               Type.Bounds(None, None),
               Nil,
               Nil
@@ -384,7 +384,7 @@ class NewFunctionsSuite extends BaseDottySuite {
             Type.Param(
               Nil,
               Type.Name("G"),
-              List(Type.Param(Nil, Name(""), Nil, Type.Bounds(None, None), Nil, Nil)),
+              List(Type.Param(Nil, phName, Nil, Type.Bounds(None, None), Nil, Nil)),
               Type.Bounds(None, None),
               Nil,
               Nil
@@ -448,7 +448,7 @@ class NewFunctionsSuite extends BaseDottySuite {
             Type.Param(
               Nil,
               Type.Name("F"),
-              List(Type.Param(Nil, Name(""), Nil, Type.Bounds(None, None), Nil, Nil)),
+              List(Type.Param(Nil, phName, Nil, Type.Bounds(None, None), Nil, Nil)),
               Type.Bounds(None, None),
               Nil,
               Nil
@@ -686,7 +686,7 @@ class NewFunctionsSuite extends BaseDottySuite {
           Type.Param(
             Nil,
             Type.Name("F"),
-            List(Type.Param(Nil, Name(""), Nil, Type.Bounds(None, None), Nil, Nil)),
+            List(Type.Param(Nil, phName, Nil, Type.Bounds(None, None), Nil, Nil)),
             Type.Bounds(None, None),
             Nil,
             List(
@@ -695,7 +695,7 @@ class NewFunctionsSuite extends BaseDottySuite {
                   Type.Param(
                     Nil,
                     Type.Name("G"),
-                    List(Type.Param(Nil, Name(""), Nil, Type.Bounds(None, None), Nil, Nil)),
+                    List(Type.Param(Nil, phName, Nil, Type.Bounds(None, None), Nil, Nil)),
                     Type.Bounds(None, None),
                     Nil,
                     Nil


### PR DESCRIPTION
Name.Anonymous was designed to be used when the name is not actually present; thus, using it for `_` is inconsistent and leads to complex handling.