### PR TITLE
Origin: extract input/dialect into separate class

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/Pos.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/Pos.scala
@@ -23,7 +23,9 @@ class IndexPos(index: => Int) extends Pos {
 
 class TreePos(tree: Tree) extends Pos {
   val (startTokenPos, endTokenPos) = tree.origin match {
-    case Origin.Parsed(_, _, pos) => (pos.start, pos.end - 1)
+    case x: Origin.Parsed =>
+      val pos = x.pos
+      (pos.start, pos.end - 1)
     case _ =>
       sys.error(s"internal error: unpositioned prototype ${tree.syntax}: ${tree.structure}")
   }

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -341,6 +341,8 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
     finally next()
   }
 
+  private val originSource = new Origin.ParsedSource(input)
+
   def atPosWithBody[T <: Tree](startPos: Int, body: T, endPos: Int): T = {
     @tailrec def getStart(pos: Int): Int =
       if (pos > endPos) startPos else if (tokens(pos).is[Trivia]) getStart(pos + 1) else pos
@@ -350,7 +352,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
     val end = if (endPos < startPos) startPos - 1 else getEnd(endPos)
     val endExcl = if (start == end && tokens(start).is[Trivia]) end else end + 1
     val pos = TokenStreamPosition(start, endExcl)
-    body.withOrigin(Origin.Parsed(input, dialect, pos))
+    body.withOrigin(Origin.Parsed(originSource, pos))
   }
 
   def atPosTry[T <: Tree](start: StartPos, end: EndPos)(body: => Try[T]): Try[T] = {

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -1136,7 +1136,7 @@ object TreeSyntax {
         // NOTE: Options don't really matter,
         // because if we've parsed a tree, it's not gonna contain lazy seqs anyway.
         // case Origin.Parsed(_, originalDialect, _) if dialect == originalDialect && options == Options.Eager =>
-        case o @ Origin.Parsed(_, `dialect`, _) => s(o.position.text)
+        case o: Origin.Parsed if o.dialect eq dialect => s(o.position.text)
         case _ => reprint(x)(dialect)
       }
     }

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/Origin.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/Origin.scala
@@ -6,8 +6,8 @@ import org.scalameta.adt
 import scala.meta.common._
 import scala.meta.inputs._
 import scala.meta.internal.tokens._
-import scala.meta.tokens._
 import scala.meta.tokenizers._
+import scala.meta.tokens._
 
 @adt.root
 trait Origin extends Optional
@@ -16,8 +16,8 @@ object Origin {
   object None extends Origin
 
   @adt.leaf
-  class Parsed(input: Input, dialect: Dialect, pos: TokenStreamPosition) extends Origin {
-    @inline private def tokenize() = dialect(input).tokenize.get
+  class Parsed(source: ParsedSource, pos: TokenStreamPosition) extends Origin {
+    @inline private def tokenize() = source.tokens
 
     def position: Position = {
       val tokens = tokenize()
@@ -29,6 +29,14 @@ object Origin {
     def tokens: Tokens = {
       tokenize().slice(pos.start, pos.end)
     }
+
+    @inline def input: Input = source.input
+    @inline def dialect: Dialect = source.dialect
+  }
+
+  class ParsedSource(val input: Input)(implicit val dialect: Dialect) {
+    lazy val tokenized = implicitly[Tokenize].apply(input, dialect)
+    @inline def tokens = tokenized.get
   }
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -1823,7 +1823,8 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     val syntax = "('\\n', '\\n')"
     val tree = super.term(expr)
     val charN = Lit.Char('\n')
-    val origin = Origin.Parsed(Input.String(exprU), implicitly[Dialect], TokenStreamPosition(1, 2))
+    val originSource = new Origin.ParsedSource(Input.String(exprU))
+    val origin = Origin.Parsed(originSource, TokenStreamPosition(1, 2))
     val charU = charN.withOrigin(origin)
     checkTree(tree, expr) {
       Term.Tuple(List(charN, charU))


### PR DESCRIPTION
When we implement lifting of origin in quasiquotes, it would make the resulting code more compact if the common part (input and dialect) are lifted only once, rather than for every subtree, thus leaving only the position field to change.

Helps with #3425.