### PR TITLE
TreeStructure: describe Lit.Null correctly

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeStructure.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeStructure.scala
@@ -39,7 +39,7 @@ object TreeStructure {
                 default
               case Lit(value: String) =>
                 s(enquote(value, DoubleQuotes))
-              case _: Lit.Unit =>
+              case _: Lit.Unit | _: Lit.Null =>
                 s()
               case x: Lit.Double =>
                 s(x.tokens.mkString)

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/TreeStructureSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/TreeStructureSuite.scala
@@ -22,7 +22,7 @@ class TreeStructureSuite extends ParseSuite {
   assertStructure(Lit.Double("12.30d"))("Lit.Double(12.30d)")
   assertStructure(Lit.Long(1230))("Lit.Long(1230L)")
   assertStructure(Lit.Int(1230))("Lit.Int(1230)")
-  assertStructure(Lit.Null())("Lit.Null(null)")
+  assertStructure(Lit.Null())("Lit.Null()")
   assertStructure(Lit.Boolean(false))("Lit.Boolean(false)")
   assertStructure(Lit.Boolean(true))("Lit.Boolean(true)")
   assertStructure(Lit.String("lit.str"))("""Lit.String("lit.str")""")


### PR DESCRIPTION
Its constructor doesn't take parameters.