### PR TITLE
improvement: Explicitely use empty Term.ArgClause

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/TreeSuiteBase.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/TreeSuiteBase.scala
@@ -6,6 +6,8 @@ import scala.meta._
 
 abstract class TreeSuiteBase extends FunSuite {
 
+  def emptyArgClause = Seq.empty[Term.ArgClause]
+
   protected def assertTree(obtained: Tree)(expected: Tree)(implicit loc: munit.Location): Unit =
     assertNoDiff(obtained.structure, expected.structure)
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TemplateSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TemplateSuite.scala
@@ -47,7 +47,12 @@ class TemplateSuite extends ParseSuite {
         Type.Name("A"),
         Type.ParamClause(Nil),
         EmptyCtor(),
-        Template(Nil, Init(Type.Name("B"), Name.Anonymous(), Nil) :: Nil, EmptySelf(), Nil)
+        Template(
+          Nil,
+          Init(Type.Name("B"), Name.Anonymous(), emptyArgClause) :: Nil,
+          EmptySelf(),
+          Nil
+        )
       )
     }
   }
@@ -78,7 +83,7 @@ class TemplateSuite extends ParseSuite {
         EmptyCtor(),
         Template(
           Defn.Val(Nil, List(Pat.Var(Term.Name("x"))), Some(Type.Name("Int")), Lit.Int(2)) :: Nil,
-          Init(Type.Name("B"), Name.Anonymous(), Nil) :: Nil,
+          Init(Type.Name("B"), Name.Anonymous(), emptyArgClause) :: Nil,
           EmptySelf(),
           Nil
         )
@@ -142,7 +147,12 @@ class TemplateSuite extends ParseSuite {
         Type.Name("A"),
         Type.ParamClause(Nil),
         EmptyCtor(),
-        Template(Nil, Init(Type.Name("B"), Name.Anonymous(), Nil) :: Nil, EmptySelf(), Nil)
+        Template(
+          Nil,
+          Init(Type.Name("B"), Name.Anonymous(), emptyArgClause) :: Nil,
+          EmptySelf(),
+          Nil
+        )
       )
     }
   }
@@ -156,7 +166,7 @@ class TemplateSuite extends ParseSuite {
         EmptyCtor(),
         Template(
           Defn.Val(Nil, List(Pat.Var(Term.Name("x"))), Some(Type.Name("Int")), Lit.Int(2)) :: Nil,
-          Init(Type.Name("B"), Name.Anonymous(), Nil) :: Nil,
+          Init(Type.Name("B"), Name.Anonymous(), emptyArgClause) :: Nil,
           EmptySelf(),
           Nil
         )
@@ -356,7 +366,7 @@ class TemplateSuite extends ParseSuite {
     val Object(
       Nil,
       Term.Name("A"),
-      Template(Nil, Init(Type.Name("B"), Name.Anonymous(), Nil) :: Nil, EmptySelf(), Nil)
+      Template(Nil, Init(Type.Name("B"), Name.Anonymous(), emptyArgClause) :: Nil, EmptySelf(), Nil)
     ) =
       templStat("object A extends B")
   }
@@ -367,7 +377,7 @@ class TemplateSuite extends ParseSuite {
       Term.Name("A"),
       Template(
         Defn.Val(Nil, List(Pat.Var(Term.Name("x"))), Some(Type.Name("Int")), Lit(2)) :: Nil,
-        Init(Type.Name("B"), Name.Anonymous(), Nil) :: Nil,
+        Init(Type.Name("B"), Name.Anonymous(), emptyArgClause) :: Nil,
         EmptySelf(),
         Nil
       )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -220,7 +220,10 @@ class TermSuite extends ParseSuite {
 
   test("1: @foo") {
     assertTerm("1: @foo") {
-      Annotate(Lit.Int(1), Mod.Annot(Init(Type.Name("foo"), Name.Anonymous(), Nil)) :: Nil)
+      Annotate(
+        Lit.Int(1),
+        Mod.Annot(Init(Type.Name("foo"), Name.Anonymous(), emptyArgClause)) :: Nil
+      )
     }
   }
 
@@ -584,7 +587,7 @@ class TermSuite extends ParseSuite {
 
   test("new A") {
     assertTerm("new A") {
-      New(Init(Type.Name("A"), Name.Anonymous(), Nil))
+      New(Init(Type.Name("A"), Name.Anonymous(), emptyArgClause))
     }
   }
 
@@ -597,7 +600,12 @@ class TermSuite extends ParseSuite {
   test("new A {}") {
     assertTerm("new A {}") {
       NewAnonymous(
-        Template(Nil, Init(Type.Name("A"), Name.Anonymous(), Nil) :: Nil, EmptySelf(), Nil)
+        Template(
+          Nil,
+          Init(Type.Name("A"), Name.Anonymous(), emptyArgClause) :: Nil,
+          EmptySelf(),
+          Nil
+        )
       )
     }
   }
@@ -607,8 +615,8 @@ class TermSuite extends ParseSuite {
       NewAnonymous(
         Template(
           Nil,
-          Init(Type.Name("A"), Name.Anonymous(), Nil) ::
-            Init(Type.Name("B"), Name.Anonymous(), Nil) :: Nil,
+          Init(Type.Name("A"), Name.Anonymous(), emptyArgClause) ::
+            Init(Type.Name("B"), Name.Anonymous(), emptyArgClause) :: Nil,
           EmptySelf(),
           Nil
         )
@@ -621,7 +629,7 @@ class TermSuite extends ParseSuite {
       NewAnonymous(
         Template(
           Defn.Val(Nil, List(Pat.Var(Term.Name("x"))), Some(Type.Name("Int")), Lit.Int(1)) :: Nil,
-          Init(Type.Name("A"), Name.Anonymous(), Nil) :: Nil,
+          Init(Type.Name("A"), Name.Anonymous(), emptyArgClause) :: Nil,
           EmptySelf(),
           Nil
         )
@@ -1685,7 +1693,7 @@ class TermSuite extends ParseSuite {
               Term.Select(Term.Select(Term.Name("mbr"), Term.Name("info")), Term.Name("loBound"))
             )
           ),
-          List(Mod.Annot(Init(Type.Name("unchecked"), Name.Anonymous(), Nil)))
+          List(Mod.Annot(Init(Type.Name("unchecked"), Name.Anonymous(), emptyArgClause)))
         ),
         List(
           Case(Pat.Typed(Pat.Var(Term.Name("ref")), Type.Name("TypeRef")), None, Term.Block(Nil))

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TypeSuite.scala
@@ -96,7 +96,10 @@ class TypeSuite extends ParseSuite {
   }
 
   test("T @foo") {
-    val Annotate(TypeName("T"), Mod.Annot(Init(Type.Name("foo"), Name.Anonymous(), Nil)) :: Nil) =
+    val Annotate(
+      TypeName("T"),
+      Mod.Annot(Init(Type.Name("foo"), Name.Anonymous(), emptyArgClause)) :: Nil
+    ) =
       tpe("T @foo")
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/DerivesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/DerivesSuite.scala
@@ -231,7 +231,7 @@ class DerivesSuite extends BaseDottySuite {
       ctorp(List(tparam("a", "Int"), tparam("b", "Int"))),
       Template(
         Nil,
-        List(Init(Type.Apply(pname("Alpha"), List(pname("T"))), Name(""), Nil)),
+        List(Init(Type.Apply(pname("Alpha"), List(pname("T"))), Name(""), emptyArgClause)),
         slf,
         List(Defn.Def(Nil, tname("a"), Nil, None, tname("???"))),
         List(Type.Apply(pname("Epsilon"), List(pname("T"))))
@@ -276,7 +276,7 @@ class DerivesSuite extends BaseDottySuite {
       ctorp(List(tparam("a", "Int"), tparam("b", "Int"))),
       Template(
         Nil,
-        List(Init(Type.Apply(pname("Alpha"), List(pname("T"))), anon, Nil)),
+        List(Init(Type.Apply(pname("Alpha"), List(pname("T"))), anon, emptyArgClause)),
         slf,
         List(Term.Apply(tname("require"), List(bool(true)))),
         List(Type.Apply(pname("Epsilon"), List(pname("T"))))
@@ -322,8 +322,8 @@ class DerivesSuite extends BaseDottySuite {
       Template(
         Nil,
         List(
-          Init(Type.Apply(pname("Alpha"), List(pname("T"))), anon, Nil),
-          Init(Type.Apply(pname("Epsilon"), List(pname("T"))), anon, Nil)
+          Init(Type.Apply(pname("Alpha"), List(pname("T"))), anon, emptyArgClause),
+          Init(Type.Apply(pname("Epsilon"), List(pname("T"))), anon, emptyArgClause)
         ),
         slf,
         List(Term.Apply(tname("require"), List(bool(true)))),
@@ -369,7 +369,7 @@ class DerivesSuite extends BaseDottySuite {
       ctorp(List(tparam("a", "Int"), tparam("b", "Int"))),
       Template(
         Nil,
-        List(Init(Type.Apply(pname("Alpha"), List(pname("T"))), anon, Nil)),
+        List(Init(Type.Apply(pname("Alpha"), List(pname("T"))), anon, emptyArgClause)),
         slf,
         List(Term.Apply(tname("require"), List(bool(true)))),
         Nil

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EnumSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EnumSuite.scala
@@ -161,7 +161,7 @@ class EnumSuite extends BaseDottySuite {
     val tparam =
       Type.Param(List(Mod.Covariant()), pname("T"), Nil, Type.Bounds(None, None), Nil, Nil)
     val xparam = List(Term.Param(Nil, tname("x"), Some(pname("T")), None))
-    def ext(tp: String) = Init(Type.Apply(pname("Option"), List(pname(tp))), anon, Nil)
+    def ext(tp: String) = Init(Type.Apply(pname("Option"), List(pname(tp))), anon, emptyArgClause)
 
     {
       val opt = """
@@ -348,7 +348,7 @@ class EnumSuite extends BaseDottySuite {
       enumWithCase(
         "Option",
         Defn.EnumCase(
-          List(Mod.Annot(Init(Type.Name("deprecated"), Name(""), Nil))),
+          List(Mod.Annot(Init(Type.Name("deprecated"), Name(""), emptyArgClause))),
           tname("Some"),
           Nil,
           ctorp(List(tparam("x", "Int"))),
@@ -369,7 +369,7 @@ class EnumSuite extends BaseDottySuite {
   }
 
   test("case-extends") {
-    val init = Init(Type.Apply(pname("Option"), List(pname("Nothing"))), anon, Nil)
+    val init = Init(Type.Apply(pname("Option"), List(pname("Nothing"))), anon, emptyArgClause)
     runTestAssert[Stat]("enum Option { case None extends Option[Nothing] }")(
       enumWithCase("Option", Defn.EnumCase(Nil, tname("None"), Nil, ctor, List(init)))
     )
@@ -444,7 +444,7 @@ class EnumSuite extends BaseDottySuite {
     val expected = "@annot enum A { case B, C }"
     runTestAssert[Stat](code, assertLayout = Some(expected))(
       Defn.Enum(
-        List(Mod.Annot(Init(Type.Name("annot"), Name(""), Nil))),
+        List(Mod.Annot(Init(Type.Name("annot"), Name(""), emptyArgClause))),
         Type.Name("A"),
         Nil,
         Ctor.Primary(Nil, Name(""), Nil),

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ErasedDefsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ErasedDefsSuite.scala
@@ -84,7 +84,7 @@ class ErasedDefsSuite extends BaseDottySuite {
           ) :: Nil
         ),
         Some(Type.Apply(pname("Machine"), List(pname("On")))),
-        Term.New(Init(Type.Apply(pname("Machine"), List(pname("On"))), anon, Nil))
+        Term.New(Init(Type.Apply(pname("Machine"), List(pname("On"))), anon, emptyArgClause))
       )
     )
   }
@@ -104,7 +104,7 @@ class ErasedDefsSuite extends BaseDottySuite {
         anon,
         None,
         Type.Apply(pname("IsEmpty"), List(pname("Empty"))),
-        Term.New(Init(Type.Apply(pname("IsEmpty"), List(pname("Empty"))), anon, Nil))
+        Term.New(Init(Type.Apply(pname("IsEmpty"), List(pname("Empty"))), anon, emptyArgClause))
       )
     )
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExtensionMethodsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExtensionMethodsSuite.scala
@@ -741,14 +741,14 @@ class ExtensionMethodsSuite extends BaseDottySuite {
             Term.Block(
               List(
                 Defn.Def(
-                  List(Mod.Annot(Init(pname("annoFoo"), Name.Anonymous(), Nil))),
+                  List(Mod.Annot(Init(pname("annoFoo"), Name.Anonymous(), emptyArgClause))),
                   tname("foo"),
                   Nil,
                   Some(pname("Foo")),
                   tname("getFoo")
                 ),
                 Defn.Def(
-                  List(Mod.Annot(Init(pname("annoBar"), Name.Anonymous(), Nil))),
+                  List(Mod.Annot(Init(pname("annoBar"), Name.Anonymous(), emptyArgClause))),
                   tname("bar"),
                   Nil,
                   Some(pname("Bar")),

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
@@ -34,7 +34,9 @@ class GivenUsingSuite extends BaseDottySuite {
         Nil,
         Template(
           Nil,
-          List(Init(Type.Apply(Type.Name("Ord"), List(Type.Name("Int"))), Name(""), Nil)),
+          List(
+            Init(Type.Apply(Type.Name("Ord"), List(Type.Name("Int"))), Name(""), emptyArgClause)
+          ),
           Self(Name(""), None),
           List(defone),
           Nil
@@ -52,7 +54,9 @@ class GivenUsingSuite extends BaseDottySuite {
         Nil,
         Template(
           Nil,
-          List(Init(Type.Apply(Type.Name("Ord"), List(Type.Name("Int"))), Name(""), Nil)),
+          List(
+            Init(Type.Apply(Type.Name("Ord"), List(Type.Name("Int"))), Name(""), emptyArgClause)
+          ),
           Self(Name(""), None),
           List(defone),
           Nil
@@ -70,7 +74,9 @@ class GivenUsingSuite extends BaseDottySuite {
         Nil,
         Template(
           Nil,
-          List(Init(Type.Apply(Type.Name("Ord"), List(Type.Name("Int"))), Name(""), Nil)),
+          List(
+            Init(Type.Apply(Type.Name("Ord"), List(Type.Name("Int"))), Name(""), emptyArgClause)
+          ),
           Self(Name(""), None),
           List(defone),
           Nil
@@ -88,8 +94,8 @@ class GivenUsingSuite extends BaseDottySuite {
       Template(
         Nil,
         List(
-          Init(Type.Apply(Type.Name("Ord"), List(Type.Name("Int"))), Name(""), Nil),
-          Init(Type.Apply(Type.Name("Eq"), List(Type.Name("Int"))), Name(""), Nil)
+          Init(Type.Apply(Type.Name("Ord"), List(Type.Name("Int"))), Name(""), emptyArgClause),
+          Init(Type.Apply(Type.Name("Eq"), List(Type.Name("Int"))), Name(""), emptyArgClause)
         ),
         Self(Name(""), None),
         List(Defn.Def(Nil, Term.Name("fx"), Nil, Nil, None, Lit.Int(3))),
@@ -119,7 +125,9 @@ class GivenUsingSuite extends BaseDottySuite {
         Nil,
         Template(
           Nil,
-          List(Init(Type.Apply(Type.Name("Ord"), List(Type.Name("Int"))), Name(""), Nil)),
+          List(
+            Init(Type.Apply(Type.Name("Ord"), List(Type.Name("Int"))), Name(""), emptyArgClause)
+          ),
           Self(Name(""), None),
           List(defone(List(Mod.Override()))),
           Nil
@@ -143,7 +151,9 @@ class GivenUsingSuite extends BaseDottySuite {
         Nil,
         Template(
           Nil,
-          List(Init(Type.Apply(Type.Name("Ord"), List(Type.Name("Int"))), Name(""), Nil)),
+          List(
+            Init(Type.Apply(Type.Name("Ord"), List(Type.Name("Int"))), Name(""), emptyArgClause)
+          ),
           Self(Name(""), None),
           List(Defn.Def(Nil, Term.Name("fn"), Nil, Nil, None, Lit.Unit())),
           Nil
@@ -180,7 +190,7 @@ class GivenUsingSuite extends BaseDottySuite {
                 List(Type.Name("Json"))
               ),
               Name(""),
-              Nil
+              emptyArgClause
             )
           ),
           Self(Name(""), None),
@@ -203,7 +213,9 @@ class GivenUsingSuite extends BaseDottySuite {
         Nil,
         Template(
           Nil,
-          List(Init(Type.Apply(Type.Name("Ord"), List(Type.Name("Int"))), Name(""), Nil)),
+          List(
+            Init(Type.Apply(Type.Name("Ord"), List(Type.Name("Int"))), Name(""), emptyArgClause)
+          ),
           Self(Term.Name("current"), None),
           Nil,
           Nil
@@ -233,7 +245,7 @@ class GivenUsingSuite extends BaseDottySuite {
               Type
                 .Apply(Type.Name("Ord"), List(Type.Apply(Type.Name("List"), List(Type.Name("T"))))),
               Name(""),
-              Nil
+              emptyArgClause
             )
           ),
           Self(Name(""), None),
@@ -258,7 +270,7 @@ class GivenUsingSuite extends BaseDottySuite {
               Type
                 .Apply(Type.Name("Ord"), List(Type.Apply(Type.Name("List"), List(Type.Name("T"))))),
               Name(""),
-              Nil
+              emptyArgClause
             )
           ),
           Self(Name(""), None),
@@ -379,7 +391,13 @@ class GivenUsingSuite extends BaseDottySuite {
         Name(""),
         Nil,
         Nil,
-        Template(Nil, List(Init(Type.Name("C"), Name(""), Nil)), Self(Name(""), None), Nil, Nil)
+        Template(
+          Nil,
+          List(Init(Type.Name("C"), Name(""), emptyArgClause)),
+          Self(Name(""), None),
+          Nil,
+          Nil
+        )
       )
     )
   }
@@ -432,7 +450,7 @@ class GivenUsingSuite extends BaseDottySuite {
         Template(
           Nil,
           List(
-            Init(Type.Name("AnyRef"), Name(""), Nil)
+            Init(Type.Name("AnyRef"), Name(""), emptyArgClause)
           ),
           Self(Name(""), None),
           List(
@@ -495,7 +513,9 @@ class GivenUsingSuite extends BaseDottySuite {
         Nil,
         Template(
           Nil,
-          List(Init(Type.Apply(Type.Name("Ord"), List(Type.Name("Int"))), Name(""), Nil)),
+          List(
+            Init(Type.Apply(Type.Name("Ord"), List(Type.Name("Int"))), Name(""), emptyArgClause)
+          ),
           Self(Name(""), None),
           List(
             Import(
@@ -529,7 +549,9 @@ class GivenUsingSuite extends BaseDottySuite {
         Nil,
         Template(
           Nil,
-          List(Init(Type.Apply(Type.Name("Ord"), List(Type.Name("Int"))), Name(""), Nil)),
+          List(
+            Init(Type.Apply(Type.Name("Ord"), List(Type.Name("Int"))), Name(""), emptyArgClause)
+          ),
           Self(Name(""), None),
           List(
             Export(List(Importer(Term.Name("math"), List(Importee.Name(Name("max")))))),
@@ -557,7 +579,7 @@ class GivenUsingSuite extends BaseDottySuite {
         Nil,
         Template(
           Nil,
-          List(Init(Type.Refine(None, Nil), Name(""), Nil)),
+          List(Init(Type.Refine(None, Nil), Name(""), emptyArgClause)),
           Self(Name(""), None),
           List(
             Defn.ExtensionGroup(
@@ -1042,7 +1064,7 @@ class GivenUsingSuite extends BaseDottySuite {
           Case(
             Pat.Bind(Pat.Var(Term.Name("ctx")), Pat.Given(Type.Name("Context"))),
             None,
-            Term.New(Init(Type.Name("Provider"), Name(""), Nil))
+            Term.New(Init(Type.Name("Provider"), Name(""), emptyArgClause))
           ),
           Case(
             Pat.Bind(
@@ -1050,7 +1072,7 @@ class GivenUsingSuite extends BaseDottySuite {
               Pat.Given(Type.Function(List(Type.Name("Context")), Type.Name("String")))
             ),
             None,
-            Term.New(Init(Type.Name("Provider"), Name(""), Nil))
+            Term.New(Init(Type.Name("Provider"), Name(""), emptyArgClause))
           )
         ),
         Nil

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
@@ -107,7 +107,12 @@ class InfixSuite extends BaseDottySuite {
         List(List(Term.Param(Nil, tname("infix"), Some(pname("infix")), None))),
         Some(pname("infix")),
         Term.NewAnonymous(
-          Template(Nil, List(Init(pname("infix"), Name(""), Nil)), Self(Name(""), None), Nil)
+          Template(
+            Nil,
+            List(Init(pname("infix"), Name(""), emptyArgClause)),
+            Self(Name(""), None),
+            Nil
+          )
         )
       )
     )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InlineSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InlineSuite.scala
@@ -385,7 +385,7 @@ class InlineSuite extends BaseDottySuite {
         Term.Block(
           List(
             Term.Match(
-              Term.New(Init(Type.Name("X"), Name(""), Nil)),
+              Term.New(Init(Type.Name("X"), Name(""), emptyArgClause)),
               List(Case(Pat.Var(Term.Name("x")), None, Term.Name("x"))),
               List(Mod.Inline())
             )
@@ -455,8 +455,8 @@ class InlineSuite extends BaseDottySuite {
         Some(Type.Name("A")),
         Term.If(
           Term.Name("b"),
-          Term.New(Init(Type.Name("A"), Name(""), Nil)),
-          Term.New(Init(Type.Name("B"), Name(""), Nil)),
+          Term.New(Init(Type.Name("A"), Name(""), emptyArgClause)),
+          Term.New(Init(Type.Name("B"), Name(""), emptyArgClause)),
           Nil
         )
       )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -593,7 +593,7 @@ class MinorDottySuite extends BaseDottySuite {
         Some(
           Type.Annotate(
             Type.AnonymousName(),
-            List(Mod.Annot(Init(Type.Name("unchecked"), Name(""), Nil)))
+            List(Mod.Annot(Init(Type.Name("unchecked"), Name(""), emptyArgClause)))
           )
         ),
         Term.Name("args")
@@ -609,7 +609,11 @@ class MinorDottySuite extends BaseDottySuite {
             Type.AnonymousName(),
             List(
               Mod.Annot(
-                Init(Type.Select(Term.Name("annotation"), Type.Name("switch")), Name(""), Nil)
+                Init(
+                  Type.Select(Term.Name("annotation"), Type.Name("switch")),
+                  Name(""),
+                  emptyArgClause
+                )
               )
             )
           )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NewFunctionsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NewFunctionsSuite.scala
@@ -116,7 +116,7 @@ class NewFunctionsSuite extends BaseDottySuite {
               Pat.Var(Term.Name("t")),
               Type.Annotate(
                 Type.ContextFunction(List(Type.Name("Context")), Type.Name("Symbol")),
-                List(Mod.Annot(Init(Type.Name("unchecked"), Name(""), Nil)))
+                List(Mod.Annot(Init(Type.Name("unchecked"), Name(""), emptyArgClause)))
               )
             ),
             None,

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -95,7 +95,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
       Term.NewAnonymous(
         Template(
           Nil,
-          List(Init(pname("A"), Name(""), Nil)),
+          List(Init(pname("A"), Name(""), emptyArgClause)),
           Self(Name(""), None),
           List(Decl.Def(Nil, tname("f"), Nil, Nil, pname("Int"))),
           Nil
@@ -119,7 +119,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
             Term.NewAnonymous(
               Template(
                 Nil,
-                List(Init(Type.Name("A"), Name(""), Nil)),
+                List(Init(Type.Name("A"), Name(""), emptyArgClause)),
                 Self(Name(""), None),
                 List(Decl.Def(Nil, Term.Name("f"), Nil, Type.Name("Int"))),
                 Nil
@@ -406,7 +406,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
         Ctor.Primary(Nil, Name(""), Nil),
         Template(
           Nil,
-          List(Init(pname("B"), Name(""), Nil)),
+          List(Init(pname("B"), Name(""), emptyArgClause)),
           Self(tname("thisPhase"), None),
           List(tname("expr1"), tname("expr2"))
         )
@@ -862,7 +862,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
         Nil,
         Template(
           Nil,
-          List(Init(Type.Apply(pname("Ord"), List(pname("Int"))), Name(""), Nil)),
+          List(Init(Type.Apply(pname("Ord"), List(pname("Int"))), Name(""), emptyArgClause)),
           Self(Name(""), None),
           List(
             Defn.Def(Nil, tname("fa"), Nil, Nil, Some(pname("Int")), int(1)),
@@ -904,7 +904,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
         Ctor.Primary(Nil, Name(""), Nil),
         Template(
           Nil,
-          List(Init(pname("A"), Name(""), Nil), Init(pname("B"), Name(""), Nil)),
+          List(Init(pname("A"), Name(""), Nil), Init(pname("B"), Name(""), emptyArgClause)),
           Self(Name(""), None),
           Nil,
           Nil
@@ -935,7 +935,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
                 Nil,
                 tname("a"),
                 Some(pname("A")),
-                Some(Term.New(Init(pname("A"), Name(""), Nil)))
+                Some(Term.New(Init(pname("A"), Name(""), emptyArgClause)))
               )
             )
           )
@@ -1950,7 +1950,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
               tname("ExampleThing"),
               Template(
                 Nil,
-                List(Init(pname("CompositeThing"), Name(""), Nil)),
+                List(Init(pname("CompositeThing"), Name(""), emptyArgClause)),
                 Self(Name(""), None),
                 Nil,
                 Nil
@@ -2310,7 +2310,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
         Nil,
         Template(
           Nil,
-          List(Init(pname("Foo"), Name(""), Nil)),
+          List(Init(pname("Foo"), Name(""), emptyArgClause)),
           Self(Name(""), None),
           List(
             Defn.Def(Nil, tname("foo"), Nil, Nil, Some(pname("Int")), tname("???")),
@@ -2338,7 +2338,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
         Nil,
         Template(
           Nil,
-          List(Init(pname("Foo"), Name(""), Nil)),
+          List(Init(pname("Foo"), Name(""), emptyArgClause)),
           Self(Name(""), None),
           List(
             Defn.Def(Nil, tname("foo"), Nil, Nil, Some(pname("Int")), tname("???")),
@@ -2380,7 +2380,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
                     pname("StaticAnnotation")
                   ),
                   Name(""),
-                  Nil
+                  emptyArgClause
                 )
               ),
               Self(Name(""), None),
@@ -2402,7 +2402,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
                     pname("StaticAnnotation")
                   ),
                   Name(""),
-                  Nil
+                  emptyArgClause
                 )
               ),
               Self(Name(""), None),
@@ -2412,8 +2412,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
           ),
           Defn.Class(
             List(
-              Mod.Annot(Init(pname("A1"), Name(""), Nil)),
-              Mod.Annot(Init(pname("A2"), Name(""), Nil))
+              Mod.Annot(Init(pname("A1"), Name(""), emptyArgClause)),
+              Mod.Annot(Init(pname("A2"), Name(""), emptyArgClause))
             ),
             pname("B"),
             Nil,
@@ -2539,7 +2539,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
                       Term.NewAnonymous(
                         Template(
                           Nil,
-                          List(Init(pname("Object"), Name(""), Nil)),
+                          List(Init(pname("Object"), Name(""), emptyArgClause)),
                           Self(tname("obj"), None),
                           List(Term.Apply(tname("println"), List(tname("toString")))),
                           Nil

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
@@ -356,7 +356,10 @@ class TypeSuite extends BaseDottySuite {
   }
 
   test("T @foo") {
-    val Annotate(TypeName("T"), Mod.Annot(Init(Type.Name("foo"), Name.Anonymous(), Nil)) :: Nil) =
+    val Annotate(
+      TypeName("T"),
+      Mod.Annot(Init(Type.Name("foo"), Name.Anonymous(), emptyArgClause)) :: Nil
+    ) =
       tpe("T @foo")
   }
 
@@ -640,7 +643,7 @@ class TypeSuite extends BaseDottySuite {
               )
             ),
             anon,
-            Nil
+            emptyArgClause
           ) :: Nil,
           List(
             Defn.Def(

--- a/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -505,13 +505,13 @@ class SuccessSuite extends TreeSuiteBase {
 
   test("1 q\"throw expr\"") {
     val q"throw $expr" = q"throw new RuntimeException"
-    assertTree(expr)(Term.New(Init(Type.Name("RuntimeException"), Name(""), Nil)))
+    assertTree(expr)(Term.New(Init(Type.Name("RuntimeException"), Name(""), emptyArgClause)))
   }
 
   test("2 q\"throw expr\"") {
     val expr = q"new RuntimeException"
     assertTree(q"throw $expr")(
-      Term.Throw(Term.New(Init(Type.Name("RuntimeException"), Name(""), Nil)))
+      Term.Throw(Term.New(Init(Type.Name("RuntimeException"), Name(""), emptyArgClause)))
     )
   }
 
@@ -532,8 +532,8 @@ class SuccessSuite extends TreeSuiteBase {
     assertTree(exprr)(Term.Name("foo"))
     assertEquals(annotz.toString, "List(@w, @e)")
     assertTrees(annotz: _*)(
-      Mod.Annot(Init(Type.Name("w"), Name(""), Nil)),
-      Mod.Annot(Init(Type.Name("e"), Name(""), Nil))
+      Mod.Annot(Init(Type.Name("w"), Name(""), emptyArgClause)),
+      Mod.Annot(Init(Type.Name("e"), Name(""), emptyArgClause))
     )
     assertTree(ar)(Mod.Annot(Init(Type.Name("r"), Name(""), Nil)))
   }
@@ -544,10 +544,10 @@ class SuccessSuite extends TreeSuiteBase {
       Term.Annotate(
         Term.Name("foo"),
         List(
-          Mod.Annot(Init(Type.Name("q"), Name(""), Nil)),
-          Mod.Annot(Init(Type.Name("w"), Name(""), Nil)),
-          Mod.Annot(Init(Type.Name("e"), Name(""), Nil)),
-          Mod.Annot(Init(Type.Name("r"), Name(""), Nil))
+          Mod.Annot(Init(Type.Name("q"), Name(""), emptyArgClause)),
+          Mod.Annot(Init(Type.Name("w"), Name(""), emptyArgClause)),
+          Mod.Annot(Init(Type.Name("e"), Name(""), emptyArgClause)),
+          Mod.Annot(Init(Type.Name("r"), Name(""), emptyArgClause))
         )
       )
     )
@@ -893,7 +893,7 @@ class SuccessSuite extends TreeSuiteBase {
 
   test("1 q\"new { ..stat } with ..inits { self => ..stats }\"") {
     val q"new $x" = q"new Foo"
-    assertTree(x)(Init(Type.Name("Foo"), Name(""), Nil))
+    assertTree(x)(Init(Type.Name("Foo"), Name(""), emptyArgClause))
   }
 
   test("2 q\"new { ..stat } with ..inits { self => ..stats }\"") {
@@ -901,7 +901,7 @@ class SuccessSuite extends TreeSuiteBase {
       q"new {val a = 2; val b = 4} with A { self => val b = 3 }"
     assertEquals(stats.toString, "List(val a = 2)")
     assertTrees(stats: _*)(Defn.Val(Nil, List(Pat.Var(Term.Name("a"))), None, Lit.Int(2)))
-    assertTree(a)(Init(Type.Name("A"), Name(""), Nil))
+    assertTree(a)(Init(Type.Name("A"), Name(""), emptyArgClause))
     assertTree(self)(Self(Term.Name("self"), None))
     assertEquals(statz.toString, "List(val b = 3)")
     assertTrees(statz: _*)(Defn.Val(Nil, List(Pat.Var(Term.Name("b"))), None, Lit.Int(3)))
@@ -924,7 +924,7 @@ class SuccessSuite extends TreeSuiteBase {
             Defn.Val(Nil, List(Pat.Var(Term.Name("a"))), None, Lit.Int(2)),
             Defn.Val(Nil, List(Pat.Var(Term.Name("b"))), None, Lit.Int(4))
           ),
-          List(Init(Type.Name("A"), Name(""), Nil)),
+          List(Init(Type.Name("A"), Name(""), emptyArgClause)),
           Self(Term.Name("self"), Some(Type.Name("A"))),
           List(Defn.Val(Nil, List(Pat.Var(Term.Name("b"))), None, Lit.Int(3))),
           Nil
@@ -1117,8 +1117,8 @@ class SuccessSuite extends TreeSuiteBase {
     assertTree(tpe)(Type.Name("X"))
     assertEquals(annots.toString, "List(@a, @b)")
     assertTrees(annots: _*)(
-      Mod.Annot(Init(Type.Name("a"), Name(""), Nil)),
-      Mod.Annot(Init(Type.Name("b"), Name(""), Nil))
+      Mod.Annot(Init(Type.Name("a"), Name(""), emptyArgClause)),
+      Mod.Annot(Init(Type.Name("b"), Name(""), emptyArgClause))
     )
   }
 
@@ -1129,8 +1129,8 @@ class SuccessSuite extends TreeSuiteBase {
       Type.Annotate(
         Type.Name("X"),
         List(
-          Mod.Annot(Init(Type.Name("a"), Name(""), Nil)),
-          Mod.Annot(Init(Type.Name("b"), Name(""), Nil))
+          Mod.Annot(Init(Type.Name("a"), Name(""), emptyArgClause)),
+          Mod.Annot(Init(Type.Name("b"), Name(""), emptyArgClause))
         )
       )
     )
@@ -1768,7 +1768,13 @@ class SuccessSuite extends TreeSuiteBase {
       )
     })
     assertTree(template)(
-      Template(Nil, List(Init(Type.Name("Y"), Name(""), Nil)), Self(Name(""), None), Nil, Nil)
+      Template(
+        Nil,
+        List(Init(Type.Name("Y"), Name(""), emptyArgClause)),
+        Self(Name(""), None),
+        Nil,
+        Nil
+      )
     )
   }
 
@@ -1833,7 +1839,7 @@ class SuccessSuite extends TreeSuiteBase {
         ),
         Template(
           Nil,
-          List(Init(Type.Name("F"), Name(""), Nil)),
+          List(Init(Type.Name("F"), Name(""), emptyArgClause)),
           Self(Name(""), None),
           List(Defn.Def(Nil, Term.Name("m"), Nil, Nil, None, Lit.Int(42))),
           Nil
@@ -1856,7 +1862,13 @@ class SuccessSuite extends TreeSuiteBase {
       )
     })
     assertTree(template)(
-      Template(Nil, List(Init(Type.Name("Y"), Name(""), Nil)), Self(Name(""), None), Nil, Nil)
+      Template(
+        Nil,
+        List(Init(Type.Name("Y"), Name(""), emptyArgClause)),
+        Self(Name(""), None),
+        Nil,
+        Nil
+      )
     )
   }
 
@@ -1903,7 +1915,7 @@ class SuccessSuite extends TreeSuiteBase {
         Ctor.Primary(Nil, Name(""), Nil),
         Template(
           Nil,
-          List(Init(Type.Name("F"), Name(""), Nil)),
+          List(Init(Type.Name("F"), Name(""), emptyArgClause)),
           Self(Name(""), None),
           List(Defn.Def(Nil, Term.Name("m"), Nil, Nil, None, Lit.Int(42))),
           Nil
@@ -1918,7 +1930,13 @@ class SuccessSuite extends TreeSuiteBase {
     assertTrees(mods: _*)(Mod.Private(Name("")), Mod.Final())
     assertTree(name)(Term.Name("Q"))
     assertTree(template)(
-      Template(Nil, List(Init(Type.Name("Y"), Name(""), Nil)), Self(Name(""), None), Nil, Nil)
+      Template(
+        Nil,
+        List(Init(Type.Name("Y"), Name(""), emptyArgClause)),
+        Self(Name(""), None),
+        Nil,
+        Nil
+      )
     )
   }
 
@@ -1952,7 +1970,7 @@ class SuccessSuite extends TreeSuiteBase {
         Term.Name("Q"),
         Template(
           Nil,
-          List(Init(Type.Name("F"), Name(""), Nil)),
+          List(Init(Type.Name("F"), Name(""), emptyArgClause)),
           Self(Name(""), None),
           List(Defn.Def(Nil, Term.Name("m"), Nil, Nil, None, Lit.Int(42))),
           Nil
@@ -1965,7 +1983,13 @@ class SuccessSuite extends TreeSuiteBase {
     val q"package object $name $template" = q"package object Q extends Y"
     assertTree(name)(Term.Name("Q"))
     assertTree(template)(
-      Template(Nil, List(Init(Type.Name("Y"), Name(""), Nil)), Self(Name(""), None), Nil, Nil)
+      Template(
+        Nil,
+        List(Init(Type.Name("Y"), Name(""), emptyArgClause)),
+        Self(Name(""), None),
+        Nil,
+        Nil
+      )
     )
   }
 
@@ -1996,7 +2020,7 @@ class SuccessSuite extends TreeSuiteBase {
         Term.Name("Q"),
         Template(
           Nil,
-          List(Init(Type.Name("F"), Name(""), Nil)),
+          List(Init(Type.Name("F"), Name(""), emptyArgClause)),
           Self(Name(""), None),
           List(Defn.Def(Nil, Term.Name("m"), Nil, Nil, None, Lit.Int(42))),
           Nil
@@ -2273,7 +2297,10 @@ class SuccessSuite extends TreeSuiteBase {
       Defn.Val(Nil, List(Pat.Var(Term.Name("b"))), None, Lit.Int(2))
     )
     assertEquals(inits.toString, "List(T, U)")
-    assertTrees(inits: _*)(Init(Type.Name("T"), Name(""), Nil), Init(Type.Name("U"), Name(""), Nil))
+    assertTrees(inits: _*)(
+      Init(Type.Name("T"), Name(""), emptyArgClause),
+      Init(Type.Name("U"), Name(""), emptyArgClause)
+    )
     assertTree(self)(Self(Term.Name("self"), Some(Type.Name("Z"))))
     assertEquals(stats2.toString, "List(def m = 2, def n = 2)")
     assertTrees(stats2: _*)(
@@ -2293,7 +2320,10 @@ class SuccessSuite extends TreeSuiteBase {
           Defn.Val(Nil, List(Pat.Var(Term.Name("a"))), None, Lit.Int(2)),
           Defn.Val(Nil, List(Pat.Var(Term.Name("b"))), None, Lit.Int(2))
         ),
-        List(Init(Type.Name("T"), Name(""), Nil), Init(Type.Name("U"), Name(""), Nil)),
+        List(
+          Init(Type.Name("T"), Name(""), emptyArgClause),
+          Init(Type.Name("U"), Name(""), emptyArgClause)
+        ),
         Self(Term.Name("self"), Some(Type.Name("S"))),
         List(
           Defn.Def(Nil, Term.Name("m"), Nil, Nil, None, Lit.Int(2)),
@@ -2306,12 +2336,12 @@ class SuccessSuite extends TreeSuiteBase {
 
   test("1 mod\"@expr\"") {
     val mod"@$expr" = mod"@a"
-    assertTree(expr)(Mod.Annot(Init(Type.Name("a"), Name(""), Nil)))
+    assertTree(expr)(Mod.Annot(Init(Type.Name("a"), Name(""), emptyArgClause)))
   }
 
   test("2 mod\"@expr\"") {
     val expr = mod"@a"
-    assertTree(mod"@$expr")(Mod.Annot(Init(Type.Name("a"), Name(""), Nil)))
+    assertTree(mod"@$expr")(Mod.Annot(Init(Type.Name("a"), Name(""), emptyArgClause)))
   }
 
   test("1 mod\"private[name]\"") {
@@ -2871,7 +2901,7 @@ class SuccessSuite extends TreeSuiteBase {
   test("#2841 empty, with extends") {
     val q"..$mods object $ename extends $template" = q"object X extends Y"
     assertTree(template) {
-      Init(Type.Name("Y"), Name(""), Nil)
+      Init(Type.Name("Y"), Name(""), emptyArgClause)
     }
     assertEquals(mods, Nil)
   }
@@ -2879,7 +2909,13 @@ class SuccessSuite extends TreeSuiteBase {
   test("#2841 empty") {
     val q"..$mods object $ename $template" = q"object X extends Y"
     assertTree(template) {
-      Template(Nil, List(Init(Type.Name("Y"), Name(""), Nil)), Self(Name(""), None), Nil, Nil)
+      Template(
+        Nil,
+        List(Init(Type.Name("Y"), Name(""), emptyArgClause)),
+        Self(Name(""), None),
+        Nil,
+        Nil
+      )
     }
     assertEquals(mods, Nil)
   }
@@ -2895,7 +2931,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertTree(template) {
       Template(
         Nil,
-        List(Init(Type.Name("Y"), Name(""), Nil)),
+        List(Init(Type.Name("Y"), Name(""), emptyArgClause)),
         Self(Name(""), None),
         List(Decl.Def(Nil, Term.Name("foo"), Nil, Nil, Type.Name("Unit"))),
         Nil
@@ -2910,7 +2946,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertEquals(mods, Nil)
     assertEquals(earlydefns, Nil)
     assertTrees(parents: _*) {
-      Init(Type.Name("Y"), Name.Anonymous(), Nil)
+      Init(Type.Name("Y"), Name.Anonymous(), emptyArgClause)
     }
     assertTree(self)(Self(Name(""), None))
     assertEquals(stats, Nil)
@@ -2922,7 +2958,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertEquals(mods, Nil)
     assertEquals(earlydefns, Nil)
     assertTrees(parents: _*) {
-      Init(Type.Name("Y"), Name.Anonymous(), Nil)
+      Init(Type.Name("Y"), Name.Anonymous(), emptyArgClause)
     }
     assertTree(self)(Self(Name(""), None))
     assertTrees(stats: _*) {
@@ -2935,7 +2971,7 @@ class SuccessSuite extends TreeSuiteBase {
       q"object X extends Y"
     assertEquals(mods, Nil)
     assertTrees(parents: _*) {
-      Init(Type.Name("Y"), Name.Anonymous(), Nil)
+      Init(Type.Name("Y"), Name.Anonymous(), emptyArgClause)
     }
     assertEquals(stats, Nil)
   }
@@ -2945,7 +2981,7 @@ class SuccessSuite extends TreeSuiteBase {
       q"object X extends Y { def foo }"
     assertEquals(mods, Nil)
     assertTrees(parents: _*) {
-      Init(Type.Name("Y"), Name.Anonymous(), Nil)
+      Init(Type.Name("Y"), Name.Anonymous(), emptyArgClause)
     }
     assertTrees(stats: _*) {
       Decl.Def(Nil, Term.Name("foo"), Nil, Nil, Type.Name("Unit"))

--- a/tests/shared/src/test/scala/scala/meta/tests/trees/InvariantSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/trees/InvariantSuite.scala
@@ -13,7 +13,7 @@ class InvariantSuite extends TreeSuiteBase {
       Nil,
       Name.Anonymous(),
       List(List()),
-      Init(Type.Singleton(Term.This(Name.Anonymous())), Name.Anonymous(), Nil),
+      Init(Type.Singleton(Term.This(Name.Anonymous())), Name.Anonymous(), emptyArgClause),
       Nil
     )
     val stats = List(secondaryCtor)


### PR DESCRIPTION
For Scala 3 the tests started failing here since both apply and the constructor could be applied there, because the new keyword is no longer required.

There is a bunch of other classes with that problem, but I will do it one by one.