### PR TITLE
ScalametaParser: bug fix, restore `(` pos in infix

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2037,6 +2037,8 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
       }
     }
 
+    val startPos = auto.startTokenPos
+
     // Start the infix chain.
     // We'll use `a + b` as our running example.
     val rhs0 = prefixExpr(allowRepeated)
@@ -2051,7 +2053,11 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
     // base contains pending UnfinishedInfix parts and rhsN is the final rhs.
     // For our running example, this'll be List([a +]) and [b].
     // Afterwards, `lhsResult` will be List([a + b]).
-    val lhsResult = ctx.reduceStack(base, rhsN, in.prevTokenPos, None)
+    val endPos = auto.endTokenPos
+    val lhsResult = ctx.reduceStack(base, rhsN, endPos, None) match {
+      case `rhs0` => rhs0
+      case res => atPos(startPos, endPos)(res)
+    }
 
     maybeAnonymousFunctionUnlessPostfix(lhsResult)(location)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/BasicPositionSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/BasicPositionSuite.scala
@@ -154,7 +154,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
 
   checkPositions[Stat](
     """(((a +: b) +: c) +: d)""",
-    """|Term.ApplyInfix a +: b) +: c
+    """|Term.ApplyInfix (a +: b) +: c
        |Term.ApplyInfix a +: b
        |Type.ArgClause (((a +: @@b) +: c) +: d)
        |Type.ArgClause (((a +: b) +: @@c) +: d)
@@ -164,7 +164,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
 
   checkPositions[Stat](
     """(((a :+ b) :+ c) :+ d)""",
-    """|Term.ApplyInfix a :+ b) :+ c
+    """|Term.ApplyInfix (a :+ b) :+ c
        |Term.ApplyInfix a :+ b
        |Type.ArgClause (((a :+ @@b) :+ c) :+ d)
        |Type.ArgClause (((a :+ b) :+ @@c) :+ d)
@@ -238,7 +238,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
 
   checkPositions[Stat](
     """(((c d) b) a)""",
-    """|Term.Select c d) b
+    """|Term.Select (c d) b
        |Term.Select c d
        |""".stripMargin
   )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/BasicPositionSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/BasicPositionSuite.scala
@@ -152,4 +152,95 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
     assert(last.text == "            // line 2")
   }
 
+  checkPositions[Stat](
+    """(((a +: b) +: c) +: d)""",
+    """|Term.ApplyInfix a +: b) +: c
+       |Term.ApplyInfix a +: b
+       |Type.ArgClause (((a +: @@b) +: c) +: d)
+       |Type.ArgClause (((a +: b) +: @@c) +: d)
+       |Type.ArgClause (((a +: b) +: c) +: @@d)
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """(((a :+ b) :+ c) :+ d)""",
+    """|Term.ApplyInfix a :+ b) :+ c
+       |Term.ApplyInfix a :+ b
+       |Type.ArgClause (((a :+ @@b) :+ c) :+ d)
+       |Type.ArgClause (((a :+ b) :+ @@c) :+ d)
+       |Type.ArgClause (((a :+ b) :+ c) :+ @@d)
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """(a +: (b +: (c +: d) +: b) +: a)""",
+    """|Type.ArgClause (a +: @@(b +: (c +: d) +: b) +: a)
+       |Term.ApplyInfix (b +: (c +: d) +: b) +: a
+       |Term.ApplyInfix b +: (c +: d) +: b
+       |Type.ArgClause (a +: (b +: @@(c +: d) +: b) +: a)
+       |Term.ApplyInfix (c +: d) +: b
+       |Term.ApplyInfix c +: d
+       |Type.ArgClause (a +: (b +: (c +: @@d) +: b) +: a)
+       |Type.ArgClause (a +: (b +: (c +: d) +: @@b) +: a)
+       |Type.ArgClause (a +: (b +: (c +: d) +: b) +: @@a)
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """(a +: (b +: (c +: d)))""",
+    """|Type.ArgClause (a +: @@(b +: (c +: d)))
+       |Term.ApplyInfix b +: (c +: d)
+       |Type.ArgClause (a +: (b +: @@(c +: d)))
+       |Term.ApplyInfix c +: d
+       |Type.ArgClause (a +: (b +: (c +: @@d)))
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """(a :+ (b :+ (c :+ d)))""",
+    """|Type.ArgClause (a :+ @@(b :+ (c :+ d)))
+       |Term.ApplyInfix b :+ (c :+ d)
+       |Type.ArgClause (a :+ (b :+ @@(c :+ d)))
+       |Term.ApplyInfix c :+ d
+       |Type.ArgClause (a :+ (b :+ (c :+ @@d)))
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """(a :+ (b :+ (c :+ d) :+ b) :+ a)""",
+    """|Term.ApplyInfix a :+ (b :+ (c :+ d) :+ b)
+       |Type.ArgClause (a :+ @@(b :+ (c :+ d) :+ b) :+ a)
+       |Term.ApplyInfix b :+ (c :+ d) :+ b
+       |Term.ApplyInfix b :+ (c :+ d)
+       |Type.ArgClause (a :+ (b :+ @@(c :+ d) :+ b) :+ a)
+       |Term.ApplyInfix c :+ d
+       |Type.ArgClause (a :+ (b :+ (c :+ @@d) :+ b) :+ a)
+       |Type.ArgClause (a :+ (b :+ (c :+ d) :+ @@b) :+ a)
+       |Type.ArgClause (a :+ (b :+ (c :+ d) :+ b) :+ @@a)
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """(a (b (c d) b) a)""",
+    """|Term.Apply a (b (c d) b)
+       |Term.Select b (c d) b
+       |Term.Apply b (c d)
+       |Term.Select c d
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """(a (b (c d)))""",
+    """|Term.Apply b (c d)
+       |Term.Select c d
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """(((c d) b) a)""",
+    """|Term.Select c d) b
+       |Term.Select c d
+       |""".stripMargin
+  )
+
 }


### PR DESCRIPTION
Follow up to #2941.