### PR TITLE
SBT: remove geny dependency in testkit

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -347,14 +347,11 @@ lazy val semanticdbIntegrationMacros = project
 
 lazy val testkit = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .in(file("scalameta/testkit"))
-  .enablePlugins(ShadingPlugin)
   .settings(
     publishableSettings,
-    shadingSettings,
     hasLargeIntegrationTests,
     libraryDependencies ++= Seq(
-      "org.scalameta" %%% "munit" % munitVersion,
-      "com.lihaoyi" %%% "geny" % "0.7.1"
+      "org.scalameta" %%% "munit" % munitVersion
     ),
     testFrameworks := List(new TestFramework("munit.Framework")),
     description := "Testing utilities for scalameta APIs"

--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -46,6 +46,9 @@ object Mima {
     ProblemFilters.exclude[A]("scala.meta." + metaType)
 
   val apiCompatibilityExceptions: Seq[ProblemFilter] = Seq(
+    // testkit
+    exclude[IncompatibleResultTypeProblem]("testkit.Corpus.files"),
+    exclude[IncompatibleResultTypeProblem]("testkit.FileOps.listFiles"),
     // newField; these methods should have been package-private
     exclude[DirectMissingMethodProblem]("Defn#Type.setBounds"),
     exclude[DirectMissingMethodProblem]("Template.setDerives"),

--- a/scalameta/testkit/jvm/src/main/scala/scala/meta/testkit/Corpus.scala
+++ b/scalameta/testkit/jvm/src/main/scala/scala/meta/testkit/Corpus.scala
@@ -3,8 +3,6 @@ package scala.meta.testkit
 import java.io.File
 import java.net.URL
 
-import geny.Generator
-
 import sys.process._
 import java.net.URL
 import java.io.File
@@ -113,17 +111,17 @@ object Corpus {
    * @param corpus
    *   See [[Corpus]].
    * @return
-   *   A generator of [[CorpusFile]]. Use Generator.take to limit the size of your experiment and
+   *   An iterator of [[CorpusFile]]. Use Iterator.take to limit the size of your experiment and
    *   Generator.toBuffer.par to run analysis using all available cores on the machine.
    */
-  def files(corpus: Corpus): Generator[CorpusFile] = {
+  def files(corpus: Corpus): Iterator[CorpusFile] = {
     val repos = createReposDir(corpus)
     val files = Option(repos.listFiles()).getOrElse {
       throw new IllegalStateException(
         s"${repos.getAbsolutePath} is not a directory! Please delete if it's a file and retry."
       )
     }
-    Generator.from(files.toList).flatMap { repo =>
+    files.iterator.flatMap { repo =>
       val commit = FileOps.readFile(new File(repo, "COMMIT")).trim
       val url = FileOps.readFile(new File(repo, "URL")).trim
       FileOps


### PR DESCRIPTION
Apparently, geny.Generator is the result type of a public method within this library, and since it's used only for testing, and only in `scalafmt` benchmarks, changing that result type should be ok.