### PR TITLE
ScalametaParser: keep delims around body

### DIFF
--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -1052,7 +1052,8 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |  type T>: Null
        """.stripMargin,
     """|Type.ParamClause type A @@= AnyRef with
-       |Type.Refine type T>: Null
+       |Type.Refine AnyRef with
+       |  type T>: Null
        |Decl.Type type T>: Null
        |Type.ParamClause   type T@@>: Null
        |Type.Bounds >: Null

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -1032,4 +1032,32 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |""".stripMargin
   )
 
+  checkPositions[Stat](
+    """|val x: (C { type U = T } { type T = String }) # U
+       |""".stripMargin,
+    """|Type.Project (C { type U = T } { type T = String }) # U
+       |Type.Refine C { type U = T } { type T = String }
+       |Type.Refine C { type U = T }
+       |Defn.Type type U = T
+       |Type.ParamClause val x: (C { type U @@= T } { type T = String }) # U
+       |Type.Bounds val x: (C { type U = @@T } { type T = String }) # U
+       |Defn.Type type T = String
+       |Type.ParamClause val x: (C { type U = T } { type T @@= String }) # U
+       |Type.Bounds val x: (C { type U = T } { type T = @@String }) # U
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """|type A = AnyRef with
+       |  type T>: Null
+       """.stripMargin,
+    """|Type.ParamClause type A @@= AnyRef with
+       |Type.Refine type T>: Null
+       |Decl.Type type T>: Null
+       |Type.ParamClause   type T@@>: Null
+       |Type.Bounds >: Null
+       |Type.Bounds type A = @@AnyRef with
+       |""".stripMargin
+  )
+
 }

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
@@ -158,30 +158,37 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
   )
   checkPositions[Stat](
     "(f)((((a))))",
-    """|Term.ArgClause ((((a))))
+    """|Term.Name (f)
+       |Term.ArgClause ((((a))))
+       |Term.Name (((a)))
        |""".stripMargin
   )
   checkPositions[Stat](
     "(f)((a))",
-    """|Term.ArgClause ((a))
+    """|Term.Name (f)
+       |Term.ArgClause ((a))
+       |Term.Name (a)
        |""".stripMargin
   )
   checkPositions[Stat](
     "(f)({ case a => a })",
-    """|Term.ArgClause ({ case a => a })
+    """|Term.Name (f)
+       |Term.ArgClause ({ case a => a })
        |Term.PartialFunction { case a => a }
        |Case case a => a
        |""".stripMargin
   )
   checkPositions[Stat](
     "(f)({ x })",
-    """|Term.ArgClause ({ x })
+    """|Term.Name (f)
+       |Term.ArgClause ({ x })
        |Term.Block { x }
        |""".stripMargin
   )
   checkPositions[Stat](
     "(a) op (b)",
-    """|Type.ArgClause (a) op @@(b)
+    """|Term.Name (a)
+       |Type.ArgClause (a) op @@(b)
        |Term.ArgClause (b)
        |""".stripMargin
   )
@@ -219,25 +226,34 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
   )
   checkPositions[Stat](
     "(f) [A,B]",
-    """|Type.ArgClause [A,B]
+    """|Term.Name (f)
+       |Type.ArgClause [A,B]
        |""".stripMargin
   )
   checkPositions[Stat](
     "(f) [A]",
-    """|Type.ArgClause [A]
+    """|Term.Name (f)
+       |Type.ArgClause [A]
        |""".stripMargin
   )
   checkPositions[Stat](
     "- (a)"
   )
   checkPositions[Stat](
-    "(a): (A)"
+    "(a): (A)",
+    """|Type.Name (A)
+       |""".stripMargin
   )
   checkPositions[Stat](
-    "(a) = (b)"
+    "(a) = (b)",
+    """|Term.Name (b)
+       |""".stripMargin
   )
   checkPositions[Stat](
-    "{ (a); (b) }"
+    "{ (a); (b) }",
+    """|Term.Name (a)
+       |Term.Name (b)
+       |""".stripMargin
   )
   checkPositions[Stat](
     "do {d} while (p)",
@@ -245,30 +261,41 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
        |""".stripMargin
   )
   checkPositions[Stat](
-    "(f) _"
+    "(f) _",
+    """|Term.Name (f)
+       |""".stripMargin
   )
   checkPositions[Stat](
     "for { x <- xs } (f)",
     """|Enumerator.Generator x <- xs
+       |Term.Name (f)
        |""".stripMargin
   )
   checkPositions[Stat](
     "for { x <- xs } yield (f)",
     """|Enumerator.Generator x <- xs
+       |Term.Name (f)
        |""".stripMargin
   )
   checkPositions[Stat](
     "((a), (b)) => (a)",
-    """|Term.Param a
-       |Term.Param b
+    """|Term.Param (a)
+       |Term.Name (a)
+       |Term.Param (b)
+       |Term.Name (b)
+       |Term.Name (a)
        |""".stripMargin
   )
   checkPositions[Stat](
-    "if (p) (t) else (f)"
+    "if (p) (t) else (f)",
+    """|Term.Name (t)
+       |Term.Name (f)
+       |""".stripMargin
   )
   checkPositions[Stat](
     "if (p) (t)",
-    """|Lit.Unit if (p) (t)@@
+    """|Term.Name (t)
+       |Lit.Unit if (p) (t)@@
        |""".stripMargin
   )
   checkPositions[Stat](
@@ -285,7 +312,9 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
        |""".stripMargin
   )
   checkPositions[Stat](
-    """ s"start ${(a)} end""""
+    """ s"start ${(a)} end"""",
+    """|Term.Name (a)
+       |""".stripMargin
   )
   checkPositions[Stat](
     "(a) match { case x => x }",
@@ -295,12 +324,14 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Stat](
     "new (A)",
     """|Init (A)
+       |Type.Name (A)
        |""".stripMargin
   )
   checkPositions[Stat](
     "new (A){}",
     """|Template (A){}
        |Init (A)
+       |Type.Name (A)
        |Self new (A){@@}
        |""".stripMargin
   )
@@ -309,6 +340,7 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
     """|Type.ParamClause def f@@(a: A = (da)): A
        |Term.ParamClause (a: A = (da))
        |Term.Param a: A = (da)
+       |Term.Name (da)
        |""".stripMargin
   )
   checkPositions[Stat](
@@ -324,10 +356,14 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
        |""".stripMargin
   )
   checkPositions[Stat](
-    "return (a)"
+    "return (a)",
+    """|Term.Name (a)
+       |""".stripMargin
   )
   checkPositions[Stat](
-    "(a).b"
+    "(a).b",
+    """|Term.Name (a)
+       |""".stripMargin
   )
   checkPositions[Stat](
     "a.super[B].c",
@@ -336,18 +372,23 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
   )
   checkPositions[Stat]("a.this")
   checkPositions[Stat](
-    "throw (e)"
+    "throw (e)",
+    """|Term.Name (e)
+       |""".stripMargin
   )
   checkPositions[Stat](
     "try (f) catch { case x => x; case y => y } finally { }",
-    """|Case case x => x;
+    """|Term.Name (f)
+       |Case case x => x;
        |Case case y => y
        |Term.Block { }
        |""".stripMargin
   )
   checkPositions[Stat](
     "try (f) catch { case x => (x); case y => y } finally { }",
-    """|Case case x => (x);
+    """|Term.Name (f)
+       |Case case x => (x);
+       |Term.Name (x)
        |Case case y => y
        |Term.Block { }
        |""".stripMargin
@@ -369,29 +410,36 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Stat](
     "try (a.b).c",
     """|Term.Select (a.b).c
-       |Term.Select a.b
+       |Term.Select (a.b)
        |""".stripMargin
   )
   checkPositions[Stat](
     "try (f) catch (h) finally { }",
-    """|Term.Block { }
+    """|Term.Name (f)
+       |Term.Name (h)
+       |Term.Block { }
        |""".stripMargin
   )
   checkPositions[Stat](
     "try (true, false) catch (h) finally (1, 2)",
     """|Term.Tuple (true, false)
+       |Term.Name (h)
        |Term.Tuple (1, 2)
        |""".stripMargin
   )
   checkPositions[Stat](
     "try (a.b).c catch (h) finally (1, 2)",
     """|Term.Select (a.b).c
-       |Term.Select a.b
+       |Term.Select (a.b)
+       |Term.Name (h)
        |Term.Tuple (1, 2)
        |""".stripMargin
   )
   checkPositions[Stat](
-    "((a), (b))"
+    "((a), (b))",
+    """|Term.Name (a)
+       |Term.Name (b)
+       |""".stripMargin
   )
   checkPositions[Stat](
     "while (p) {d}",
@@ -522,7 +570,7 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
     "@(a @b) def x = 1",
     """|Mod.Annot @(a @b)
        |Init (a @b)
-       |Type.Annotate a @b
+       |Type.Annotate (a @b)
        |Mod.Annot @b
        |Type.ParamClause @(a @b) def x @@= 1
        |""".stripMargin
@@ -531,7 +579,7 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
     "@(a @b(1, 2)(3)) def x = 1",
     """|Mod.Annot @(a @b(1, 2)(3))
        |Init (a @b(1, 2)(3))
-       |Type.Annotate a @b(1, 2)(3)
+       |Type.Annotate (a @b(1, 2)(3))
        |Mod.Annot @b(1, 2)(3)
        |Init b(1, 2)(3)
        |Term.ArgClause (1, 2)
@@ -775,8 +823,8 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
 
   checkPositions[Term](
     "( (a.b), (( a.b(c) )) )",
-    """|Term.Select a.b
-       |Term.Apply a.b(c)
+    """|Term.Select (a.b)
+       |Term.Apply (( a.b(c) ))
        |Term.Select a.b
        |Term.ArgClause (c)
        |""".stripMargin
@@ -784,9 +832,9 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
 
   checkPositions[Term](
     "( (a + b), (a match { case foo => foo }) )",
-    """|Term.ApplyInfix a + b
+    """|Term.ApplyInfix (a + b)
        |Type.ArgClause ( (a + @@b), (a match { case foo => foo }) )
-       |Term.Match a match { case foo => foo }
+       |Term.Match (a match { case foo => foo })
        |Case case foo => foo
        |""".stripMargin
   )
@@ -794,9 +842,9 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Term](
     "{ ( (a + b), (a match { case foo => foo }) ) }",
     """|Term.Tuple ( (a + b), (a match { case foo => foo }) )
-       |Term.ApplyInfix a + b
+       |Term.ApplyInfix (a + b)
        |Type.ArgClause { ( (a + @@b), (a match { case foo => foo }) ) }
-       |Term.Match a match { case foo => foo }
+       |Term.Match (a match { case foo => foo })
        |Case case foo => foo
        |""".stripMargin
   )

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
@@ -345,6 +345,13 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
        |Term.Block { }
        |""".stripMargin
   )
+  checkPositions[Stat](
+    "try (f) catch { case x => (x); case y => y } finally { }",
+    """|Case case x => (x);
+       |Case case y => y
+       |Term.Block { }
+       |""".stripMargin
+  )
   checkPositions[Stat]("try ()")
   checkPositions[Stat](
     "try (true, false)",
@@ -766,4 +773,31 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
        |""".stripMargin
   )
 
+  checkPositions[Term](
+    "( (a.b), (( a.b(c) )) )",
+    """|Term.Select a.b
+       |Term.Apply a.b(c)
+       |Term.Select a.b
+       |Term.ArgClause (c)
+       |""".stripMargin
+  )
+
+  checkPositions[Term](
+    "( (a + b), (a match { case foo => foo }) )",
+    """|Term.ApplyInfix a + b
+       |Type.ArgClause ( (a + @@b), (a match { case foo => foo }) )
+       |Term.Match a match { case foo => foo }
+       |Case case foo => foo
+       |""".stripMargin
+  )
+
+  checkPositions[Term](
+    "{ ( (a + b), (a match { case foo => foo }) ) }",
+    """|Term.Tuple ( (a + b), (a match { case foo => foo }) )
+       |Term.ApplyInfix a + b
+       |Type.ArgClause { ( (a + @@b), (a match { case foo => foo }) ) }
+       |Term.Match a match { case foo => foo }
+       |Case case foo => foo
+       |""".stripMargin
+  )
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/BasicPositionSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/BasicPositionSuite.scala
@@ -10,7 +10,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
     "1 + (2 / 3) * 4",
     """|Type.ArgClause 1 + @@(2 / 3) * 4
        |Term.ApplyInfix (2 / 3) * 4
-       |Term.ApplyInfix 2 / 3
+       |Term.ApplyInfix (2 / 3)
        |Type.ArgClause 1 + (2 / @@3) * 4
        |Type.ArgClause 1 + (2 / 3) * @@4
        |""".stripMargin
@@ -20,6 +20,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
     "1 + (()) * 4",
     """|Type.ArgClause 1 + @@(()) * 4
        |Term.ApplyInfix (()) * 4
+       |Lit.Unit (())
        |Type.ArgClause 1 + (()) * @@4
        |""".stripMargin
   )
@@ -28,7 +29,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
     "1 + ((1, 2, 3)) * 4",
     """|Type.ArgClause 1 + @@((1, 2, 3)) * 4
        |Term.ApplyInfix ((1, 2, 3)) * 4
-       |Term.Tuple (1, 2, 3)
+       |Term.Tuple ((1, 2, 3))
        |Type.ArgClause 1 + ((1, 2, 3)) * @@4
        |""".stripMargin
   )
@@ -73,6 +74,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
     "a f (()).foo",
     """|Type.ArgClause a f @@(()).foo
        |Term.Select (()).foo
+       |Lit.Unit (())
        |""".stripMargin
   )
 
@@ -80,6 +82,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
     "a f (())(b)",
     """|Type.ArgClause a f @@(())(b)
        |Term.Apply (())(b)
+       |Lit.Unit (())
        |Term.ArgClause (b)
        |""".stripMargin
   )
@@ -106,7 +109,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
 
   checkPositions[Term](
     "(1 + 2).foo",
-    """|Term.ApplyInfix 1 + 2
+    """|Term.ApplyInfix (1 + 2)
        |Type.ArgClause (1 + @@2).foo
        |""".stripMargin
   )
@@ -115,7 +118,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
     """|Type.ArgClause foo == @@(a + b).c(d)
        |Term.Apply (a + b).c(d)
        |Term.Select (a + b).c
-       |Term.ApplyInfix a + b
+       |Term.ApplyInfix (a + b)
        |Type.ArgClause foo == (a + @@b).c(d)
        |Term.ArgClause (d)
        |""".stripMargin
@@ -161,8 +164,8 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
 
   checkPositions[Stat](
     """(((a +: b) +: c) +: d)""",
-    """|Term.ApplyInfix (a +: b) +: c
-       |Term.ApplyInfix a +: b
+    """|Term.ApplyInfix ((a +: b) +: c)
+       |Term.ApplyInfix (a +: b)
        |Type.ArgClause (((a +: @@b) +: c) +: d)
        |Type.ArgClause (((a +: b) +: @@c) +: d)
        |Type.ArgClause (((a +: b) +: c) +: @@d)
@@ -171,8 +174,8 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
 
   checkPositions[Stat](
     """(((a :+ b) :+ c) :+ d)""",
-    """|Term.ApplyInfix (a :+ b) :+ c
-       |Term.ApplyInfix a :+ b
+    """|Term.ApplyInfix ((a :+ b) :+ c)
+       |Term.ApplyInfix (a :+ b)
        |Type.ArgClause (((a :+ @@b) :+ c) :+ d)
        |Type.ArgClause (((a :+ b) :+ @@c) :+ d)
        |Type.ArgClause (((a :+ b) :+ c) :+ @@d)
@@ -183,10 +186,10 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
     """(a +: (b +: (c +: d) +: b) +: a)""",
     """|Type.ArgClause (a +: @@(b +: (c +: d) +: b) +: a)
        |Term.ApplyInfix (b +: (c +: d) +: b) +: a
-       |Term.ApplyInfix b +: (c +: d) +: b
+       |Term.ApplyInfix (b +: (c +: d) +: b)
        |Type.ArgClause (a +: (b +: @@(c +: d) +: b) +: a)
        |Term.ApplyInfix (c +: d) +: b
-       |Term.ApplyInfix c +: d
+       |Term.ApplyInfix (c +: d)
        |Type.ArgClause (a +: (b +: (c +: @@d) +: b) +: a)
        |Type.ArgClause (a +: (b +: (c +: d) +: @@b) +: a)
        |Type.ArgClause (a +: (b +: (c +: d) +: b) +: @@a)
@@ -266,14 +269,14 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
 
   checkPositions[Stat](
     """(((c d) b) a)""",
-    """|Term.Select (c d) b
-       |Term.Select c d
+    """|Term.Select ((c d) b)
+       |Term.Select (c d)
        |""".stripMargin
   )
 
   checkPositions[Case](
     """case foo => (a -> b)""",
-    """|Term.ApplyInfix a -> b
+    """|Term.ApplyInfix (a -> b)
        |Type.ArgClause case foo => (a -> @@b)
        |""".stripMargin
   )
@@ -281,7 +284,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Case](
     """case foo => (a -> b) -> c""",
     """|Term.ApplyInfix (a -> b) -> c
-       |Term.ApplyInfix a -> b
+       |Term.ApplyInfix (a -> b)
        |Type.ArgClause case foo => (a -> @@b) -> c
        |Type.ArgClause case foo => (a -> b) -> @@c
        |""".stripMargin
@@ -289,7 +292,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
 
   checkPositions[Case](
     """case foo => (a :+ b)""",
-    """|Term.ApplyInfix a :+ b
+    """|Term.ApplyInfix (a :+ b)
        |Type.ArgClause case foo => (a :+ @@b)
        |""".stripMargin
   )
@@ -297,7 +300,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Case](
     """case foo => (a :+ b) :+ c""",
     """|Term.ApplyInfix (a :+ b) :+ c
-       |Term.ApplyInfix a :+ b
+       |Term.ApplyInfix (a :+ b)
        |Type.ArgClause case foo => (a :+ @@b) :+ c
        |Type.ArgClause case foo => (a :+ b) :+ @@c
        |""".stripMargin
@@ -305,7 +308,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
 
   checkPositions[Case](
     """case foo => (a +: b)""",
-    """|Term.ApplyInfix a +: b
+    """|Term.ApplyInfix (a +: b)
        |Type.ArgClause case foo => (a +: @@b)
        |""".stripMargin
   )
@@ -313,7 +316,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Case](
     """case foo => (a +: b) +: c""",
     """|Term.ApplyInfix (a +: b) +: c
-       |Term.ApplyInfix a +: b
+       |Term.ApplyInfix (a +: b)
        |Type.ArgClause case foo => (a +: @@b) +: c
        |Type.ArgClause case foo => (a +: b) +: @@c
        |""".stripMargin
@@ -335,7 +338,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Case](
     """case foo => {(a -> b)}""",
     """|Term.Block {(a -> b)}
-       |Term.ApplyInfix a -> b
+       |Term.ApplyInfix (a -> b)
        |Type.ArgClause case foo => {(a -> @@b)}
        |""".stripMargin
   )
@@ -343,7 +346,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Case](
     """case foo => {(a :+ b)}""",
     """|Term.Block {(a :+ b)}
-       |Term.ApplyInfix a :+ b
+       |Term.ApplyInfix (a :+ b)
        |Type.ArgClause case foo => {(a :+ @@b)}
        |""".stripMargin
   )
@@ -351,7 +354,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Case](
     """case foo => {(a +: b)}""",
     """|Term.Block {(a +: b)}
-       |Term.ApplyInfix a +: b
+       |Term.ApplyInfix (a +: b)
        |Type.ArgClause case foo => {(a +: @@b)}
        |""".stripMargin
   )
@@ -365,7 +368,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
 
   checkPositions[Stat](
     """val foo = (a -> b)""",
-    """|Term.ApplyInfix a -> b
+    """|Term.ApplyInfix (a -> b)
        |Type.ArgClause val foo = (a -> @@b)
        |""".stripMargin
   )
@@ -373,7 +376,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Stat](
     """val foo = (a -> b) -> c""",
     """|Term.ApplyInfix (a -> b) -> c
-       |Term.ApplyInfix a -> b
+       |Term.ApplyInfix (a -> b)
        |Type.ArgClause val foo = (a -> @@b) -> c
        |Type.ArgClause val foo = (a -> b) -> @@c
        |""".stripMargin
@@ -381,7 +384,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
 
   checkPositions[Stat](
     """val foo = (a :+ b)""",
-    """|Term.ApplyInfix a :+ b
+    """|Term.ApplyInfix (a :+ b)
        |Type.ArgClause val foo = (a :+ @@b)
        |""".stripMargin
   )
@@ -389,7 +392,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Stat](
     """val foo = (a :+ b) :+ c""",
     """|Term.ApplyInfix (a :+ b) :+ c
-       |Term.ApplyInfix a :+ b
+       |Term.ApplyInfix (a :+ b)
        |Type.ArgClause val foo = (a :+ @@b) :+ c
        |Type.ArgClause val foo = (a :+ b) :+ @@c
        |""".stripMargin
@@ -397,7 +400,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
 
   checkPositions[Stat](
     """val foo = (a +: b)""",
-    """|Term.ApplyInfix a +: b
+    """|Term.ApplyInfix (a +: b)
        |Type.ArgClause val foo = (a +: @@b)
        |""".stripMargin
   )
@@ -405,7 +408,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Stat](
     """val foo = (a +: b) +: c""",
     """|Term.ApplyInfix (a +: b) +: c
-       |Term.ApplyInfix a +: b
+       |Term.ApplyInfix (a +: b)
        |Type.ArgClause val foo = (a +: @@b) +: c
        |Type.ArgClause val foo = (a +: b) +: @@c
        |""".stripMargin
@@ -427,7 +430,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Stat](
     """val foo = {(a -> b)}""",
     """|Term.Block {(a -> b)}
-       |Term.ApplyInfix a -> b
+       |Term.ApplyInfix (a -> b)
        |Type.ArgClause val foo = {(a -> @@b)}
        |""".stripMargin
   )
@@ -435,7 +438,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Stat](
     """val foo = {(a :+ b)}""",
     """|Term.Block {(a :+ b)}
-       |Term.ApplyInfix a :+ b
+       |Term.ApplyInfix (a :+ b)
        |Type.ArgClause val foo = {(a :+ @@b)}
        |""".stripMargin
   )
@@ -443,7 +446,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Stat](
     """val foo = {(a +: b)}""",
     """|Term.Block {(a +: b)}
-       |Term.ApplyInfix a +: b
+       |Term.ApplyInfix (a +: b)
        |Type.ArgClause val foo = {(a +: @@b)}
        |""".stripMargin
   )
@@ -458,7 +461,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Stat](
     """type foo = (a -> b)""",
     """|Type.ParamClause type foo @@= (a -> b)
-       |Type.ApplyInfix a -> b
+       |Type.ApplyInfix (a -> b)
        |Type.Bounds type foo = @@(a -> b)
        |""".stripMargin
   )
@@ -466,7 +469,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Stat](
     """type foo = (a -> b) -> c""",
     """|Type.ParamClause type foo @@= (a -> b) -> c
-       |Type.ApplyInfix a -> b) -> c
+       |Type.ApplyInfix (a -> b) -> c
        |Type.ApplyInfix a -> b
        |Type.Bounds type foo = @@(a -> b) -> c
        |""".stripMargin
@@ -475,7 +478,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Stat](
     """type foo = (a :+ b)""",
     """|Type.ParamClause type foo @@= (a :+ b)
-       |Type.ApplyInfix a :+ b
+       |Type.ApplyInfix (a :+ b)
        |Type.Bounds type foo = @@(a :+ b)
        |""".stripMargin
   )
@@ -483,7 +486,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Stat](
     """type foo = (a :+ b) :+ c""",
     """|Type.ParamClause type foo @@= (a :+ b) :+ c
-       |Type.ApplyInfix a :+ b) :+ c
+       |Type.ApplyInfix (a :+ b) :+ c
        |Type.ApplyInfix a :+ b
        |Type.Bounds type foo = @@(a :+ b) :+ c
        |""".stripMargin
@@ -492,7 +495,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Stat](
     """type foo = (a +: b)""",
     """|Type.ParamClause type foo @@= (a +: b)
-       |Type.ApplyInfix a +: b
+       |Type.ApplyInfix (a +: b)
        |Type.Bounds type foo = @@(a +: b)
        |""".stripMargin
   )
@@ -500,7 +503,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
   checkPositions[Stat](
     """type foo = (a +: b) +: c""",
     """|Type.ParamClause type foo @@= (a +: b) +: c
-       |Type.ApplyInfix a +: b) +: c
+       |Type.ApplyInfix (a +: b) +: c
        |Type.ApplyInfix a +: b
        |Type.Bounds type foo = @@(a +: b) +: c
        |""".stripMargin
@@ -587,7 +590,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
        |  (try foo finally bar)
        |}
        |Self   @@(try foo finally bar)
-       |Term.Try try foo finally bar
+       |Term.Try (try foo finally bar)
        |""".stripMargin
   )
 
@@ -599,7 +602,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
     """|Term.Block {
        |  (try foo finally bar)
        |}
-       |Term.Try try foo finally bar
+       |Term.Try (try foo finally bar)
        |""".stripMargin
   )
 
@@ -610,7 +613,9 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
        |} yield c
        |""".stripMargin,
     """|Enumerator.Generator a <- (b)
+       |Term.Name (b)
        |Enumerator.Val c = (d)
+       |Term.Name (d)
        |""".stripMargin
   )
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/BasicPositionSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/BasicPositionSuite.scala
@@ -245,6 +245,17 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
   )
 
   checkPositions[Stat](
+    """(a + (b + (c d)))""",
+    """|Type.ArgClause (a + @@(b + (c d)))
+       |Term.ArgClause (b + (c d))
+       |Term.ApplyInfix b + (c d)
+       |Type.ArgClause (a + (b + @@(c d)))
+       |Term.ArgClause (c d)
+       |Term.Select c d
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
     """(a (b (c d)))""",
     """|Term.ArgClause (b (c d))
        |Term.Apply b (c d)
@@ -257,6 +268,349 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
     """(((c d) b) a)""",
     """|Term.Select (c d) b
        |Term.Select c d
+       |""".stripMargin
+  )
+
+  checkPositions[Case](
+    """case foo => (a -> b)""",
+    """|Term.ApplyInfix a -> b
+       |Type.ArgClause case foo => (a -> @@b)
+       |""".stripMargin
+  )
+
+  checkPositions[Case](
+    """case foo => (a -> b) -> c""",
+    """|Term.ApplyInfix (a -> b) -> c
+       |Term.ApplyInfix a -> b
+       |Type.ArgClause case foo => (a -> @@b) -> c
+       |Type.ArgClause case foo => (a -> b) -> @@c
+       |""".stripMargin
+  )
+
+  checkPositions[Case](
+    """case foo => (a :+ b)""",
+    """|Term.ApplyInfix a :+ b
+       |Type.ArgClause case foo => (a :+ @@b)
+       |""".stripMargin
+  )
+
+  checkPositions[Case](
+    """case foo => (a :+ b) :+ c""",
+    """|Term.ApplyInfix (a :+ b) :+ c
+       |Term.ApplyInfix a :+ b
+       |Type.ArgClause case foo => (a :+ @@b) :+ c
+       |Type.ArgClause case foo => (a :+ b) :+ @@c
+       |""".stripMargin
+  )
+
+  checkPositions[Case](
+    """case foo => (a +: b)""",
+    """|Term.ApplyInfix a +: b
+       |Type.ArgClause case foo => (a +: @@b)
+       |""".stripMargin
+  )
+
+  checkPositions[Case](
+    """case foo => (a +: b) +: c""",
+    """|Term.ApplyInfix (a +: b) +: c
+       |Term.ApplyInfix a +: b
+       |Type.ArgClause case foo => (a +: @@b) +: c
+       |Type.ArgClause case foo => (a +: b) +: @@c
+       |""".stripMargin
+  )
+
+  checkPositions[Case](
+    """case foo => (a, b)""",
+    """|Term.Tuple (a, b)
+       |""".stripMargin
+  )
+
+  checkPositions[Case](
+    """case foo => (a, b).bar""",
+    """|Term.Select (a, b).bar
+       |Term.Tuple (a, b)
+       |""".stripMargin
+  )
+
+  checkPositions[Case](
+    """case foo => {(a -> b)}""",
+    """|Term.Block {(a -> b)}
+       |Term.ApplyInfix a -> b
+       |Type.ArgClause case foo => {(a -> @@b)}
+       |""".stripMargin
+  )
+
+  checkPositions[Case](
+    """case foo => {(a :+ b)}""",
+    """|Term.Block {(a :+ b)}
+       |Term.ApplyInfix a :+ b
+       |Type.ArgClause case foo => {(a :+ @@b)}
+       |""".stripMargin
+  )
+
+  checkPositions[Case](
+    """case foo => {(a +: b)}""",
+    """|Term.Block {(a +: b)}
+       |Term.ApplyInfix a +: b
+       |Type.ArgClause case foo => {(a +: @@b)}
+       |""".stripMargin
+  )
+
+  checkPositions[Case](
+    """case foo => {(a, b)}""",
+    """|Term.Block {(a, b)}
+       |Term.Tuple (a, b)
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """val foo = (a -> b)""",
+    """|Term.ApplyInfix a -> b
+       |Type.ArgClause val foo = (a -> @@b)
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """val foo = (a -> b) -> c""",
+    """|Term.ApplyInfix (a -> b) -> c
+       |Term.ApplyInfix a -> b
+       |Type.ArgClause val foo = (a -> @@b) -> c
+       |Type.ArgClause val foo = (a -> b) -> @@c
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """val foo = (a :+ b)""",
+    """|Term.ApplyInfix a :+ b
+       |Type.ArgClause val foo = (a :+ @@b)
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """val foo = (a :+ b) :+ c""",
+    """|Term.ApplyInfix (a :+ b) :+ c
+       |Term.ApplyInfix a :+ b
+       |Type.ArgClause val foo = (a :+ @@b) :+ c
+       |Type.ArgClause val foo = (a :+ b) :+ @@c
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """val foo = (a +: b)""",
+    """|Term.ApplyInfix a +: b
+       |Type.ArgClause val foo = (a +: @@b)
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """val foo = (a +: b) +: c""",
+    """|Term.ApplyInfix (a +: b) +: c
+       |Term.ApplyInfix a +: b
+       |Type.ArgClause val foo = (a +: @@b) +: c
+       |Type.ArgClause val foo = (a +: b) +: @@c
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """val foo = (a, b)""",
+    """|Term.Tuple (a, b)
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """val foo = (a, b).bar""",
+    """|Term.Select (a, b).bar
+       |Term.Tuple (a, b)
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """val foo = {(a -> b)}""",
+    """|Term.Block {(a -> b)}
+       |Term.ApplyInfix a -> b
+       |Type.ArgClause val foo = {(a -> @@b)}
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """val foo = {(a :+ b)}""",
+    """|Term.Block {(a :+ b)}
+       |Term.ApplyInfix a :+ b
+       |Type.ArgClause val foo = {(a :+ @@b)}
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """val foo = {(a +: b)}""",
+    """|Term.Block {(a +: b)}
+       |Term.ApplyInfix a +: b
+       |Type.ArgClause val foo = {(a +: @@b)}
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """val foo = {(a, b)}""",
+    """|Term.Block {(a, b)}
+       |Term.Tuple (a, b)
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """type foo = (a -> b)""",
+    """|Type.ParamClause type foo @@= (a -> b)
+       |Type.ApplyInfix a -> b
+       |Type.Bounds type foo = @@(a -> b)
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """type foo = (a -> b) -> c""",
+    """|Type.ParamClause type foo @@= (a -> b) -> c
+       |Type.ApplyInfix a -> b) -> c
+       |Type.ApplyInfix a -> b
+       |Type.Bounds type foo = @@(a -> b) -> c
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """type foo = (a :+ b)""",
+    """|Type.ParamClause type foo @@= (a :+ b)
+       |Type.ApplyInfix a :+ b
+       |Type.Bounds type foo = @@(a :+ b)
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """type foo = (a :+ b) :+ c""",
+    """|Type.ParamClause type foo @@= (a :+ b) :+ c
+       |Type.ApplyInfix a :+ b) :+ c
+       |Type.ApplyInfix a :+ b
+       |Type.Bounds type foo = @@(a :+ b) :+ c
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """type foo = (a +: b)""",
+    """|Type.ParamClause type foo @@= (a +: b)
+       |Type.ApplyInfix a +: b
+       |Type.Bounds type foo = @@(a +: b)
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """type foo = (a +: b) +: c""",
+    """|Type.ParamClause type foo @@= (a +: b) +: c
+       |Type.ApplyInfix a +: b) +: c
+       |Type.ApplyInfix a +: b
+       |Type.Bounds type foo = @@(a +: b) +: c
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """type foo = (a, b)""",
+    """|Type.ParamClause type foo @@= (a, b)
+       |Type.Tuple (a, b)
+       |Type.Bounds type foo = @@(a, b)
+       |""".stripMargin
+  )
+
+  //
+  checkPositions[Pat](
+    """foo @ (a -> b)""",
+    """|Pat.ExtractInfix (a -> b)
+       |""".stripMargin
+  )
+
+  checkPositions[Pat](
+    """foo @ (a -> b) -> c""",
+    """|Pat.ExtractInfix (a -> b) -> c
+       |Pat.ExtractInfix (a -> b)
+       |""".stripMargin
+  )
+
+  checkPositions[Pat](
+    """foo @ (a :+ b)""",
+    """|Pat.ExtractInfix (a :+ b)
+       |""".stripMargin
+  )
+
+  checkPositions[Pat](
+    """foo @ (a :+ b) :+ c""",
+    """|Pat.ExtractInfix (a :+ b) :+ c
+       |Pat.ExtractInfix (a :+ b)
+       |""".stripMargin
+  )
+
+  checkPositions[Pat](
+    """foo @ (a +: b)""",
+    """|Pat.ExtractInfix (a +: b)
+       |""".stripMargin
+  )
+
+  checkPositions[Pat](
+    """foo @ (a +: b) +: c""",
+    """|Pat.ExtractInfix (a +: b) +: c
+       |Pat.ExtractInfix (a +: b)
+       |""".stripMargin
+  )
+
+  checkPositions[Pat](
+    """foo @ (a, b)""",
+    """|Pat.Tuple (a, b)
+       |""".stripMargin
+  )
+
+  checkPositions[Pat](
+    """foo @ ((a) | (b))""",
+    """|Pat.Alternative ((a) | (b))
+       |Pat.Var (a)
+       |Pat.Var (b)
+       |""".stripMargin
+  )
+
+  checkPositions[Pat](
+    """foo @ ((a) | ((b) | (c)))""",
+    """|Pat.Alternative ((a) | ((b) | (c)))
+       |Pat.Var (a)
+       |Pat.Alternative ((b) | (c))
+       |Pat.Var (b)
+       |Pat.Var (c)
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """|object A {
+       |  (try foo finally bar)
+       |}
+       |""".stripMargin,
+    """|Template {
+       |  (try foo finally bar)
+       |}
+       |Self   @@(try foo finally bar)
+       |Term.Try try foo finally bar
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """|val A = {
+       |  (try foo finally bar)
+       |}
+       |""".stripMargin,
+    """|Term.Block {
+       |  (try foo finally bar)
+       |}
+       |Term.Try try foo finally bar
+       |""".stripMargin
+  )
+
+  checkPositions[Stat](
+    """|for {
+       |  a <- (b)
+       |  c = (d)
+       |} yield c
+       |""".stripMargin,
+    """|Enumerator.Generator a <- (b)
+       |Enumerator.Val c = (d)
        |""".stripMargin
   )
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
@@ -33,7 +33,7 @@ class ParseSuite extends TreeSuiteBase with CommonTrees {
   def templStat(code: String)(implicit dialect: Dialect) =
     parseRule(code, p => p.statSeq(p.templateStat()).head)
   def blockStat(code: String)(implicit dialect: Dialect) = parseRule(code, _.blockStatSeq().head)
-  def caseClause(code: String)(implicit dialect: Dialect) = parseRule(code, _.caseClause())
+  def parseCase(code: String)(implicit dialect: Dialect) = code.applyRule(_.parseCase())
   def source(code: String)(implicit dialect: Dialect) = parseRule(code, _.source())
 
   def ammonite(code: String)(implicit dialect: Dialect) =

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -19,8 +19,8 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     super.templStat(code)(dialect).resetAllOrigins
   override def blockStat(code: String)(implicit dialect: Dialect) =
     super.blockStat(code)(dialect).resetAllOrigins
-  override def caseClause(code: String)(implicit dialect: Dialect) =
-    super.caseClause(code)(dialect).resetAllOrigins
+  override def parseCase(code: String)(implicit dialect: Dialect) =
+    super.parseCase(code)(dialect).resetAllOrigins
   override def source(code: String)(implicit dialect: Dialect) =
     super.source(code)(dialect).resetAllOrigins
   implicit class XtensionResetOrigin[T <: Tree](tree: T) {


### PR DESCRIPTION
Partial undo of #2941. Turns out it's very hard to handle enclosed trees when their enclosing parens belong to a parent.