### PR TITLE
Fix end marker handling

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -3418,13 +3418,10 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
   def endMarker(): Stat = autoPos {
     assert(token.text == "end")
     next()
-    if (token.is[Ident]) {
-      Term.EndMarker(termName())
-    } else {
-      val r = Term.EndMarker(atPos(token)(Term.Name(token.text)))
-      next()
-      r
-    }
+    Term.EndMarker(atCurPosNext(Term.Name(token match {
+      case t: Ident => t.value
+      case t => t.text
+    })))
   }
 
   def patDefOrDcl(mods: List[Mod]): Stat = autoEndPos(mods) {

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -159,27 +159,18 @@ class ScannerTokens(tokens: Tokens, input: Input)(implicit dialect: Dialect) {
     }
 
     @classifier
-    trait EndMarkerWord {
-      def unapply(token: Token): Boolean = token match {
-        case _: Ident | _: KwIf | _: KwWhile | _: KwFor | _: KwMatch | _: KwTry | _: KwNew |
-            _: KwThis | _: KwGiven | _: KwVal =>
-          true
-        case _ => false
-      }
-    }
-
-    @classifier
     trait EndMarkerIntro {
-      def unapply(token: Token): Boolean = token match {
-        case Ident("end") if dialect.allowEndMarker =>
-          val nt = token.strictNext
-          nt.is[EndMarkerWord] && {
-            val nt2 = nt.strictNext
-            nt2.is[EOF] || nt2.is[AtEOL]
+      def unapply(token: Token): Boolean = token.is[soft.KwEnd] && (token.strictNext match {
+        case nt @ (_: Ident | _: KwIf | _: KwWhile | _: KwFor | _: KwMatch | _: KwTry | _: KwNew |
+            _: KwThis | _: KwGiven | _: KwVal) =>
+          nt.strictNext match {
+            case _: EOF | _: AtEOL => true
+            case _ => false
           }
         case _ => false
-      }
+      })
     }
+
     // then  else  do  catch  finally  yield  match
     @classifier
     trait CanContinueOnNextLine {

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SoftKeywords.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SoftKeywords.scala
@@ -69,7 +69,7 @@ class SoftKeywords(dialect: Dialect) {
   @classifier
   trait KwEnd {
     val name = "end"
-    @inline def isEnabled = dialect.allowSignificantIndentation
+    @inline def isEnabled = dialect.allowEndMarker
     @inline final def unapply(token: Token): Boolean = isEnabled && name == token.toString
     @inline final def unapply(token: String): Boolean = isEnabled && name == token
   }


### PR DESCRIPTION
Use the right dialect flag, reuse soft keyword KwEnd properly handling `end` identifiers in backquotes.