### PR TITLE
LegacyScanner: treat comment chars differently

### DIFF
--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/CharArrayReader.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/CharArrayReader.scala
@@ -132,13 +132,18 @@ class CharArrayReader(input: Input, dialect: Dialect, reporter: Reporter)
 
   /** Handle line ends */
   private def potentialLineEnd(): Unit = {
-    if (ch == LF || ch == FF) {
-      if (!dialect.allowMultilinePrograms) {
-        readerError("line breaks are not allowed in single-line quasiquotes", at = charOffset - 1)
-      }
+    if (checkLineEnd() && !dialect.allowMultilinePrograms) {
+      readerError("line breaks are not allowed in single-line quasiquotes", at = charOffset - 1)
+    }
+  }
+
+  private def checkLineEnd(): Boolean = {
+    val ok = ch == LF || ch == FF
+    if (ok) {
       lastLineStartOffset = lineStartOffset
       lineStartOffset = charOffset
     }
+    ok
   }
 
   /** A new reader that takes off at the current character position */

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/CharArrayReader.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/CharArrayReader.scala
@@ -55,6 +55,16 @@ class CharArrayReader(input: Input, dialect: Dialect, reporter: Reporter)
     }
   }
 
+  final def nextCommentChar(): Unit = {
+    if (charOffset >= buf.length) {
+      ch = SU
+    } else {
+      ch = buf(charOffset)
+      charOffset += 1
+      checkLineEnd()
+    }
+  }
+
   /**
    * Advance one character, leaving CR;LF pairs intact. This is for use in multi-line strings, so
    * there are no "potential line ends" here.

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
@@ -23,7 +23,7 @@ class LegacyScanner(input: Input, dialect: Dialect) {
 
   private def isDigit(c: Char) = java.lang.Character isDigit c
   private var openComments = 0
-  protected def putCommentChar(): Unit = nextChar()
+  protected def putCommentChar(): Unit = nextCommentChar()
 
   @tailrec private def skipLineComment(): Unit = ch match {
     case SU | CR | LF =>

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
@@ -654,6 +654,21 @@ class TokenizerSuite extends BaseTokenizerSuite {
     """.trim.stripMargin)
   }
 
+  test("showRaw with comments - skip unicode escape 1") {
+    val comment = "// Note: '\\u000A' = '\\n'"
+    intercept[TokenizeException] {
+      tokenize(comment).map(_.structure).mkString("\n")
+    }
+  }
+
+  test("showRaw with comments - skip unicode escape 2") {
+    val comment = "/* Note: '\\u000A' = '\\n' */"
+    assertNoDiff(
+      tokenize(comment).map(_.structure).mkString("\n"),
+      Seq("BOF [0..0)", s"$comment [0..27)", "EOF [27..27)").mkString("\n")
+    )
+  }
+
   test("interpolation start & end - episode 01") {
     assert(tokenize("q\"\"").map(_.structure).mkString("\n") == """
       |BOF [0..0)

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
@@ -656,9 +656,10 @@ class TokenizerSuite extends BaseTokenizerSuite {
 
   test("showRaw with comments - skip unicode escape 1") {
     val comment = "// Note: '\\u000A' = '\\n'"
-    intercept[TokenizeException] {
-      tokenize(comment).map(_.structure).mkString("\n")
-    }
+    assertNoDiff(
+      tokenize(comment).map(_.structure).mkString("\n"),
+      Seq("BOF [0..0)", s"$comment [0..24)", "EOF [24..24)").mkString("\n")
+    )
   }
 
   test("showRaw with comments - skip unicode escape 2") {


### PR DESCRIPTION
Specifically, do not interpret unicode escapes, double quotes etc. Fixes #3095.