### PR TITLE
ScalametaParser: refactor token checks

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -106,6 +106,11 @@ class ScannerTokens(tokens: Tokens, input: Input)(implicit dialect: Dialect) {
       @inline
       def strictNext: Token = getStrictAfterSafe(nextSafe)
 
+      def isBackquoted: Boolean = {
+        val text = token.text
+        text.startsWith("`") && text.endsWith("`")
+      }
+
       def isLeadingInfixOperator: Boolean = dialect.allowInfixOperatorAfterNL && {
         val text = token.text
         @tailrec


### PR DESCRIPTION
Also, move `isBackquoted` to ScannerTokens and use `token.text`, to get actual source backquoting. For #2880.