### PR TITLE
ScannerTokens: expand comma rule

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SepRegion.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SepRegion.scala
@@ -19,17 +19,16 @@ sealed trait SepRegionNonIndented extends SepRegion {
 
 // this describes delimiters (indent, parens, braces, brackets)
 sealed trait RegionDelim extends SepRegion
+// this describes delimiters which are non-indented
+sealed trait RegionDelimNonIndented extends SepRegionNonIndented with RegionDelim
 // this describes non-delimiters which are also non-indented (likely all of them)
 sealed trait RegionNonDelimNonIndented extends SepRegionNonIndented
 
 case class RegionIndent(override val indent: Int) extends SepRegionIndented with RegionDelim
 
-case object RegionParen extends SepRegionNonIndented with RegionDelim
-
-case object RegionBracket extends SepRegionNonIndented with RegionDelim
-
-case class RegionBrace(override val indent: Int)
-    extends SepRegionNonIndented with CanProduceLF with RegionDelim
+case object RegionParen extends RegionDelimNonIndented
+case object RegionBracket extends RegionDelimNonIndented
+case class RegionBrace(override val indent: Int) extends RegionDelimNonIndented with CanProduceLF
 
 case object RegionCaseMark extends RegionNonDelimNonIndented
 final class RegionCaseExpr(override val indent: Int) extends RegionNonDelimNonIndented

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -2851,4 +2851,36 @@ class SignificantIndentationSuite extends BaseDottySuite {
     }
   }
 
+  test("#3257 `new` in arg value after indent, then comma") {
+    val code =
+      """|object a:
+         |  A(
+         |    b =
+         |      new B,
+         |    c = d
+         |  )
+         |""".stripMargin
+    val error =
+      """|<input>:4: error: ; expected but , found
+         |      new B,
+         |           ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("#3257 `if-no-else` in arg value after indent, then comma") {
+    val code =
+      """|object a:
+         |  A(
+         |    b =
+         |      if (a + b) c,
+         |    c = d
+         |  )
+         |""".stripMargin
+    val error =
+      """|<input>:4: error: ; expected but , found
+         |      if (a + b) c,
+         |                  ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -2860,11 +2860,22 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |    c = d
          |  )
          |""".stripMargin
-    val error =
-      """|<input>:4: error: ; expected but , found
-         |      new B,
-         |           ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "object a { A(b = new B, c = d) }"
+    runTestAssert[Stat](code, Some(layout)) {
+      Defn.Object(
+        Nil,
+        tname("a"),
+        tpl(
+          Term.Apply(
+            tname("A"),
+            List(
+              Term.Assign(tname("b"), Term.New(init("B"))),
+              Term.Assign(tname("c"), tname("d"))
+            )
+          ) :: Nil
+        )
+      )
+    }
   }
 
   test("#3257 `if-no-else` in arg value after indent, then comma") {
@@ -2876,11 +2887,30 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |    c = d
          |  )
          |""".stripMargin
-    val error =
-      """|<input>:4: error: ; expected but , found
-         |      if (a + b) c,
-         |                  ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "object a { A(b = if (a + b) c, c = d) }"
+    runTestAssert[Stat](code, Some(layout)) {
+      Defn.Object(
+        Nil,
+        tname("a"),
+        tpl(
+          Term.Apply(
+            tname("A"),
+            List(
+              Term.Assign(
+                tname("b"),
+                Term.If(
+                  Term.ApplyInfix(tname("a"), tname("+"), Nil, List(tname("b"))),
+                  tname("c"),
+                  Lit.Unit(),
+                  Nil
+                )
+              ),
+              Term.Assign(tname("c"), tname("d"))
+            )
+          ) :: Nil
+        )
+      )
+    }
   }
 
 }


### PR DESCRIPTION
Follow-up to #3254. Fixes #3257.