### PR TITLE
ScannerTokens: expose token index operations

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/LazyTokenIterator.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/LazyTokenIterator.scala
@@ -354,7 +354,7 @@ private[parsers] class LazyTokenIterator private (
           case _: RegionIndent | _: RegionIndentEnum => true
           case x: RegionParen => x.canProduceLF
           case _ => false
-        } && !next.isLeadingInfixOperator
+        } && !isLeadingInfixOperator(nextPos)
       }
 
       def getIfCanProduceLF =
@@ -385,7 +385,7 @@ private[parsers] class LazyTokenIterator private (
               val ok =
                 if (nextIndent < r.indent)
                   r.closeOnNonCase ||
-                  !(!newlines && next.isLeadingInfixOperator && // exclude leading infix op
+                  !(!newlines && isLeadingInfixOperator(nextPos) && // exclude leading infix op
                     tail.find(_.isIndented).forall(_.indent <= nextIndent)) &&
                   // need to check prev.prev in case of `end match`
                   (prev.isNot[CanContinueOnNextLine] || prev.prev.is[soft.KwEnd])


### PR DESCRIPTION
That way, we will not look up the index when we already have it, or look it up multiple times for each successive or iterative invocation.