### PR TITLE
ScaladocParser: require space after list prefix

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
@@ -115,8 +115,10 @@ object ScaladocParser {
   private def nextPartParser[_: P](indent: Int, mdOffset: Int = 0): P[Unit] = P {
     // used to terminate previous part, hence indent can be less
     nl | hspacesMinWithLen(0).flatMap { offset =>
+      def dedented = if (offset < indent) Pass else Fail
       def mdCodeBlockPrefix = if (offset <= getMdOffsetMax(mdOffset)) mdCodeBlockFence else Fail
-      CharIn("@=") |
+      dedented |
+        CharIn("@=") |
         (codePrefix ~ nl) | mdCodeBlockPrefix |
         tableSep | tableDelim |
         listPrefix

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
@@ -121,7 +121,7 @@ object ScaladocParser {
         CharIn("@=") |
         (codePrefix ~ nl) | mdCodeBlockPrefix |
         tableSep | tableDelim |
-        listPrefix
+        listPrefix ~ &(" ")
     }
   }
 

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
@@ -112,30 +112,34 @@ object ScaladocParser {
     pattern.map { case (x, y) => new Link(x, y) }
   }
 
-  private def nextPartParser[_: P](mdOffset: Int = 0): P[Unit] = P {
+  private def nextPartParser[_: P](indent: Int, mdOffset: Int = 0): P[Unit] = P {
     // used to terminate previous part, hence indent can be less
-    def mdCodeBlockPrefix = hspace.rep(max = getMdOffsetMax(mdOffset)) ~ mdCodeBlockFence
-    def anotherBeg = P(CharIn("@=") | (codePrefix ~ nl) | listPrefix | tableSep | tableDelim)
-    nl | mdCodeBlockPrefix | hspaces0 ~/ anotherBeg
+    nl | hspacesMinWithLen(0).flatMap { offset =>
+      def mdCodeBlockPrefix = if (offset <= getMdOffsetMax(mdOffset)) mdCodeBlockFence else Fail
+      CharIn("@=") |
+        (codePrefix ~ nl) | mdCodeBlockPrefix |
+        tableSep | tableDelim |
+        listPrefix
+    }
   }
 
-  private def textParser[_: P](mdOffset: Int = 0): P[Text] = P {
-    def end = P(nl ~/ nextPartParser(mdOffset))
+  private def textParser[_: P](indent: Int, mdOffset: Int = 0): P[Text] = P {
+    def end = P(nl ~/ nextPartParser(indent, mdOffset))
     def part: P[TextPart] = P(codeExprParser | linkParser | wordParser)
     def sep = P(!end ~ nl.? ~ hspaces0)
     hspaces0 ~ part.rep(1, sep = sep).map(x => Text(x))
   }
 
   // this is to be used at the start of a line
-  private def leadTextParser[_: P](mdOffset: Int = 0) =
-    !nextPartParser(mdOffset) ~ textParser(mdOffset)
+  private def leadTextParser[_: P](indent: Int, mdOffset: Int = 0) =
+    !nextPartParser(indent, mdOffset) ~ textParser(indent, mdOffset)
 
-  private def tagParser[_: P]: P[Tag] = P {
-    def label = P((nl ~ !nextPartParser()).? ~ hspaces0 ~ wordParser)
+  private def tagParser[_: P](indent: Int): P[Tag] = P {
+    def label = P((nl ~ !nextPartParser(indent)).? ~ hspaces0 ~ wordParser)
     // special case: @usecase takes a single code line, on the same line
     def labelInline = P(hspaces0 ~ (!nl ~ AnyChar).rep(1).!.map(Word))
     def desc = P {
-      (textParser().? ~ embeddedTermsParser())
+      (textParser(indent).? ~ embeddedTermsParser())
         .map { case (x, terms) => x.fold(terms)(_ +: terms) }
     }
     hspaces0 ~ ("@" ~ labelParser).!.flatMap { tag =>
@@ -162,7 +166,7 @@ object ScaladocParser {
   }
 
   private def listItemParser[_: P](indent: Int, mdOffset: Int) = P {
-    (textParser(mdOffset) ~ embeddedTermsParser(indent, mdOffset))
+    (textParser(indent, mdOffset) ~ embeddedTermsParser(indent, mdOffset))
       .map { case (x, terms) => ListItem(x, terms) }
   }
 
@@ -238,16 +242,16 @@ object ScaladocParser {
 
   private def termParser[_: P] = P {
     def leadingParser = // might not consume full line
-      tagParser
+      tagParser(0)
     def completeParser = // will consume full line
       listBlockParser() |
         mdCodeBlockParser() |
         codeBlockParser |
         headingParser |
         tableParser |
-        textParser() // keep at the end, this is the fallback
+        textParser(0) // keep at the end, this is the fallback
     (nl | Start) ~ (leadingParser | (completeParser ~ nlOrEndPeek)) |
-      textParser() // could be following an element leaving trailing text, e.g. tagParser
+      textParser(0) // could be following an element leaving trailing text, e.g. tagParser
   }
 
   private def embeddedTermsParser[_: P](indent: Int = 0, mdOffset: Int = 0): P[Seq[Term]] = P {
@@ -256,7 +260,7 @@ object ScaladocParser {
         mdCodeBlockParser(mdOffset) |
         codeBlockParser |
         tableParser |
-        leadTextParser(mdOffset) // keep at the end, this is the fallback
+        leadTextParser(indent, mdOffset) // keep at the end, this is the fallback
     (nl ~ completeParser ~ nlOrEndPeek).rep
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
@@ -644,21 +644,19 @@ class ScaladocParserSuite extends FunSuite {
                   ListItem(
                     Text(
                       Seq(
-                        Word(list11)
+                        Word(list11),
+                        Word("i.e."),
+                        Word("foo")
+                      )
+                    ),
+                    Seq(
+                      ListBlock(
+                        "i.",
+                        Seq(ListItem(Text(Seq(Word(list21)))))
                       )
                     )
                   )
                 )
-              ),
-              Text(
-                Seq(
-                  Word("i.e."),
-                  Word("foo")
-                )
-              ),
-              ListBlock(
-                "i.",
-                Seq(ListItem(Text(Seq(Word(list21)))))
               ),
               ListBlock(
                 "-",
@@ -672,8 +670,25 @@ class ScaladocParserSuite extends FunSuite {
                           ListItem(
                             Text(
                               Seq(
-                                Word(list22)
+                                Word(list22),
+                                Word("i.e."),
+                                Word("bar")
                               )
+                            ),
+                            Seq(
+                              ListBlock(
+                                "i.",
+                                Seq(
+                                  ListItem(
+                                    Text(
+                                      Seq(
+                                        Word(list32)
+                                      )
+                                    )
+                                  )
+                                )
+                              ),
+                              Text(Seq(Word("baz")))
                             )
                           )
                         )
@@ -681,26 +696,7 @@ class ScaladocParserSuite extends FunSuite {
                     )
                   )
                 )
-              ),
-              Text(
-                Seq(
-                  Word("i.e."),
-                  Word("bar")
-                )
-              ),
-              ListBlock(
-                "i.",
-                Seq(
-                  ListItem(
-                    Text(
-                      Seq(
-                        Word(list32)
-                      )
-                    )
-                  )
-                )
-              ),
-              Text(Seq(Word("baz")))
+              )
             )
           )
         )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
@@ -694,13 +694,13 @@ class ScaladocParserSuite extends FunSuite {
                   ListItem(
                     Text(
                       Seq(
-                        Word(list32),
-                        Word("baz")
+                        Word(list32)
                       )
                     )
                   )
                 )
-              )
+              ),
+              Text(Seq(Word("baz")))
             )
           )
         )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
@@ -609,6 +609,106 @@ class ScaladocParserSuite extends FunSuite {
     assertEquals(result, expected)
   }
 
+  test("lists 2: #3145") {
+    val list11 = "List11"
+    val list12 = "List12"
+    val list21 = "List21"
+    val list22 = "List22"
+    val list32 = "List32"
+
+    val result =
+      parseString(
+        s"""
+      /**
+        * Some text:
+        * 1. $list11
+        *  i.e. foo
+        *  i. $list21
+        * - $list12
+        *  i. $list22
+        *  i.e. bar
+        *   i. $list32
+        *  baz
+        */
+       """
+      )
+    val expected = Option(
+      Scaladoc(
+        Seq(
+          Paragraph(
+            Seq(
+              Text(Seq(Word("Some"), Word("text:"))),
+              ListBlock(
+                "1.",
+                Seq(
+                  ListItem(
+                    Text(
+                      Seq(
+                        Word(list11)
+                      )
+                    )
+                  )
+                )
+              ),
+              Text(
+                Seq(
+                  Word("i.e."),
+                  Word("foo")
+                )
+              ),
+              ListBlock(
+                "i.",
+                Seq(ListItem(Text(Seq(Word(list21)))))
+              ),
+              ListBlock(
+                "-",
+                Seq(
+                  ListItem(
+                    Text(Seq(Word(list12))),
+                    Seq(
+                      ListBlock(
+                        "i.",
+                        Seq(
+                          ListItem(
+                            Text(
+                              Seq(
+                                Word(list22)
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              ),
+              Text(
+                Seq(
+                  Word("i.e."),
+                  Word("bar")
+                )
+              ),
+              ListBlock(
+                "i.",
+                Seq(
+                  ListItem(
+                    Text(
+                      Seq(
+                        Word(list32),
+                        Word("baz")
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    assertEquals(result, expected)
+  }
+
   test("lists 3") {
     val list11 = "List11"
     val list12 = "List12"


### PR DESCRIPTION
Fixes #3145.