### PR TITLE
LazyTokenIterator: don't outdent before `=>`

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/LazyTokenIterator.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/LazyTokenIterator.scala
@@ -372,7 +372,10 @@ private[parsers] class LazyTokenIterator private (
         else None
 
       val resOpt =
-        if (next == null || !hasLF) None
+        if (next == null || !hasLF || (next match {
+            case _: RightArrow | _: LeftArrow | _: ContextArrow | _: TypeLambdaArrow => true
+            case _ => false
+          })) None
         else if (!dialect.allowSignificantIndentation) getIfCanProduceLF
         else {
           val (nextIndent, indentPos) = countIndentAndNewlineIndex(nextPos)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NewFunctionsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NewFunctionsSuite.scala
@@ -637,6 +637,60 @@ class NewFunctionsSuite extends BaseDottySuite {
     )
   }
 
+  test("dependent-type-arrow-after-nl") {
+    val expectedSyntax = "type T = (e: Entry) => e.Key"
+    val expectedTree = Defn.Type(
+      Nil,
+      pname("T"),
+      Nil,
+      Type.Function(
+        List(Type.TypedParam(pname("e"), pname("Entry"))),
+        Type.Select(tname("e"), pname("Key"))
+      ),
+      Type.Bounds(None, None)
+    )
+
+    runTestAssert[Stat](
+      """|type T = 
+         |  (e: Entry) 
+         |  => e.Key
+         |""".stripMargin,
+      Some(expectedSyntax)
+    )(expectedTree)
+
+    runTestError[Stat](
+      """|type T = 
+         |  (e: Entry) 
+         |=> e.Key
+         |""".stripMargin,
+      """|error: ; expected but => found
+         |=> e.Key
+         |^""".stripMargin
+    )
+  }
+
+  test("context-function-arrow-after-nl") {
+    runTestError[Stat](
+      """|type Executable[T] =
+         |  ExecutionContext
+         |  ?=> T
+         |""".stripMargin,
+      """|error: outdent expected but ?=> found
+         |  ?=> T
+         |  ^""".stripMargin
+    )
+
+    runTestError[Stat](
+      """|type Executable[T] =
+         |  ExecutionContext
+         |?=> T
+         |""".stripMargin,
+      """|error: illegal start of definition ?=>
+         |?=> T
+         |^""".stripMargin
+    )
+  }
+
   test("type-lambda-bounds") {
     runTestAssert[Stat](
       "type U <: [X] =>> Any"

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NewFunctionsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NewFunctionsSuite.scala
@@ -658,37 +658,39 @@ class NewFunctionsSuite extends BaseDottySuite {
       Some(expectedSyntax)
     )(expectedTree)
 
-    runTestError[Stat](
+    runTestAssert[Stat](
       """|type T = 
          |  (e: Entry) 
          |=> e.Key
          |""".stripMargin,
-      """|error: ; expected but => found
-         |=> e.Key
-         |^""".stripMargin
-    )
+      Some(expectedSyntax)
+    )(expectedTree)
   }
 
   test("context-function-arrow-after-nl") {
-    runTestError[Stat](
-      """|type Executable[T] =
-         |  ExecutionContext
-         |  ?=> T
-         |""".stripMargin,
-      """|error: outdent expected but ?=> found
-         |  ?=> T
-         |  ^""".stripMargin
+    val expectedSyntax = "type Executable[T] = ExecutionContext ?=> T"
+    val expectedTree = Defn.Type(
+      Nil,
+      pname("Executable"),
+      List(pparam("T")),
+      Type.ContextFunction(List(pname("ExecutionContext")), pname("T"))
     )
 
-    runTestError[Stat](
+    runTestAssert[Stat](
+      """|type Executable[T] =
+         |  ExecutionContext
+         |  ?=> T
+         |""".stripMargin,
+      Some(expectedSyntax)
+    )(expectedTree)
+
+    runTestAssert[Stat](
       """|type Executable[T] =
          |  ExecutionContext
          |?=> T
          |""".stripMargin,
-      """|error: illegal start of definition ?=>
-         |?=> T
-         |^""".stripMargin
-    )
+      Some(expectedSyntax)
+    )(expectedTree)
   }
 
   test("type-lambda-bounds") {


### PR DESCRIPTION
In #3003, along with checking for backquote in possible leading infix, we accidentally added an otherwise valid check for the Ident token. (Proves once again that each commit should be about a single explicit atomic change.)

Unfortunately, it looks like the "leading infix" check happened to cover some unrelated cases, such as the `=>`, and that commit broke the logic.