### PR TITLE
Trees: avoid named/default args in annotations

### DIFF
--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/ast.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/ast.scala
@@ -706,7 +706,7 @@ class AstNamerMacros(val c: Context) extends Reflection with CommonNamerMacros {
   }
 
   private def getDeprecatedAnno(v: Version) =
-    q"new scala.deprecated(since = ${Literal(Constant(versionToString(v)))})"
+    q"new scala.deprecated(${Literal(Constant(versionToString(v)))})"
 
   private def asValDecl(p: ValOrDefDef): ValDef =
     q"val ${p.name}: ${deannotateType(p)}"


### PR DESCRIPTION
They cause compile warnings.