### PR TITLE
ScalametaParser: use expr in implicit closure

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1802,12 +1802,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
       Term.Param(List(atPos(implicitPos)(Mod.Implicit())), paramName, paramTpt, None)
     )
     accept[RightArrow]
-    autoEndPos(implicitPos)(
-      Term.Function(
-        List(param),
-        if (location != BlockStat) expr() else blockExpr(isBlockOptional = true)
-      )
-    )
+    autoEndPos(implicitPos)(Term.Function(List(param), expr(location, allowRepeated = false)))
   }
 
   // Encapsulates state and behavior of parsing infix syntax.

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
@@ -174,6 +174,15 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
        |""".stripMargin
   )
   checkPositions[Stat](
+    "foo { implicit a => { b }: C }",
+    """|Term.Block { implicit a => { b }: C }
+       |Term.Function implicit a => { b }: C
+       |Term.Param implicit a
+       |Term.Ascribe { b }: C
+       |Term.Block { b }
+       |""".stripMargin
+  )
+  checkPositions[Stat](
     "(f)({ x })",
     """|Term.ArgClause ({ x })
        |Term.Block { x }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -1444,11 +1444,28 @@ class TermSuite extends ParseSuite {
                   |  }: qux
                   |}
                   |""".stripMargin
-    interceptMessage[ParseException](
-      """|<input>:5: error: ; expected but : found
-         |    }: qux
-         |     ^""".stripMargin
-    )(term(code))
+    checkTerm(code) {
+      Term.Apply(
+        Term.Name("foo"),
+        Term.ArgClause(
+          Term.Block(
+            Term.Function(
+              List(Term.Param(List(Mod.Implicit()), Term.Name("a"), None, None)),
+              Term.Function(
+                List(Term.Param(List(Mod.Implicit()), Term.Name("b"), None, None)),
+                Term.Ascribe(
+                  Term.PartialFunction(
+                    List(Case(Pat.Var(Term.Name("bar")), None, Term.Name("baz")))
+                  ),
+                  Type.Name("qux")
+                )
+              )
+            ) :: Nil
+          ) :: Nil,
+          None
+        )
+      )
+    }
   }
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -1437,4 +1437,18 @@ class TermSuite extends ParseSuite {
     }
   }
 
+  test("implicit closure with ascribe") {
+    val code = """|foo {
+                  |  implicit a => implicit b => {
+                  |    case bar => baz
+                  |  }: qux
+                  |}
+                  |""".stripMargin
+    interceptMessage[ParseException](
+      """|<input>:5: error: ; expected but : found
+         |    }: qux
+         |     ^""".stripMargin
+    )(term(code))
+  }
+
 }


### PR DESCRIPTION
Fixes #2959.