### PR TITLE
refactor: Use Ctor.Primary primary apply by default

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -4039,7 +4039,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
       val paramss = termParamClauses(ownerIsType = true, owner == OwnedByCaseClass)
       Ctor.Primary(mods, name, paramss)
     } else {
-      Ctor.Primary(Nil, anonNameEmpty(), Seq.empty)
+      Ctor.Primary(Nil, anonNameEmpty(), Seq.empty[Term.ParamClause])
     }
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/TreeSuiteBase.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/TreeSuiteBase.scala
@@ -3,8 +3,9 @@ package scala.meta.tests
 import munit._
 
 import scala.meta._
+import scala.meta.tests.parsers.CommonTrees
 
-abstract class TreeSuiteBase extends FunSuite {
+abstract class TreeSuiteBase extends FunSuite with CommonTrees {
 
   def emptyArgClause = Seq.empty[Term.ArgClause]
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
@@ -27,7 +27,7 @@ trait CommonTrees {
   }
 
   object EmptyCtor {
-    def apply() = Ctor.Primary(Nil, Name.Anonymous(), Nil)
+    def apply() = Ctor.Primary(Nil, anon, Seq.empty[Term.ParamClause])
     def unapply(tree: Tree): Boolean = tree match {
       case Ctor.Primary(Nil, Name.Anonymous(), Nil) => true
       case _ => false
@@ -44,7 +44,7 @@ trait CommonTrees {
 
   final val anon = meta.Name.Anonymous()
   final val phName = meta.Name.Placeholder()
-  final val ctor = Ctor.Primary(Nil, anon, Nil)
+  final val ctor = EmptyCtor()
   final def ctorp(lp: List[Term.Param] = Nil) = Ctor.Primary(Nil, anon, List(lp))
   final val slf = meta.Self(anon, None)
   final def self(name: String, tpe: String = null) = meta.Self(tname(name), Option(tpe).map(pname))

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/LitSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/LitSuite.scala
@@ -155,7 +155,7 @@ class LitSuite extends ParseSuite {
         Nil,
         Type.Name("Foo"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(
           Nil,
           Nil,

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
@@ -13,7 +13,7 @@ class ModSuite extends ParseSuite {
         List(Mod.Implicit()),
         Type.Name("A"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Seq.empty[Term.ParamClause]),
+        EmptyCtor(),
         Template(Nil, Nil, EmptySelf(), Nil)
       )
     )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TemplateSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TemplateSuite.scala
@@ -417,7 +417,7 @@ class TemplateSuite extends ParseSuite {
       Nil,
       Type.Name("foo"),
       Nil,
-      Ctor.Primary(Nil, Name(""), Nil),
+      EmptyCtor(),
       Template(Nil, Nil, Self(Name.Placeholder(), Some(Type.Name("Int"))), Nil, Nil)
     )
     checkStat(code, code)(tree)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -1367,7 +1367,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
         Nil,
         pname("A"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(
           Nil,
           Nil,

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EndMarkerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EndMarkerSuite.scala
@@ -307,7 +307,7 @@ class EndMarkerSuite extends BaseDottySuite {
             Nil,
             Type.Name("Foo"),
             Nil,
-            Ctor.Primary(Nil, Name(""), Nil),
+            EmptyCtor(),
             Template(Nil, Nil, Self(Name(""), None), Nil, Nil)
           ),
           Term.EndMarker(Term.Name("Foo"))
@@ -329,7 +329,7 @@ class EndMarkerSuite extends BaseDottySuite {
             Nil,
             Type.Name("Foo"),
             Nil,
-            Ctor.Primary(Nil, Name(""), Nil),
+            EmptyCtor(),
             Template(Nil, Nil, Self(Name(""), None), Nil, Nil)
           ),
           Term.EndMarker(Term.Name("Foo"))

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EnumSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EnumSuite.scala
@@ -38,7 +38,7 @@ class EnumSuite extends BaseDottySuite {
         Nil,
         Type.Name("Color"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(
           Nil,
           Nil,
@@ -48,14 +48,14 @@ class EnumSuite extends BaseDottySuite {
               List(Mod.Private(Name(""))),
               Term.Name("R"),
               Nil,
-              Ctor.Primary(Nil, Name(""), Nil),
+              EmptyCtor(),
               Nil
             ),
             Defn.EnumCase(
               List(Mod.Protected(Name(""))),
               Term.Name("G"),
               Nil,
-              Ctor.Primary(Nil, Name(""), Nil),
+              EmptyCtor(),
               Nil
             )
           ),
@@ -103,7 +103,7 @@ class EnumSuite extends BaseDottySuite {
         Nil,
         Type.Name("Color"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(Nil, Nil, Self(Name(""), None), Nil)
       )
     )
@@ -112,7 +112,7 @@ class EnumSuite extends BaseDottySuite {
         Nil,
         Type.Name("Color"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(
           Nil,
           Nil,
@@ -384,7 +384,7 @@ class EnumSuite extends BaseDottySuite {
           Nil,
           Term.Name("Red"),
           Nil,
-          Ctor.Primary(Nil, Name(""), Nil),
+          EmptyCtor(),
           List(Init(Type.Name("Color"), Name(""), List(List(Lit.Int(65280)))))
         )
       )
@@ -447,7 +447,7 @@ class EnumSuite extends BaseDottySuite {
         List(Mod.Annot(Init(Type.Name("annot"), Name(""), emptyArgClause))),
         Type.Name("A"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(
           Nil,
           Nil,
@@ -471,7 +471,7 @@ class EnumSuite extends BaseDottySuite {
         Nil,
         Type.Name("A"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(
           Nil,
           Nil,
@@ -525,7 +525,7 @@ class EnumSuite extends BaseDottySuite {
         Nil,
         Type.Name("A"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(
           Nil,
           Nil,
@@ -634,7 +634,7 @@ class EnumSuite extends BaseDottySuite {
               Nil,
               Type.Name("A"),
               Nil,
-              Ctor.Primary(Nil, Name(""), Nil),
+              EmptyCtor(),
               Template(
                 Nil,
                 Nil,
@@ -675,13 +675,13 @@ class EnumSuite extends BaseDottySuite {
         Nil,
         Type.Name("T2Enum"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(
           Nil,
           Nil,
           Self(Name(""), None),
           List(
-            Defn.EnumCase(Nil, Term.Name("Hmm"), Nil, Ctor.Primary(Nil, Name(""), Nil), Nil),
+            Defn.EnumCase(Nil, Term.Name("Hmm"), Nil, EmptyCtor(), Nil),
             Defn.Val(
               Nil,
               List(Pat.Var(Term.Name("a"))),
@@ -702,7 +702,7 @@ class EnumSuite extends BaseDottySuite {
     Nil,
     Type.Name(name),
     Nil,
-    Ctor.Primary(Nil, Name(""), Nil),
+    EmptyCtor(),
     Template(
       Nil,
       Nil,

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
@@ -486,7 +486,7 @@ class FewerBracesSuite extends BaseDottySuite {
         Nil,
         Type.Name("C"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(
           Nil,
           Nil,

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
@@ -38,7 +38,7 @@ class InfixSuite extends BaseDottySuite {
         Nil,
         pname("A"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(
           Nil,
           Nil,
@@ -77,7 +77,7 @@ class InfixSuite extends BaseDottySuite {
           pparam("B"),
           pparam("C")
         ),
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(Nil, Nil, Self(Name(""), None), Nil)
       )
     )
@@ -92,7 +92,7 @@ class InfixSuite extends BaseDottySuite {
           pparam("B"),
           pparam("C")
         ),
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(Nil, Nil, Self(Name(""), None), Nil)
       )
     )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InlineSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InlineSuite.scala
@@ -471,7 +471,7 @@ class InlineSuite extends BaseDottySuite {
         List(Mod.Transparent()),
         Type.Name("S"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(Nil, Nil, Self(Name(""), None), Nil, Nil)
       )
     )
@@ -488,7 +488,7 @@ class InlineSuite extends BaseDottySuite {
         List(Mod.Transparent()),
         Type.Name("S"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(Nil, Nil, Self(Name(""), None), Nil, Nil)
       )
     )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -297,7 +297,7 @@ class MinorDottySuite extends BaseDottySuite {
         List(
           Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, List(Type.Name("Eq")))
         ),
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(Nil, Nil, Self(Name(""), None), Nil, Nil)
       )
     )
@@ -332,7 +332,7 @@ class MinorDottySuite extends BaseDottySuite {
         Nil,
         Type.Name("Foo"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(Nil, List(init("A"), init("B"), init("C")), Self(Name(""), None), Nil)
       )
     )
@@ -379,7 +379,7 @@ class MinorDottySuite extends BaseDottySuite {
         Nil,
         Type.Name("A"),
         Type.ParamClause(Nil),
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(
           Nil,
           Init(
@@ -521,7 +521,7 @@ class MinorDottySuite extends BaseDottySuite {
         Nil,
         Type.Name("Foo"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(
           Nil,
           Nil,
@@ -640,7 +640,7 @@ class MinorDottySuite extends BaseDottySuite {
         Nil,
         Type.Name("X"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(
           Nil,
           Nil,
@@ -676,7 +676,7 @@ class MinorDottySuite extends BaseDottySuite {
         Nil,
         Type.Name("Kind"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(
           Nil,
           Nil,

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NewFunctionsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NewFunctionsSuite.scala
@@ -834,7 +834,7 @@ class NewFunctionsSuite extends BaseDottySuite {
             )
           )
         ),
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(Nil, Nil, Self(Name(""), None), Nil, Nil)
       )
     )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -25,7 +25,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
         Nil,
         pname("A"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(Nil, Nil, Self(Name(""), None), List(defx))
       )
     )
@@ -73,7 +73,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
         Nil,
         pname("A"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(
           Nil,
           Nil,
@@ -196,7 +196,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
               Nil,
               pname("T"),
               Nil,
-              Ctor.Primary(Nil, Name(""), Nil),
+              EmptyCtor(),
               Template(
                 Nil,
                 Nil,
@@ -282,7 +282,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
         Nil,
         pname("X"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(
           Nil,
           Nil,
@@ -319,7 +319,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
         Nil,
         pname("X"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(
           Nil,
           Nil,
@@ -359,7 +359,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
         Nil,
         pname("X"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(
           Nil,
           Nil,
@@ -403,7 +403,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
         Nil,
         pname("A"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(
           Nil,
           List(Init(pname("B"), Name(""), emptyArgClause)),
@@ -538,7 +538,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
         Nil,
         pname("A"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(
           Nil,
           Nil,
@@ -580,7 +580,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
         Nil,
         pname("A"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(
           Nil,
           Nil,
@@ -729,7 +729,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
         List(Mod.Abstract()),
         pname("Documentation"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(
           Nil,
           Nil,
@@ -739,7 +739,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
               Nil,
               pname("Graph"),
               Nil,
-              Ctor.Primary(Nil, Name(""), Nil),
+              EmptyCtor(),
               Template(
                 Nil,
                 Nil,
@@ -901,7 +901,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
         Nil,
         pname("A"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(
           Nil,
           List(Init(pname("A"), Name(""), Nil), Init(pname("B"), Name(""), emptyArgClause)),
@@ -2005,7 +2005,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
               Nil,
               tname("xhtml"),
               Nil,
-              Ctor.Primary(Nil, Name(""), Nil),
+              EmptyCtor(),
               List(
                 Init(
                   pname("Namespace"),
@@ -2148,7 +2148,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
                     Nil,
                     pname("SomeOtherPackage"),
                     Nil,
-                    Ctor.Primary(Nil, Name(""), Nil),
+                    EmptyCtor(),
                     tpl(Nil)
                   )
                 )
@@ -2157,7 +2157,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
                 Nil,
                 pname("BrokenLink"),
                 Nil,
-                Ctor.Primary(Nil, Name(""), Nil),
+                EmptyCtor(),
                 tpl(Nil)
               )
             )
@@ -2370,7 +2370,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
             Nil,
             pname("A1"),
             Nil,
-            Ctor.Primary(Nil, Name(""), Nil),
+            EmptyCtor(),
             Template(
               Nil,
               List(
@@ -2392,7 +2392,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
             Nil,
             pname("A2"),
             Nil,
-            Ctor.Primary(Nil, Name(""), Nil),
+            EmptyCtor(),
             Template(
               Nil,
               List(
@@ -2417,7 +2417,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
             ),
             pname("B"),
             Nil,
-            Ctor.Primary(Nil, Name(""), Nil),
+            EmptyCtor(),
             tpl(Nil)
           )
         )
@@ -2447,7 +2447,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
             Nil,
             pname("T2"),
             Nil,
-            Ctor.Primary(Nil, Name(""), Nil),
+            EmptyCtor(),
             Template(
               Nil,
               Nil,
@@ -2457,7 +2457,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
                   Nil,
                   pname("T2Enum"),
                   Nil,
-                  Ctor.Primary(Nil, Name(""), Nil),
+                  EmptyCtor(),
                   Template(
                     Nil,
                     Nil,
@@ -2467,7 +2467,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
                         Nil,
                         tname("EnumCase"),
                         Nil,
-                        Ctor.Primary(Nil, Name(""), Nil),
+                        EmptyCtor(),
                         Nil
                       )
                     ),

--- a/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -1912,7 +1912,7 @@ class SuccessSuite extends TreeSuiteBase {
           Type.Param(Nil, Type.Name("T"), Nil, Type.Bounds(None, None), Nil, Nil),
           Type.Param(Nil, Type.Name("W"), Nil, Type.Bounds(None, None), Nil, Nil)
         ),
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(
           Nil,
           List(Init(Type.Name("F"), Name(""), emptyArgClause)),
@@ -2038,7 +2038,7 @@ class SuccessSuite extends TreeSuiteBase {
         Nil,
         Type.Name("A"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(Nil, Nil, Self(Name(""), None), Nil, Nil)
       ),
       Defn.Object(Nil, Term.Name("B"), Template(Nil, Nil, Self(Name(""), None), Nil, Nil))
@@ -2056,7 +2056,7 @@ class SuccessSuite extends TreeSuiteBase {
             Nil,
             Type.Name("A"),
             Nil,
-            Ctor.Primary(Nil, Name(""), Nil),
+            EmptyCtor(),
             Template(Nil, Nil, Self(Name(""), None), Nil, Nil)
           ),
           Defn.Object(Nil, Term.Name("B"), Template(Nil, Nil, Self(Name(""), None), Nil, Nil))
@@ -2079,7 +2079,7 @@ class SuccessSuite extends TreeSuiteBase {
             Nil,
             Type.Name("A"),
             Nil,
-            Ctor.Primary(Nil, Name(""), Nil),
+            EmptyCtor(),
             Template(Nil, Nil, Self(Name(""), None), Nil, Nil)
           ),
           Defn.Object(Nil, Term.Name("B"), Template(Nil, Nil, Self(Name(""), None), Nil, Nil))
@@ -2545,7 +2545,7 @@ class SuccessSuite extends TreeSuiteBase {
         Nil,
         Type.Name("A"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(
           Nil,
           Nil,
@@ -2566,7 +2566,7 @@ class SuccessSuite extends TreeSuiteBase {
         Nil,
         Type.Name("A"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(
           Nil,
           Nil,
@@ -2587,7 +2587,7 @@ class SuccessSuite extends TreeSuiteBase {
             Nil,
             Type.Name("A"),
             Nil,
-            Ctor.Primary(Nil, Name(""), Nil),
+            EmptyCtor(),
             Template(
               Nil,
               Nil,
@@ -2674,7 +2674,7 @@ class SuccessSuite extends TreeSuiteBase {
         Nil,
         Type.Name("C"),
         Nil,
-        Ctor.Primary(Nil, Name(""), Nil),
+        EmptyCtor(),
         Template(
           Nil,
           Nil,

--- a/tests/shared/src/test/scala/scala/meta/tests/trees/InvariantSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/trees/InvariantSuite.scala
@@ -8,7 +8,7 @@ import scala.meta.dialects.Scala211
 
 class InvariantSuite extends TreeSuiteBase {
   test("secondary constructors in templates") {
-    val primaryCtor = Ctor.Primary(Nil, Name.Anonymous(), Nil)
+    val primaryCtor = EmptyCtor()
     val secondaryCtor = Ctor.Secondary(
       Nil,
       Name.Anonymous(),


### PR DESCRIPTION
For compatibility with Scala 3 where the new keyword is not needed.