### PR TITLE
SBT: downgrade back to 1.6.2

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.1
+sbt.version=1.6.2


### PR DESCRIPTION
Currently, `+publish` doesn't apply any of the workarounds mentioned in https://github.com/sbt/sbt/issues/7327#issuecomment-1627805403. Reverts #3243.