### PR TITLE
ScalametaParser: fewer-braces colon must start rhs

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2096,9 +2096,14 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
           getNextRhs(op, targs) // [a]
           // afterwards, ctx.stack = List([a +])
         } else {
-          (if (token.is[Colon] && dialect.allowFewerBraces) getFewerBracesArgOnColon() else None)
-            .map(arg => getNextRhsWith(op, targs, arg))
-            .getOrElse(getPostfix(op, targs))
+          val argPos = tokenPos
+          (token match {
+            case _: Colon if dialect.allowFewerBraces => getFewerBracesArgOnColon()
+            case _ => None
+          }) match {
+            case None => getPostfix(op, targs)
+            case Some(x) => getNextRhsWith(op, targs, autoEndPos(argPos)(Term.Tuple(x :: Nil)))
+          }
         }
       }
 

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -1107,6 +1107,8 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
     """|Term.ApplyInfix bar foreach:
        |    baz
        |Type.ArgClause   bar foreach@@:
+       |Term.ArgClause :
+       |    baz
        |""".stripMargin
   )
   checkPositions[Stat](
@@ -1117,6 +1119,8 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
     """|Term.ApplyInfix bar foreach: baz =>
        |    println(baz)
        |Type.ArgClause   bar foreach@@: baz =>
+       |Term.ArgClause : baz =>
+       |    println(baz)
        |Term.Function baz =>
        |    println(baz)
        |Term.ParamClause baz

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -1098,4 +1098,32 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |""".stripMargin
   )
 
+  // #3319
+  checkPositions[Stat](
+    """|val foo =
+       |  bar foreach:
+       |    baz
+       |""".stripMargin,
+    """|Term.ApplyInfix bar foreach:
+       |    baz
+       |Type.ArgClause   bar foreach@@:
+       |""".stripMargin
+  )
+  checkPositions[Stat](
+    """|val foo =
+       |  bar foreach: baz =>
+       |    println(baz)
+       |""".stripMargin,
+    """|Term.ApplyInfix bar foreach: baz =>
+       |    println(baz)
+       |Type.ArgClause   bar foreach@@: baz =>
+       |Term.Function baz =>
+       |    println(baz)
+       |Term.ParamClause baz
+       |Term.Param baz
+       |Term.Apply println(baz)
+       |Term.ArgClause (baz)
+       |""".stripMargin
+  )
+
 }


### PR DESCRIPTION
Follow-on to #3322. Helps with scalameta/scalafmt#3623.