### PR TITLE
ScalametaParser: skip NL before func type arrows

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NewFunctionsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NewFunctionsSuite.scala
@@ -637,6 +637,110 @@ class NewFunctionsSuite extends BaseDottySuite {
     )
   }
 
+  test("dependent-type-arrow-after-nl") {
+    runTestAssert[Stat](
+      """|type T = 
+         |  (e: Entry) 
+         |  => e.Key
+         |""".stripMargin,
+      Some("type T = (e: Entry) => e.Key")
+    )(
+      Defn.Type(
+        Nil,
+        pname("T"),
+        Nil,
+        Type.Function(
+          List(Type.TypedParam(pname("e"), pname("Entry"))),
+          Type.Select(tname("e"), pname("Key"))
+        ),
+        Type.Bounds(None, None)
+      )
+    )
+  }
+
+  test("dependent-type-arrow-after-nl bad indent") {
+    runTestError[Stat](
+      """|type T = 
+         |  (e: Entry) 
+         |=> e.Key
+         |""".stripMargin,
+      """|error: ; expected but => found
+         |=> e.Key
+         |^""".stripMargin
+    )
+  }
+
+  test("context-function-arrow-after-nl") {
+    runTestError[Stat](
+      """|type Executable[T] =
+         |  ExecutionContext
+         |  ?=> T
+         |""".stripMargin,
+      """|error: outdent expected but ?=> found
+         |  ?=> T
+         |  ^""".stripMargin
+    )
+  }
+
+  test("context-function-arrow-after-nl with parens") {
+    runTestError[Stat](
+      """|type Executable[T] =
+         |  (ExecutionContext)
+         |  ?=> T
+         |""".stripMargin,
+      """|error: outdent expected but ?=> found
+         |  ?=> T
+         |  ^""".stripMargin
+    )
+  }
+
+  test("context-function-arrow-after-nl bad indent") {
+    runTestError[Stat](
+      """|type Executable[T] =
+         |  ExecutionContext
+         |?=> T
+         |""".stripMargin,
+      """|error: illegal start of definition ?=>
+         |?=> T
+         |^""".stripMargin
+    )
+  }
+
+  test("lambda-function-arrow-after-nl") {
+    runTestError[Stat](
+      """|type Tuple =
+         |  [X]
+         |  =>> (X, X)
+         |""".stripMargin,
+      """|error: expected =>> or =>
+         |  [X]
+         |     ^""".stripMargin
+    )
+  }
+
+  test("lambda-function-arrow-after-nl no NL after =") {
+    runTestError[Stat](
+      """|type Tuple = [X]
+         |  =>> (X, X)
+         |""".stripMargin,
+      """|error: expected =>> or =>
+         |type Tuple = [X]
+         |                ^""".stripMargin
+    )
+  }
+
+  test("lambda-function-arrow-after-nl bad indent") {
+    runTestError[Stat](
+      """|type Tuple =
+         |  [X]
+         |=>> (X, X)
+         |""".stripMargin,
+      """|error: expected =>> or =>
+         |  [X]
+         |     ^""".stripMargin
+    )
+  }
+
   test("type-lambda-bounds") {
     runTestAssert[Stat](
       "type U <: [X] =>> Any"

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NewFunctionsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NewFunctionsSuite.scala
@@ -671,26 +671,38 @@ class NewFunctionsSuite extends BaseDottySuite {
   }
 
   test("context-function-arrow-after-nl") {
-    runTestError[Stat](
+    runTestAssert[Stat](
       """|type Executable[T] =
          |  ExecutionContext
          |  ?=> T
          |""".stripMargin,
-      """|error: outdent expected but ?=> found
-         |  ?=> T
-         |  ^""".stripMargin
+      Some("type Executable[T] = ExecutionContext ?=> T")
+    )(
+      Defn.Type(
+        Nil,
+        pname("Executable"),
+        pparam("T") :: Nil,
+        Type.ContextFunction(pname("ExecutionContext") :: Nil, pname("T")),
+        Type.Bounds(None, None)
+      )
     )
   }
 
   test("context-function-arrow-after-nl with parens") {
-    runTestError[Stat](
+    runTestAssert[Stat](
       """|type Executable[T] =
          |  (ExecutionContext)
          |  ?=> T
          |""".stripMargin,
-      """|error: outdent expected but ?=> found
-         |  ?=> T
-         |  ^""".stripMargin
+      Some("type Executable[T] = ExecutionContext ?=> T")
+    )(
+      Defn.Type(
+        Nil,
+        pname("Executable"),
+        pparam("T") :: Nil,
+        Type.ContextFunction(pname("ExecutionContext") :: Nil, pname("T")),
+        Type.Bounds(None, None)
+      )
     )
   }
 
@@ -707,25 +719,37 @@ class NewFunctionsSuite extends BaseDottySuite {
   }
 
   test("lambda-function-arrow-after-nl") {
-    runTestError[Stat](
+    runTestAssert[Stat](
       """|type Tuple =
          |  [X]
          |  =>> (X, X)
          |""".stripMargin,
-      """|error: expected =>> or =>
-         |  [X]
-         |     ^""".stripMargin
+      Some("type Tuple = [X] =>> (X, X)")
+    )(
+      Defn.Type(
+        Nil,
+        pname("Tuple"),
+        Nil,
+        Type.Lambda(pparam("X") :: Nil, Type.Tuple(List(pname("X"), pname("X")))),
+        Type.Bounds(None, None)
+      )
     )
   }
 
   test("lambda-function-arrow-after-nl no NL after =") {
-    runTestError[Stat](
+    runTestAssert[Stat](
       """|type Tuple = [X]
          |  =>> (X, X)
          |""".stripMargin,
-      """|error: expected =>> or =>
-         |type Tuple = [X]
-         |                ^""".stripMargin
+      Some("type Tuple = [X] =>> (X, X)")
+    )(
+      Defn.Type(
+        Nil,
+        pname("Tuple"),
+        Nil,
+        Type.Lambda(pparam("X") :: Nil, Type.Tuple(List(pname("X"), pname("X")))),
+        Type.Bounds(None, None)
+      )
     )
   }
 


### PR DESCRIPTION
Possibly a more compliant fix for #3020.