### PR TITLE
TokenIterator: add peekToken

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/LazyTokenIterator.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/LazyTokenIterator.scala
@@ -107,14 +107,16 @@ private[parsers] class LazyTokenIterator private (
     })
   }
 
-  def currentIndentation: Int = {
-    val foundIndentation = countIndent(curr.pointPos)
+  private def getIndentation(ref: TokenRef): Int = {
+    val foundIndentation = countIndent(ref.pointPos)
     if (foundIndentation < 0)
       // empty sepregions means we are at toplevel
-      curr.regions.headOption.fold(0)(_.indent)
+      ref.regions.headOption.fold(0)(_.indent)
     else
       foundIndentation
   }
+
+  override def currentIndentation: Int = getIndentation(curr)
 
   def previousIndentation: Int = curr.regions match {
     case _ :: r :: _ => r.indent
@@ -143,5 +145,14 @@ private[parsers] class LazyTokenIterator private (
 
   override def fork: TokenIterator =
     new LazyTokenIterator(scannerTokens, prev, curr)
+
+  override def peekIndentation: Int =
+    getIndentation(getNextTokenRef())
+
+  override def peekToken: Token =
+    getNextTokenRef().token
+
+  override def peekIndex: Int =
+    getNextTokenRef().pointPos
 
 }

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/TokenIterator.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/TokenIterator.scala
@@ -19,4 +19,8 @@ trait TokenIterator {
   def observeOutdented(): Boolean
   def observeIndentedEnum(): Boolean
   def undoIndent(): Unit
+
+  def peekToken: Token
+  def peekIndex: Int
+  def peekIndentation: Int
 }


### PR DESCRIPTION
That way, we substantially reduce overhead of looking ahead. This also allows avoiding forking in ScalametaParser in many cases. For #3031.