### PR TITLE
SBT: shade platform-specific dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -865,11 +865,11 @@ lazy val docs = project
   .enablePlugins(BuildInfoPlugin, DocusaurusPlugin)
 
 lazy val shadingSettings = Def.settings(
-  shadedModules ++= {
+  shadedDependencies ++= {
     if (!isScala211.value)
       Set(
-        "com.lihaoyi" %% "geny",
-        "com.lihaoyi" %% "fastparse"
+        "com.lihaoyi" %%% "geny" % "foo",
+        "com.lihaoyi" %%% "fastparse" % "foo"
       )
     else Set.empty
   },
@@ -894,7 +894,7 @@ def crossPlatformPublishSettings(project: sbtcrossproject.CrossProject) =
 
 def crossPlatformShading(project: sbtcrossproject.CrossProject) =
   if (shadingSettings.nonEmpty)
-    project.jvmConfigure(_.enablePlugins(ShadingPlugin).settings(shadingSettings))
+    project.enablePlugins(ShadingPlugin).settings(shadingSettings)
   else project
 
 val publishJVMSettings = platformPublishSettings(JVMPlatform)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
+resolvers ++= Resolver.sonatypeOssRepos("snapshots")
+
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.1")
 
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
@@ -31,4 +33,4 @@ addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.14")
 
 addSbtPlugin("io.chrisdavenport" %% "sbt-npm-package" % "0.1.2")
 
-addSbtPlugin("io.get-coursier" % "sbt-shading" % "2.1.1")
+addSbtPlugin("io.get-coursier" % "sbt-shading" % "2.1.3+9-9143b95e-SNAPSHOT")


### PR DESCRIPTION
For now, use a snapshot version of the sbt-shading plugin as formal releases aren't available yet. Fixes #3259.