### PR TITLE
bugfix: properly forward error/warning count to and from wrapped scalac reporter

### DIFF
--- a/semanticdb/scalac/library/src/main/scala-2.12.13/scala/meta/internal/semanticdb/scalac/SemanticdbReporter.scala
+++ b/semanticdb/scalac/library/src/main/scala-2.12.13/scala/meta/internal/semanticdb/scalac/SemanticdbReporter.scala
@@ -1,35 +1,26 @@
 package scala.meta.internal.semanticdb.scalac
 
 import scala.reflect.internal.util.Position
+import scala.tools.nsc.reporters.{FilteringReporter, StoreReporter}
 import scala.tools.nsc.Settings
-import scala.tools.nsc.reporters.{Reporter, StoreReporter}
 
-class SemanticdbReporter(underlying: Reporter)
-    extends StoreReporter(SemanticdbReporter.defaultSettings()) {
-  override protected def info0(
-      pos: Position,
-      msg: String,
-      severity: Severity,
-      force: Boolean
-  ): Unit = {
-    super.info0(pos, msg, severity, force)
-    severity.id match {
-      case 0 => underlying.info(pos, msg, force)
-      case 1 => underlying.warning(pos, msg)
-      case 2 => underlying.error(pos, msg)
-      case _ =>
-    }
-
+class SemanticdbReporter(underlying: FilteringReporter)
+    extends StoreReporter(SemanticdbReporter.defaultSettings(underlying.settings)) {
+  override def doReport(pos: Position, msg: String, severity: Severity): Unit = {
+    super.doReport(pos, msg, severity)
+    underlying.doReport(pos, msg, severity)
   }
 
-  override def hasErrors: Boolean = underlying.hasErrors
+  // overriding increment is enough so make sure that error/warning
+  // counts are the same as in underlying reporter
 
-  override def hasWarnings: Boolean = underlying.hasWarnings
-
+  override def increment(severity: Severity): Unit = {
+    super.increment(severity)
+    underlying.increment(severity)
+  }
 }
 object SemanticdbReporter {
-  def defaultSettings(): Settings = {
-    val s = new Settings()
+  def defaultSettings(s: Settings): Settings = {
     s.processArguments(List("-Xmaxwarns", "-1", "-Xmaxerrs", "-1"), true)
     s
   }

--- a/semanticdb/scalac/library/src/main/scala-2.12.14/scala/meta/internal/semanticdb/scalac/SemanticdbReporter.scala
+++ b/semanticdb/scalac/library/src/main/scala-2.12.14/scala/meta/internal/semanticdb/scalac/SemanticdbReporter.scala
@@ -1,36 +1,26 @@
 package scala.meta.internal.semanticdb.scalac
 
 import scala.reflect.internal.util.Position
+import scala.tools.nsc.reporters.{FilteringReporter, StoreReporter}
 import scala.tools.nsc.Settings
-import scala.tools.nsc.reporters.{Reporter, StoreReporter}
 
-class SemanticdbReporter(underlying: Reporter)
-    extends StoreReporter(SemanticdbReporter.defaultSettings()) {
-  override protected def info0(
-      pos: Position,
-      msg: String,
-      severity: Severity,
-      force: Boolean
-  ): Unit = {
-    super.info0(pos, msg, severity, force)
-    severity.id match {
-      case 0 => underlying.info(pos, msg, force)
-      case 1 => underlying.warning(pos, msg)
-      case 2 => underlying.error(pos, msg)
-      case _ =>
-    }
-
+class SemanticdbReporter(underlying: FilteringReporter)
+    extends StoreReporter(SemanticdbReporter.defaultSettings(underlying.settings)) {
+  override def doReport(pos: Position, msg: String, severity: Severity): Unit = {
+    super.doReport(pos, msg, severity)
+    underlying.doReport(pos, msg, severity)
   }
 
-  override def hasErrors: Boolean = underlying.hasErrors
+  // overriding increment is enough so make sure that error/warning
+  // counts are the same as in underlying reporter
 
-  override def hasWarnings: Boolean = underlying.hasWarnings
-
+  override def increment(severity: Severity): Unit = {
+    super.increment(severity)
+    underlying.increment(severity)
+  }
 }
-
 object SemanticdbReporter {
-  def defaultSettings(): Settings = {
-    val s = new Settings()
+  def defaultSettings(s: Settings): Settings = {
     s.processArguments(List("-Xmaxwarns", "-1", "-Xmaxerrs", "-1"), true)
     s
   }

--- a/semanticdb/scalac/library/src/main/scala-2.12.15/scala/meta/internal/semanticdb/scalac/SemanticdbReporter.scala
+++ b/semanticdb/scalac/library/src/main/scala-2.12.15/scala/meta/internal/semanticdb/scalac/SemanticdbReporter.scala
@@ -1,36 +1,26 @@
 package scala.meta.internal.semanticdb.scalac
 
 import scala.reflect.internal.util.Position
+import scala.tools.nsc.reporters.{FilteringReporter, StoreReporter}
 import scala.tools.nsc.Settings
-import scala.tools.nsc.reporters.{Reporter, StoreReporter}
 
-class SemanticdbReporter(underlying: Reporter)
-    extends StoreReporter(SemanticdbReporter.defaultSettings()) {
-  override protected def info0(
-      pos: Position,
-      msg: String,
-      severity: Severity,
-      force: Boolean
-  ): Unit = {
-    super.info0(pos, msg, severity, force)
-    severity.id match {
-      case 0 => underlying.info(pos, msg, force)
-      case 1 => underlying.warning(pos, msg)
-      case 2 => underlying.error(pos, msg)
-      case _ =>
-    }
-
+class SemanticdbReporter(underlying: FilteringReporter)
+    extends StoreReporter(SemanticdbReporter.defaultSettings(underlying.settings)) {
+  override def doReport(pos: Position, msg: String, severity: Severity): Unit = {
+    super.doReport(pos, msg, severity)
+    underlying.doReport(pos, msg, severity)
   }
 
-  override def hasErrors: Boolean = underlying.hasErrors
+  // overriding increment is enough so make sure that error/warning
+  // counts are the same as in underlying reporter
 
-  override def hasWarnings: Boolean = underlying.hasWarnings
-
+  override def increment(severity: Severity): Unit = {
+    super.increment(severity)
+    underlying.increment(severity)
+  }
 }
-
 object SemanticdbReporter {
-  def defaultSettings(): Settings = {
-    val s = new Settings()
+  def defaultSettings(s: Settings): Settings = {
     s.processArguments(List("-Xmaxwarns", "-1", "-Xmaxerrs", "-1"), true)
     s
   }

--- a/semanticdb/scalac/library/src/main/scala-2.12.16/scala/meta/internal/semanticdb/scalac/SemanticdbReporter.scala
+++ b/semanticdb/scalac/library/src/main/scala-2.12.16/scala/meta/internal/semanticdb/scalac/SemanticdbReporter.scala
@@ -1,36 +1,26 @@
 package scala.meta.internal.semanticdb.scalac
 
 import scala.reflect.internal.util.Position
+import scala.tools.nsc.reporters.{FilteringReporter, StoreReporter}
 import scala.tools.nsc.Settings
-import scala.tools.nsc.reporters.{Reporter, StoreReporter}
 
-class SemanticdbReporter(underlying: Reporter)
-    extends StoreReporter(SemanticdbReporter.defaultSettings()) {
-  override protected def info0(
-      pos: Position,
-      msg: String,
-      severity: Severity,
-      force: Boolean
-  ): Unit = {
-    super.info0(pos, msg, severity, force)
-    severity.id match {
-      case 0 => underlying.info(pos, msg, force)
-      case 1 => underlying.warning(pos, msg)
-      case 2 => underlying.error(pos, msg)
-      case _ =>
-    }
-
+class SemanticdbReporter(underlying: FilteringReporter)
+    extends StoreReporter(SemanticdbReporter.defaultSettings(underlying.settings)) {
+  override def doReport(pos: Position, msg: String, severity: Severity): Unit = {
+    super.doReport(pos, msg, severity)
+    underlying.doReport(pos, msg, severity)
   }
 
-  override def hasErrors: Boolean = underlying.hasErrors
+  // overriding increment is enough so make sure that error/warning
+  // counts are the same as in underlying reporter
 
-  override def hasWarnings: Boolean = underlying.hasWarnings
-
+  override def increment(severity: Severity): Unit = {
+    super.increment(severity)
+    underlying.increment(severity)
+  }
 }
-
 object SemanticdbReporter {
-  def defaultSettings(): Settings = {
-    val s = new Settings()
+  def defaultSettings(s: Settings): Settings = {
     s.processArguments(List("-Xmaxwarns", "-1", "-Xmaxerrs", "-1"), true)
     s
   }

--- a/semanticdb/scalac/library/src/main/scala-2.12.17/scala/meta/internal/semanticdb/scalac/SemanticdbReporter.scala
+++ b/semanticdb/scalac/library/src/main/scala-2.12.17/scala/meta/internal/semanticdb/scalac/SemanticdbReporter.scala
@@ -1,36 +1,26 @@
 package scala.meta.internal.semanticdb.scalac
 
 import scala.reflect.internal.util.Position
+import scala.tools.nsc.reporters.{FilteringReporter, StoreReporter}
 import scala.tools.nsc.Settings
-import scala.tools.nsc.reporters.{Reporter, StoreReporter}
 
-class SemanticdbReporter(underlying: Reporter)
-    extends StoreReporter(SemanticdbReporter.defaultSettings()) {
-  override protected def info0(
-      pos: Position,
-      msg: String,
-      severity: Severity,
-      force: Boolean
-  ): Unit = {
-    super.info0(pos, msg, severity, force)
-    severity.id match {
-      case 0 => underlying.info(pos, msg, force)
-      case 1 => underlying.warning(pos, msg)
-      case 2 => underlying.error(pos, msg)
-      case _ =>
-    }
-
+class SemanticdbReporter(underlying: FilteringReporter)
+    extends StoreReporter(SemanticdbReporter.defaultSettings(underlying.settings)) {
+  override def doReport(pos: Position, msg: String, severity: Severity): Unit = {
+    super.doReport(pos, msg, severity)
+    underlying.doReport(pos, msg, severity)
   }
 
-  override def hasErrors: Boolean = underlying.hasErrors
+  // overriding increment is enough so make sure that error/warning
+  // counts are the same as in underlying reporter
 
-  override def hasWarnings: Boolean = underlying.hasWarnings
-
+  override def increment(severity: Severity): Unit = {
+    super.increment(severity)
+    underlying.increment(severity)
+  }
 }
-
 object SemanticdbReporter {
-  def defaultSettings(): Settings = {
-    val s = new Settings()
+  def defaultSettings(s: Settings): Settings = {
     s.processArguments(List("-Xmaxwarns", "-1", "-Xmaxerrs", "-1"), true)
     s
   }


### PR DESCRIPTION
Fix for issue https://github.com/scalameta/scalameta/issues/3099. The same reporter change that was made in Scala 2.13.1 was also made in Scala 2.12.13. Apply the same fix to Scala 2.12.13+.

Copied the reporter from:
https://github.com/bmarker/scalameta/blob/v4.7.6/semanticdb/scalac/library/src/main/scala-2.13/scala/meta/internal/semanticdb/scalac/SemanticdbReporter.scala

To:
https://github.com/bmarker/scalameta/blob/v4.7.6/semanticdb/scalac/library/src/main/scala-2.12.13/scala/meta/internal/semanticdb/scalac/SemanticdbReporter.scala
https://github.com/bmarker/scalameta/blob/v4.7.6/semanticdb/scalac/library/src/main/scala-2.12.14/scala/meta/internal/semanticdb/scalac/SemanticdbReporter.scala
https://github.com/bmarker/scalameta/blob/v4.7.6/semanticdb/scalac/library/src/main/scala-2.12.15/scala/meta/internal/semanticdb/scalac/SemanticdbReporter.scala
https://github.com/bmarker/scalameta/blob/v4.7.6/semanticdb/scalac/library/src/main/scala-2.12.16/scala/meta/internal/semanticdb/scalac/SemanticdbReporter.scala
https://github.com/bmarker/scalameta/blob/v4.7.6/semanticdb/scalac/library/src/main/scala-2.12.17/scala/meta/internal/semanticdb/scalac/SemanticdbReporter.scala