### PR TITLE
TreeSyntax: separate block in scala3 stats

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -302,7 +302,7 @@ object TreeSyntax {
       case _: Decl.Val | _: Decl.Var | _: Decl.Def | _: Defn.Type | _: Term.Ref | _: Member.Apply |
           _: Term.Ascribe | _: Term.Tuple | _: Term.New | _: Term.Interpolate | _: Term.Xml |
           _: Lit =>
-        true
+        !dialect.allowSignificantIndentation
       case t: Term.Do => false
       case t: Tree.WithBody => guessNeedsLineSep(t.body)
       case t: Stat.WithTemplate => t.templ.self.isEmpty && t.templ.stats.isEmpty
@@ -1119,8 +1119,7 @@ object TreeSyntax {
       builder.result()
     }
 
-    implicit def syntaxStats: Syntax[Seq[Stat]] =
-      if (dialect.allowSignificantIndentation) Syntax(x => r(x.map(i(_)))) else Syntax(printStats)
+    implicit def syntaxStats: Syntax[Seq[Stat]] = Syntax(printStats)
 
   }
   def apply[T <: Tree](dialect: Dialect): Syntax[T] = {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -3333,6 +3333,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
     val layout =
       """|class DerivationSpec {
          |  case class Foo()
+         |
          |  {
          |    deriveEncoder[Foo]
          |  }
@@ -3360,10 +3361,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
         )
       )
     )
-    // code parses as specified tree
-    checkStat(code, layout)(tree)
-    // however, the parsed layout itself has different syntax (and, hence, tree)
-    assertNotEquals(parseStat(layout, implicitly[Dialect]).reprint, layout)
+    runTestAssert[Stat](code, Some(layout))(tree)
   }
 
   test("blank after template 2") {
@@ -3383,6 +3381,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
     val layout =
       """|class DerivationSpec {
          |  case class Foo() extends Bar
+         |
          |  {
          |    deriveEncoder[Foo]
          |  }
@@ -3410,10 +3409,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
         )
       )
     )
-    // code parses as specified tree
-    checkStat(code, layout)(tree)
-    // however, the parsed layout itself has different syntax (and, hence, tree)
-    assertNotEquals(parseStat(layout, implicitly[Dialect]).reprint, layout)
+    runTestAssert[Stat](code, Some(layout))(tree)
   }
 
 }


### PR DESCRIPTION
Follow-on to #3139 and #3269.