### PR TITLE
adt.Liftables: include private fields if requested

### DIFF
--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/Liftables.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/Liftables.scala
@@ -3,6 +3,7 @@ package internal
 package trees
 
 import scala.language.experimental.macros
+import scala.language.implicitConversions
 import scala.reflect.macros.blackbox.Context
 import org.scalameta.adt.{LiftableMacros => AdtLiftableMacros}
 import scala.meta.internal.trees.{Reflection => AstReflection}
@@ -11,7 +12,8 @@ import scala.meta.internal.trees.Metadata.Ast
 // Implementation of the scala.reflect.api.Universe#Liftable interface for asts.
 trait Liftables {
   val u: scala.reflect.macros.Universe
-  implicit def materializeAst[T <: Ast]: u.Liftable[T] = macro LiftableMacros.impl[T]
+  implicit def materializeAst[T <: Ast](isPrivateOKExpr: Boolean): u.Liftable[T] =
+    macro LiftableMacros.impl[T]
 }
 
 class LiftableMacros(override val c: Context) extends AdtLiftableMacros(c) with AstReflection {

--- a/scalameta/quasiquotes/shared/src/main/scala/scala/meta/internal/quasiquotes/ReificationMacros.scala
+++ b/scalameta/quasiquotes/shared/src/main/scala/scala/meta/internal/quasiquotes/ReificationMacros.scala
@@ -379,8 +379,11 @@ class ReificationMacros(val c: Context) extends AstReflection with AdtLiftables 
     object Liftables {
       // NOTE: we could write just `implicitly[Liftable[MetaTree]].apply(meta)`
       // but that would bloat the code significantly with duplicated instances for denotations and sigmas
-      implicit def liftableSubTree[T <: MetaTree]: Liftable[T] =
-        Liftable((tree: T) => materializeAst[MetaTree].apply(tree))
+      implicit val liftableSubTree: Liftable[MetaTree] =
+        if (isTerm)
+          materializeAst[MetaTree](true)
+        else
+          materializeAst[MetaTree](false)
       implicit def liftableSubSeqTree[T <: MetaTree]: Liftable[Seq[T]] =
         Liftable((trees: Seq[T]) => Lifts.liftTrees(trees))
       implicit def liftableSubTrees[T <: MetaTree]: Liftable[List[T]] =


### PR DESCRIPTION
In ReificationMacros, request them for term quasiquotes only, so that possibly private state is saved by the compiler, but not for pattern.

This is one of key changes enabling storing of origin for quasiquotes. Helps with #3425.
