### PR TITLE
TokenIterator: replace {current,peek}Indentation

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1444,10 +1444,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
   }
 
   def newLineOptWhenFollowedBySignificantIndentationAnd(cond: Token => Boolean): Boolean = {
-    token.is[LF] && {
-      val prev = in.currentIndentation
-      prev >= 0 && nextIf(cond(peekToken) && in.peekIndentation > prev)
-    }
+    nextIf(in.indenting && cond(peekToken))
   }
 
   def isAfterOptNewLine[T: ClassTag]: Boolean = {

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/TokenIterator.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/TokenIterator.scala
@@ -13,9 +13,8 @@ trait TokenIterator {
 
   def token: Token
   def tokenPos: Int
-  def currentIndentation: Int
+  def indenting: Boolean
 
   def peekToken: Token
   def peekIndex: Int
-  def peekIndentation: Int
 }


### PR DESCRIPTION
Instead, add the `indenting` method which specifically validates whether there's an increase in significant indentation at given newline. Helps with scalameta/scalafmt#3720.