### PR TITLE
ScannerTokens: infer coloneol indent automatically

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -147,8 +147,8 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
 
   /* ------------- TOKEN STREAM HELPERS -------------------------------------------- */
 
-  private def isColonEol(): Boolean =
-    token.is[Colon] && dialect.allowSignificantIndentation && isEolAfter(tokenPos)
+  @inline private def isColonIndent(): Boolean = token.is[Colon] && isIndentAfter()
+  @inline private def isIndentAfter(): Boolean = peekToken.is[Indentation.Indent]
 
   @tailrec
   private def isEolAfter(index: Int): Boolean = {
@@ -2264,7 +2264,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
              */
             val param = simpleExpr(allowRepeated = false)
             val contextFunction = token.is[ContextArrow]
-            if ((contextFunction || token.is[RightArrow]) && peekToken.is[Indentation.Indent])
+            if ((contextFunction || token.is[RightArrow]) && isIndentAfter())
               convertToParamClause(param)(true, true).map { pc =>
                 val params = autoEndPos(paramPos)(pc)
                 next()
@@ -4180,18 +4180,10 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
   def templateBodyOpt(owner: TemplateOwner): (Self, List[Stat]) = {
     if (isAfterOptNewLine[LeftBrace]) {
       templateBody(owner)
-    } else if (isColonEol()) {
-      accept[Colon]
-
-      if (!owner.isEnumCaseAllowed)
-        in.observeIndented()
-
-      if (acceptOpt[Indentation.Indent])
-        indentedAfterOpen(templateStatSeq(owner))
-      else if (!owner.isEnumCaseAllowed && isEndMarkerIntro(tokenPos))
-        (selfEmpty(), Nil)
-      else
-        syntaxError("expected template body", token)
+    } else if (token.is[Colon] && peekToken.isAny[Indentation, LF]) {
+      next()
+      if (!token.is[Indentation.Indent]) syntaxError("expected template body", token)
+      indentedOnOpen(templateStatSeq(owner))
     } else if (token.is[LeftParen]) {
       if (owner.isPrimaryCtorAllowed)
         syntaxError("unexpected opening parenthesis", at = token)
@@ -4212,7 +4204,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
       refinementInBraces(innerType, -1)
     else if (!token.isAny[Colon, KwWith])
       refinementInBraces(innerType, in.previousIndentation + 1)
-    else if (tryAhead[Indentation.Indent] || tryAhead(in.observeIndented()))
+    else if (tryAhead[Indentation.Indent])
       Some(refineWith(innerType, indented(refineStatSeq())))
     else innerType
 
@@ -4472,10 +4464,9 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
       Pkg.Object(Nil, termName(), templateOpt(OwnedByObject))
     else {
       def packageBody =
-        if (isColonEol()) {
+        if (isColonIndent()) {
           next()
-          in.observeIndented()
-          indented(statSeq(statpf))
+          indentedOnOpen(statSeq(statpf))
         } else {
           inBracesOrNil(statSeq(statpf))
         }
@@ -4509,10 +4500,9 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
         if (token.is[LeftBrace]) {
           inPackage(inBracesOnOpen(statSeq(statpf)))
           bracelessPackageStats(f)
-        } else if (isColonEol()) {
+        } else if (isColonIndent()) {
           next()
-          in.observeIndented()
-          inPackage(indented(statSeq(statpf)))
+          inPackage(indentedOnOpen(statSeq(statpf)))
           bracelessPackageStats(f)
         } else {
           bracelessPackageStats(x => f(List(autoEndPos(startPos)(Pkg(qid, x)))))
@@ -4531,7 +4521,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
       else {
         val ref = qualId()
         newLineOpt()
-        if (token.is[LeftBrace] || isColonEol()) None
+        if (token.is[LeftBrace] || isColonIndent()) None
         else Some(List(autoEndPos(startPos)(Pkg(ref, bracelessPackageStats(identity)))))
       }
     }

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SepRegion.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SepRegion.scala
@@ -36,8 +36,20 @@ final class RegionCaseExpr(override val indent: Int) extends RegionNonDelimNonIn
 final class RegionCaseBody(override val indent: Int, val arrow: Token)
     extends SepRegionNonIndented with CanProduceLF
 
-// NOTE: Special case for Enum region is needed because parsing of 'case' statement is done differently
-case object RegionEnumArtificialMark extends RegionNonDelimNonIndented
+/** region hierarchy to mark packages, classes, etc which can use `colon-eol` before template */
+sealed trait RegionTemplateDecl extends RegionNonDelimNonIndented
+
+/** the initial part of declaration, before the template */
+case object RegionTemplateMark extends RegionTemplateDecl
+
+/** the initial part of the template, containing any inherit clauses */
+case object RegionTemplateInherit extends RegionTemplateDecl
+
+/**
+ * this marks the template body; for instance, helps override handling of `case` designed for
+ * catch/match/partial function but inappropriate for enum
+ */
+case object RegionTemplateBody extends RegionNonDelimNonIndented
 
 /**
  * All control statements

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EndMarkerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EndMarkerSuite.scala
@@ -346,9 +346,9 @@ class EndMarkerSuite extends BaseDottySuite {
          |  end Bar
          |end Foo
          |""".stripMargin,
-      """|<input>:3: error: expected template body
-         |  trait Bar:
-         |  ^""".stripMargin
+      """|<input>:2: error: expected template body
+         |  trait Baz:
+         |            ^""".stripMargin
     )
   }
 
@@ -368,9 +368,9 @@ class EndMarkerSuite extends BaseDottySuite {
     runTestError[Source](
       """|trait Foo:
          |""".stripMargin,
-      """|<input>:2: error: expected template body
-         |
-         |^""".stripMargin
+      """|<input>:1: error: expected template body
+         |trait Foo:
+         |          ^""".stripMargin
     )
   }
 


### PR DESCRIPTION
To do that, generalize enum mark to cover all elements using coloneol. For #3045.