### PR TITLE
SBT: build only for the last 4 versions of scala

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -3,8 +3,8 @@ package build
 
 object Versions {
   val Scala211Versions = getVersions(2, 11, 12 to 12)
-  val Scala212Versions = getVersions(2, 12, 9 to 18)
-  val Scala213Versions = getVersions(2, 13, 1 to 11)
+  val Scala212Versions = getVersions(2, 12, 15 to 18)
+  val Scala213Versions = getVersions(2, 13, 8 to 11)
   val LatestScala211 = Scala211Versions.head
   val LatestScala212 = Scala212Versions.head
   val LatestScala213 = Scala213Versions.head
@@ -15,6 +15,8 @@ object Versions {
 
   // returns versions from newest to oldest
   private def getVersions(major: Int, minor: Int, range: Range) = {
+    if (range.length > 4)
+      throw new Exception(s"Too many versions for scala-$major.$minor: ${range.length} > 4")
     val desc = if (range.step > 0) range.reverse else range
     desc.map { x => s"$major.$minor.$x" }
   }


### PR DESCRIPTION
Let's include, for each minor version, up to 4 patch versions.