### PR TITLE
Fix #3103

### DIFF
--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/package.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/package.scala
@@ -13,10 +13,10 @@ package object scalac {
         if (append) StandardOpenOption.APPEND
         else StandardOpenOption.TRUNCATE_EXISTING
       val out = SemanticdbPaths.toSemanticdb(sdocument, targetroot)
+      val bytes = s.TextDocuments(sdocument :: Nil).toByteArray
       if (!Files.exists(out.toNIO.getParent)) {
         Files.createDirectories(out.toNIO.getParent)
       }
-      val bytes = s.TextDocuments(sdocument :: Nil).toByteArray
       Files.write(out.toNIO, bytes, StandardOpenOption.CREATE, openOption)
     }
     def save(targetroot: AbsolutePath): Unit =


### PR DESCRIPTION
Move protobuf serialization before directory creation. This reduces the chance of a race condition with the file-deletion code, when running inside Hydra, the parallel Scala compiler.