### PR TITLE
NestedContext: move all contexts to parser

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/NestedContext.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/NestedContext.scala
@@ -14,13 +14,3 @@ private[parsers] trait NestedContext {
   @inline def isInside() = isDeeper(0)
   @inline def isDeeper(level: Int) = nested > level
 }
-
-private[parsers] object QuotedSpliceContext extends NestedContext
-
-private[parsers] object QuotedPatternContext extends NestedContext
-
-private[parsers] object ReturnTypeContext extends NestedContext
-
-private[parsers] object TypeBracketsContext extends NestedContext
-
-private[parsers] object PatternTypeContext extends NestedContext

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -33,6 +33,14 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
   private val scannerTokens: ScannerTokens = ScannerTokens(input)
   import scannerTokens._
 
+  /* ------------- NESTED CONTEXT OBJECTS ----------------------------------------- */
+  // must all be parser-specific, to avoid sharing state with other parsers
+  private object QuotedSpliceContext extends NestedContext
+  private object QuotedPatternContext extends NestedContext
+  private object ReturnTypeContext extends NestedContext
+  private object TypeBracketsContext extends NestedContext
+  private object PatternTypeContext extends NestedContext
+
   /* ------------- PARSER ENTRY POINTS -------------------------------------------- */
 
   def parseRule[T <: Tree](rule: this.type => T): T = {


### PR DESCRIPTION
The current implementation was mistakenly sharing context with any other instantiated parsers, which would cause problems in a multi-threaded use such as within scalafmt. Fixes #3063.