### PR TITLE
ScalametaParser: shared mtd for Term.Function body

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -1468,4 +1468,18 @@ class TermSuite extends ParseSuite {
     }
   }
 
+  test("implicit closure with val") {
+    val code =
+      """|foo { implicit a =>
+         |  val bar = baz
+         |  bar
+         |}
+         |""".stripMargin
+    interceptMessage[ParseException](
+      """|<input>:2: error: illegal start of simple expression
+         |  val bar = baz
+         |  ^""".stripMargin
+    )(term(code))
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -1475,11 +1475,28 @@ class TermSuite extends ParseSuite {
          |  bar
          |}
          |""".stripMargin
-    interceptMessage[ParseException](
-      """|<input>:2: error: illegal start of simple expression
-         |  val bar = baz
-         |  ^""".stripMargin
-    )(term(code))
+    checkTerm(code) {
+      Term.Apply(
+        Term.Name("foo"),
+        Term.ArgClause(
+          Term.Block(
+            Term.Function(
+              Term.ParamClause(
+                List(Term.Param(List(Mod.Implicit()), Term.Name("a"), None, None)),
+                Some(Mod.Implicit())
+              ),
+              Term.Block(
+                List(
+                  Defn.Val(Nil, List(Pat.Var(Term.Name("bar"))), None, Term.Name("baz")),
+                  Term.Name("bar")
+                )
+              )
+            ) :: Nil
+          ) :: Nil,
+          None
+        )
+      )
+    }
   }
 
 }


### PR DESCRIPTION
Follow-on to #2965 which introduced a bug.