### PR TITLE
avoid deprecated `java.net.URL` constructor

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ commands += Command.command("mima") { s =>
 commands += Command.command("download-scala-library") { s =>
   val out = file("target/scala-library")
   IO.unzipURL(
-    new URL(s"https://github.com/scala/scala/archive/v$LatestScala213.zip"),
+    url(s"https://github.com/scala/scala/archive/v$LatestScala213.zip"),
     toDirectory = out,
     filter = s"scala-$LatestScala213/src/library/*"
   )

--- a/scalameta/testkit/jvm/src/main/scala/scala/meta/testkit/Corpus.scala
+++ b/scalameta/testkit/jvm/src/main/scala/scala/meta/testkit/Corpus.scala
@@ -1,7 +1,7 @@
 package scala.meta.testkit
 
 import java.io.File
-import java.net.URL
+import java.net.URI
 
 import sys.process._
 import java.net.URL
@@ -101,7 +101,7 @@ object Corpus {
 
   private def downloadReposTar(corpus: Corpus, destination: File): Unit = {
     Phase.run(s"download ${corpus.url}") {
-      new URL(corpus.url).#>(destination).!!
+      new URI(corpus.url).toURL.#>(destination).!!
     }
   }
 


### PR DESCRIPTION
https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/net/URL.html#%3Cinit%3E(java.lang.String)