### PR TITLE
SemanticDB: allow silencing info/warning/error

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -322,6 +322,7 @@ lazy val semanticdbIntegration = project
         "-Xplugin-require:semanticdb",
         warnUnusedImports,
         "-Yrangepos",
+        "-P:semanticdb:reporter_severity:error", // don't report below error
         "-P:semanticdb:text:on", // include text to print occurrences in expect suite
         "-P:semanticdb:failures:error", // fail fast during development.
         "-P:semanticdb:exclude:Exclude.scala",

--- a/docs/semanticdb/guide.md
+++ b/docs/semanticdb/guide.md
@@ -203,6 +203,20 @@ and the "Value" column describes the `<value>` component):
     <td><code>warning</code></td>
   </tr>
   <tr>
+    <td><code>reporter_severity</code></td>
+    <td>
+      same as <code>failures</code> above
+    </td>
+    <td>
+      SemanticDB requires the compiler to report various messages, by
+      inserting itself as a compiler reporter, but we might not want to
+      see them displayed (or passed to the original, downstream compiler
+      reporters). This option allows the user to specify the severity
+      level of messages to be forwarded to the original reporter.
+    </td>
+    <td><code>info</code></td>
+  </tr>
+  <tr>
     <td><code>profiling</code></td>
     <td>
       <code>on</code>,<br/>

--- a/semanticdb/scalac/library/src/main/scala-2.11/scala/meta/internal/semanticdb/scalac/SemanticdbReporter.scala
+++ b/semanticdb/scalac/library/src/main/scala-2.11/scala/meta/internal/semanticdb/scalac/SemanticdbReporter.scala
@@ -3,7 +3,7 @@ package scala.meta.internal.semanticdb.scalac
 import scala.reflect.internal.util.Position
 import scala.tools.nsc.reporters.{Reporter, StoreReporter}
 
-class SemanticdbReporter(underlying: Reporter) extends StoreReporter {
+class SemanticdbReporter(underlying: Reporter, minSeverity: FailureMode) extends StoreReporter {
   override protected def info0(
       pos: Position,
       msg: String,
@@ -12,9 +12,9 @@ class SemanticdbReporter(underlying: Reporter) extends StoreReporter {
   ): Unit = {
     super.info0(pos, msg, severity, force)
     severity.id match {
-      case 0 => underlying.info(pos, msg, force)
-      case 1 => underlying.warning(pos, msg)
-      case 2 => underlying.error(pos, msg)
+      case 0 if minSeverity.level <= FailureMode.Info.level => underlying.info(pos, msg, force)
+      case 1 if minSeverity.level <= FailureMode.Warning.level => underlying.warning(pos, msg)
+      case 2 if minSeverity.level <= FailureMode.Error.level => underlying.error(pos, msg)
       case _ =>
     }
 

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SemanticdbPlugin.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SemanticdbPlugin.scala
@@ -20,7 +20,7 @@ class SemanticdbPlugin(val global: Global) extends Plugin with SemanticdbPipelin
     config = SemanticdbConfig.parse(originalOptions, errFn, g.reporter, baseConfig)
     g.reporter match {
       case _: SemanticdbReporter => // do nothing, already hijacked
-      case r => if (isSupportedCompiler) g.reporter = new SemanticdbReporter(r)
+      case r => if (isSupportedCompiler) g.reporter = new SemanticdbReporter(r, config.severity)
     }
     true
   }


### PR DESCRIPTION
Capture them only in semanticdb and not report further.

The reason why this is useful is because scalac's `-Xreporter` option is not yet supported in scala3 -- and it's also ignored by sbt, which uses the `compilerReporter` setting instead (which isn't readily documented).