### PR TITLE
ScalametaParser: fix detection of leading infix op

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2024,10 +2024,10 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
             val opLine = opPos.startLine
             val argLine = argPos.startLine
             val opCol = opPos.startColumn
-            val okInfix = isExprIntro(argToken, tokenPos) && {
+            val okInfix = canBeLeadingInfixArg(argToken, tokenPos) && {
               if (opLine == argLine) opPos.endColumn < argPos.startColumn // space on same line
               else opLine == argLine - 1 && opCol <= argPos.startColumn // indent on next line
-            } && !isLeadingInfixOperator(tokenPos)
+            }
             if (okInfix) Some(Right(getNextRhs(op, autoPos(Type.ArgClause(Nil)))))
             else {
               val indentedWithoutArg = opLine != argLine &&

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
@@ -419,7 +419,9 @@ class InfixSuite extends BaseDottySuite {
          |""".stripMargin,
       Some(
         """|{
-           |  println("hello") ??? ??? match {
+           |  println("hello")
+           |  ???
+           |  ??? match {
            |    case 0 => 1
            |  }
            |}
@@ -427,22 +429,21 @@ class InfixSuite extends BaseDottySuite {
       )
     )(
       Term.Block(
-        Term.Match(
-          Term.ApplyInfix(
-            Term.Apply(tname("println"), List(str("hello"))),
+        List(
+          Term.Apply(tname("println"), List(str("hello"))),
+          tname("???"),
+          Term.Match(
             tname("???"),
-            Nil,
-            List(tname("???"))
-          ),
-          List(Case(int(0), None, int(1))),
-          Nil
-        ) :: Nil
+            List(Case(int(0), None, int(1))),
+            Nil
+          )
+        )
       )
     )
   }
 
   test("scala3 infix syntax 5.2") {
-    runTestAssert[Stat](
+    runTestError[Stat](
       """|{
          |  println("hello")
          |    ???
@@ -451,27 +452,9 @@ class InfixSuite extends BaseDottySuite {
          |    }
          |}
          |""".stripMargin,
-      Some(
-        """|{
-           |  println("hello") ??? ??? match {
-           |    case 0 => 1
-           |  }
-           |}
-           |""".stripMargin
-      )
-    )(
-      Term.Block(
-        Term.Match(
-          Term.ApplyInfix(
-            Term.Apply(tname("println"), List(str("hello"))),
-            tname("???"),
-            Nil,
-            List(tname("???"))
-          ),
-          List(Case(int(0), None, int(1))),
-          Nil
-        ) :: Nil
-      )
+      """|error: Invalid indented leading infix operator found
+         |    ???
+         |    ^""".stripMargin
     )
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -437,7 +437,9 @@ class MinorDottySuite extends BaseDottySuite {
          |""".stripMargin,
       Some(
         """|object X {
-           |  println("hello") ??? ??? match {
+           |  println("hello")
+           |  ???
+           |  ??? match {
            |    case 0 => 1
            |  }
            |}
@@ -452,16 +454,11 @@ class MinorDottySuite extends BaseDottySuite {
             Nil,
             Nil,
             Self(Name(""), None),
-            Term.Match(
-              Term.ApplyInfix(
-                Term.Apply(tname("println"), List(str("hello"))),
-                tname("???"),
-                Nil,
-                List(tname("???"))
-              ),
-              List(Case(int(0), None, int(1))),
-              Nil
-            ) :: Nil,
+            List(
+              Term.Apply(tname("println"), List(str("hello"))),
+              tname("???"),
+              Term.Match(tname("???"), List(Case(int(0), None, int(1))), Nil)
+            ),
             Nil
           )
         ) :: Nil


### PR DESCRIPTION
Fixes #3094.