### PR TITLE
SepRegion: rename regions for case expressions

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/LazyTokenIterator.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/LazyTokenIterator.scala
@@ -81,7 +81,7 @@ private[parsers] class LazyTokenIterator private (
           case Some(RegionEnumArtificialMark) if token.is[KwEnum] => prev.tail
           case Some(_: RegionBrace) if token.is[LeftBrace] => prev.tail
           //  Handle fewer braces and partial function.
-          case Some(RegionArrow) if dialect.allowFewerBraces && token.is[KwCase] => prev.tail
+          case Some(RegionCaseExpr) if dialect.allowFewerBraces && token.is[KwCase] => prev.tail
           case _ => prev
         }
       RegionIndent(i, false) :: undoRegionChange
@@ -91,7 +91,7 @@ private[parsers] class LazyTokenIterator private (
   def observeIndentedEnum(): Boolean = {
     observeIndented0((i, prev) => {
       val nextPrev = prev match {
-        case RegionArrow :: RegionEnumArtificialMark :: other => other
+        case RegionCaseExpr :: RegionEnumArtificialMark :: other => other
         case RegionEnumArtificialMark :: other => other
         case x => x
       }

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SepRegion.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SepRegion.scala
@@ -24,13 +24,12 @@ case object RegionBracket extends SepRegionNonIndented
 case class RegionBrace(override val indent: Int, override val indentOnArrow: Boolean)
     extends SepRegionNonIndented
 
-case class RegionCase(override val indent: Int) extends SepRegionNonIndented
+case object RegionCaseExpr extends SepRegionNonIndented
+case class RegionCaseBody(override val indent: Int) extends SepRegionNonIndented
 
 case class RegionEnum(override val indent: Int) extends SepRegionNonIndented
 
 case class RegionIndentEnum(override val indent: Int) extends SepRegionIndented
-
-case object RegionArrow extends SepRegionNonIndented
 
 // NOTE: Special case for Enum region is needed because parsing of 'case' statement is done differently
 case object RegionEnumArtificialMark extends SepRegionNonIndented


### PR DESCRIPTION
Let's rename Region{Arrow,Case} for clarity
  - RegionArrow was inserted on `case` (before arrow), whereas
  - RegionCase was inserted on arrow, leading to a bit of confusion.
 
For #3045.