### PR TITLE
ScannerTokens: allow top-level `case`

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -494,6 +494,8 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
                 case _ => !next.isClassOrObject
               }) =>
             expr() :: sepRegions
+          // `case` is at top-level (likely quasiquote)
+          case Nil if prevPos == 0 && !next.isClassOrObject => expr() :: Nil
           case xs => xs
         })
       case _: KwFinally =>

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/PatSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/PatSuite.scala
@@ -271,12 +271,13 @@ class PatSuite extends ParseSuite {
          |  if true =>
          |  List(bar)
          |""".stripMargin
-    runTestError[Case](
-      code,
-      """|<input>:1: error: => expected but \n found
-         |case foo
-         |        ^""".stripMargin
-    )
+    checkTree(parseCase(code)) {
+      Case(
+        Pat.Var(Term.Name("foo")),
+        Some(Lit.Boolean(true)),
+        Term.Apply(Term.Name("List"), List(Term.Name("bar")))
+      )
+    }
   }
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/PatSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/PatSuite.scala
@@ -16,6 +16,8 @@ class PatSuite extends ParseSuite {
     assertTree(patternTyp(expr))(tree)
   }
 
+  implicit def caseParser(code: String, dialect: Dialect): Case = super.parseCase(code)(dialect)
+
   test("_") {
     val Wildcard() = pat("_")
   }
@@ -261,6 +263,20 @@ class PatSuite extends ParseSuite {
         List(Term.Name("A"), Term.Name("B"), Term.Name("C"))
       )
     }
+  }
+
+  test("case: at top level") {
+    val code =
+      """|case foo
+         |  if true =>
+         |  List(bar)
+         |""".stripMargin
+    runTestError[Case](
+      code,
+      """|<input>:1: error: => expected but \n found
+         |case foo
+         |        ^""".stripMargin
+    )
   }
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -1642,4 +1642,29 @@ class TermSuite extends ParseSuite {
     runTestAssert[Stat](codeOnSameLine, Some(syntaxOnSameLine))(treeOnSameLine)
   }
 
+  test("case: inside partial function") {
+    runTestAssert[Term](
+      """|{
+         |  case foo
+         |    if true =>
+         |    List(bar)
+         |}
+         |""".stripMargin,
+      Some(
+        """|{
+           |  case foo if true =>
+           |    List(bar)
+           |}""".stripMargin
+      )
+    )(
+      Term.PartialFunction(
+        Case(
+          Pat.Var(Term.Name("foo")),
+          Some(Lit.Boolean(true)),
+          Term.Apply(Term.Name("List"), List(Term.Name("bar")))
+        ) :: Nil
+      )
+    )
+  }
+
 }


### PR DESCRIPTION
For #3045.