### PR TITLE
ScannerTokens: refactor indent, avoid consecutive

### DIFF
--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -475,7 +475,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |Case case aa =>
        |Term.Block   @@case bb =>
        |Case case bb =>
-       |Term.Block   @@finally
+       |Term.Block   case bb =>@@
        |Term.Block cc
        |  dd
        |""".stripMargin

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -2449,8 +2449,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
            |      println(ex)
            |    case ex: Throwable =>
            |      throw ex
-           |      end try
            |  }
+           |  end try
            |}
            |""".stripMargin
       )
@@ -2499,11 +2499,12 @@ class ControlSyntaxSuite extends BaseDottySuite {
                 Case(
                   Pat.Typed(Pat.Var(tname("ex")), pname("Throwable")),
                   None,
-                  Term.Block(List(Term.Throw(tname("ex")), Term.EndMarker(tname("try"))))
+                  Term.Throw(tname("ex"))
                 )
               ),
               None
-            )
+            ),
+            Term.EndMarker(tname("try"))
           ),
           Nil
         )


### PR DESCRIPTION
Since an indent cannot follow another indent or outdent, make sure to add that check -- and fix a test along the way. For #3045.