### PR TITLE
ScannerTokens: handle outdent before `then`, `do`

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/LazyTokenIterator.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/LazyTokenIterator.scala
@@ -77,7 +77,7 @@ private[parsers] class LazyTokenIterator private (
        */
       val undoRegionChange =
         prev.headOption match {
-          case Some(_: RegionParen) if token.is[LeftParen] => prev.tail
+          case Some(RegionParen) if token.is[LeftParen] => prev.tail
           case Some(RegionEnumArtificialMark) if token.is[KwEnum] => prev.tail
           case Some(_: RegionBrace) if token.is[LeftBrace] => prev.tail
           //  Handle fewer braces and partial function.
@@ -118,7 +118,6 @@ private[parsers] class LazyTokenIterator private (
   def observeOutdented(): Boolean =
     dialect.allowSignificantIndentation && (curr.regions match {
       case (region: SepRegionIndented) :: tail if (curr.token match {
-            case _: KwThen | _: KwElse | _: KwDo | _: KwYield => true
             case _: KwMatch | _: KwCatch | _: KwFinally => true
             case _ => false
           }) =>

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -281,10 +281,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
   }
   @inline private def indentedAfterOpen[T](body: T): T = {
     newLinesOpt()
-    if (!acceptOpt[Indentation.Outdent]) {
-      in.observeOutdented()
-      accept[Indentation.Outdent]
-    }
+    accept[Indentation.Outdent]
     body
   }
 
@@ -1488,7 +1485,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
         }
       }.getOrElse {
         newLinesOpt()
-        if (!acceptOpt[T]) in.observeIndented()
+        acceptOpt[T]
         simpleExpr
       }
     } else {
@@ -1585,7 +1582,6 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
         } else if (acceptOpt[KwYield]) {
           Term.ForYield(enums, exprMaybeIndented())
         } else {
-          in.observeIndented()
           Term.For(enums, exprMaybeIndented())
         }
       case KwReturn() =>
@@ -4432,7 +4428,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
       case _ => true
     }
 
-    @tailrec def iter(): Unit = if (notCaseDefEnd() && !in.observeOutdented()) token match {
+    @tailrec def iter(): Unit = if (notCaseDefEnd()) token match {
       case _: KwExport =>
         stats += exportStmt()
         acceptStatSepOpt()


### PR DESCRIPTION
For #3045.