### PR TITLE
ScalametaParser: validate parameter modifiers

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
@@ -778,24 +778,28 @@ class ModSuite extends ParseSuite {
   }
 
   test("missing val after parameter modifier") {
-    assertNoDiff(
-      templStat("class A(implicit b: B, implicit c: C)").syntax,
-      "class A(implicit b: B, implicit c: C)"
-    )
+    val actual = interceptParseError("class A(implicit b: B, implicit c: C)")
+    val expected =
+      s"""|error: val expected but identifier found
+          |class A(implicit b: B, implicit c: C)
+          |                                ^""".stripMargin
+    assert(actual.contains(expected), actual)
   }
 
-  test("repeated parameter modifier") {
-    assertNoDiff(
-      templStat("class A(implicit implicit b: B)").syntax,
-      "class A(implicit implicit b: B)"
-    )
+  test("repeated parameter modifier on first parameter") {
+    val actual = interceptParseError("class A(implicit implicit val b: B)")
+    val expected =
+      s"""|error: repeated modifier
+          |class A(implicit implicit val b: B)
+          |                 ^""".stripMargin
+    assert(actual.contains(expected), actual)
   }
 
   test("repeated parameter modifier on second parameter") {
-    val actual = interceptParseError("class A(implicit b: B, implicit implicit c: C)")
+    val actual = interceptParseError("class A(implicit b: B, implicit implicit val c: C)")
     val expected =
       s"""|error: repeated modifier
-          |class A(implicit b: B, implicit implicit c: C)
+          |class A(implicit b: B, implicit implicit val c: C)
           |                                ^""".stripMargin
     assert(actual.contains(expected), actual)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -2127,9 +2127,8 @@ class SuccessSuite extends TreeSuiteBase {
   }
 
   test("1 param\"..mods paramname: tpeopt = expropt\"") {
-    val param"..$mods $paramname: $tpeopt = $expropt" = param"private final x: X = 42"
-    assertEquals(mods.toString, "List(private, final)")
-    assertTrees(mods: _*)(Mod.Private(Name("")), Mod.Final())
+    val param"..$mods $paramname: $tpeopt = $expropt" = param"private final val x: X = 42"
+    assertTrees(mods: _*)(Mod.Private(Name("")), Mod.Final(), Mod.ValParam())
     assertTree(paramname)(Term.Name("x"))
     assertTree(tpeopt)(Some(Type.Name("X")))
     assertTree(expropt)(Some(Lit.Int(42)))


### PR DESCRIPTION
1. check that val must follow explicit param modifiers

2. check there's no repeated implicit modifier on the first parameter; the existing code already checks for repeated modifiers except for the implicit/using modifier on the first parameter because the clause modifier is parsed outside of the `termParam` method.
