### PR TITLE
bugfix: Don't allow * as type lambda by default

### DIFF
--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -142,7 +142,6 @@ package object dialects {
     .withAllowStarWildcardImport(true)
     .withAllowProcedureSyntax(false)
     .withAllowDoWhile(false)
-    .withAllowStarAsTypePlaceholder(true)
     .withUseInfixTypePrecedence(true)
     .withAllowInfixOperatorAfterNL(true)
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -1455,6 +1455,7 @@ class MinorDottySuite extends BaseDottySuite {
   }
 
   test("kleisli") {
+    val localDialect = dialect.withAllowStarAsTypePlaceholder(true)
     runTestAssert[Stat](
       "new (Kleisli[F, Span[F], *] ~> F) {}"
     )(
@@ -1486,7 +1487,7 @@ class MinorDottySuite extends BaseDottySuite {
           Nil
         )
       )
-    )
+    )(stat(_)(_), localDialect)
   }
 
   test("class Baz1 @deprecated(implicit c: C)") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/PatSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/PatSuite.scala
@@ -73,7 +73,7 @@ class PatSuite extends ParseSuite {
 
   test("_: F[*]") {
     // might be deprecated later
-    implicit val Scala3: Dialect = scala.meta.dialects.Scala31
+    implicit val Scala3: Dialect = scala.meta.dialects.Scala31.withAllowStarAsTypePlaceholder(true)
     assertPat("_: F[*]") {
       Typed(
         Wildcard(),


### PR DESCRIPTION
This currently needs to be enabled with a compiler flag, so I think it makes sense not to have it on as default. In Metals we can properly detect the flag, while in scalafmt people will most likely need to set it themselves.

Related to https://github.com/scalameta/metals/issues/5573