### PR TITLE
Fix FuncParamClause not adding parentheses for Type.Function

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -582,7 +582,9 @@ object TreeSyntax {
       case t: Type.FuncParamClause =>
         t.values match {
           case arg :: Nil if (arg match {
-                case _: Type.Tuple | _: Type.ByName | _: Type.FunctionParamOrArg => false
+                case _: Type.Tuple | _: Type.ByName | _: Type.FunctionParamOrArg |
+                    _: Type.Function =>
+                  false
                 case _ => true
               }) =>
             s(arg)

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -1304,6 +1304,17 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     checkStat("list reduce (_.a.b.c + _.d.e.f)")(q"list reduce (_.a.b.c + _.d.e.f)")
     checkStat("list reduce (_.a(foo) + _.b(bar))")(q"list reduce (_.a(foo) + _.b(bar))")
   }
+  test("parentheses on function param clauses") {
+    List(
+      "def f: (B => B) => A" -> q"def f: (B => B) => A",
+      "def f: B => B => A" -> q"def f: B => B => A",
+      "def f: B => A" -> q"def f: B => A",
+      "def f: (B => B) => A => A" -> q"def f: (B => B) => A => A",
+      "def f: (B => B) => (A => A) => A" -> q"def f: (B => B) => (A => A) => A"
+    ).foreach { case (code, expected) =>
+      checkStat(code, code)(expected)
+    }
+  }
 
   test("#1864 Terms with leading numerics are backquoted") {
     checkStat("`123foo`")(Term.Name("123foo"))


### PR DESCRIPTION
Before:

```scala
q"def f: (B => B) => A".syntax
// "def f: B => B => A"
```

After:

```scala
q"def f: (B => B) => A".syntax
// "def f: (B => B) => A"
```

See the added test for more examples. Other cases are welcome as I might have missed something
