### PR TITLE
ScalametaParser: parse path-like types explicitly

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
@@ -617,4 +617,17 @@ class TypeSuite extends BaseDottySuite {
     )
   }
 
+  test("star-dot") {
+
+    runTestError[Stat](
+      """|
+         |given Conversion[*.type, List[*.type]] with
+         |  def apply(ast: *.type) = ast :: Nil
+         |""".stripMargin,
+      """|<input>:2: error: ] expected but . found
+         |given Conversion[*.type, List[*.type]] with
+         |                  ^""".stripMargin
+    )
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
@@ -619,14 +619,41 @@ class TypeSuite extends BaseDottySuite {
 
   test("star-dot") {
 
-    runTestError[Stat](
+    runTestAssert[Stat](
       """|
          |given Conversion[*.type, List[*.type]] with
          |  def apply(ast: *.type) = ast :: Nil
          |""".stripMargin,
-      """|<input>:2: error: ] expected but . found
-         |given Conversion[*.type, List[*.type]] with
-         |                  ^""".stripMargin
+      Some("given Conversion[*.type, List[*.type]] with { def apply(ast: *.type) = ast :: Nil }")
+    )(
+      Defn.Given(
+        Nil,
+        anon,
+        None,
+        tpl(
+          Init(
+            Type.Apply(
+              pname("Conversion"),
+              List(
+                Type.Singleton(tname("*")),
+                Type.Apply(pname("List"), List(Type.Singleton(tname("*"))))
+              )
+            ),
+            anon,
+            Nil
+          ) :: Nil,
+          List(
+            Defn.Def(
+              Nil,
+              tname("apply"),
+              Nil,
+              List(List(tparam("ast", Type.Singleton(tname("*"))))),
+              None,
+              Term.ApplyInfix(tname("ast"), tname("::"), Nil, List(tname("Nil")))
+            )
+          )
+        )
+      )
     )
   }
 


### PR DESCRIPTION
Possibly supersedes #3320.