### PR TITLE
SBT: integration uses jar from SemanticDB plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -339,7 +339,7 @@ lazy val semanticdbIntegration = project
     },
     javacOptions += "-parameters"
   )
-  .dependsOn(semanticdbIntegrationMacros)
+  .dependsOn(semanticdbIntegrationMacros, semanticdbScalacPlugin)
 
 lazy val semanticdbIntegrationMacros = project
   .in(file("semanticdb/integration-macros"))


### PR DESCRIPTION
Perhaps it should depends on that project.