### PR TITLE
ScannerTokens: use RegionFor for scala2 also

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -543,7 +543,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
             new RegionCaseBody(bodyIndent, curr) :: xs
           case xs => xs
         })
-      case _: KwFor if dialect.allowSignificantIndentation =>
+      case _: KwFor =>
         currRef(RegionFor(next) :: sepRegions)
       case _: KwWhile if dialect.allowSignificantIndentation =>
         currRef(RegionWhile(next) :: sepRegions)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -1702,11 +1702,22 @@ class TermSuite extends ParseSuite {
          |  x <- a to b
          |} yield x
          |""".stripMargin
-    val error =
-      """|<input>:3: error: } expected but <- found
-         |  x <- a to b
-         |    ^""".stripMargin
-    runTestError[Term](code, error)
+    val layout = "for ( case (a, b) <- pairs; x <- a to b) yield x"
+    runTestAssert[Term](code, Some(layout))(
+      Term.ForYield(
+        List(
+          Enumerator.CaseGenerator(
+            Pat.Tuple(List(Pat.Var(tname("a")), Pat.Var(tname("b")))),
+            tname("pairs")
+          ),
+          Enumerator.Generator(
+            Pat.Var(tname("x")),
+            Term.ApplyInfix(tname("a"), tname("to"), Nil, List(tname("b")))
+          )
+        ),
+        tname("x")
+      )
+    )
   }
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -1695,4 +1695,18 @@ class TermSuite extends ParseSuite {
     )
   }
 
+  test("#3220") {
+    val code =
+      """|for {
+         |  case (a, b) <- pairs
+         |  x <- a to b
+         |} yield x
+         |""".stripMargin
+    val error =
+      """|<input>:3: error: } expected but <- found
+         |  x <- a to b
+         |    ^""".stripMargin
+    runTestError[Term](code, error)
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -3701,4 +3701,29 @@ class ControlSyntaxSuite extends BaseDottySuite {
     )
   }
 
+  test("#3220") {
+    val code =
+      """|for {
+         |  case (a, b) <- pairs
+         |  x <- a to b
+         |} yield x
+         |""".stripMargin
+    val layout = "for ( case (a, b) <- pairs; x <- a to b) yield x"
+    runTestAssert[Stat](code, Some(layout))(
+      Term.ForYield(
+        List(
+          Enumerator.CaseGenerator(
+            Pat.Tuple(List(Pat.Var(tname("a")), Pat.Var(tname("b")))),
+            tname("pairs")
+          ),
+          Enumerator.Generator(
+            Pat.Var(tname("x")),
+            Term.ApplyInfix(tname("a"), tname("to"), Nil, List(tname("b")))
+          )
+        ),
+        tname("x")
+      )
+    )
+  }
+
 }


### PR DESCRIPTION
Unlike other control regions, where the primary goal is to detect purely scala3 constructs (conditions without parens, instead using significant indentation and a terminating token), RegionFor is also used to handle `case` that is not for `catch/match` -- nor a partial function.

Fixes #3220.