### PR TITLE
Allow Optional Braces Around Template Bodies anyway

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -4175,14 +4175,13 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
     } else if (isColonEol()) {
       accept[Colon]
 
-      val nextIndented =
-        if (enumCaseAllowed)
-          in.observeIndentedEnum()
-        else
-          in.observeIndented()
+      if (enumCaseAllowed)
+        in.observeIndentedEnum()
+      else
+        in.observeIndented()
 
-      if (nextIndented)
-        indentedOnOpen(templateStatSeq(enumCaseAllowed, secondaryConstructorAllowed))
+      if (acceptOpt[Indentation.Indent])
+        indentedAfterOpen(templateStatSeq(enumCaseAllowed, secondaryConstructorAllowed))
       else if (!enumCaseAllowed && isEndMarkerIntro(tokenPos))
         (selfEmpty(), Nil)
       else

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -104,6 +104,35 @@ class SignificantIndentationSuite extends BaseDottySuite {
     )
   }
 
+  // https://github.com/scalameta/scalameta/issues/3093
+  test("anonymous-class-in-block") {
+    val code = """|if(x) {
+                  |  new A:
+                  |    def f: Int
+                  |}
+                  |""".stripMargin
+    runTestAssert[Stat](code, assertLayout = None)(
+      Term.If(
+        Term.Name("x"),
+        Term.Block(
+          List(
+            Term.NewAnonymous(
+              Template(
+                Nil,
+                List(Init(Type.Name("A"), Name(""), Nil)),
+                Self(Name(""), None),
+                List(Decl.Def(Nil, Term.Name("f"), Nil, Type.Name("Int"))),
+                Nil
+              )
+            )
+          )
+        ),
+        Lit.Unit(),
+        Nil
+      )
+    )
+  }
+
   test("empty-anonymous-class") {
     val code = """|new:
                   |  def f: Int


### PR DESCRIPTION
fix https://github.com/scalameta/scalameta/issues/3093

It seems like we should accept the optional braces around template body when we accept `:`, even inside the block with braces.

I'm trying to confirm this is valid change from syntax specification https://docs.scala-lang.org/scala3/reference/other-new-features/indentation.html (that's why it's still draft)...