### PR TITLE
adt.Reflection: retrieve fields in sorted order

### DIFF
--- a/scalameta/common/shared/src/main/scala/org/scalameta/adt/Reflection.scala
+++ b/scalameta/common/shared/src/main/scala/org/scalameta/adt/Reflection.scala
@@ -77,7 +77,7 @@ trait Reflection {
 
     def root: Symbol = sym.asClass.baseClasses.reverse.find(_.isRoot).getOrElse(NoSymbol)
     def fields: List[Symbol] = allFields.filter(p => p.isPayload)
-    def allFields: List[Symbol] = sym.info.decls.filter(_.isField).toList
+    def allFields: List[Symbol] = sym.info.decls.sorted.filter(_.isField)
   }
 
   abstract class Adt(val sym: Symbol) {


### PR DESCRIPTION
Documentation for `.decls` indicates the declarations could be returned in arbitrary order, which goes against the assumption around this method that the fields can be used to pass to companion `apply()` and hence are expected to be in the order that apply uses them. Helps with #3425.