### PR TITLE
ast: move private fields to before other fields

### DIFF
--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/ast.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/ast.scala
@@ -121,7 +121,14 @@ class AstNamerMacros(val c: Context) extends Reflection with CommonNamerMacros {
         stats1 ++= imports
         stats1 ++= quasiExtraAbstractDefs
 
-        // step 4: turn all parameters into vars, create getters and setters
+        // step 4: implement the unimplemented methods in InternalTree (part 1)
+        val bparams1 = List(
+          q"@$TransientAnnotation private[meta] val privatePrototype: $iname",
+          q"private[meta] val privateParent: $TreeClass",
+          q"private[meta] val privateOrigin: $OriginClass"
+        )
+
+        // step 5: turn all parameters into vars, create getters and setters
         params.foreach { p =>
           val getterAnns = q"new $AstMetadataModule.astField" :: p.mods.annotations
           istats1 += declareGetter(p.name, p.tpt, getterAnns)
@@ -132,13 +139,6 @@ class AstNamerMacros(val c: Context) extends Reflection with CommonNamerMacros {
           val mods1 = p.mods.mkMutable.unPrivate.unOverride.unDefault
           q"$mods1 val ${internalize(p.name)}: ${p.tpt}"
         }
-
-        // step 5: implement the unimplemented methods in InternalTree (part 1)
-        val bparams1 = List(
-          q"@$TransientAnnotation private[meta] val privatePrototype: $iname",
-          q"private[meta] val privateParent: $TreeClass",
-          q"private[meta] val privateOrigin: $OriginClass"
-        )
 
         // step 6: implement the unimplemented methods in InternalTree (part 1)
         // The purpose of privateCopy is to provide extremely cheap cloning


### PR DESCRIPTION
That way, when we eventually create additional apply methods which take these private field values, they will put these values first and will align with the underlying class constructor. Liftable macros will need to construct apply parameters using the order of fields in the class. Helps with #3425.