### PR TITLE
bugfix: Fix nested types with underscore

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/NestedContext.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/NestedContext.scala
@@ -22,3 +22,5 @@ private[parsers] object QuotedPatternContext extends NestedContext
 private[parsers] object ReturnTypeContext extends NestedContext
 
 private[parsers] object TypeBracketsContext extends NestedContext
+
+private[parsers] object PatternTypeContext extends NestedContext

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -964,7 +964,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
           next(); Type.PatWildcard()
         case _: Underscore
             if dialect.allowUnderscoreAsTypePlaceholder ||
-              dialect.allowTypeLambdas &&
+              dialect.allowTypeLambdas && !PatternTypeContext.isInside() &&
               TypeBracketsContext.isDeeper(1) && !peekToken.isAny[Supertype, Subtype] =>
           next(); Type.AnonymousParam(None)
         case _: Underscore =>
@@ -1107,7 +1107,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
         case tpe: Lit =>
           tpe
       })
-      val t: Type = {
+      val t: Type = PatternTypeContext.within {
         if (allowInfix) {
           val t = if (token.is[LeftParen]) tupleInfixType() else compoundType()
           token match {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -1610,9 +1610,7 @@ class MinorDottySuite extends BaseDottySuite {
             Pat.Var(tname("arr")),
             Type.Apply(
               pname("Array"),
-              Type.AnonymousLambda(
-                Type.Apply(pname("Array"), List(Type.AnonymousParam(None)))
-              ) :: Nil
+              List(Type.Apply(pname("Array"), List(Type.Wildcard(noBounds))))
             )
           ),
           None,


### PR DESCRIPTION
Fixes scalameta/metals#5437. Supersedes #3253.