### PR TITLE
ScannerTokens: introduce a line-indent region

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/LazyTokenIterator.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/LazyTokenIterator.scala
@@ -37,13 +37,15 @@ private[parsers] class LazyTokenIterator private (
     curr = ref
   }
 
-  override def indenting: Boolean = curr.token.is[Token.EOL] && {
-    // empty sepregions means we are at toplevel
-    val lastIndentation = curr.regions.headOption.fold(0)(_.indent)
-    lastIndentation >= 0 && lastIndentation < peekToken.pos.startColumn
+  override def indenting: Boolean = curr.regions match {
+    case (r: RegionLine) :: rs if curr.token.is[Token.EOL] =>
+      // empty sepregions means we are at toplevel
+      rs.headOption.forall(x => x.indent >= 0 && x.indent < r.indent)
+    case _ => false
   }
 
   def previousIndentation: Int = curr.regions match {
+    case (r: RegionLine) :: _ if !curr.token.is[Token.EOL] => r.indent
     case _ :: r :: _ => r.indent
     case _ => 0
   }

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SepRegion.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SepRegion.scala
@@ -26,6 +26,8 @@ sealed trait RegionNonDelimNonIndented extends SepRegionNonIndented
 
 case class RegionIndent(override val indent: Int) extends SepRegionIndented with RegionDelim
 
+case class RegionLine(override val indent: Int) extends RegionNonDelimNonIndented with CanProduceLF
+
 case object RegionParen extends RegionDelimNonIndented
 case object RegionBracket extends RegionDelimNonIndented
 case class RegionBrace(override val indent: Int) extends RegionDelimNonIndented with CanProduceLF

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
@@ -1014,10 +1014,12 @@ class FewerBracesSuite extends BaseDottySuite {
         |    arg
         |  ++ qux
         |""".stripMargin
-    val layout = "baz(arg ++ qux)"
-    val tree = Term.Apply(
-      tname("baz"),
-      List(Term.ApplyInfix(tname("arg"), tname("++"), Nil, List(tname("qux"))))
+    val layout = "baz(arg) ++ qux"
+    val tree = Term.ApplyInfix(
+      Term.Apply(tname("baz"), List(tname("arg"))),
+      tname("++"),
+      Nil,
+      List(tname("qux"))
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -1082,18 +1084,17 @@ class FewerBracesSuite extends BaseDottySuite {
         |  ++
         |  qux
         |""".stripMargin
-    val layout =
-      """
-        |foo.bar(arg) ++ baz {
-        |  arg
-        |  ++
-        |}
-        |""".stripMargin
+    val layout = "foo.bar(arg) ++ baz(arg) ++ qux"
     val tree = Term.ApplyInfix(
-      Term.Apply(Term.Select(tname("foo"), tname("bar")), List(tname("arg"))),
+      Term.ApplyInfix(
+        Term.Apply(Term.Select(tname("foo"), tname("bar")), List(tname("arg"))),
+        tname("++"),
+        Nil,
+        List(Term.Apply(tname("baz"), List(tname("arg"))))
+      ),
       tname("++"),
       Nil,
-      List(Term.Apply(tname("baz"), List(Term.Block(List(tname("arg"), tname("++"))))))
+      List(tname("qux"))
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -1109,16 +1110,17 @@ class FewerBracesSuite extends BaseDottySuite {
         |  ++
         |  qux
         |""".stripMargin
-    val layout =
-      """
-        |foo.bar {
-        |  arg
-        |  ++
-        |}
-        |""".stripMargin
-    val tree = Term.Apply(
-      Term.Select(tname("foo"), tname("bar")),
-      List(Term.Block(List(tname("arg"), tname("++"))))
+    val layout = "foo.bar(arg) ++ baz(arg) ++ qux"
+    val tree = Term.ApplyInfix(
+      Term.ApplyInfix(
+        Term.Apply(Term.Select(tname("foo"), tname("bar")), List(tname("arg"))),
+        tname("++"),
+        Nil,
+        List(Term.Apply(tname("baz"), List(tname("arg"))))
+      ),
+      tname("++"),
+      Nil,
+      List(tname("qux"))
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -1200,15 +1202,17 @@ class FewerBracesSuite extends BaseDottySuite {
         |    arg
         |  ++ qux
         |""".stripMargin
-    val layout = "foo.bar(arg) ++ baz(arg ++ qux)"
+    val layout = "foo.bar(arg) ++ baz(arg) ++ qux"
     val tree = Term.ApplyInfix(
-      Term.Apply(Term.Select(tname("foo"), tname("bar")), List(tname("arg"))),
+      Term.ApplyInfix(
+        Term.Apply(Term.Select(tname("foo"), tname("bar")), List(tname("arg"))),
+        tname("++"),
+        Nil,
+        List(Term.Apply(tname("baz"), List(tname("arg"))))
+      ),
       tname("++"),
       Nil,
-      Term.Apply(
-        tname("baz"),
-        List(Term.ApplyInfix(tname("arg"), tname("++"), Nil, List(tname("qux"))))
-      ) :: Nil
+      List(tname("qux"))
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -1223,20 +1227,17 @@ class FewerBracesSuite extends BaseDottySuite {
         |      arg
         |    ++ qux
         |""".stripMargin
-    val layout = "foo.bar(arg ++ baz(arg) ++ qux)"
-    val tree = Term.Apply(
-      Term.Select(tname("foo"), tname("bar")),
+    val layout = "foo.bar(arg) ++ baz(arg) ++ qux"
+    val tree = Term.ApplyInfix(
       Term.ApplyInfix(
-        Term.ApplyInfix(
-          tname("arg"),
-          tname("++"),
-          Nil,
-          List(Term.Apply(tname("baz"), List(tname("arg"))))
-        ),
+        Term.Apply(Term.Select(tname("foo"), tname("bar")), List(tname("arg"))),
         tname("++"),
         Nil,
-        List(tname("qux"))
-      ) :: Nil
+        List(Term.Apply(tname("baz"), List(tname("arg"))))
+      ),
+      tname("++"),
+      Nil,
+      List(tname("qux"))
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -1253,19 +1254,21 @@ class FewerBracesSuite extends BaseDottySuite {
         |    ++ qux
         |}
         |""".stripMargin
-    val layout = "object a { foo.bar(arg) ++ baz(arg ++ qux) }"
+    val layout = "object a { foo.bar(arg) ++ baz(arg) ++ qux }"
     val tree = Defn.Object(
       Nil,
       tname("a"),
       tpl(
         Term.ApplyInfix(
-          Term.Apply(Term.Select(tname("foo"), tname("bar")), List(tname("arg"))),
+          Term.ApplyInfix(
+            Term.Apply(Term.Select(tname("foo"), tname("bar")), List(tname("arg"))),
+            tname("++"),
+            Nil,
+            List(Term.Apply(tname("baz"), List(tname("arg"))))
+          ),
           tname("++"),
           Nil,
-          Term.Apply(
-            tname("baz"),
-            List(Term.ApplyInfix(tname("arg"), tname("++"), Nil, List(tname("qux"))))
-          ) :: Nil
+          List(tname("qux"))
         ) :: Nil
       )
     )
@@ -1283,19 +1286,24 @@ class FewerBracesSuite extends BaseDottySuite {
         |      arg
         |    ++ qux
         |""".stripMargin
-    val layout = "object a { foo.bar(arg) ++ baz(arg ++ qux) }"
+    val layout = "object a { foo.bar(arg) ++ baz(arg) ++ qux }"
     val tree = Defn.Object(
       Nil,
       tname("a"),
       tpl(
         Term.ApplyInfix(
-          Term.Apply(Term.Select(tname("foo"), tname("bar")), List(tname("arg"))),
+          Term.ApplyInfix(
+            Term.Apply(
+              Term.Select(tname("foo"), tname("bar")),
+              List(tname("arg"))
+            ),
+            tname("++"),
+            Nil,
+            List(Term.Apply(tname("baz"), List(tname("arg"))))
+          ),
           tname("++"),
           Nil,
-          Term.Apply(
-            tname("baz"),
-            List(Term.ApplyInfix(tname("arg"), tname("++"), Nil, List(tname("qux"))))
-          ) :: Nil
+          List(tname("qux"))
         ) :: Nil
       )
     )
@@ -1563,13 +1571,7 @@ class FewerBracesSuite extends BaseDottySuite {
         |        */ abc:
         |                arg3
         |""".stripMargin
-    val layout =
-      """
-        |def mtd = abc(arg1) ++ abc {
-        |  arg2
-        |  ++
-        |} abc arg3
-        |""".stripMargin
+    val layout = "def mtd = abc(arg1) ++ abc(arg2) ++ abc(arg3)"
     val tree = Defn.Def(
       Nil,
       tname("mtd"),
@@ -1580,11 +1582,11 @@ class FewerBracesSuite extends BaseDottySuite {
           Term.Apply(tname("abc"), List(tname("arg1"))),
           tname("++"),
           Nil,
-          List(Term.Apply(tname("abc"), List(Term.Block(List(tname("arg2"), tname("++"))))))
+          List(Term.Apply(tname("abc"), List(tname("arg2"))))
         ),
-        tname("abc"),
+        tname("++"),
         Nil,
-        List(tname("arg3"))
+        List(Term.Apply(tname("abc"), List(tname("arg3"))))
       )
     )
     runTestAssert[Stat](code, Some(layout))(tree)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
@@ -601,4 +601,51 @@ class InfixSuite extends BaseDottySuite {
     runTestAssert[Case](code, Some(layout))(tree)
   }
 
+  test("scalafmt #3720 different leading infix indentations") {
+    val code =
+      """
+        |object a:
+        |  def mtd =
+        |    abc(
+        |        arg1
+        |    )
+        |    ++
+        |    abc(arg2)
+        |      ++
+        |        abc(arg3)
+        |  ++
+        |    abc(arg4)
+        |""".stripMargin
+    val layout = "object a { def mtd = abc(arg1) ++ abc(arg2) ++ abc(arg3) ++ abc(arg4) }"
+    val tree = Defn.Object(
+      Nil,
+      tname("a"),
+      tpl(
+        Defn.Def(
+          Nil,
+          tname("mtd"),
+          Nil,
+          None,
+          Term.ApplyInfix(
+            Term.ApplyInfix(
+              Term.ApplyInfix(
+                Term.Apply(tname("abc"), List(tname("arg1"))),
+                tname("++"),
+                Nil,
+                List(Term.Apply(tname("abc"), List(tname("arg2"))))
+              ),
+              tname("++"),
+              Nil,
+              List(Term.Apply(tname("abc"), List(tname("arg3"))))
+            ),
+            tname("++"),
+            Nil,
+            List(Term.Apply(tname("abc"), List(tname("arg4"))))
+          )
+        ) :: Nil
+      )
+    )
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -3412,4 +3412,78 @@ class SignificantIndentationSuite extends BaseDottySuite {
     runTestAssert[Stat](code, Some(layout))(tree)
   }
 
+  test("def name after newline") {
+    val code =
+      """|def
+         |  foo: Bar =
+         |    baz
+         |""".stripMargin
+    val layout = "def foo: Bar = baz"
+    val tree = Defn.Def(Nil, tname("foo"), Nil, Some(pname("Bar")), tname("baz"))
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
+  test("def colon after newline") {
+    val code =
+      """|def foo
+         |  : Bar =
+         |    baz
+         |""".stripMargin
+    val layout = "def foo: Bar = baz"
+    val tree = Defn.Def(Nil, tname("foo"), Nil, Some(pname("Bar")), tname("baz"))
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
+  test("def newline after colon") {
+    val code =
+      """|def foo
+         |  :
+         |  Bar =
+         |    baz
+         |""".stripMargin
+    val layout = "def foo: Bar = baz"
+    val tree = Defn.Def(Nil, tname("foo"), Nil, Some(pname("Bar")), tname("baz"))
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
+  test("def newline around hash") {
+    val code =
+      """|def foo: Bar
+         |  #
+         |  SubBar =
+         |    baz
+         |""".stripMargin
+    val layout = "def foo: Bar#SubBar = baz"
+    val tree = Defn.Def(
+      Nil,
+      tname("foo"),
+      Nil,
+      Some(Type.Project(pname("Bar"), pname("SubBar"))),
+      tname("baz")
+    )
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
+  test("def equals after newline, without type") {
+    val code =
+      """|def foo
+         |  =
+         |    baz
+         |""".stripMargin
+    val layout = "def foo = baz"
+    val tree = Defn.Def(Nil, tname("foo"), Nil, None, tname("baz"))
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
+  test("def equals after newline, with type") {
+    val code =
+      """|def foo: Bar
+         |  =
+         |    baz
+         |""".stripMargin
+    val layout = "def foo: Bar = baz"
+    val tree = Defn.Def(Nil, tname("foo"), Nil, Some(pname("Bar")), tname("baz"))
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
 }


### PR DESCRIPTION
Use it when an LF token is emitted, to preserve the indent. It is useful in order to identify when to outdent a fewer-braces region, especially when leading-infix operators are used with smaller indentation than the significant-indentation region they belong to but larger than the outer.


Helps with scalameta/scalafmt#3720.