### PR TITLE
TreeSyntax: enquote embedded '"""' if needed

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -1926,4 +1926,9 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     }
   }
 
+  test("#3065 embedded triple quotes") {
+    val tree = Lit.String("\n\"\"\"")
+    assertSyntax(tree, "\"\"\"\n\"\"\"\"\"\"")(tree)
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -1928,7 +1928,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
 
   test("#3065 embedded triple quotes") {
     val tree = Lit.String("\n\"\"\"")
-    assertSyntax(tree, "\"\"\"\n\"\"\"\"\"\"")(tree)
+    assertSyntax(tree, "\"\"\"\n\\\"\\\"\\\"\"\"\"")(tree)
   }
 
 }


### PR DESCRIPTION
Fixes #3065.