### PR TITLE
ScannerTokens: `extension` can also start block

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -596,7 +596,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
           case soft.KwDerives() => getTemplateInherit(sepRegions)
           case soft.KwExtension()
               if next.isAny[LeftParen, LeftBracket] &&
-                prevToken.isAny[StatSep, Indentation.Outdent] =>
+                prevToken.isAny[StatSep, Indentation, LeftBrace] =>
             currRef(RegionExtensionMark :: sepRegions)
           case _ => currRef(sepRegions)
         }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExtensionMethodsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExtensionMethodsSuite.scala
@@ -618,10 +618,12 @@ class ExtensionMethodsSuite extends BaseDottySuite {
          |""".stripMargin,
       assertLayout = Some(
         """|object MtagsEnrichments extends ScalametaCommonEnrichments {
-           |  extension (x: X) def foo: Foo = getFoo
-           |  end foo
-           |  def bar: Bar = getBar
-           |  end bar
+           |  extension (x: X){
+           |    def foo: Foo = getFoo
+           |    end foo
+           |    def bar: Bar = getBar
+           |    end bar
+           |  }
            |}
            |""".stripMargin
       )
@@ -633,16 +635,18 @@ class ExtensionMethodsSuite extends BaseDottySuite {
           Nil,
           List(init("ScalametaCommonEnrichments")),
           slf,
-          List(
-            Defn.ExtensionGroup(
-              Nil,
-              List(List(tparam("x", "X"))),
-              Defn.Def(Nil, tname("foo"), Nil, Some(pname("Foo")), tname("getFoo"))
-            ),
-            Term.EndMarker(tname("foo")),
-            Defn.Def(Nil, tname("bar"), Nil, Some(pname("Bar")), tname("getBar")),
-            Term.EndMarker(tname("bar"))
-          ),
+          Defn.ExtensionGroup(
+            Nil,
+            List(List(tparam("x", "X"))),
+            Term.Block(
+              List(
+                Defn.Def(Nil, tname("foo"), Nil, Some(pname("Foo")), tname("getFoo")),
+                Term.EndMarker(tname("foo")),
+                Defn.Def(Nil, tname("bar"), Nil, Some(pname("Bar")), tname("getBar")),
+                Term.EndMarker(tname("bar"))
+              )
+            )
+          ) :: Nil,
           Nil
         )
       )
@@ -665,10 +669,12 @@ class ExtensionMethodsSuite extends BaseDottySuite {
          |""".stripMargin,
       assertLayout = Some(
         """|object MtagsEnrichments extends ScalametaCommonEnrichments {
-           |  extension (x: X) def foo: Foo = getFoo
-           |  end foo
-           |  def bar: Bar = getBar
-           |  end bar
+           |  extension (x: X){
+           |    def foo: Foo = getFoo
+           |    end foo
+           |    def bar: Bar = getBar
+           |    end bar
+           |  }
            |}
            |""".stripMargin
       )
@@ -680,16 +686,18 @@ class ExtensionMethodsSuite extends BaseDottySuite {
           Nil,
           List(init("ScalametaCommonEnrichments")),
           slf,
-          List(
-            Defn.ExtensionGroup(
-              Nil,
-              List(List(tparam("x", "X"))),
-              Defn.Def(Nil, tname("foo"), Nil, Some(pname("Foo")), tname("getFoo"))
-            ),
-            Term.EndMarker(tname("foo")),
-            Defn.Def(Nil, tname("bar"), Nil, Some(pname("Bar")), tname("getBar")),
-            Term.EndMarker(tname("bar"))
-          ),
+          Defn.ExtensionGroup(
+            Nil,
+            List(List(tparam("x", "X"))),
+            Term.Block(
+              List(
+                Defn.Def(Nil, tname("foo"), Nil, Some(pname("Foo")), tname("getFoo")),
+                Term.EndMarker(tname("foo")),
+                Defn.Def(Nil, tname("bar"), Nil, Some(pname("Bar")), tname("getBar")),
+                Term.EndMarker(tname("bar"))
+              )
+            )
+          ) :: Nil,
           Nil
         )
       )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExtensionMethodsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExtensionMethodsSuite.scala
@@ -566,4 +566,134 @@ class ExtensionMethodsSuite extends BaseDottySuite {
     )
   }
 
+  test("#3215 1") {
+    runTestAssert[Stat](
+      """|  extension (x: X)
+         |
+         |    def foo: Foo =
+         |      getFoo
+         |    end foo
+         |
+         |    def bar: Bar =
+         |      getBar
+         |    end bar
+         |""".stripMargin,
+      assertLayout = Some(
+        """|extension (x: X){
+           |  def foo: Foo = getFoo
+           |  end foo
+           |  def bar: Bar = getBar
+           |  end bar
+           |}
+           |""".stripMargin
+      )
+    )(
+      Defn.ExtensionGroup(
+        Nil,
+        List(List(tparam("x", "X"))),
+        Term.Block(
+          List(
+            Defn.Def(Nil, tname("foo"), Nil, Some(pname("Foo")), tname("getFoo")),
+            Term.EndMarker(tname("foo")),
+            Defn.Def(Nil, tname("bar"), Nil, Some(pname("Bar")), tname("getBar")),
+            Term.EndMarker(tname("bar"))
+          )
+        )
+      )
+    )
+  }
+
+  test("#3215 2") {
+    runTestAssert[Stat](
+      """|object MtagsEnrichments extends ScalametaCommonEnrichments:
+         |  extension (x: X)
+         |
+         |    def foo: Foo =
+         |      getFoo
+         |    end foo
+         |
+         |    def bar: Bar =
+         |      getBar
+         |    end bar
+         |""".stripMargin,
+      assertLayout = Some(
+        """|object MtagsEnrichments extends ScalametaCommonEnrichments {
+           |  extension (x: X) def foo: Foo = getFoo
+           |  end foo
+           |  def bar: Bar = getBar
+           |  end bar
+           |}
+           |""".stripMargin
+      )
+    )(
+      Defn.Object(
+        Nil,
+        tname("MtagsEnrichments"),
+        Template(
+          Nil,
+          List(init("ScalametaCommonEnrichments")),
+          slf,
+          List(
+            Defn.ExtensionGroup(
+              Nil,
+              List(List(tparam("x", "X"))),
+              Defn.Def(Nil, tname("foo"), Nil, Some(pname("Foo")), tname("getFoo"))
+            ),
+            Term.EndMarker(tname("foo")),
+            Defn.Def(Nil, tname("bar"), Nil, Some(pname("Bar")), tname("getBar")),
+            Term.EndMarker(tname("bar"))
+          ),
+          Nil
+        )
+      )
+    )
+  }
+
+  test("#3215 3") {
+    runTestAssert[Stat](
+      """|object MtagsEnrichments extends ScalametaCommonEnrichments {
+         |  extension (x: X)
+         |
+         |    def foo: Foo =
+         |      getFoo
+         |    end foo
+         |
+         |    def bar: Bar =
+         |      getBar
+         |    end bar
+         |}
+         |""".stripMargin,
+      assertLayout = Some(
+        """|object MtagsEnrichments extends ScalametaCommonEnrichments {
+           |  extension (x: X) def foo: Foo = getFoo
+           |  end foo
+           |  def bar: Bar = getBar
+           |  end bar
+           |}
+           |""".stripMargin
+      )
+    )(
+      Defn.Object(
+        Nil,
+        tname("MtagsEnrichments"),
+        Template(
+          Nil,
+          List(init("ScalametaCommonEnrichments")),
+          slf,
+          List(
+            Defn.ExtensionGroup(
+              Nil,
+              List(List(tparam("x", "X"))),
+              Defn.Def(Nil, tname("foo"), Nil, Some(pname("Foo")), tname("getFoo"))
+            ),
+            Term.EndMarker(tname("foo")),
+            Defn.Def(Nil, tname("bar"), Nil, Some(pname("Bar")), tname("getBar")),
+            Term.EndMarker(tname("bar"))
+          ),
+          Nil
+        )
+      )
+    )
+  }
+
 }


### PR DESCRIPTION
Fixes #3215.