### PR TITLE
TreeSyntax: separate block in all stat sequences

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TemplateSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TemplateSuite.scala
@@ -420,6 +420,7 @@ class TemplateSuite extends ParseSuite {
     val layout =
       """|class DerivationSpec {
          |  case class Foo()
+         |
          |  {
          |    deriveEncoder[Foo]
          |  }
@@ -447,10 +448,7 @@ class TemplateSuite extends ParseSuite {
         )
       )
     )
-    // code parses as specified tree
-    checkStat(code, layout)(tree)
-    // however, the parsed layout itself has different syntax (and, hence, tree)
-    assertNotEquals(parseStat(layout, implicitly[Dialect]).reprint, layout)
+    runTestAssert[Stat](code, Some(layout))(tree)
   }
 
   test("blank after template 2") {
@@ -470,6 +468,7 @@ class TemplateSuite extends ParseSuite {
     val layout =
       """|class DerivationSpec {
          |  case class Foo() extends Bar
+         |
          |  {
          |    deriveEncoder[Foo]
          |  }
@@ -497,10 +496,7 @@ class TemplateSuite extends ParseSuite {
         )
       )
     )
-    // code parses as specified tree
-    checkStat(code, layout)(tree)
-    // however, the parsed layout itself has different syntax (and, hence, tree)
-    assertNotEquals(parseStat(layout, implicitly[Dialect]).reprint, layout)
+    runTestAssert[Stat](code, Some(layout))(tree)
   }
 
 }


### PR DESCRIPTION
Follow-on to #3139.