### PR TITLE
ast: support ellipses past rank 2

### DIFF
--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/ast.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/ast.scala
@@ -403,10 +403,8 @@ class AstNamerMacros(val c: Context) extends Reflection with CommonNamerMacros {
             (this match {
               case $mname(0, tree) =>
                 ev.quasi(0, tree)
-              case $mname(1, nested @ $mname(0, tree)) =>
-                ev.quasi(1, nested.become[T])
-              case $mname(2, nested @ $mname(0, tree)) =>
-                ev.quasi(2, nested.become[T])
+              case $mname(rank, nested @ $mname(0, tree)) =>
+                ev.quasi(rank, nested.become[T])
               case _ =>
                 throw new Exception("complex ellipses are not supported yet")
             }).withOrigin(this.origin): T with $QuasiClass


### PR DESCRIPTION
For interleaved param clause groups, we will use rank 3. Needed by #2929.