### PR TITLE
PrettyPrinter bug fix on Term.Block

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -1933,4 +1933,36 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     assertSyntax(tree, "\"\"\"\n\\\"\\\"\\\"\"\"\"")(tree)
   }
 
+  test("#2046 new line separator required before some Term.Block") {
+    assertEquals(
+      blockStat("{{a}; val b = 1; val c = 2; {d}; {e}}").syntax,
+      s"""|{
+          |  {
+          |    a
+          |  }
+          |  val b = 1
+          |  val c = 2
+          |
+          |  {
+          |    d
+          |  }
+          |  {
+          |    e
+          |  }
+          |}
+        """.stripMargin.trim.replace("\n", EOL)
+    )
+    assertEquals(
+      blockStat("{if (a) while (b) for (c <- d) -e; {f}}").syntax,
+      s"""|{
+          |  if (a) while (b) for (c <- d) -e
+          |
+          |  {
+          |    f
+          |  }
+          |}
+        """.stripMargin.trim.replace("\n", EOL)
+    )
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/TreeSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/TreeSyntaxSuite.scala
@@ -18,7 +18,7 @@ class TreeSyntaxSuite extends scala.meta.tests.parsers.ParseSuite {
   ): Unit = {
     val stat = statStr.trim // make sure no trailing newlines
     test(s"${loc.line}: $stat") {
-      val sep = "" // XXX: after fixing TreeSyntax, modify this
+      val sep = if (needNL) "\n" else ""
       val statSyntax = Option(syntaxStr).getOrElse(stat).replace("\n", "\n  ")
 
       val expectedSyntax =


### PR DESCRIPTION
Fixes #2046 

I tried to create a complete solution that works in all cases, not just the ones reported in the issue.
I added tests for all `Stat` combinations that I could find in https://scalameta.org/docs/trees/quasiquotes.html. Let me know if there is any relevant one that I missed.

---

### Code style
In `guessNeedsLineSep` function I "expanded" the pattern matching of the stats (e.g. `Defn.Val(_, _, _, rhs) =>`), but maybe you would prefer a more concise solution.
Maybe something like this instead?
```scala
...
case t: Decl.Type => false
case t: Defn.Val => guessNeedsLineSep(t.rhs)
case t: Defn.Var => guessNeedsLineSep(t.body)
case t: Defn.Def => guessNeedsLineSep(t.body)
...
```

---

Note:
I think it would be better to not merge until the bugs I found while working on this (#3136 and #3138) are resolved.