### PR TITLE
ScalametaParser: refactor condExprInParens

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -153,17 +153,6 @@ class ScannerTokens(tokens: Tokens, input: Input)(implicit dialect: Dialect) {
     }
 
     @classifier
-    trait StopScanToken {
-      def unapply(token: Token): Boolean = token match {
-        case _: KwPackage | _: KwExport | _: KwImport | _: KwIf | _: KwElse | _: KwWhile | _: KwDo |
-            _: KwFor | _: KwYield | _: KwNew | _: KwTry | _: KwCatch | _: KwFinally | _: KwThrow |
-            _: KwReturn | _: KwMatch | _: EOF | _: Semicolon | Modifier() | DefIntro() =>
-          true
-        case _ => false
-      }
-    }
-
-    @classifier
     trait EndMarkerIntro {
       def unapply(token: Token): Boolean = token match {
         case Ident("end") if dialect.allowEndMarker =>

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -1499,4 +1499,29 @@ class TermSuite extends ParseSuite {
     }
   }
 
+  test("if-with-parens-no-block [scala2]") {
+    assertTerm(
+      """|if (isEmpty)
+         |  (None, None)
+         |else {
+         |  (Some(e), Some(f))
+         |}
+         |""".stripMargin
+    )(
+      Term.If(
+        Term.Name("isEmpty"),
+        Term.Tuple(List(Term.Name("None"), Term.Name("None"))),
+        Term.Block(
+          Term.Tuple(
+            List(
+              Term.Apply(Term.Name("Some"), List(Term.Name("e"))),
+              Term.Apply(Term.Name("Some"), List(Term.Name("f")))
+            )
+          ) :: Nil
+        ),
+        Nil
+      )
+    )
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -131,11 +131,27 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |    x += 1
          |}
          |""".stripMargin
-    runTestError[Stat](
-      code,
-      """|error: then expected but \n found
-         |  if (x > 0) && (y > 0)
-         |                       ^""".stripMargin
+    val layout =
+      """|{
+         |  if (x > 0) &&(y > 0)
+         |  x += 1
+         |}
+         |""".stripMargin
+    runTestAssert[Stat](code, Some(layout))(
+      Term.Block(
+        List(
+          Term.If(
+            Term.ApplyInfix(tname("x"), tname(">"), Nil, List(int(0))),
+            Term.Apply(
+              tname("&&"),
+              List(Term.ApplyInfix(tname("y"), tname(">"), Nil, List(int(0))))
+            ),
+            Lit.Unit(),
+            Nil
+          ),
+          Term.ApplyInfix(tname("x"), tname("+="), Nil, List(int(1)))
+        )
+      )
     )
   }
 
@@ -148,9 +164,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin
     runTestError[Stat](
       code,
-      """|error: then expected but \n found
+      """|error: ; expected but integer constant found
          |  if (x > 0) && y > 0
-         |                     ^""".stripMargin
+         |                    ^""".stripMargin
     )
   }
 
@@ -1298,11 +1314,25 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |    x += 1
          |}
          |""".stripMargin
-    runTestError[Stat](
-      code,
-      """|error: do expected but \n found
-         |  while (x > 0) && (y > 0)
-         |                          ^""".stripMargin
+    val layout =
+      """|{
+         |  while (x > 0) &&(y > 0)
+         |  x += 1
+         |}
+         |""".stripMargin
+    runTestAssert[Stat](code, Some(layout))(
+      Term.Block(
+        List(
+          Term.While(
+            Term.ApplyInfix(tname("x"), tname(">"), Nil, List(int(0))),
+            Term.Apply(
+              tname("&&"),
+              List(Term.ApplyInfix(tname("y"), tname(">"), Nil, List(int(0))))
+            )
+          ),
+          Term.ApplyInfix(tname("x"), tname("+="), Nil, List(int(1)))
+        )
+      )
     )
   }
 
@@ -1315,9 +1345,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin
     runTestError[Stat](
       code,
-      """|error: do expected but \n found
+      """|error: ; expected but integer constant found
          |  while (x > 0) && y > 0
-         |                        ^""".stripMargin
+         |                       ^""".stripMargin
     )
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -126,10 +126,32 @@ class ControlSyntaxSuite extends BaseDottySuite {
 
   test("new-if-expr-without-then") {
     val code =
-      """|if (x > 0) && (y > 0)
-         |  x += 1
+      """|{
+         |  if (x > 0) && (y > 0)
+         |    x += 1
+         |}
          |""".stripMargin
-    runTestError[Stat](code, "then expected but \\n found")
+    runTestError[Stat](
+      code,
+      """|error: then expected but \n found
+         |  if (x > 0) && (y > 0)
+         |                       ^""".stripMargin
+    )
+  }
+
+  test("new-if-expr-without-then-2") {
+    val code =
+      """|{
+         |  if (x > 0) && y > 0
+         |    x += 1
+         |}
+         |""".stripMargin
+    runTestError[Stat](
+      code,
+      """|error: then expected but \n found
+         |  if (x > 0) && y > 0
+         |                     ^""".stripMargin
+    )
   }
 
   test("new-if-else-multiple") {
@@ -1178,12 +1200,125 @@ class ControlSyntaxSuite extends BaseDottySuite {
     )
   }
 
+  test("while-cond-expr-do [non symbolic op]") {
+    val output = "while (x > 0 and y > 0) x += 1"
+    val expected = Term.While(
+      Term.ApplyInfix(
+        Term.ApplyInfix(tname("x"), tname(">"), Nil, List(int(0))),
+        tname("and"),
+        Nil,
+        List(Term.ApplyInfix(tname("y"), tname(">"), Nil, List(int(0))))
+      ),
+      Term.ApplyInfix(tname("x"), tname("+="), Nil, List(int(1)))
+    )
+
+    val code1 =
+      """|  while (x > 0) and (y > 0) do
+         |    x += 1
+         |""".stripMargin
+    runTestAssert[Stat](code1, assertLayout = Some(output))(expected)
+
+    val code2 =
+      """|  while (x > 0) and (y > 0)
+         |  do
+         |    x += 1
+         |""".stripMargin
+    runTestAssert[Stat](code2, assertLayout = Some(output))(expected)
+  }
+
+  test("if-cond-expr-with-apply-type") {
+    val code =
+      """|if (sym == defn.BooleanClass) classOf[Boolean]
+         |else if (sym == defn.ByteClass) classOf[Byte]
+         |""".stripMargin
+    val layout =
+      "if (sym == defn.BooleanClass) classOf[Boolean] else if (sym == defn.ByteClass) classOf[Byte]"
+    val expected = Term.If(
+      Term.ApplyInfix(
+        tname("sym"),
+        tname("=="),
+        Nil,
+        List(Term.Select(tname("defn"), tname("BooleanClass")))
+      ),
+      Term.ApplyType(tname("classOf"), List(pname("Boolean"))),
+      Term.If(
+        Term.ApplyInfix(
+          tname("sym"),
+          tname("=="),
+          Nil,
+          List(Term.Select(tname("defn"), tname("ByteClass")))
+        ),
+        Term.ApplyType(tname("classOf"), List(pname("Byte"))),
+        Lit.Unit(),
+        Nil
+      ),
+      Nil
+    )
+    runTestAssert[Stat](code, Some(layout))(expected)
+  }
+
+  test("if-cond-expr-with-block") {
+    val code =
+      """|if (sym == defn.BooleanClass) { classOf[Boolean] }
+         |else if (sym == defn.ByteClass) classOf[Byte]
+         |""".stripMargin
+    val layout =
+      """|if (sym == defn.BooleanClass) {
+         |  classOf[Boolean]
+         |} else if (sym == defn.ByteClass) classOf[Byte]
+         |""".stripMargin
+    val expected = Term.If(
+      Term.ApplyInfix(
+        tname("sym"),
+        tname("=="),
+        Nil,
+        List(Term.Select(tname("defn"), tname("BooleanClass")))
+      ),
+      Term.Block(Term.ApplyType(tname("classOf"), List(pname("Boolean"))) :: Nil),
+      Term.If(
+        Term.ApplyInfix(
+          tname("sym"),
+          tname("=="),
+          Nil,
+          List(Term.Select(tname("defn"), tname("ByteClass")))
+        ),
+        Term.ApplyType(tname("classOf"), List(pname("Byte"))),
+        Lit.Unit(),
+        Nil
+      ),
+      Nil
+    )
+    runTestAssert[Stat](code, Some(layout))(expected)
+  }
+
   test("while-cond-expr-without-do") {
     val code =
-      """|while (x > 0) && (y > 0)
-         |  x += 1
+      """|{
+         |  while (x > 0) && (y > 0)
+         |    x += 1
+         |}
          |""".stripMargin
-    runTestError[Stat](code, "do expected but \\n found")
+    runTestError[Stat](
+      code,
+      """|error: do expected but \n found
+         |  while (x > 0) && (y > 0)
+         |                          ^""".stripMargin
+    )
+  }
+
+  test("while-cond-expr-without-do-2") {
+    val code =
+      """|{
+         |  while (x > 0) && y > 0
+         |    x += 1
+         |}
+         |""".stripMargin
+    runTestError[Stat](
+      code,
+      """|error: do expected but \n found
+         |  while (x > 0) && y > 0
+         |                        ^""".stripMargin
+    )
   }
 
   // --------------------------


### PR DESCRIPTION
Specifically, do not use `isLeadingInfixOperator` anymore as that is not appropriate (no requirement for it to be leading, or for this feature to be enabled to parse `if/while` conditions in scala3).

Also, make sure that condExprInParens also consumes the terminating `do/then` keyword if found.