### PR TITLE
ScannerTokens: handle `yield` in scala2

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -534,7 +534,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
           case (_: RegionDelim) :: (_: RegionFor) :: _ => sepRegions
           case xs => RegionIf(next) :: xs
         })
-      case _: KwThen if dialect.allowSignificantIndentation =>
+      case _: KwThen =>
         sepRegions match {
           case (r: RegionIndent) :: (_: RegionIf) :: xs =>
             outdentThenCurrRef(r, xs, Some(RegionThen))
@@ -548,7 +548,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
           case (_: RegionControl) :: xs => currRef(xs)
           case xs => currRef(xs)
         }
-      case _: KwDo | _: KwYield if dialect.allowSignificantIndentation =>
+      case _: KwDo | _: KwYield =>
         sepRegions match {
           case (r: RegionIndent) :: (_: RegionControl) :: xs =>
             outdentThenCurrRef(r, xs)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -1720,4 +1720,23 @@ class TermSuite extends ParseSuite {
     )
   }
 
+  test("#3224") {
+    val code =
+      """|for {
+         |  x2 <- x1
+         |} yield x2
+         |  .x3 {
+         |    case x4
+         |        if x5.x6
+         |          .x7(x8) =>
+         |        x9
+         |  }
+         |""".stripMargin
+    val error =
+      """|<input>:5: error: => expected but \n found
+         |    case x4
+         |           ^""".stripMargin
+    runTestError[Term](code, error)
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -1732,11 +1732,31 @@ class TermSuite extends ParseSuite {
          |        x9
          |  }
          |""".stripMargin
-    val error =
-      """|<input>:5: error: => expected but \n found
-         |    case x4
-         |           ^""".stripMargin
-    runTestError[Term](code, error)
+    val layout =
+      """|for (x2 <- x1) yield x2.x3({
+         |  case x4 if x5.x6.x7(x8) => x9
+         |})
+         |""".stripMargin
+    runTestAssert[Term](code, Some(layout))(
+      Term.ForYield(
+        List(Enumerator.Generator(Pat.Var(tname("x2")), tname("x1"))),
+        Term.Apply(
+          Term.Select(tname("x2"), tname("x3")),
+          Term.PartialFunction(
+            Case(
+              Pat.Var(tname("x4")),
+              Some(
+                Term.Apply(
+                  Term.Select(Term.Select(tname("x5"), tname("x6")), tname("x7")),
+                  List(tname("x8"))
+                )
+              ),
+              tname("x9")
+            ) :: Nil
+          ) :: Nil
+        )
+      )
+    )
   }
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -3726,4 +3726,43 @@ class ControlSyntaxSuite extends BaseDottySuite {
     )
   }
 
+  test("#3224") {
+    val code =
+      """|for {
+         |  x2 <- x1
+         |} yield x2
+         |  .x3 {
+         |    case x4
+         |        if x5.x6
+         |          .x7(x8) =>
+         |        x9
+         |  }
+         |""".stripMargin
+    val layout =
+      """|for (x2 <- x1) yield x2.x3({
+         |  case x4 if x5.x6.x7(x8) => x9
+         |})
+         |""".stripMargin
+    runTestAssert[Stat](code, Some(layout))(
+      Term.ForYield(
+        List(Enumerator.Generator(Pat.Var(tname("x2")), tname("x1"))),
+        Term.Apply(
+          Term.Select(tname("x2"), tname("x3")),
+          Term.PartialFunction(
+            Case(
+              Pat.Var(tname("x4")),
+              Some(
+                Term.Apply(
+                  Term.Select(Term.Select(tname("x5"), tname("x6")), tname("x7")),
+                  List(tname("x8"))
+                )
+              ),
+              tname("x9")
+            ) :: Nil
+          ) :: Nil
+        )
+      )
+    )
+  }
+
 }


### PR DESCRIPTION
Also remove scala3 check for `do` and `then` as these keywords naturally imply scala3. Fixes #3224. Follow-up to #3221.