### PR TITLE
scalapb: 0.11.11 → 0.11.13, scalajs: 1.8.0 → 1.12.0

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.4")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6")
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.11"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.13"
 
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,7 +19,7 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.1")
 
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.1")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.8.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.12.0")
 
 addSbtPlugin("org.scala-debugger" % "sbt-jdi-tools" % "1.1.1")
 


### PR DESCRIPTION
https://mvnrepository.com/artifact/com.thesamet.scalapb/scalapb-runtime_2.13/0.11.11

CVEs:

- https://nvd.nist.gov/vuln/detail/CVE-2022-3510 (High: 7.5 CVSS)
- https://nvd.nist.gov/vuln/detail/CVE-2022-3509 (High: 7.5 CVSS)
- https://nvd.nist.gov/vuln/detail/CVE-2022-3171 (High: 7.5 CVSS)