### PR TITLE
LazyTokenIterator: move indent/outdent to NL

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -75,7 +75,7 @@ class ScannerTokens(val tokens: Tokens, input: Input)(implicit dialect: Dialect)
 
         def originMatch =
           (token.is[LFLF] || token.is[Indentation.Outdent] || token.is[Indentation.Indent]) &&
-            scannerToken.start == token.start && scannerToken.end == token.end
+            scannerToken.start == token.start
 
         if (exactMatch || originMatch) roughIndex
         else lurk(roughIndex - 1)


### PR DESCRIPTION
Previously, there were positioned around the next non-trivial token.