### PR TITLE
SoftKeywords: use token.text, not .toString

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -149,7 +149,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
       isDclIntro(next) || isModifier(next) || f(tokens(next))
     }
 
-    tokens(index).toString match {
+    tokens(index).text match {
       case soft.KwTransparent() => nextIsDclIntroOrModifierOr(_.is[KwTrait])
       case soft.KwOpaque() => nextIsDclIntroOrModifierOr(_ => false)
       case soft.KwInline() => nextIsDclIntroOrModifierOr(matchesAfterInlineMatchMod)
@@ -207,7 +207,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
   @classifier
   trait NonParamsModifier {
     def unapply(token: Token): Boolean = {
-      token.toString match {
+      token.text match {
         case soft.KwOpen() | soft.KwOpaque() | soft.KwTransparent() | soft.KwInfix() => true
         case _ => false
       }

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SoftKeywords.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SoftKeywords.scala
@@ -14,7 +14,7 @@ class SoftKeywords(dialect: Dialect) {
   trait KwAs {
     val name = "as"
     @inline def isEnabled = dialect.allowAsForImportRename
-    @inline final def unapply(token: Token): Boolean = isEnabled && name == token.toString
+    @inline final def unapply(token: Token): Boolean = isEnabled && name == token.text
     @inline final def unapply(token: String): Boolean = isEnabled && name == token
   }
 
@@ -22,7 +22,7 @@ class SoftKeywords(dialect: Dialect) {
   trait KwUsing {
     val name = "using"
     @inline def isEnabled = dialect.allowGivenUsing
-    @inline final def unapply(token: Token): Boolean = isEnabled && name == token.toString
+    @inline final def unapply(token: Token): Boolean = isEnabled && name == token.text
     @inline final def unapply(token: String): Boolean = isEnabled && name == token
   }
 
@@ -30,7 +30,7 @@ class SoftKeywords(dialect: Dialect) {
   trait KwInline {
     val name = "inline"
     @inline def isEnabled = dialect.allowInlineMods
-    @inline final def unapply(token: Token): Boolean = isEnabled && name == token.toString
+    @inline final def unapply(token: Token): Boolean = isEnabled && name == token.text
     @inline final def unapply(token: String): Boolean = isEnabled && name == token
   }
 
@@ -38,7 +38,7 @@ class SoftKeywords(dialect: Dialect) {
   trait KwOpaque {
     val name = "opaque"
     @inline def isEnabled = dialect.allowOpaqueTypes
-    @inline final def unapply(token: Token): Boolean = isEnabled && name == token.toString
+    @inline final def unapply(token: Token): Boolean = isEnabled && name == token.text
     @inline final def unapply(token: String): Boolean = isEnabled && name == token
   }
 
@@ -46,7 +46,7 @@ class SoftKeywords(dialect: Dialect) {
   trait KwOpen {
     val name = "open"
     @inline def isEnabled = dialect.allowOpenClass
-    @inline final def unapply(token: Token): Boolean = isEnabled && name == token.toString
+    @inline final def unapply(token: Token): Boolean = isEnabled && name == token.text
     @inline final def unapply(token: String): Boolean = isEnabled && name == token
   }
 
@@ -54,7 +54,7 @@ class SoftKeywords(dialect: Dialect) {
   trait KwTransparent {
     val name = "transparent"
     @inline def isEnabled = dialect.allowInlineMods
-    @inline final def unapply(token: Token): Boolean = isEnabled && name == token.toString
+    @inline final def unapply(token: Token): Boolean = isEnabled && name == token.text
     @inline final def unapply(token: String): Boolean = isEnabled && name == token
   }
 
@@ -62,7 +62,7 @@ class SoftKeywords(dialect: Dialect) {
   trait KwDerives {
     val name = "derives"
     @inline def isEnabled = dialect.allowDerives
-    @inline final def unapply(token: Token): Boolean = isEnabled && name == token.toString
+    @inline final def unapply(token: Token): Boolean = isEnabled && name == token.text
     @inline final def unapply(token: String): Boolean = isEnabled && name == token
   }
 
@@ -70,7 +70,7 @@ class SoftKeywords(dialect: Dialect) {
   trait KwEnd {
     val name = "end"
     @inline def isEnabled = dialect.allowEndMarker
-    @inline final def unapply(token: Token): Boolean = isEnabled && name == token.toString
+    @inline final def unapply(token: Token): Boolean = isEnabled && name == token.text
     @inline final def unapply(token: String): Boolean = isEnabled && name == token
   }
 
@@ -78,7 +78,7 @@ class SoftKeywords(dialect: Dialect) {
   trait KwInfix {
     val name = "infix"
     @inline def isEnabled = dialect.allowInfixMods
-    @inline final def unapply(token: Token): Boolean = isEnabled && name == token.toString
+    @inline final def unapply(token: Token): Boolean = isEnabled && name == token.text
     @inline final def unapply(token: String): Boolean = isEnabled && name == token
   }
 
@@ -86,7 +86,7 @@ class SoftKeywords(dialect: Dialect) {
   trait KwExtension {
     val name = "extension"
     @inline def isEnabled = dialect.allowExtensionMethods
-    @inline final def unapply(token: Token): Boolean = isEnabled && name == token.toString
+    @inline final def unapply(token: Token): Boolean = isEnabled && name == token.text
     @inline final def unapply(token: String): Boolean = isEnabled && name == token
   }
 }


### PR DESCRIPTION
The first method shows how token was constructed while the second one includes some sanity checks which are not appropriate in this context.