### PR TITLE
ScalametaParser: fix parameter by-name logic

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -3143,9 +3143,9 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
                 val tpt = paramType()
                 if (tpt.is[Type.ByName]) {
                   def mayNotBeByName(mod: Mod) =
-                    syntaxError(s"$mod parameters may not be call-by-name", at = name)
+                    syntaxError(s"`$mod' parameters may not be call-by-name", at = name)
                   val isLocalToThis: Boolean =
-                    ownerIsCase || varOrVarParamMod.isEmpty || mods.exists {
+                    (!ownerIsCase && varOrVarParamMod.isEmpty) || mods.exists {
                       case Mod.Private(_: Term.This) => true; case _ => false
                     }
                   val badMod =

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
@@ -817,7 +817,6 @@ class ModSuite extends ParseSuite {
   }
 
   test("by-name parameter: case class with val") {
-    // XXX: fails before #3084, succeeds after it
     val actual = interceptParseError("case class A(val b: => B)")
     val expected =
       s"""|error: `val' parameters may not be call-by-name

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
@@ -800,4 +800,39 @@ class ModSuite extends ParseSuite {
     assert(actual.contains(expected), actual)
   }
 
+  test("by-name parameter: class with val") {
+    val actual = interceptParseError("class A(val b: => B)")
+    val expected =
+      s"""|error: `val' parameters may not be call-by-name
+          |class A(val b: => B)
+          |            ^""".stripMargin
+    assert(actual.contains(expected), actual)
+  }
+
+  test("by-name parameter: class with private[this] val") {
+    assertNoDiff(
+      templStat("class A(private[this] val b: => B)").syntax,
+      "class A(private[this] val b: => B)"
+    )
+  }
+
+  test("by-name parameter: case class with val") {
+    // XXX: fails before #3084, succeeds after it
+    val actual = interceptParseError("case class A(val b: => B)")
+    val expected =
+      s"""|error: `val' parameters may not be call-by-name
+          |case class A(val b: => B)
+          |                 ^""".stripMargin
+    assert(actual.contains(expected), actual)
+  }
+
+  test("by-name parameter: class with implicit val") {
+    val actual = interceptParseError("class A(implicit val b: => B)")
+    val expected =
+      s"""|error: `val' parameters may not be call-by-name
+          |class A(implicit val b: => B)
+          |                     ^""".stripMargin
+    assert(actual.contains(expected), actual)
+  }
+
 }


### PR DESCRIPTION
It was introduced in #3084 by mistake.