### PR TITLE
ScalametaParser: fix handling of `match` postfix

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -1807,14 +1807,12 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |  case 2 => false
          |""".stripMargin,
       Some(
-        """|val hello = xs match {
-           |  case Nil =>
-           |    0
-           |  case x :: xs1 =>
-           |    1 + 1 match {
-           |      case 1 => true
-           |      case 2 => false
-           |    }
+        """|val hello = (xs match {
+           |  case Nil => 0
+           |  case x :: xs1 => 1
+           |}) + 1 match {
+           |  case 1 => true
+           |  case 2 => false
            |}
            |""".stripMargin
       )
@@ -1824,18 +1822,25 @@ class ControlSyntaxSuite extends BaseDottySuite {
         List(Pat.Var(tname("hello"))),
         None,
         Term.Match(
-          tname("xs"),
-          List(
-            Case(tname("Nil"), None, int(0)),
-            Case(
-              Pat.ExtractInfix(Pat.Var(tname("x")), tname("::"), List(Pat.Var(tname("xs1")))),
-              None,
-              Term.Match(
-                Term.ApplyInfix(int(1), tname("+"), Nil, List(int(1))),
-                List(Case(int(1), None, bool(true)), Case(int(2), None, bool(false)))
-              )
-            )
-          )
+          Term.ApplyInfix(
+            Term.Match(
+              tname("xs"),
+              List(
+                Case(tname("Nil"), None, int(0)),
+                Case(
+                  Pat.ExtractInfix(Pat.Var(tname("x")), tname("::"), List(Pat.Var(tname("xs1")))),
+                  None,
+                  int(1)
+                )
+              ),
+              Nil
+            ),
+            tname("+"),
+            Nil,
+            List(int(1))
+          ),
+          List(Case(int(1), None, bool(true)), Case(int(2), None, bool(false))),
+          Nil
         )
       )
     )
@@ -1851,14 +1856,12 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |  case 2 => false
          |""".stripMargin,
       Some(
-        """|val hello = 1 + xs match {
-           |  case Nil =>
-           |    0
-           |  case x :: xs1 =>
-           |    1 + 1 match {
-           |      case 1 => true
-           |      case 2 => false
-           |    }
+        """|val hello = (1 + xs match {
+           |  case Nil => 0
+           |  case x :: xs1 => 1
+           |}) + 1 match {
+           |  case 1 => true
+           |  case 2 => false
            |}
            |""".stripMargin
       )
@@ -1868,19 +1871,24 @@ class ControlSyntaxSuite extends BaseDottySuite {
         List(Pat.Var(tname("hello"))),
         None,
         Term.Match(
-          Term.ApplyInfix(int(1), tname("+"), Nil, List(tname("xs"))),
-          List(
-            Case(tname("Nil"), None, int(0)),
-            Case(
-              Pat.ExtractInfix(Pat.Var(tname("x")), tname("::"), List(Pat.Var(tname("xs1")))),
-              None,
-              Term.Match(
-                Term.ApplyInfix(int(1), tname("+"), Nil, List(int(1))),
-                List(Case(int(1), None, bool(true)), Case(int(2), None, bool(false))),
-                Nil
-              )
-            )
+          Term.ApplyInfix(
+            Term.Match(
+              Term.ApplyInfix(int(1), tname("+"), Nil, List(tname("xs"))),
+              List(
+                Case(tname("Nil"), None, int(0)),
+                Case(
+                  Pat.ExtractInfix(Pat.Var(tname("x")), tname("::"), List(Pat.Var(tname("xs1")))),
+                  None,
+                  int(1)
+                )
+              ),
+              Nil
+            ),
+            tname("+"),
+            Nil,
+            List(int(1))
           ),
+          List(Case(int(1), None, bool(true)), Case(int(2), None, bool(false))),
           Nil
         )
       )
@@ -1898,14 +1906,12 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |    case 2 => false
          |""".stripMargin,
       Some(
-        """|val hello = 1 + xs match {
-           |  case Nil =>
-           |    0
-           |  case x :: xs1 =>
-           |    1 + 1 match {
-           |      case 1 => true
-           |      case 2 => false
-           |    }
+        """|val hello = (1 + xs match {
+           |  case Nil => 0
+           |  case x :: xs1 => 1
+           |}) + 1 match {
+           |  case 1 => true
+           |  case 2 => false
            |}
            |""".stripMargin
       )
@@ -1915,19 +1921,24 @@ class ControlSyntaxSuite extends BaseDottySuite {
         List(Pat.Var(tname("hello"))),
         None,
         Term.Match(
-          Term.ApplyInfix(int(1), tname("+"), Nil, List(tname("xs"))),
-          List(
-            Case(tname("Nil"), None, int(0)),
-            Case(
-              Pat.ExtractInfix(Pat.Var(tname("x")), tname("::"), List(Pat.Var(tname("xs1")))),
-              None,
-              Term.Match(
-                Term.ApplyInfix(int(1), tname("+"), Nil, List(int(1))),
-                List(Case(int(1), None, bool(true)), Case(int(2), None, bool(false))),
-                Nil
-              )
-            )
+          Term.ApplyInfix(
+            Term.Match(
+              Term.ApplyInfix(int(1), tname("+"), Nil, List(tname("xs"))),
+              List(
+                Case(tname("Nil"), None, int(0)),
+                Case(
+                  Pat.ExtractInfix(Pat.Var(tname("x")), tname("::"), List(Pat.Var(tname("xs1")))),
+                  None,
+                  int(1)
+                )
+              ),
+              Nil
+            ),
+            tname("+"),
+            Nil,
+            List(int(1))
           ),
+          List(Case(int(1), None, bool(true)), Case(int(2), None, bool(false))),
           Nil
         )
       )
@@ -1945,14 +1956,12 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |
          |""".stripMargin,
       Some(
-        """|val hello = 1 foo xs match {
-           |  case Nil =>
-           |    0
-           |  case x :: xs1 =>
-           |    1 foo 1 match {
-           |      case 1 => true
-           |      case 2 => false
-           |    }
+        """|val hello = (1 foo xs match {
+           |  case Nil => 0
+           |  case x :: xs1 => 1
+           |}) foo 1 match {
+           |  case 1 => true
+           |  case 2 => false
            |}""".stripMargin
       )
     )(
@@ -1961,19 +1970,24 @@ class ControlSyntaxSuite extends BaseDottySuite {
         List(Pat.Var(tname("hello"))),
         None,
         Term.Match(
-          Term.ApplyInfix(int(1), tname("foo"), Nil, List(tname("xs"))),
-          List(
-            Case(tname("Nil"), None, int(0)),
-            Case(
-              Pat.ExtractInfix(Pat.Var(tname("x")), tname("::"), List(Pat.Var(tname("xs1")))),
-              None,
-              Term.Match(
-                Term.ApplyInfix(int(1), tname("foo"), Nil, List(int(1))),
-                List(Case(int(1), None, bool(true)), Case(int(2), None, bool(false))),
-                Nil
-              )
-            )
+          Term.ApplyInfix(
+            Term.Match(
+              Term.ApplyInfix(int(1), tname("foo"), Nil, List(tname("xs"))),
+              List(
+                Case(tname("Nil"), None, int(0)),
+                Case(
+                  Pat.ExtractInfix(Pat.Var(tname("x")), tname("::"), List(Pat.Var(tname("xs1")))),
+                  None,
+                  int(1)
+                )
+              ),
+              Nil
+            ),
+            tname("foo"),
+            Nil,
+            List(int(1))
           ),
+          List(Case(int(1), None, bool(true)), Case(int(2), None, bool(false))),
           Nil
         )
       )
@@ -1991,14 +2005,12 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |
          |""".stripMargin,
       Some(
-        """|val hello = 1 foo xs match {
-           |  case Nil =>
-           |    0
-           |  case x :: xs1 =>
-           |    1 foo 1 match {
-           |      case 1 => true
-           |      case 2 => false
-           |    }
+        """|val hello = (1 foo xs match {
+           |  case Nil => 0
+           |  case x :: xs1 => 1
+           |}) foo 1 match {
+           |  case 1 => true
+           |  case 2 => false
            |}""".stripMargin
       )
     )(
@@ -2007,19 +2019,24 @@ class ControlSyntaxSuite extends BaseDottySuite {
         List(Pat.Var(tname("hello"))),
         None,
         Term.Match(
-          Term.ApplyInfix(int(1), tname("foo"), Nil, List(tname("xs"))),
-          List(
-            Case(tname("Nil"), None, int(0)),
-            Case(
-              Pat.ExtractInfix(Pat.Var(tname("x")), tname("::"), List(Pat.Var(tname("xs1")))),
-              None,
-              Term.Match(
-                Term.ApplyInfix(int(1), tname("foo"), Nil, List(int(1))),
-                List(Case(int(1), None, bool(true)), Case(int(2), None, bool(false))),
-                Nil
-              )
-            )
+          Term.ApplyInfix(
+            Term.Match(
+              Term.ApplyInfix(int(1), tname("foo"), Nil, List(tname("xs"))),
+              List(
+                Case(tname("Nil"), None, int(0)),
+                Case(
+                  Pat.ExtractInfix(Pat.Var(tname("x")), tname("::"), List(Pat.Var(tname("xs1")))),
+                  None,
+                  int(1)
+                )
+              ),
+              Nil
+            ),
+            tname("foo"),
+            Nil,
+            List(int(1))
           ),
+          List(Case(int(1), None, bool(true)), Case(int(2), None, bool(false))),
           Nil
         )
       )


### PR DESCRIPTION
For #2880.