### PR TITLE
ScannerTokens: `case class` can be in `case` body

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
@@ -354,11 +354,34 @@ class DefnSuite extends ParseSuite {
          |    object A9
          |}
          |""".stripMargin
-    val error =
-      """|<input>:5: error: ; expected but object found
+    val layout =
+      """|a3 match {
+         |  case Some(_) =>
+         |    case class A6(a7: A8)
          |    object A9
-         |    ^""".stripMargin
-    runTestError[Stat](code, error)
+         |}
+         |""".stripMargin
+    val tree = Term.Match(
+      tname("a3"),
+      Case(
+        Pat.Extract(tname("Some"), List(Pat.Wildcard())),
+        None,
+        Term.Block(
+          List(
+            Defn.Class(
+              List(Mod.Case()),
+              pname("A6"),
+              Nil,
+              ctorp(List(tparam("a7", "A8"))),
+              tpl(Nil)
+            ),
+            Defn.Object(Nil, tname("A9"), tpl(Nil))
+          )
+        )
+      ) :: Nil,
+      Nil
+    )
+    runTestAssert[Stat](code, assertLayout = Some(layout))(tree)
   }
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
@@ -344,4 +344,21 @@ class DefnSuite extends ParseSuite {
       blockStat("infix def x = 42")
     }
   }
+
+  test("#3210") {
+    val code =
+      """|a3 match {
+         |  case Some(_) =>
+         |    case class A6(a7: A8)
+         |
+         |    object A9
+         |}
+         |""".stripMargin
+    val error =
+      """|<input>:5: error: ; expected but object found
+         |    object A9
+         |    ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -2626,4 +2626,43 @@ class SignificantIndentationSuite extends BaseDottySuite {
     )(tree)
   }
 
+  test("#3210") {
+    val code =
+      """|a3 match {
+         |  case Some(_) =>
+         |    case class A6(a7: A8)
+         |
+         |    object A9
+         |}
+         |""".stripMargin
+    val layout =
+      """|a3 match {
+         |  case Some(_) =>
+         |    case class A6(a7: A8)
+         |    object A9
+         |}
+         |""".stripMargin
+    val tree = Term.Match(
+      tname("a3"),
+      Case(
+        Pat.Extract(tname("Some"), List(Pat.Wildcard())),
+        None,
+        Term.Block(
+          List(
+            Defn.Class(
+              List(Mod.Case()),
+              pname("A6"),
+              Nil,
+              ctorp(List(tparam("a7", "A8"))),
+              tpl(Nil)
+            ),
+            Defn.Object(Nil, tname("A9"), tpl(Nil))
+          )
+        )
+      ) :: Nil,
+      Nil
+    )
+    runTestAssert[Stat](code, assertLayout = Some(layout))(tree)
+  }
+
 }


### PR DESCRIPTION
Fixes #3210.