### PR TITLE
Tokens: check index out of bounds in `apply`

### DIFF
--- a/scalameta/tokens/shared/src/main/scala/scala/meta/tokens/Tokens.scala
+++ b/scalameta/tokens/shared/src/main/scala/scala/meta/tokens/Tokens.scala
@@ -31,7 +31,10 @@ import scala.meta.internal.prettyprinters._
     private val start: Int,
     val length: Int
 ) extends immutable.IndexedSeq[Token] with IndexedSeqOptimized[Token] {
-  def apply(idx: Int): Token = tokens(start + idx)
+  @inline private def get(idx: Int): Token = tokens(start + idx)
+  def apply(idx: Int): Token =
+    if (idx >= 0 && idx < length) get(idx)
+    else throw new NoSuchElementException(s"token $idx out of $length")
   def end: Int = start + length // for MIMA compat
   override def slice(from: Int, until: Int): Tokens = {
     val lo = start + from.max(0).min(length)
@@ -44,8 +47,10 @@ import scala.meta.internal.prettyprinters._
    * https://github.com/scala/scala/commit/b20dd00b11f06c14c823d277cdfb58043a2586fc
    */
   override def head: Token = apply(0)
+  override def headOption: Option[Token] = if (isEmpty) None else Some(get(0))
 
-  override def headOption: Option[Token] = if (isEmpty) None else Some(head)
+  override def last: Token = apply(length - 1)
+  override def lastOption: Option[Token] = if (isEmpty) None else Some(get(length - 1))
 
   override def toString = scala.meta.internal.prettyprinters.TokensToString(this)
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TemplateSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TemplateSuite.scala
@@ -6,9 +6,18 @@ import scala.meta.dialects.Scala211
 
 class TemplateSuite extends ParseSuite {
   test("trait T") {
-    assertTree(templStat("trait T")) {
+    val tree = templStat("trait T")
+    assertTree(tree) {
       Trait(Nil, Type.Name("T"), Type.ParamClause(Nil), EmptyCtor(), EmptyTemplate())
     }
+    def testTokens(t: Tree): Unit = {
+      assertNoDiff(t.tokens.head.productPrefix, "EOF")
+      assertNoDiff(t.tokens.last.productPrefix, "Ident")
+    }
+    val traitTree = tree.asInstanceOf[Trait]
+    testTokens(traitTree.tparamClause)
+    testTokens(traitTree.ctor)
+    testTokens(traitTree.templ)
   }
 
   test("trait T {}") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TemplateSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TemplateSuite.scala
@@ -11,8 +11,8 @@ class TemplateSuite extends ParseSuite {
       Trait(Nil, Type.Name("T"), Type.ParamClause(Nil), EmptyCtor(), EmptyTemplate())
     }
     def testTokens(t: Tree): Unit = {
-      assertNoDiff(t.tokens.head.productPrefix, "EOF")
-      assertNoDiff(t.tokens.last.productPrefix, "Ident")
+      interceptMessage[NoSuchElementException]("token 0 out of 0")(t.tokens.head)
+      interceptMessage[NoSuchElementException]("token -1 out of 0")(t.tokens.last)
     }
     val traitTree = tree.asInstanceOf[Trait]
     testTokens(traitTree.tparamClause)


### PR DESCRIPTION
Fixes #3235.