### PR TITLE
ScalametaParser: higher-kinded are not wildcard

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/NestedContext.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/NestedContext.scala
@@ -11,7 +11,8 @@ private[parsers] trait NestedContext {
       nested -= 1
     }
   }
-  def isInside() = nested > 0
+  @inline def isInside() = isDeeper(0)
+  @inline def isDeeper(level: Int) = nested > level
 }
 
 private[parsers] object QuotedSpliceContext extends NestedContext
@@ -19,3 +20,5 @@ private[parsers] object QuotedSpliceContext extends NestedContext
 private[parsers] object QuotedPatternContext extends NestedContext
 
 private[parsers] object ReturnTypeContext extends NestedContext
+
+private[parsers] object TypeBracketsContext extends NestedContext

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
@@ -539,7 +539,7 @@ class TypeSuite extends BaseDottySuite {
           Nil,
           Type.Bounds(
             None,
-            Some(Type.Apply(pname("C"), List(Type.Wildcard(noBounds))))
+            Some(Type.AnonymousLambda(Type.Apply(pname("C"), List(Type.AnonymousParam(None)))))
           ),
           Nil,
           Nil
@@ -550,7 +550,7 @@ class TypeSuite extends BaseDottySuite {
           Term.Select(tname("bar"), tname("baz")),
           List(
             Type.Wildcard(noBounds),
-            Type.Apply(pname("F"), List(Type.Wildcard(Type.Bounds(None, None))))
+            Type.AnonymousLambda(Type.Apply(pname("F"), List(Type.AnonymousParam(None))))
           )
         )
       )
@@ -592,9 +592,11 @@ class TypeSuite extends BaseDottySuite {
     runTestAssert[Stat]("gr.pure[Resource[F, _]]")(
       Term.ApplyType(
         Term.Select(tname("gr"), tname("pure")),
-        Type.Apply(
-          pname("Resource"),
-          List(pname("F"), Type.Wildcard(noBounds))
+        Type.AnonymousLambda(
+          Type.Apply(
+            pname("Resource"),
+            List(pname("F"), Type.AnonymousParam(None))
+          )
         ) :: Nil
       )
     )


### PR DESCRIPTION
Fixes #3162.