### PR TITLE
ScalametaParser: include infix start in first lhs

### DIFF
--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -1082,7 +1082,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
   // #3219
   checkPositions[Stat](
     "(10) + 1 toInt",
-    """|Term.ApplyInfix 10) + 1
+    """|Term.ApplyInfix (10) + 1
        |Type.ArgClause (10) + @@1 toInt
        |""".stripMargin
   )
@@ -1091,7 +1091,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |  fx
        |""".stripMargin,
     """|Term.ApplyInfix (10) + 1 == 11
-       |Term.ApplyInfix 10) + 1
+       |Term.ApplyInfix (10) + 1
        |Type.ArgClause if (10) + @@1 == 11 then
        |Type.ArgClause if (10) + 1 == @@11 then
        |Lit.Unit @@

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -1079,4 +1079,23 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |""".stripMargin
   )
 
+  // #3219
+  checkPositions[Stat](
+    "(10) + 1 toInt",
+    """|Term.ApplyInfix 10) + 1
+       |Type.ArgClause (10) + @@1 toInt
+       |""".stripMargin
+  )
+  checkPositions[Stat](
+    """|if (10) + 1 == 11 then
+       |  fx
+       |""".stripMargin,
+    """|Term.ApplyInfix (10) + 1 == 11
+       |Term.ApplyInfix 10) + 1
+       |Type.ArgClause if (10) + @@1 == 11 then
+       |Type.ArgClause if (10) + 1 == @@11 then
+       |Lit.Unit @@
+       |""".stripMargin
+  )
+
 }

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
@@ -816,4 +816,12 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
        |Case case foo => foo
        |""".stripMargin
   )
+
+  // #3219
+  checkPositions[Term](
+    "(10) + 1 toInt",
+    """|Term.ApplyInfix 10) + 1
+       |Type.ArgClause (10) + @@1 toInt
+       |""".stripMargin
+  )
 }

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
@@ -820,7 +820,7 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
   // #3219
   checkPositions[Term](
     "(10) + 1 toInt",
-    """|Term.ApplyInfix 10) + 1
+    """|Term.ApplyInfix (10) + 1
        |Type.ArgClause (10) + @@1 toInt
        |""".stripMargin
   )


### PR DESCRIPTION
Fixes #3219.