### PR TITLE
ScalametaParser: don't fail on `override` in class

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/Messages.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/Messages.scala
@@ -29,8 +29,6 @@ object Messages {
   val InvalidImplicit =
     "`implicit' modifier can be used only for values, variables, methods and classes"
   val InvalidImplicitTrait = "traits cannot be implicit"
-  val InvalidImplicitClass = "classes cannot be implicit"
   val InvalidAbstract = "`abstract' modifier can be used only for classes"
-  val InvalidOverrideClass = "`override' modifier not allowed for classes"
   val InvalidLazyClasses = "classes cannot be lazy"
 }

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -3832,7 +3832,6 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
 
   def classDef(mods: List[Mod]): Defn.Class = autoEndPos(mods) {
     accept[KwClass]
-    rejectMod[Mod.Override](mods, Messages.InvalidOverrideClass)
 
     val className = typeName()
     def culprit = Some(s"class $className")

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
@@ -201,8 +201,6 @@ class ModSuite extends ParseSuite {
       "override override case class A(a: Int)",
       "override override type A",
       "def foo(override val a: Int): Int = a",
-      "override class A",
-      "override case class A(a: Int)",
       "override trait A"
     )
   }
@@ -329,9 +327,7 @@ class ModSuite extends ParseSuite {
       "abstract override abstract override trait A",
       "abstract override abstract override case class A(a: Int)",
       "abstract override abstract override type A",
-      "def foo(abstract override val a: Int): Int = a",
-      "abstract override class A",
-      "abstract override case class A(a: Int)"
+      "def foo(abstract override val a: Int): Int = a"
     )
   }
 


### PR DESCRIPTION
Fixes #3201.