### PR TITLE
ConfigOps: sourceroot as relative to targetroot

### DIFF
--- a/docs/semanticdb/guide.md
+++ b/docs/semanticdb/guide.md
@@ -234,6 +234,10 @@ and the "Value" column describes the `<value>` component):
     <td>
       Used to relativize source file paths into
       <code>TextDocument.uri</code>.
+      <br/>
+      If the value starts with `targetroot:`, the remaining part is 
+      interpreted as relative to `targetroot` (see below; must be
+      specified first) instead of current working directory.
     </td>
     <td>Current working directory</td>
   </tr>

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/ConfigOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/ConfigOps.scala
@@ -104,8 +104,18 @@ object SemanticdbConfig {
         config = config.copy(fileFilter = config.fileFilter.copy(include = include.r))
       case SetExclude(exclude) =>
         config = config.copy(fileFilter = config.fileFilter.copy(exclude = exclude.r))
-      case SetSourceroot(path) =>
-        config = config.copy(sourceroot = AbsolutePath(path))
+      case SetSourceroot(pattern) =>
+        val abspath = pattern match {
+          case SetTargetroot(relative) =>
+            if (config.targetroot eq SemanticdbConfig.default.targetroot)
+              reporter.error(
+                NoPosition,
+                s"${prefix}sourceroot:$pattern must follow '${prefix}targetroot:'."
+              )
+            config.targetroot.resolve(relative)
+          case p => AbsolutePath(p)
+        }
+        config = config.copy(sourceroot = abspath)
       case SetTargetroot(path) =>
         config = config.copy(targetroot = AbsolutePath(path))
       case SetText(BinaryMode(mode)) =>


### PR DESCRIPTION
That is, one could specify `-P:semanticdb:sourceroot:targetroot:../xyz`. Fixes #2515.