### PR TITLE
LazyTokenIterator: turn TokenRef into linked list

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -371,6 +371,10 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
     }
   }
 
+  @inline
+  private[parsers] def nextToken(ref: TokenRef): TokenRef =
+    nextToken(ref.token, ref.pos, ref.nextPos, ref.regions)
+
   @tailrec
   private[parsers] def nextToken(
       prevToken: Token,
@@ -401,7 +405,8 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
       TokenRef(regions, mkOutdentToken(pointPos), prevPos, currPos, pointPos)
     }
 
-    def currRef(regions: List[SepRegion]): TokenRef = TokenRef(regions, curr, currPos)
+    def currRef(regions: List[SepRegion], next: TokenRef = null): TokenRef =
+      TokenRef(regions, curr, currPos, next)
 
     def nonTrivial = curr match {
       case _: LeftParen => currRef(RegionParen(false) :: sepRegions)
@@ -511,7 +516,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
         val token = tokens(lastNewlinePos)
         val out =
           if (newlines) LFLF(token.input, token.dialect, token.start, token.end) else token
-        TokenRef(sepRegions, out, lastNewlinePos)
+        TokenRef(sepRegions, out, lastNewlinePos, null)
       }
 
       def canProduceLF: Boolean = {

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/TokenRef.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/TokenRef.scala
@@ -7,7 +7,8 @@ private[parsers] class TokenRef private (
     val token: Token,
     val pos: Int,
     val nextPos: Int,
-    val pointPos: Int
+    val pointPos: Int,
+    var next: TokenRef = null
 ) {
   def withRegions(regions: List[SepRegion]): TokenRef =
     new TokenRef(regions, token, pos, nextPos, pointPos)
@@ -17,15 +18,17 @@ private[parsers] object TokenRef {
   def apply(
       regions: List[SepRegion],
       token: Token,
-      pos: Int
+      pos: Int,
+      next: TokenRef
   ): TokenRef =
-    apply(regions, token, pos, pos + 1, pos)
+    apply(regions, token, pos, pos + 1, pos, next)
   def apply(
       regions: List[SepRegion],
       token: Token,
       pos: Int,
       nextPos: Int,
-      pointPos: Int
+      pointPos: Int,
+      next: TokenRef = null
   ): TokenRef =
-    new TokenRef(regions, token, pos, nextPos, pointPos)
+    new TokenRef(regions, token, pos, nextPos, pointPos, next)
 }


### PR DESCRIPTION
Thus, regardless of forking, we should only compute each subsequent token once, with the exception of `observeIndented` cases which adjust the sequence during parsing. For #3031.