### PR TITLE
ScannerTokens: fix `case` clause in fewer braces

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -469,9 +469,10 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
         currRef(sepRegions match {
           // `case` follows the body of a previous case
           case (_: RegionCaseBody) :: xs => expr() :: xs
-          // x could be RegionIndent or RegionBrace
+          // head could be RegionIndent or RegionBrace
           case x :: RegionCaseMark :: xs => expr() :: x :: xs
-          case (_: RegionBrace) :: (_: RegionFor | RegionTemplateBody) :: _ => sepRegions
+          case (_: RegionDelim) :: (_: RegionFor | RegionTemplateBody) :: _ => sepRegions
+          // partial function
           case (_: RegionBrace) :: _ => expr() :: sepRegions
           case (_: RegionIndent) :: _ if prev.is[Equals] && prevToken.is[Indentation.Indent] =>
             expr() :: sepRegions

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
@@ -682,4 +682,30 @@ class FewerBracesSuite extends BaseDottySuite {
     )
   }
 
+  test("#3296") {
+    val code =
+      """object MyApp:
+        |
+        |  def test(str: String)(block: => Boolean): Unit =
+        |    println(str + " : " + block)
+        |
+        |  test("First test"):
+        |    case class Foo(x: Int, y: String)
+        |    1 == 1
+        |
+        |  test("Second test"):
+        |    1 == 1
+        |""".stripMargin
+    val layout =
+      """|object MyApp {
+         |  def test(str: String)(block: => Boolean): Unit = println(str + " : " + block)
+         |  (test("First test") {
+         |    case class Foo(x: Int, y: String)
+         |    1 == 1
+         |  } test "Second test")(1 == 1)
+         |}
+         |""".stripMargin
+    assertNoDiff(parseStat(code, dialect).reprint, layout)
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
@@ -699,10 +699,11 @@ class FewerBracesSuite extends BaseDottySuite {
     val layout =
       """|object MyApp {
          |  def test(str: String)(block: => Boolean): Unit = println(str + " : " + block)
-         |  (test("First test") {
+         |  test("First test") {
          |    case class Foo(x: Int, y: String)
          |    1 == 1
-         |  } test "Second test")(1 == 1)
+         |  }
+         |  test("Second test")(1 == 1)
          |}
          |""".stripMargin
     assertNoDiff(parseStat(code, dialect).reprint, layout)


### PR DESCRIPTION
Fixes #3296.