### PR TITLE
ast: parse current build version

### DIFF
--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/Version.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/Version.scala
@@ -10,6 +10,8 @@ case class Version(major: Int, minor: Int, patch: Int) {
 
 object Version {
 
+  final val zero = Version(0, 0, 0)
+
   implicit val ordering = new Ordering[Version] {
     override def compare(x: Version, y: Version): Int = {
       val cmpMajor = x.major.compare(y.major)


### PR DESCRIPTION
Also, make sure the version annotations don't refer to future versions.