### PR TITLE
refactor: Don't use pattern match on val in TokenSuite

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/Scala3SyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/Scala3SyntaxSuite.scala
@@ -39,8 +39,11 @@ class Scala3SyntaxSuite extends BaseDottySuite {
       templStat("enum C extends A with B { case D }").syntax,
       "enum C extends A with B { case D }"
     )
-    val q"enum $name $template" = q"enum C extends A with B { case D }"
-    assertEquals(template.syntax, "extends A with B { case D }")
+    stat("enum C extends A with B { case D }") match {
+      case Defn.Enum(_, _, _, _, template) =>
+        assertEquals(template.syntax, "extends A with B { case D }")
+      case _ => fail("Should parse as enumCaseDef")
+    }
   }
 
   test("protected enum C extends A with B { case D }") {
@@ -50,9 +53,11 @@ class Scala3SyntaxSuite extends BaseDottySuite {
       templStat("protected enum C extends A with B { case D }").syntax,
       "protected enum C extends A with B { case D }"
     )
-    val q"protected enum $name $template" =
-      q"protected enum C extends A with B { case D }"
-    assertEquals(template.syntax, "extends A with B { case D }")
+    stat("protected enum C extends A with B { case D }") match {
+      case Defn.Enum(_, _, _, _, template) =>
+        assertEquals(template.syntax, "extends A with B { case D }")
+      case _ => fail("Should parse as enum")
+    }
   }
 
   test("given intOrd: Ord[Int]") {

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/BaseTokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/BaseTokenizerSuite.scala
@@ -8,11 +8,19 @@ import scala.meta.tests.TreeSuiteBase
 
 abstract class BaseTokenizerSuite extends TreeSuiteBase {
 
-  def tokenize(code: String): Tokens = {
+  def tokenize(code: String, dialect: Dialect = Scala211): Tokens = {
     val convert = scala.meta.inputs.Input.stringToInput
     val tokenize = scala.meta.tokenizers.Tokenize.scalametaTokenize
-    val dialect = Scala211
+
     code.tokenize(convert, tokenize, dialect).get
+  }
+
+  def assertTokens(
+      code: String,
+      dialect: Dialect = Scala211
+  )(expected: PartialFunction[Tokens, Unit]) = {
+    val obtained = tokenize(code, dialect)
+    expected.lift(obtained).getOrElse(fail("Got unexpected tokens: " + obtained))
   }
 
   def assertTokenizedAsStructureLines(code: String, expected: String)(


### PR DESCRIPTION
This shows a lot of warning when compiling with Scala 3 (I am down to like 80!) and also don't use quasiquotes in Scala3SyntaxSuite as it's not needed and not supported in Scala 3