### PR TITLE
Use EOL/AtEOL instead of LF or LFLF in matching

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/LazyTokenIterator.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/LazyTokenIterator.scala
@@ -37,7 +37,7 @@ private[parsers] class LazyTokenIterator private (
     curr = ref
   }
 
-  override def indenting: Boolean = curr.token.is[Token.LF] && {
+  override def indenting: Boolean = curr.token.is[Token.EOL] && {
     // empty sepregions means we are at toplevel
     val lastIndentation = curr.regions.headOption.fold(0)(_.indent)
     lastIndentation >= 0 && lastIndentation < peekToken.pos.startColumn

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -241,8 +241,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
       case _: KwCatch | _: KwElse | _: KwExtends | _: KwFinally | _: KwForsome | _: KwMatch |
           _: KwWith | _: KwYield | _: RightParen | _: LeftBracket | _: RightBracket |
           _: RightBrace | _: Comma | _: Colon | _: Dot | _: Equals | _: Semicolon | _: Hash |
-          _: RightArrow | _: LeftArrow | _: Subtype | _: Supertype | _: Viewbound | _: LF |
-          _: LFLF | _: EOF =>
+          _: RightArrow | _: LeftArrow | _: Subtype | _: Supertype | _: Viewbound | _: AtEOLorF =>
         true
       case _ => false
     }
@@ -348,7 +347,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
     val nextPos = currentPosition + 1
     nextPos < tokens.length && {
       val nextToken = tokens(nextPos)
-      nextToken.is[LF] || nextToken.is[Trivia] && isAheadNewLine(nextPos)
+      nextToken.is[EOL] || nextToken.is[Trivia] && isAheadNewLine(nextPos)
     }
   }
 

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
@@ -34,7 +34,7 @@ class ScalametaTokenizer(input: Input, dialect: Dialect) {
     val isAmmoniteInput: Boolean = input.isInstanceOf[Input.Ammonite]
     def isAtLineStart: Boolean = {
       val last = tokens.get(tokens.size() - 1) // tokens is non-empty, contains BOF
-      last.isInstanceOf[Token.LF] || last.isInstanceOf[Token.FF] || last.isInstanceOf[Token.BOF]
+      last.isInstanceOf[Token.EOL] || last.isInstanceOf[Token.BOF]
     }
 
     def pushLegacyToken(curr: LegacyTokenData, next: => Option[LegacyTokenData]): Unit = {


### PR DESCRIPTION
Helps with scalameta/scalafmt#3720.