### PR TITLE
ScalametaParser: fail if no fewer-braces body

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1616,7 +1616,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
     } else if (token.is[Colon] && dialect.allowFewerBraces && isEolAfter(tokenPos)) {
       val colonPos = tokenPos
       next()
-      in.observeIndented()
+      if (!in.observeIndented()) syntaxError("expected fewer-braces method body", prevToken)
       val args = blockExpr(allowRepeated = false)
       val argClause = autoEndPos(colonPos)(Term.ArgClause(args :: Nil))
       val arguments = addPos(Term.Apply(t, argClause))
@@ -2232,7 +2232,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
         // map:
         val argsOpt = if (isEolAfter(colonPos)) Some {
           next()
-          in.observeIndented()
+          if (!in.observeIndented()) syntaxError("expected fewer-braces method body", prevToken)
           blockExpr(allowRepeated = false)
         }
         else

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
@@ -628,45 +628,25 @@ class FewerBracesSuite extends BaseDottySuite {
   }
 
   test("#3164 empty argument 1") {
-    runTestAssert[Stat](
+    runTestError[Stat](
       """|object a:
          |  test("foo"):
          |""".stripMargin,
-      Some("""object a { test("foo") {} }""")
-    )(
-      Defn.Object(
-        Nil,
-        tname("a"),
-        Template(
-          Nil,
-          Nil,
-          slf,
-          List(Term.Apply(Term.Apply(tname("test"), List(str("foo"))), List(Term.Block(Nil)))),
-          Nil
-        )
-      )
+      """|<input>:2: error: expected fewer-braces method body
+         |  test("foo"):
+         |             ^""".stripMargin
     )
   }
 
   test("#3164 empty argument 2") {
-    runTestAssert[Stat](
+    runTestError[Stat](
       """|object a:
          |  foo :
          |  bar
          |""".stripMargin,
-      Some("object a { foo(bar) }")
-    )(
-      Defn.Object(
-        Nil,
-        tname("a"),
-        Template(
-          Nil,
-          Nil,
-          slf,
-          List(Term.Apply(tname("foo"), List(tname("bar")))),
-          Nil
-        )
-      )
+      """|<input>:2: error: expected fewer-braces method body
+         |  foo :
+         |      ^""".stripMargin
     )
   }
 


### PR DESCRIPTION
Fixes #3164. By making it explicitly invalid...