### PR TITLE
bugfix: Don't shade for 2.11.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -865,10 +865,14 @@ lazy val docs = project
   .enablePlugins(BuildInfoPlugin, DocusaurusPlugin)
 
 lazy val shadingSettings = Def.settings(
-  shadedModules ++= Set(
-    "com.lihaoyi" %% "geny",
-    "com.lihaoyi" %% "fastparse"
-  ),
+  shadedModules ++= {
+    if (!isScala211.value)
+      Set(
+        "com.lihaoyi" %% "geny",
+        "com.lihaoyi" %% "fastparse"
+      )
+    else Set.empty
+  },
   shadingRules ++= Seq(
     "geny",
     "fastparse"


### PR DESCRIPTION
Looks like there are some issues with shading for Scala 2.11.12, so since this is a barely supported version I don't think we need to shade it. It's currently only used in Metals I think.

Related to https://github.com/scalameta/metals-vscode/issues/1420