### PR TITLE
ScannerTokens: make `isLeadingInfix` compliant

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -748,7 +748,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
               case (_: RegionNonDelimNonIndented) :: rs if (prev match {
                     // [then]  else  do  [catch]  finally  yield  [match]
                     case _: KwThen | _: KwCatch | _: KwMatch => false
-                    case _ => shouldOutdent(rs)
+                    case _ => rs.find(_.isIndented).exists(_.indent >= nextIndent)
                   }) =>
                 (Right(true), rs)
               case regions @ (r: SepRegionIndented) :: _ if nextIndent >= r.indent =>
@@ -761,12 +761,10 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
                     // then  [else]  [do]  catch  [finally]  [yield]  match
                     case _: KwElse | _: KwDo | _: KwFinally | _: KwYield => false
                     // exclude leading infix op
-                    case _ => nextIndent == 0 || shouldOutdent(rs) || !isLeadingInfix()
+                    case _ => findIndent(rs) >= nextIndent || !isLeadingInfix()
                   }) =>
                 (Left(r), rs)
             }
-          def shouldOutdent(rs: List[SepRegion]): Boolean =
-            rs.find(_.isIndented).exists(_.indent >= nextIndent)
 
           /**
            * Indent is needed in the following cases:

--- a/scalameta/tokens/shared/src/main/scala/scala/meta/tokens/Token.scala
+++ b/scalameta/tokens/shared/src/main/scala/scala/meta/tokens/Token.scala
@@ -173,6 +173,7 @@ object Token {
     def end = start
   }
   @freeform("\n\n") private[meta] class LFLF extends AtEOL
+  @freeform("\n") private[meta] class InfixLF(invalid: Option[String]) extends EOL
 
   // NOTE: in order to maintain conceptual compatibility with scala.reflect's implementation,
   // Ellipsis.rank = 1 means .., Ellipsis.rank = 2 means ..., etc

--- a/tests/jvm/src/test/scala/scala/meta/tests/tokens/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/tokens/ReflectionSuite.scala
@@ -34,6 +34,7 @@ class ReflectionSuite extends FunSuite {
       |Token.Ident
       |Token.Indentation.Indent
       |Token.Indentation.Outdent
+      |Token.InfixLF
       |Token.Interpolation.End
       |Token.Interpolation.Id
       |Token.Interpolation.Part

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
@@ -17,6 +17,7 @@ class ParseSuite extends TreeSuiteBase with CommonTrees {
   implicit def parseSource(code: String, dialect: Dialect): Source = source(code)(dialect)
   implicit def parseType(code: String, dialect: Dialect): Type = tpe(code)(dialect)
   implicit def parsePat(code: String, dialect: Dialect): Pat = pat(code)(dialect)
+  implicit def parseCaseTree(code: String, dialect: Dialect): Case = parseCase(code)(dialect)
 
   // This should eventually be replaced by DiffAssertions.assertNoDiff
   def assertSameLines(actual: String, expected: String) = {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/PatSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/PatSuite.scala
@@ -308,4 +308,14 @@ class PatSuite extends ParseSuite {
     }
   }
 
+  test("case: break before `|`") {
+    val code =
+      """|case 'a'
+         |   | 'A' =>
+         |""".stripMargin
+    val layout = "case 'a' | 'A' =>"
+    val tree = Case(Pat.Alternative(Lit.Char('a'), Lit.Char('A')), None, Term.Block(Nil))
+    runTestAssert[Case](code, Some(layout))(tree)
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
@@ -990,4 +990,639 @@ class FewerBracesSuite extends BaseDottySuite {
     runTestAssert[Stat](code, Some(layout))(tree)
   }
 
+  test("scalafmt #3720 1 simple, space after op, top-level, not indented") {
+    val code =
+      """
+        |baz:
+        |  arg
+        |++ qux
+        |""".stripMargin
+    val layout = "baz(arg) ++ qux"
+    val tree = Term.ApplyInfix(
+      Term.Apply(tname("baz"), List(tname("arg"))),
+      tname("++"),
+      Nil,
+      List(tname("qux"))
+    )
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
+  test("scalafmt #3720 1 simple, space after op, top-level, indented") {
+    val code =
+      """
+        |  baz:
+        |    arg
+        |  ++ qux
+        |""".stripMargin
+    val layout = "baz(arg ++ qux)"
+    val tree = Term.Apply(
+      tname("baz"),
+      List(Term.ApplyInfix(tname("arg"), tname("++"), Nil, List(tname("qux"))))
+    )
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
+  test("scalafmt #3720 1 simple, space after op, object in braces") {
+    val code =
+      """
+        |object a {
+        |  baz:
+        |    arg
+        |  ++ qux
+        |}
+        |""".stripMargin
+    val layout = "object a { baz(arg ++ qux) }"
+    val tree = Defn.Object(
+      Nil,
+      tname("a"),
+      tpl(
+        Term.Apply(
+          tname("baz"),
+          List(Term.ApplyInfix(tname("arg"), tname("++"), Nil, List(tname("qux"))))
+        ) :: Nil
+      )
+    )
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
+  test("scalafmt #3720 1 simple, space after op, object indented") {
+    val code =
+      """
+        |object a:
+        |  baz:
+        |    arg
+        |  ++ qux
+        |""".stripMargin
+    val layout = "object a { baz(arg) ++ qux }"
+    val tree = Defn.Object(
+      Nil,
+      tname("a"),
+      tpl(
+        Term.ApplyInfix(
+          Term.Apply(tname("baz"), List(tname("arg"))),
+          tname("++"),
+          Nil,
+          List(tname("qux"))
+        ) :: Nil
+      )
+    )
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
+  test("scalafmt #3720 2 complex, break after op, top-level, not indented") {
+    val code =
+      """
+        |foo.bar:
+        |  arg
+        |++
+        |  baz:
+        |    arg
+        |  ++
+        |  qux
+        |""".stripMargin
+    val layout = "foo.bar(arg) ++ baz(arg) ++ qux"
+    val tree = Term.ApplyInfix(
+      Term.ApplyInfix(
+        Term.Apply(Term.Select(tname("foo"), tname("bar")), List(tname("arg"))),
+        tname("++"),
+        Nil,
+        List(Term.Apply(tname("baz"), List(tname("arg"))))
+      ),
+      tname("++"),
+      Nil,
+      List(tname("qux"))
+    )
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
+  test("scalafmt #3720 2 complex, break after op, top-level, indented") {
+    val code =
+      """
+        |  foo.bar:
+        |    arg
+        |  ++
+        |  baz:
+        |    arg
+        |  ++
+        |  qux
+        |""".stripMargin
+    val layout = "foo.bar(arg) ++ baz(arg) ++ qux"
+    val tree = Term.ApplyInfix(
+      Term.ApplyInfix(
+        Term.Apply(Term.Select(tname("foo"), tname("bar")), List(tname("arg"))),
+        tname("++"),
+        Nil,
+        List(Term.Apply(tname("baz"), List(tname("arg"))))
+      ),
+      tname("++"),
+      Nil,
+      List(tname("qux"))
+    )
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
+  test("scalafmt #3720 2 complex, break after op, objeect in braces") {
+    val code =
+      """
+        |object a {
+        |  foo.bar:
+        |    arg
+        |  ++
+        |  baz:
+        |    arg
+        |  ++
+        |  qux
+        |}
+        |""".stripMargin
+    val layout = "object a { foo.bar(arg) ++ baz(arg) ++ qux }"
+    val tree = Defn.Object(
+      Nil,
+      tname("a"),
+      tpl(
+        Term.ApplyInfix(
+          Term.ApplyInfix(
+            Term.Apply(Term.Select(tname("foo"), tname("bar")), List(tname("arg"))),
+            tname("++"),
+            Nil,
+            List(Term.Apply(tname("baz"), List(tname("arg"))))
+          ),
+          tname("++"),
+          Nil,
+          List(tname("qux"))
+        ) :: Nil
+      )
+    )
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
+  test("scalafmt #3720 2 complex, break after op, objeect indented") {
+    val code =
+      """
+        |object a:
+        |  foo.bar:
+        |    arg
+        |  ++
+        |  baz:
+        |    arg
+        |  ++
+        |  qux
+        |""".stripMargin
+    val layout = "object a { foo.bar(arg) ++ baz(arg) ++ qux }"
+    val tree = Defn.Object(
+      Nil,
+      tname("a"),
+      tpl(
+        Term.ApplyInfix(
+          Term.ApplyInfix(
+            Term.Apply(Term.Select(tname("foo"), tname("bar")), List(tname("arg"))),
+            tname("++"),
+            Nil,
+            List(Term.Apply(tname("baz"), List(tname("arg"))))
+          ),
+          tname("++"),
+          Nil,
+          List(tname("qux"))
+        ) :: Nil
+      )
+    )
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
+  test("scalafmt #3720 3 complex, space after op, top-level, not indented") {
+    val code =
+      """
+        |foo.bar:
+        |  arg
+        |++
+        |  baz:
+        |    arg
+        |  ++ qux
+        |""".stripMargin
+    val layout = "foo.bar(arg) ++ baz(arg ++ qux)"
+    val tree = Term.ApplyInfix(
+      Term.Apply(Term.Select(tname("foo"), tname("bar")), List(tname("arg"))),
+      tname("++"),
+      Nil,
+      Term.Apply(
+        tname("baz"),
+        List(Term.ApplyInfix(tname("arg"), tname("++"), Nil, List(tname("qux"))))
+      ) :: Nil
+    )
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
+  test("scalafmt #3720 3 complex, space after op, top-level, indented") {
+    val code =
+      """
+        |  foo.bar:
+        |    arg
+        |  ++
+        |    baz:
+        |      arg
+        |    ++ qux
+        |""".stripMargin
+    val layout = "foo.bar(arg) ++ baz(arg ++ qux)"
+    val tree = Term.ApplyInfix(
+      Term.Apply(Term.Select(tname("foo"), tname("bar")), List(tname("arg"))),
+      tname("++"),
+      Nil,
+      Term.Apply(
+        tname("baz"),
+        List(Term.ApplyInfix(tname("arg"), tname("++"), Nil, List(tname("qux"))))
+      ) :: Nil
+    )
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
+  test("scalafmt #3720 3 complex, space after op, object in braces") {
+    val code =
+      """
+        |object a {
+        |  foo.bar:
+        |    arg
+        |  ++
+        |    baz:
+        |      arg
+        |    ++ qux
+        |}
+        |""".stripMargin
+    val layout = "object a { foo.bar(arg) ++ baz(arg ++ qux) }"
+    val tree = Defn.Object(
+      Nil,
+      tname("a"),
+      tpl(
+        Term.ApplyInfix(
+          Term.Apply(Term.Select(tname("foo"), tname("bar")), List(tname("arg"))),
+          tname("++"),
+          Nil,
+          Term.Apply(
+            tname("baz"),
+            List(Term.ApplyInfix(tname("arg"), tname("++"), Nil, List(tname("qux"))))
+          ) :: Nil
+        ) :: Nil
+      )
+    )
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
+  test("scalafmt #3720 3 complex, space after op, object indented") {
+    val code =
+      """
+        |object a:
+        |  foo.bar:
+        |    arg
+        |  ++
+        |    baz:
+        |      arg
+        |    ++ qux
+        |""".stripMargin
+    val layout = "object a { foo.bar(arg) ++ baz(arg ++ qux) }"
+    val tree = Defn.Object(
+      Nil,
+      tname("a"),
+      tpl(
+        Term.ApplyInfix(
+          Term.Apply(Term.Select(tname("foo"), tname("bar")), List(tname("arg"))),
+          tname("++"),
+          Nil,
+          Term.Apply(
+            tname("baz"),
+            List(Term.ApplyInfix(tname("arg"), tname("++"), Nil, List(tname("qux"))))
+          ) :: Nil
+        ) :: Nil
+      )
+    )
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
+  test("scalafmt #3720 4 complex, partial outdents, unindented def") {
+    val code =
+      """
+        |def mtd =
+        |    abc:
+        |        arg1
+        |      ++
+        |        abc:
+        |            arg2
+        |          ++
+        |            abc:
+        |                arg3
+        |""".stripMargin
+    val layout = "def mtd = abc(arg1) ++ abc(arg2) ++ abc(arg3)"
+    val tree = Defn.Def(
+      Nil,
+      tname("mtd"),
+      Nil,
+      None,
+      Term.ApplyInfix(
+        Term.ApplyInfix(
+          Term.Apply(tname("abc"), List(tname("arg1"))),
+          tname("++"),
+          Nil,
+          List(Term.Apply(tname("abc"), List(tname("arg2"))))
+        ),
+        tname("++"),
+        Nil,
+        List(Term.Apply(tname("abc"), List(tname("arg3"))))
+      )
+    )
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
+  test("scalafmt #3720 4 complex, partial outdents, indented def") {
+    val code =
+      """
+        |  def mtd =
+        |    abc:
+        |        arg1
+        |      ++
+        |        abc:
+        |            arg2
+        |          ++
+        |            abc:
+        |                arg3
+        |""".stripMargin
+    val layout = "def mtd = abc(arg1) ++ abc(arg2) ++ abc(arg3)"
+    val tree = Defn.Def(
+      Nil,
+      tname("mtd"),
+      Nil,
+      None,
+      Term.ApplyInfix(
+        Term.ApplyInfix(
+          Term.Apply(tname("abc"), List(tname("arg1"))),
+          tname("++"),
+          Nil,
+          List(Term.Apply(tname("abc"), List(tname("arg2"))))
+        ),
+        tname("++"),
+        Nil,
+        List(Term.Apply(tname("abc"), List(tname("arg3"))))
+      )
+    )
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
+  test("scalafmt #3720 4 complex, partial outdents, indented def in braces") {
+    val code =
+      """
+        |  def mtd = {
+        |    abc:
+        |        arg1
+        |      ++
+        |        abc:
+        |            arg2
+        |          ++
+        |            abc:
+        |                arg3
+        |}
+        |""".stripMargin
+    val layout =
+      """
+        |def mtd = {
+        |  abc(arg1) ++ abc(arg2) ++ abc(arg3)
+        |}
+        |""".stripMargin
+    val tree = Defn.Def(
+      Nil,
+      tname("mtd"),
+      Nil,
+      None,
+      Term.Block(
+        Term.ApplyInfix(
+          Term.ApplyInfix(
+            Term.Apply(tname("abc"), List(tname("arg1"))),
+            tname("++"),
+            Nil,
+            List(Term.Apply(tname("abc"), List(tname("arg2"))))
+          ),
+          tname("++"),
+          Nil,
+          List(Term.Apply(tname("abc"), List(tname("arg3"))))
+        ) :: Nil
+      )
+    )
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
+  test("scalafmt #3720 5 complex, full/partial outdents, unindented def") {
+    val code =
+      """
+        |def mtd =
+        |    abc:
+        |        arg1
+        |      ++
+        |        abc:
+        |            arg2
+        |        ++
+        |            abc:
+        |                arg3
+        |""".stripMargin
+    val layout = "def mtd = abc(arg1) ++ abc(arg2) ++ abc(arg3)"
+    val tree = Defn.Def(
+      Nil,
+      tname("mtd"),
+      Nil,
+      None,
+      Term.ApplyInfix(
+        Term.ApplyInfix(
+          Term.Apply(tname("abc"), List(tname("arg1"))),
+          tname("++"),
+          Nil,
+          List(Term.Apply(tname("abc"), List(tname("arg2"))))
+        ),
+        tname("++"),
+        Nil,
+        List(Term.Apply(tname("abc"), List(tname("arg3"))))
+      )
+    )
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
+  test("scalafmt #3720 5 complex, full/partial outdents, indented def") {
+    val code =
+      """
+        |  def mtd =
+        |    abc:
+        |        arg1
+        |      ++
+        |        abc:
+        |            arg2
+        |        ++
+        |            abc:
+        |                arg3
+        |""".stripMargin
+    val layout = "def mtd = abc(arg1) ++ abc(arg2) ++ abc(arg3)"
+    val tree = Defn.Def(
+      Nil,
+      tname("mtd"),
+      Nil,
+      None,
+      Term.ApplyInfix(
+        Term.ApplyInfix(
+          Term.Apply(tname("abc"), List(tname("arg1"))),
+          tname("++"),
+          Nil,
+          List(Term.Apply(tname("abc"), List(tname("arg2"))))
+        ),
+        tname("++"),
+        Nil,
+        List(Term.Apply(tname("abc"), List(tname("arg3"))))
+      )
+    )
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
+  test("scalafmt #3720 5 complex, full/partial outdents, indented def in braces") {
+    val code =
+      """
+        |  def mtd = {
+        |    abc:
+        |        arg1
+        |      ++
+        |        abc:
+        |            arg2
+        |        ++
+        |            abc:
+        |                arg3
+        |  }
+        |""".stripMargin
+    val layout =
+      """
+        |def mtd = {
+        |  abc(arg1) ++ abc(arg2) ++ abc(arg3)
+        |}
+        |""".stripMargin
+    val tree = Defn.Def(
+      Nil,
+      tname("mtd"),
+      Nil,
+      None,
+      Term.Block(
+        Term.ApplyInfix(
+          Term.ApplyInfix(
+            Term.Apply(tname("abc"), List(tname("arg1"))),
+            tname("++"),
+            Nil,
+            List(Term.Apply(tname("abc"), List(tname("arg2"))))
+          ),
+          tname("++"),
+          Nil,
+          List(Term.Apply(tname("abc"), List(tname("arg3"))))
+        ) :: Nil
+      )
+    )
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
+  test("scalafmt #3720 6 complex, with indented comments") {
+    val code =
+      """
+        |  def mtd =
+        |    abc:
+        |        arg1
+        |    ++ /* c1 */ // c2
+        |        abc:
+        |            arg2
+        |        ++ /*
+        |        c3
+        |        */ abc:
+        |                arg3
+        |""".stripMargin
+    val layout =
+      """
+        |def mtd = abc(arg1) ++ abc {
+        |  arg2
+        |  ++
+        |} abc arg3
+        |""".stripMargin
+    val tree = Defn.Def(
+      Nil,
+      tname("mtd"),
+      Nil,
+      None,
+      Term.ApplyInfix(
+        Term.ApplyInfix(
+          Term.Apply(tname("abc"), List(tname("arg1"))),
+          tname("++"),
+          Nil,
+          List(Term.Apply(tname("abc"), List(Term.Block(List(tname("arg2"), tname("++"))))))
+        ),
+        tname("abc"),
+        Nil,
+        List(tname("arg3"))
+      )
+    )
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
+  test("scalafmt #3720 6 complex, with outindented comments") {
+    val code =
+      """
+        |  def mtd =
+        |    abc:
+        |        arg1
+        |    ++ /*
+        |   c2
+        |    */ abc:
+        |        arg2
+        |""".stripMargin
+    val layout =
+      """
+        |def mtd = {
+        |  abc(arg1)
+        |  ++ abc arg2
+        |}
+        |""".stripMargin
+    val tree = Defn.Def(
+      Nil,
+      tname("mtd"),
+      Nil,
+      None,
+      Term.Block(
+        List(
+          Term.Apply(tname("abc"), List(tname("arg1"))),
+          Term.ApplyInfix(tname("++"), tname("abc"), Nil, List(tname("arg2")))
+        )
+      )
+    )
+    checkTree(stat(code), layout)(tree)
+  }
+
+  test("scalafmt #3720 6 complex, with newline after multiline comment") {
+    val code =
+      """
+        |  def mtd =
+        |    abc:
+        |        arg1
+        |    ++ /*
+        |       c2
+        |    */
+        |    abc:
+        |        arg2
+        |""".stripMargin
+    val layout =
+      """
+        |def mtd = {
+        |  abc(arg1)
+        |  ++
+        |  abc(arg2)
+        |}
+        |""".stripMargin
+    val tree = Defn.Def(
+      Nil,
+      tname("mtd"),
+      Nil,
+      None,
+      Term.Block(
+        List(
+          Term.Apply(tname("abc"), List(tname("arg1"))),
+          tname("++"),
+          Term.Apply(tname("abc"), List(tname("arg2")))
+        )
+      )
+    )
+    checkTree(stat(code), layout)(tree)
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
@@ -1031,14 +1031,16 @@ class FewerBracesSuite extends BaseDottySuite {
         |  ++ qux
         |}
         |""".stripMargin
-    val layout = "object a { baz(arg ++ qux) }"
+    val layout = "object a { baz(arg) ++ qux }"
     val tree = Defn.Object(
       Nil,
       tname("a"),
       tpl(
-        Term.Apply(
-          tname("baz"),
-          List(Term.ApplyInfix(tname("arg"), tname("++"), Nil, List(tname("qux"))))
+        Term.ApplyInfix(
+          Term.Apply(tname("baz"), List(tname("arg"))),
+          tname("++"),
+          Nil,
+          List(tname("qux"))
         ) :: Nil
       )
     )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
@@ -591,4 +591,14 @@ class InfixSuite extends BaseDottySuite {
     )
   }
 
+  test("case: break before `|`") {
+    val code =
+      """|case 'a'
+         |   | 'A' =>
+         |""".stripMargin
+    val layout = "case 'a' | 'A' =>"
+    val tree = Case(Pat.Alternative(Lit.Char('a'), Lit.Char('A')), None, Term.Block(Nil))
+    runTestAssert[Case](code, Some(layout))(tree)
+  }
+
 }


### PR DESCRIPTION
The implementation was incorrect, didn't check the case when the infix op was on a line by itself.

However, the fix is incomplete as it doesn't handle the very rare case when the infix expression is at the file level and not nested within a block of any kind. This will be fixed in the next commit.

Also, add a correlated fix in `getOutdentIfNeeded`.

Helps with scalameta/scalafmt#3720.