### PR TITLE
ScalametaParser: no repeated initial implicit mod

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -3103,7 +3103,10 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
     }
     mod.foreach { mod =>
       val clazz = mod.getClass
-      if (!mods.exists(_.getClass eq clazz)) mods += mod
+      mods.find(_.getClass eq clazz) match {
+        case None => mods += mod
+        case Some(x) => if (paramIdx == 0) syntaxError("repeated modifier", at = x)
+      }
     }
 
     val varOrVarParamMod = token match {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
@@ -785,10 +785,12 @@ class ModSuite extends ParseSuite {
   }
 
   test("repeated parameter modifier") {
-    assertNoDiff(
-      templStat("class A(implicit implicit b: B)").syntax,
-      "class A(implicit implicit b: B)"
-    )
+    val actual = interceptParseError("class A(implicit implicit b: B)")
+    val expected =
+      s"""|error: repeated modifier
+          |class A(implicit implicit b: B)
+          |                 ^""".stripMargin
+    assert(actual.contains(expected), actual)
   }
 
   test("repeated parameter modifier on second parameter") {


### PR DESCRIPTION
The existing code already checks for repeated modifiers on parameters except for the implicit/using modifier on the first parameter.