### PR TITLE
ScalametaParser: require indent for fewer braces

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2259,19 +2259,21 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
              * Without manual handling here, filter would be included for `(a+1).filter`
              */
             val param = simpleExpr(allowRepeated = false)
-            val contextFunction = token.is[ContextArrow]
-            if (contextFunction || token.is[RightArrow]) Some {
-              val params = autoEndPos(paramPos)(convertToParamClause(param))
-              next()
-              val trm = blockExpr(allowRepeated = false)
-              autoEndPos(paramPos) {
-                if (contextFunction)
-                  Term.ContextFunction(params, trm)
-                else
-                  Term.Function(params, trm)
+            if (peekToken.is[Indentation.Indent]) {
+              val contextFunction = token.is[ContextArrow]
+              if (contextFunction || token.is[RightArrow]) Some {
+                val params = autoEndPos(paramPos)(convertToParamClause(param))
+                next()
+                val trm = blockExpr(allowRepeated = false)
+                autoEndPos(paramPos) {
+                  if (contextFunction)
+                    Term.ContextFunction(params, trm)
+                  else
+                    Term.Function(params, trm)
+                }
               }
-            }
-            else None
+              else None
+            } else None
           }.getOrElse(None))
 
         argsOpt match {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -1524,4 +1524,30 @@ class TermSuite extends ParseSuite {
     )
   }
 
+  test("#3050 function without body") {
+    val code =
+      """|f { (x1: A, x2: B => C) =>
+         |}
+         |""".stripMargin
+    checkTerm(code, code)(
+      Term.Apply(
+        Term.Name("f"),
+        Term.Block(
+          Term.Function(
+            List(
+              Term.Param(Nil, Term.Name("x1"), Some(Type.Name("A")), None),
+              Term.Param(
+                Nil,
+                Term.Name("x2"),
+                Some(Type.Function(Type.FuncParamClause(List(Type.Name("B"))), Type.Name("C"))),
+                None
+              )
+            ),
+            Term.Block(Nil)
+          ) :: Nil
+        ) :: Nil
+      )
+    )
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NewFunctionsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NewFunctionsSuite.scala
@@ -839,4 +839,15 @@ class NewFunctionsSuite extends BaseDottySuite {
       )
     )
   }
+
+  test("#3050 function without body") {
+    runTestError[Stat](
+      """|f{ (x1: A, x2: B => C) => }
+         |""".stripMargin,
+      """|error: ; expected but => found
+         |f{ (x1: A, x2: B => C) => }
+         |                       ^""".stripMargin
+    )
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NewFunctionsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NewFunctionsSuite.scala
@@ -841,12 +841,32 @@ class NewFunctionsSuite extends BaseDottySuite {
   }
 
   test("#3050 function without body") {
-    runTestError[Stat](
+    runTestAssert[Stat](
       """|f{ (x1: A, x2: B => C) => }
          |""".stripMargin,
-      """|error: ; expected but => found
-         |f{ (x1: A, x2: B => C) => }
-         |                       ^""".stripMargin
+      Some(
+        """|f { (x1: A, x2: B => C) =>
+           |}
+           |""".stripMargin
+      )
+    )(
+      Term.Apply(
+        Term.Name("f"),
+        Term.Block(
+          Term.Function(
+            List(
+              Term.Param(Nil, Term.Name("x1"), Some(Type.Name("A")), None),
+              Term.Param(
+                Nil,
+                Term.Name("x2"),
+                Some(Type.Function(Type.FuncParamClause(List(Type.Name("B"))), Type.Name("C"))),
+                None
+              )
+            ),
+            Term.Block(Nil)
+          ) :: Nil
+        ) :: Nil
+      )
     )
   }
 


### PR DESCRIPTION
Fixes #3050.