### PR TITLE
ScannerTokens: end marker must be preceded by NL

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -40,6 +40,15 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
   def getNextToken(index: Int): Token = tokens(getNextIndex(index))
 
   @tailrec
+  final def getStrictPrev(index: Int): Int = {
+    if (index <= 0) 0
+    else {
+      val prev = index - 1
+      if (tokens(prev).isAny[HSpace, Comment]) getStrictPrev(prev) else prev
+    }
+  }
+
+  @tailrec
   final def getStrictNext(index: Int): Int = {
     if (index >= tokens.length - 1) tokens.length - 1
     else {
@@ -233,7 +242,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
         _: KwThis | _: KwType | _: RightParen | _: RightBracket | _: RightBrace | _: Underscore |
         _: Ellipsis | _: Unquote =>
       true
-    case _ => isEndMarkerIntro(getPrevIndex(index))
+    case _ => isEndMarkerIntro(getStrictPrev(index))
   }
 
   object StatSep {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EndMarkerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EndMarkerSuite.scala
@@ -379,11 +379,18 @@ class EndMarkerSuite extends BaseDottySuite {
       """|x.end match
          |    case _ => ()
          |""".stripMargin
-    val error =
-      """|<input>:1: error: { expected but \n found
-         |x.end match
-         |           ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout =
+      """|x.end match {
+         |  case _ => ()
+         |}
+         |""".stripMargin
+    runTestAssert[Stat](code, Some(layout))(
+      Term.Match(
+        Term.Select(Term.Name("x"), Term.Name("end")),
+        List(Case(Pat.Wildcard(), None, Lit.Unit())),
+        Nil
+      )
+    )
   }
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EndMarkerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EndMarkerSuite.scala
@@ -374,4 +374,16 @@ class EndMarkerSuite extends BaseDottySuite {
     )
   }
 
+  test("#3366 not an end marker") {
+    val code =
+      """|x.end match
+         |    case _ => ()
+         |""".stripMargin
+    val error =
+      """|<input>:1: error: { expected but \n found
+         |x.end match
+         |           ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
 }


### PR DESCRIPTION
Fixes #3366.