### PR TITLE
ScalametaParser: support coloneol in refined types

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -4166,9 +4166,9 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
   private def refinement(innerType: Option[Type]): Option[Type] =
     if (!dialect.allowSignificantIndentation)
       refinementInBraces(innerType, -1)
-    else if (!token.is[KwWith])
+    else if (!token.isAny[Colon, KwWith])
       refinementInBraces(innerType, previousIndentation + 1)
-    else if (tryAhead[Indentation.Indent])
+    else if (tryAhead[Indentation.Indent] || tryAhead(in.observeIndented()))
       Some(refineWith(innerType, indented(refineStatSeq())))
     else innerType
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/BaseDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/BaseDottySuite.scala
@@ -37,7 +37,10 @@ trait BaseDottySuite extends ParseSuite {
 
   final def pname(name: String): Type.Name = Type.Name(name)
   final def pparam(s: String): Type.Param =
-    Type.Param(Nil, Type.Name(s), Nil, Type.Bounds(None, None), Nil, Nil)
+    Type.Param(Nil, Type.Name(s), Nil, noBounds, Nil, Nil)
+
+  final val noBounds = Type.Bounds(None, None)
+  final def lowBound(bound: Type) = Type.Bounds(Some(bound), None)
 
   final def bool(v: Boolean) = Lit.Boolean(v)
   final def int(v: Int) = Lit.Int(v)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
@@ -98,14 +98,47 @@ class TypeSuite extends BaseDottySuite {
   }
 
   test("coloneol-type3") {
-    runTestError[Stat](
+    runTestAssert[Stat](
       """|type A = Product:
          |  type T>: Null:
          |    type D <: Product
          |""".stripMargin,
-      """|error: ; expected but : found
-         |type A = Product:
-         |                ^""".stripMargin
+      assertLayout = Some(
+        "type A = Product { type T >: Null { type D <: Product } }"
+      )
+    )(
+      Defn.Type(
+        Nil,
+        Type.Name("A"),
+        Nil,
+        Type.Refine(
+          Some(Type.Name("Product")),
+          List(
+            Decl.Type(
+              Nil,
+              Type.Name("T"),
+              Nil,
+              Type.Bounds(
+                Some(
+                  Type.Refine(
+                    Some(Type.Name("Null")),
+                    List(
+                      Decl.Type(
+                        Nil,
+                        Type.Name("D"),
+                        Nil,
+                        Type.Bounds(None, Some(Type.Name("Product")))
+                      )
+                    )
+                  )
+                ),
+                None
+              )
+            )
+          )
+        ),
+        Type.Bounds(None, None)
+      )
     )
   }
 
@@ -145,6 +178,39 @@ class TypeSuite extends BaseDottySuite {
     )(
       Defn.Type(
         Nil,
+        pname("AA"),
+        Nil,
+        Type.Refine(
+          Some(Type.With(pname("String"), pname("Int"))),
+          Decl.Type(
+            Nil,
+            pname("T"),
+            Nil,
+            lowBound(
+              Type.Refine(
+                Some(pname("Null")),
+                Decl.Type(Nil, pname("T"), Nil, lowBound(pname("Int"))) :: Nil
+              )
+            )
+          ) :: Nil
+        ),
+        noBounds
+      )
+    )
+  }
+
+  test("coloneol-followed-by-brace-indent") {
+    runTestAssert[Stat](
+      """|type AA = String with Int:
+         |    type T>: Null:
+         |        type T>: Int
+         |""".stripMargin,
+      assertLayout = Some(
+        "type AA = String with Int { type T >: Null { type T >: Int } }"
+      )
+    )(
+      Defn.Type(
+        Nil,
         Type.Name("AA"),
         Nil,
         Type.Refine(
@@ -170,18 +236,6 @@ class TypeSuite extends BaseDottySuite {
         ),
         Type.Bounds(None, None)
       )
-    )
-  }
-
-  test("coloneol-followed-by-brace-indent") {
-    runTestError[Stat](
-      """|type AA = String with Int:
-         |    type T>: Null:
-         |        type T>: Int
-         |""".stripMargin,
-      """|error: ; expected but : found
-         |type AA = String with Int:
-         |                         ^""".stripMargin
     )
   }
 


### PR DESCRIPTION
For #3045.