### PR TITLE
Scaladoc: fix syntax of EnclosedJavaTag

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/Scaladoc.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/Scaladoc.scala
@@ -49,7 +49,7 @@ object Scaladoc {
 
   /** Represents an enclosed tagged documentation remark */
   final case class EnclosedJavaTag(tag: String, desc: Seq[String] = Nil) extends TextPart {
-    override def syntax: String = desc.mkString(s"{@$tag", " ", "}")
+    override def syntax: String = (tag +: desc).mkString("{", " ", "}")
   }
 
   /** A block of one or more lines of code */

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
@@ -1857,6 +1857,8 @@ class ScaladocParserSuite extends FunSuite {
   }
 
   test("enclosed java tag") {
+    val javaTag1 = EnclosedJavaTag("@tag1")
+    val javaTag2 = EnclosedJavaTag("@tag2", List("with", "desc"))
     assertEquals(
       parseString(
         """
@@ -1873,8 +1875,8 @@ class ScaladocParserSuite extends FunSuite {
           Paragraph(
             Text(
               Seq(
-                EnclosedJavaTag("@tag1"),
-                EnclosedJavaTag("@tag2", List("with", "desc")),
+                javaTag1,
+                javaTag2,
                 Word("{@not"),
                 Word("a"),
                 Word("tag}")
@@ -1884,6 +1886,8 @@ class ScaladocParserSuite extends FunSuite {
         )
       )
     )
+    assertEquals(javaTag1.syntax, "{@@tag1}")
+    assertEquals(javaTag2.syntax, "{@@tag2with desc}")
   }
 
   test("table escaped pipe") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
@@ -1886,8 +1886,8 @@ class ScaladocParserSuite extends FunSuite {
         )
       )
     )
-    assertEquals(javaTag1.syntax, "{@@tag1}")
-    assertEquals(javaTag2.syntax, "{@@tag2with desc}")
+    assertEquals(javaTag1.syntax, "{@tag1}")
+    assertEquals(javaTag2.syntax, "{@tag2 with desc}")
   }
 
   test("table escaped pipe") {


### PR DESCRIPTION
Fixes #3392.