### PR TITLE
improvement: Don't pattern match in tests in vals

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/DeclSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/DeclSuite.scala
@@ -6,23 +6,30 @@ import scala.meta.dialects.Scala211
 
 class DeclSuite extends ParseSuite {
   test("val x: Int") {
-    val Decl.Val(Nil, List(Pat.Var(Term.Name("x"))), Type.Name("Int")) = templStat("val x: Int")
+    assertTree(templStat("val x: Int"))(
+      Decl.Val(Nil, List(Pat.Var(Term.Name("x"))), Type.Name("Int"))
+    )
   }
 
   test("var x: Int") {
-    val Decl.Var(Nil, List(Pat.Var(Term.Name("x"))), Type.Name("Int")) = templStat("var x: Int")
+    assertTree(templStat("var x: Int"))(
+      Decl.Var(Nil, List(Pat.Var(Term.Name("x"))), Type.Name("Int"))
+    )
   }
 
   test("val x, y: Int") {
-    val Decl.Val(Nil, List(Pat.Var(Term.Name("x")), Pat.Var(Term.Name("y"))), Type.Name("Int")) =
-      templStat("val x, y: Int")
-    val Decl.Var(Nil, List(Pat.Var(Term.Name("x")), Pat.Var(Term.Name("y"))), Type.Name("Int")) =
-      templStat("var x, y: Int")
+    assertTree(templStat("val x, y: Int"))(
+      Decl.Val(Nil, List(Pat.Var(Term.Name("x")), Pat.Var(Term.Name("y"))), Type.Name("Int"))
+    )
+    assertTree(templStat("var x, y: Int"))(
+      Decl.Var(Nil, List(Pat.Var(Term.Name("x")), Pat.Var(Term.Name("y"))), Type.Name("Int"))
+    )
   }
 
   test("var x, y: Int") {
-    val Decl.Var(Nil, List(Pat.Var(Term.Name("x")), Pat.Var(Term.Name("y"))), Type.Name("Int")) =
-      templStat("var x, y: Int")
+    assertTree(templStat("var x, y: Int"))(
+      Decl.Var(Nil, List(Pat.Var(Term.Name("x")), Pat.Var(Term.Name("y"))), Type.Name("Int"))
+    )
   }
 
   test("type T") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
@@ -6,51 +6,61 @@ import scala.meta.dialects.Scala213
 
 class DefnSuite extends ParseSuite {
   test("val x = 2") {
-    val Defn.Val(Nil, Pat.Var(Term.Name("x")) :: Nil, None, Lit(2)) = templStat("val x = 2")
+    assertTree(templStat("val x = 2"))(
+      Defn.Val(Nil, Pat.Var(Term.Name("x")) :: Nil, None, Lit.Int(2))
+    )
   }
 
   test("var x = 2") {
-    val Defn.Var(Nil, Pat.Var(Term.Name("x")) :: Nil, None, Some(Lit(2))) = templStat("var x = 2")
+    assertTree(templStat("var x = 2"))(
+      Defn.Var(Nil, Pat.Var(Term.Name("x")) :: Nil, None, Some(Lit.Int(2)))
+    )
   }
 
   test("val x, y = 2") {
-    val Defn.Val(Nil, Pat.Var(Term.Name("x")) :: Pat.Var(Term.Name("y")) :: Nil, None, Lit(2)) =
-      templStat("val x, y = 2")
+    assertTree(templStat("val x, y = 2"))(
+      Defn.Val(Nil, Pat.Var(Term.Name("x")) :: Pat.Var(Term.Name("y")) :: Nil, None, Lit.Int(2))
+    )
   }
 
   test("val x: Int = 2") {
-    val Defn.Val(Nil, Pat.Var(Term.Name("x")) :: Nil, Some(Type.Name("Int")), Lit(2)) =
-      templStat("val x: Int = 2")
+    assertTree(templStat("val x: Int = 2"))(
+      Defn.Val(Nil, Pat.Var(Term.Name("x")) :: Nil, Some(Type.Name("Int")), Lit.Int(2))
+    )
   }
 
   test("val `x`: Int = 2") {
-    val Defn.Val(Nil, Pat.Var(Term.Name("x")) :: Nil, Some(Type.Name("Int")), Lit(2)) =
-      templStat("val `x`: Int = 2")
+    assertTree(templStat("val `x`: Int = 2"))(
+      Defn.Val(Nil, Pat.Var(Term.Name("x")) :: Nil, Some(Type.Name("Int")), Lit.Int(2))
+    )
   }
 
   test("val f: Int => String = _.toString") {
-    val Defn.Val(
-      Nil,
-      Pat.Var(Term.Name("f")) :: Nil,
-      Some(Type.Function(Type.Name("Int") :: Nil, Type.Name("String"))),
-      Term.AnonymousFunction(Term.Select(Term.Placeholder(), Term.Name("toString")))
-    ) =
-      templStat("val f: Int => String = _.toString")
+    assertTree(templStat("val f: Int => String = _.toString"))(
+      Defn.Val(
+        Nil,
+        Pat.Var(Term.Name("f")) :: Nil,
+        Some(Type.Function(Type.Name("Int") :: Nil, Type.Name("String"))),
+        Term.AnonymousFunction(Term.Select(Term.Placeholder(), Term.Name("toString")))
+      )
+    )
   }
 
   test("var f: Int => String = _.toString") {
-    val Defn.Var(
-      Nil,
-      Pat.Var(Term.Name("f")) :: Nil,
-      Some(Type.Function(Type.Name("Int") :: Nil, Type.Name("String"))),
-      Some(Term.AnonymousFunction(Term.Select(Term.Placeholder(), Term.Name("toString"))))
-    ) =
-      templStat("var f: Int => String = _.toString")
+    assertTree(templStat("var f: Int => String = _.toString"))(
+      Defn.Var(
+        Nil,
+        Pat.Var(Term.Name("f")) :: Nil,
+        Some(Type.Function(Type.Name("Int") :: Nil, Type.Name("String"))),
+        Some(Term.AnonymousFunction(Term.Select(Term.Placeholder(), Term.Name("toString"))))
+      )
+    )
   }
 
   test("var x: Int = _") {
-    val Defn.Var(Nil, Pat.Var(Term.Name("x")) :: Nil, Some(Type.Name("Int")), None) =
-      templStat("var x: Int = _")
+    assertTree(templStat("var x: Int = _"))(
+      Defn.Var(Nil, Pat.Var(Term.Name("x")) :: Nil, Some(Type.Name("Int")), None)
+    )
   }
 
   test("var x = _ is not allowed") {
@@ -66,8 +76,9 @@ class DefnSuite extends ParseSuite {
   }
 
   test("val (x: Int) = 2") {
-    val Defn.Val(Nil, Pat.Typed(Pat.Var(Term.Name("x")), Type.Name("Int")) :: Nil, None, Lit(2)) =
-      templStat("val (x: Int) = 2")
+    assertTree(templStat("val (x: Int) = 2"))(
+      Defn.Val(Nil, Pat.Typed(Pat.Var(Term.Name("x")), Type.Name("Int")) :: Nil, None, Lit.Int(2))
+    )
   }
 
   test("type A = B") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ImportSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ImportSuite.scala
@@ -8,96 +8,113 @@ import scala.meta.parsers.ParseException
 
 class ImportSuite extends ParseSuite {
   test("import foo.bar") {
-    val Import(Importer(TermName("foo"), Name(Indeterminate("bar")) :: Nil) :: Nil) =
-      templStat("import foo.bar")
+    assertTree(templStat("import foo.bar"))(
+      Import(Importer(TermName("foo"), Name(Indeterminate("bar")) :: Nil) :: Nil)
+    )
   }
 
   test("import foo.bar.baz") {
-    val Import(
-      Importer(Select(TermName("foo"), TermName("bar")), Name(Indeterminate("baz")) :: Nil) :: Nil
-    ) =
-      templStat("import foo.bar.baz")
+    assertTree(templStat("import foo.bar.baz"))(
+      Import(
+        Importer(Select(TermName("foo"), TermName("bar")), Name(Indeterminate("baz")) :: Nil) :: Nil
+      )
+    )
   }
 
   test("import super.foo.bar") {
-    val Import(
-      Importer(
-        Select(Super(Anonymous(), Anonymous()), TermName("foo")),
-        Name(Indeterminate("bar")) :: Nil
-      ) :: Nil
-    ) =
-      templStat("import super.foo.bar")
+    assertTree(templStat("import super.foo.bar"))(
+      Import(
+        Importer(
+          Select(Super(Anonymous(), Anonymous()), TermName("foo")),
+          Name(Indeterminate("bar")) :: Nil
+        ) :: Nil
+      )
+    )
   }
 
   test("import this.foo.bar") {
-    val Import(
-      Importer(Select(This(Anonymous()), TermName("foo")), Name(Indeterminate("bar")) :: Nil) :: Nil
-    ) =
-      templStat("import this.foo.bar")
+    assertTree(templStat("import this.foo.bar"))(
+      Import(
+        Importer(
+          Select(This(Anonymous()), TermName("foo")),
+          Name(Indeterminate("bar")) :: Nil
+        ) :: Nil
+      )
+    )
   }
 
   test("import foo.bar._") {
-    val Import(Importer(Select(TermName("foo"), TermName("bar")), Wildcard() :: Nil) :: Nil) =
-      templStat("import foo.bar._")
+    assertTree(templStat("import foo.bar._"))(
+      Import(Importer(Select(TermName("foo"), TermName("bar")), Wildcard() :: Nil) :: Nil)
+    )
   }
 
   test("import super.foo._") {
-    val Import(
-      Importer(Select(Super(Anonymous(), Anonymous()), TermName("foo")), Wildcard() :: Nil) :: Nil
-    ) =
-      templStat("import super.foo._")
+    assertTree(templStat("import super.foo._"))(
+      Import(
+        Importer(Select(Super(Anonymous(), Anonymous()), TermName("foo")), Wildcard() :: Nil) :: Nil
+      )
+    )
   }
 
   test("import this.foo._") {
-    val Import(Importer(Select(This(Anonymous()), TermName("foo")), Wildcard() :: Nil) :: Nil) =
-      templStat("import this.foo._")
+    assertTree(templStat("import this.foo._"))(
+      Import(Importer(Select(This(Anonymous()), TermName("foo")), Wildcard() :: Nil) :: Nil)
+    )
   }
 
   test("import foo.{bar}") {
-    val Import(Importer(TermName("foo"), Name(Indeterminate("bar")) :: Nil) :: Nil) =
-      templStat("import foo.{bar}")
+    assertTree(templStat("import foo.{bar}"))(
+      Import(Importer(TermName("foo"), Name(Indeterminate("bar")) :: Nil) :: Nil)
+    )
   }
 
   test("import foo.{bar, baz}") {
-    val Import(
-      Importer(TermName("foo"), Name(Indeterminate("bar")) :: (Name(Indeterminate("baz"))) :: Nil)
-        :: Nil
-    ) =
-      templStat("import foo.{bar, baz}")
+    assertTree(templStat("import foo.{bar, baz}"))(
+      Import(
+        Importer(TermName("foo"), Name(Indeterminate("bar")) :: (Name(Indeterminate("baz"))) :: Nil)
+          :: Nil
+      )
+    )
   }
 
   test("import foo.{bar => baz}") {
-    val Import(
-      Importer(TermName("foo"), Rename(Indeterminate("bar"), Indeterminate("baz")) :: Nil) :: Nil
-    ) =
-      templStat("import foo.{bar => baz}")
+    assertTree(templStat("import foo.{bar => baz}"))(
+      Import(
+        Importer(TermName("foo"), Rename(Indeterminate("bar"), Indeterminate("baz")) :: Nil) :: Nil
+      )
+    )
   }
 
   test("import foo.{bar => _}") {
-    val Import(Importer(TermName("foo"), Unimport(Indeterminate("bar")) :: Nil) :: Nil) =
-      templStat("import foo.{bar => _}")
+    assertTree(templStat("import foo.{bar => _}"))(
+      Import(Importer(TermName("foo"), Unimport(Indeterminate("bar")) :: Nil) :: Nil)
+    )
   }
 
   test("import foo.{_ => _}") {
-    val Import(Importer(TermName("foo"), Wildcard() :: Nil) :: Nil) =
-      templStat("import foo.{_ => _}")
+    assertTree(templStat("import foo.{_ => _}"))(
+      Import(Importer(TermName("foo"), Wildcard() :: Nil) :: Nil)
+    )
   }
 
   test("import foo.{bar => _, _}") {
-    val Import(
-      Importer(TermName("foo"), Unimport(Indeterminate("bar")) :: Wildcard() :: Nil) :: Nil
-    ) =
-      templStat("import foo.{bar => _, _}")
+    assertTree(templStat("import foo.{bar => _, _}"))(
+      Import(
+        Importer(TermName("foo"), Unimport(Indeterminate("bar")) :: Wildcard() :: Nil) :: Nil
+      )
+    )
   }
 
   test("import foo.{bar, baz => _, _}") {
-    val Import(
-      Importer(
-        TermName("foo"),
-        (Name(Indeterminate("bar"))) :: Unimport(Indeterminate("baz")) :: Wildcard() :: Nil
-      ) :: Nil
-    ) =
-      templStat("import foo.{bar, baz => _, _}")
+    assertTree(templStat("import foo.{bar, baz => _, _}"))(
+      Import(
+        Importer(
+          TermName("foo"),
+          (Name(Indeterminate("bar"))) :: Unimport(Indeterminate("baz")) :: Wildcard() :: Nil
+        ) :: Nil
+      )
+    )
   }
 
   test("import a.b.{ _, c => _ }") {


### PR DESCRIPTION
This is showing up as warnings in Scala 3 since the left side is more specialized and need an explicit unchecked annotation.

There is still plenty to fix unfortunately, but will continue next week.