### PR TITLE
ScalametaParser: allow indent after self-type

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/LazyTokenIterator.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/LazyTokenIterator.scala
@@ -57,18 +57,6 @@ private[parsers] class LazyTokenIterator private (
     }
   }
 
-  /**
-   * Deals with different rules for indentation after self type arrow.
-   */
-  def undoIndent(): Unit = {
-    curr.regions match {
-      case (_: SepRegionIndented) :: others if curr.token.is[Indentation.Indent] =>
-        // don't change prev.next in case this fork fails
-        curr = nextToken(curr.token, curr.pos, curr.nextPos, others)
-      case _ =>
-    }
-  }
-
   def observeIndented(): Boolean = {
     observeIndented0 { prev =>
       /* When adding RegionIndent (we wrap the current code block in indentation)

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/TokenIterator.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/TokenIterator.scala
@@ -16,7 +16,6 @@ trait TokenIterator {
   def currentIndentation: Int
 
   def observeIndented(): Boolean
-  def undoIndent(): Unit
 
   def peekToken: Token
   def peekIndex: Int


### PR DESCRIPTION
That way, we can correctly process template with self-type and remove the `undoIndent` work-around. For #3045.