### PR TITLE
ScannerTokens: leading infix ops start with `@`

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -70,7 +70,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
       }
 
       val len = text.length
-      len == 0 || (text(0) != '@' && iter(len - 1, false))
+      len == 0 || iter(len - 1, false)
     }
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
@@ -552,15 +552,54 @@ class InfixSuite extends BaseDottySuite {
   }
 
   test("#3051 scala3 leading infix syntax") {
-    runTestError[Stat](
+    runTestAssert[Stat](
       """|val httpRoutes2 = (MetricsApp() ++ HomeApp() ++ GreetingApp())
          |      @@ Middleware.cors(corsConfig)
          |      @@ Middleware.metrics(MetricsApp.pathLabelMapper)
          |      @@ Middleware.debug
          |""".stripMargin,
-      """|error: ; expected but . found
-         |      @@ Middleware.cors(corsConfig)
-         |                   ^""".stripMargin
+      Some(
+        """|val httpRoutes2 = (MetricsApp() ++ HomeApp() ++ GreetingApp()) @@ Middleware.cors(corsConfig) @@ Middleware.metrics(MetricsApp.pathLabelMapper) @@ Middleware.debug
+           |""".stripMargin
+      )
+    )(
+      Defn.Val(
+        Nil,
+        List(Pat.Var(tname("httpRoutes2"))),
+        None,
+        Term.ApplyInfix(
+          Term.ApplyInfix(
+            Term.ApplyInfix(
+              Term.ApplyInfix(
+                Term.ApplyInfix(
+                  Term.Apply(tname("MetricsApp"), Nil),
+                  tname("++"),
+                  Nil,
+                  List(Term.Apply(tname("HomeApp"), Nil))
+                ),
+                tname("++"),
+                Nil,
+                List(Term.Apply(tname("GreetingApp"), Nil))
+              ),
+              tname("@@"),
+              Nil,
+              Term.Apply(
+                Term.Select(tname("Middleware"), tname("cors")),
+                List(tname("corsConfig"))
+              ) :: Nil
+            ),
+            tname("@@"),
+            Nil,
+            Term.Apply(
+              Term.Select(tname("Middleware"), tname("metrics")),
+              List(Term.Select(tname("MetricsApp"), tname("pathLabelMapper")))
+            ) :: Nil
+          ),
+          tname("@@"),
+          Nil,
+          List(Term.Select(tname("Middleware"), tname("debug")))
+        )
+      )
     )
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
@@ -551,4 +551,17 @@ class InfixSuite extends BaseDottySuite {
     )
   }
 
+  test("#3051 scala3 leading infix syntax") {
+    runTestError[Stat](
+      """|val httpRoutes2 = (MetricsApp() ++ HomeApp() ++ GreetingApp())
+         |      @@ Middleware.cors(corsConfig)
+         |      @@ Middleware.metrics(MetricsApp.pathLabelMapper)
+         |      @@ Middleware.debug
+         |""".stripMargin,
+      """|error: ; expected but . found
+         |      @@ Middleware.cors(corsConfig)
+         |                   ^""".stripMargin
+    )
+  }
+
 }


### PR DESCRIPTION
Fixes #3051.