### PR TITLE
ScalametaParser: handle leading infix correctly

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/LazyTokenIterator.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/LazyTokenIterator.scala
@@ -364,7 +364,7 @@ private[parsers] class LazyTokenIterator private (
           case _: RegionIndent | _: RegionIndentEnum => true
           case x: RegionParen => x.canProduceLF
           case _ => false
-        } && !isLeadingInfixOperator(nextPos)
+        }
       }
 
       def getIfCanProduceLF =
@@ -395,7 +395,8 @@ private[parsers] class LazyTokenIterator private (
               val ok =
                 if (nextIndent < r.indent)
                   r.closeOnNonCase ||
-                  !(!newlines && isLeadingInfixOperator(nextPos) && // exclude leading infix op
+                  !(!newlines && dialect.allowInfixOperatorAfterNL &&
+                    isLeadingInfixOperator(nextPos) && // exclude leading infix op
                     tail.find(_.isIndented).forall(_.indent <= nextIndent)) &&
                   // need to check prev.prev in case of `end match`
                   (prev.isNot[CanContinueOnNextLine] || prev.prev.is[soft.KwEnd])

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -126,7 +126,7 @@ class ScannerTokens(val tokens: Tokens, input: Input)(implicit dialect: Dialect)
     }
   }
 
-  def isLeadingInfixOperator(index: Int): Boolean = dialect.allowInfixOperatorAfterNL && {
+  def isLeadingInfixOperator(index: Int): Boolean = {
     val token = tokens(index)
     token.is[Ident] && token.isIdentSymbolicInfixOperator && {
       val nextSafeIndex = getNextSafeIndex(index)
@@ -137,6 +137,19 @@ class ScannerTokens(val tokens: Tokens, input: Input)(implicit dialect: Dialect)
       })
     }
   }
+
+  def getTokenAtLineStart(idx: Int): Token =
+    getTokenAtLineStart(idx, tokens(idx))
+
+  @tailrec
+  private def getTokenAtLineStart(idx: Int, nextNonSpace: Token): Token =
+    if (idx == 0) nextNonSpace
+    else
+      tokens(idx) match {
+        case _: AtEOL => nextNonSpace
+        case _: HSpace => getTokenAtLineStart(idx - 1, nextNonSpace)
+        case t => getTokenAtLineStart(idx - 1, t)
+      }
 
   val soft = new SoftKeywords(dialect)
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/Scala213Suite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/Scala213Suite.scala
@@ -138,17 +138,34 @@ class Scala213Suite extends ParseSuite {
 
   test("issue-2880") {
     implicit val Scala213 = dialects.Scala213Source3
-    runTestError[Stat](
+    runAssert(
       """|Flow {
          |    b.add()
          |
          |    input_< ~> filtering ~> removeItems.in0
          |}
-         |""".stripMargin,
-      """|error: ; expected but . found
-         |    input_< ~> filtering ~> removeItems.in0
-         |                                       ^""".stripMargin
-    )(templStat(_)(_), dialects.Scala213Source3)
+         |""".stripMargin
+    )(
+      Term.Apply(
+        Term.Name("Flow"),
+        Term.Block(
+          List(
+            Term.Apply(Term.Select(Term.Name("b"), Term.Name("add")), Nil),
+            Term.ApplyInfix(
+              Term.ApplyInfix(
+                Term.Name("input_<"),
+                Term.Name("~>"),
+                Nil,
+                List(Term.Name("filtering"))
+              ),
+              Term.Name("~>"),
+              Nil,
+              List(Term.Select(Term.Name("removeItems"), Term.Name("in0")))
+            )
+          )
+        ) :: Nil
+      )
+    )
   }
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -426,31 +426,45 @@ class MinorDottySuite extends BaseDottySuite {
 
   test("changed-operator-syntax") {
     // https://dotty.epfl.ch/docs/reference/changed-features/operators.html#syntax-change
-    runTestAssert[Source]("""|object X {
-                             |  println("hello")
-                             |  ???
-                             |  ??? match {
-                             |    case 0 => 1
-                             |  }
-                             |}
-                             |""".stripMargin)(
+    runTestAssert[Source](
+      """|object X {
+         |  println("hello")
+         |  ???
+         |  ??? match {
+         |    case 0 => 1
+         |  }
+         |}
+         |""".stripMargin,
+      Some(
+        """|object X {
+           |  println("hello") ??? ??? match {
+           |    case 0 => 1
+           |  }
+           |}
+           |""".stripMargin
+      )
+    )(
       Source(
-        List(
-          Defn.Object(
+        Defn.Object(
+          Nil,
+          tname("X"),
+          Template(
             Nil,
-            Term.Name("X"),
-            Template(
-              Nil,
-              Nil,
-              Self(Name(""), None),
-              List(
-                Term.Apply(Term.Name("println"), List(Lit.String("hello"))),
-                Term.Name("???"),
-                Term.Match(Term.Name("???"), List(Case(Lit.Int(0), None, Lit.Int(1))))
-              )
-            )
+            Nil,
+            Self(Name(""), None),
+            Term.Match(
+              Term.ApplyInfix(
+                Term.Apply(tname("println"), List(str("hello"))),
+                tname("???"),
+                Nil,
+                List(tname("???"))
+              ),
+              List(Case(int(0), None, int(1))),
+              Nil
+            ) :: Nil,
+            Nil
           )
-        )
+        ) :: Nil
       )
     )
   }


### PR DESCRIPTION
https://docs.scala-lang.org/scala3/reference/changed-features/operators.html#syntax-change

Fixes #2880. Supersedes #2888.