### PR TITLE
CommunityDottySuite: include commit in test label

### DIFF
--- a/community-test/src/test/scala/CommunityDottySuite.scala
+++ b/community-test/src/test/scala/CommunityDottySuite.scala
@@ -73,7 +73,7 @@ class CommunityDottySuite extends FunSuite {
   )
 
   for (build <- communityBuilds) {
-    test(s"community-build-${build.name}") {
+    test(s"community-build-${build.name}-${build.commit}") {
       check(build)
     }
   }


### PR DESCRIPTION
If we test multiple versions of a repo, the tests will by default be labelled as "-1", "-2" etc. Instead, let's include the actual commit.