### PR TITLE
semanticdb: use canonical path for sourceroot

### DIFF
--- a/scalameta/io/js/src/main/scala/java/nio/file/Path.scala
+++ b/scalameta/io/js/src/main/scala/java/nio/file/Path.scala
@@ -25,4 +25,5 @@ trait Path extends Iterable[Path] {
   def toUri: URI
   def toAbsolutePath: Path
   def toFile: java.io.File
+  def toRealPath(): Path
 }

--- a/scalameta/io/js/src/main/scala/scala/meta/internal/io/NodeNIOPath.scala
+++ b/scalameta/io/js/src/main/scala/scala/meta/internal/io/NodeNIOPath.scala
@@ -37,6 +37,8 @@ case class NodeNIOPath(filename: String) extends Path {
   override def toAbsolutePath: Path =
     if (isAbsolute) this
     else NodeNIOPath.workingDirectory.resolve(this)
+  override def toRealPath(): Path =
+    toAbsolutePath
   override def relativize(other: Path): Path =
     NodeNIOPath(JSPath.relative(filename, other.toString))
   override def getNameCount: Int = {

--- a/scalameta/io/shared/src/main/scala/scala/meta/io/RelativePath.scala
+++ b/scalameta/io/shared/src/main/scala/scala/meta/io/RelativePath.scala
@@ -12,16 +12,7 @@ import scala.collection.JavaConverters._
 sealed abstract case class RelativePath(toNIO: Path) {
   require(!toNIO.isAbsolute, s"$toNIO is not relative!")
   def toFile: File = toNIO.toFile
-  def toURI(isDirectory: Boolean): URI = {
-    val suffix = if (isDirectory) "/" else ""
-    // Can't use toNIO.toUri because it produces an absolute URI.
-    val names = toNIO.iterator().asScala
-    val uris = names.map { name =>
-      // URI encode each part of the path individually.
-      new URI(null, null, name.toString, null)
-    }
-    URI.create(uris.mkString("", "/", suffix))
-  }
+  def toURI(isDirectory: Boolean): URI = RelativePath.toURI(toNIO, isDirectory)
 
   def syntax: String = toString
   def structure: String = s"""RelativePath("$syntax")"""
@@ -46,4 +37,16 @@ object RelativePath {
   // throws Illegal argument exception if path is not relative.
   def apply(path: nio.Path): RelativePath =
     new RelativePath(path) {}
+
+  private[meta] def toURI(path: Path, isDirectory: Boolean): URI = {
+    val suffix = if (isDirectory) "/" else ""
+    // Can't use toNIO.toUri because it produces an absolute URI.
+    val names = path.iterator().asScala
+    val uris = names.map { name =>
+      // URI encode each part of the path individually.
+      new URI(null, null, name.toString, null)
+    }
+    URI.create(uris.mkString("", "/", suffix))
+  }
+
 }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/ConfigOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/ConfigOps.scala
@@ -19,6 +19,8 @@ case class SemanticdbConfig(
     synthetics: BinaryMode,
     overrides: BinaryMode
 ) {
+  private[scalac] lazy val realSourceRoot = sourceroot.toNIO.toRealPath()
+
   def syntax: String = {
     val p = SemanticdbPlugin.name
     List(

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/InputOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/InputOps.scala
@@ -3,34 +3,26 @@ package scala.meta.internal.semanticdb.scalac
 import java.net.{URI, URLEncoder}
 import java.nio.CharBuffer
 import java.nio.charset.StandardCharsets.UTF_8
-import java.nio.file.Paths
+import java.nio.file.Path
 import java.security.MessageDigest
 import scala.collection.mutable
 import scala.{meta => m}
 import scala.meta.internal.io._
-import scala.meta.io.AbsolutePath
+import scala.meta.io.{AbsolutePath, RelativePath}
 import scala.reflect.internal.util.{Position => GPosition, SourceFile => GSourceFile}
 import scala.reflect.io.VirtualFile
 import scala.reflect.io.{PlainFile => GPlainFile}
 
 trait InputOps { self: SemanticdbOps =>
 
+  import InputOps._
+
   lazy val gSourceFileInputCache = mutable.Map[GSourceFile, m.Input]()
   implicit class XtensionGSourceFileInput(gsource: GSourceFile) {
-    private def uriRelativeToSourceRoot(file: AbsolutePath): URI = {
-      if (!file.toNIO.startsWith(config.sourceroot.toNIO)) {
-        // java.net.URI.relativize returns `fileUri` unchanged when it is not contained within our sourceroot.
-        // We could attempt to return a ".." URI, but java.net doesn't provide facilities for that. While nio's Path
-        // does contain facilities for that, such relative paths cannot then be used to produce a percent-encoded,
-        // relative URI. It doesn't seem worth fighting this battle at the moment, so:
-        sys.error(s"'$file' is not located within sourceroot '${config.sourceroot}'.")
-      }
-      file.toRelative(config.sourceroot).toURI(isDirectory = false)
-    }
-
     def isInSourceroot(): Boolean = gsource.file match {
       case gfile: GPlainFile =>
-        gfile.file.toPath.startsWith(config.sourceroot.toNIO) || !gfile.file.toPath.isAbsolute
+        val gpath = gfile.file.toPath
+        !gpath.isAbsolute || config.fileInSourceRoot(gpath).isDefined
       case _: VirtualFile =>
         true // Would anyone go to the trouble of building a VirtualFile that's outside of sourceroot?
       case _ =>
@@ -39,7 +31,7 @@ trait InputOps { self: SemanticdbOps =>
 
     def toUri: String = toInput match {
       case input: m.Input.File =>
-        uriRelativeToSourceRoot(input.path).toString
+        config.uriRelativeToSourceRoot(input.path).toString
       case input: m.Input.VirtualFile =>
         input.path
       case _ =>
@@ -69,7 +61,7 @@ trait InputOps { self: SemanticdbOps =>
             case gfile: GPlainFile =>
               if (config.text.isOn) {
                 val path = m.AbsolutePath(gfile.file)
-                val label = uriRelativeToSourceRoot(path).toString
+                val label = config.uriRelativeToSourceRoot(path).toString
                 // NOTE: Can't use gsource.content because it's preprocessed by scalac.
                 val contents = FileIO.slurp(path, UTF_8)
                 m.Input.VirtualFile(label, contents)
@@ -97,4 +89,39 @@ trait InputOps { self: SemanticdbOps =>
       else m.Position.Range(input, pos.point, pos.point)
     }
   }
+}
+
+private object InputOps {
+
+  private def fileInRoot(file: Path, root: Path): Option[() => Path] =
+    if (file.startsWith(root)) Some(() => root.relativize(file)) else None
+
+  implicit class ImplicitSemanticdbConfig(private val config: SemanticdbConfig) extends AnyVal {
+
+    def fileInSourceRoot(file: Path): Option[() => Path] = {
+      val root = config.sourceroot.toNIO
+      // file is under source root; both could be symlinks to unrelated paths
+      fileInRoot(file, root).orElse {
+        val realRoot = config.realSourceRoot
+        // file is real but root was a symlink
+        (if (realRoot eq root) None else fileInRoot(file, realRoot)).orElse {
+          val realFile = file.toRealPath()
+          // file has a symlink parent but different from root
+          if (realFile eq file) None else fileInRoot(realFile, realRoot)
+        }
+      }
+    }
+
+    def uriRelativeToSourceRoot(file: AbsolutePath): URI = fileInSourceRoot(file.toNIO)
+      .map { f => RelativePath.toURI(f(), isDirectory = false) }
+      .getOrElse {
+        // java.net.URI.relativize returns `fileUri` unchanged when it is not contained within our sourceroot.
+        // We could attempt to return a ".." URI, but java.net doesn't provide facilities for that. While nio's Path
+        // does contain facilities for that, such relative paths cannot then be used to produce a percent-encoded,
+        // relative URI. It doesn't seem worth fighting this battle at the moment, so:
+        sys.error(s"'$file' is not located within sourceroot '${config.sourceroot}'.")
+      }
+
+  }
+
 }


### PR DESCRIPTION
Fixes #2518.