### PR TITLE
ast: save origin as a private field, add `apply()`

### DIFF
--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/NamerMacros.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/NamerMacros.scala
@@ -117,7 +117,7 @@ trait CommonNamerMacros extends MacroHelpers {
     """
   }
 
-  protected case class PrivateField(field: ValOrDefDef)
+  protected case class PrivateField(field: ValOrDefDef, persist: Boolean = false)
   protected case class PrivateFields(
       prototype: PrivateField,
       parent: PrivateField,
@@ -134,7 +134,8 @@ trait CommonNamerMacros extends MacroHelpers {
       q"private[meta] override val privateParent: $TreeClass = null"
     ),
     PrivateField(
-      q"private[meta] override val privateOrigin: $OriginClass = $OriginModule.None"
+      q"private[meta] override val privateOrigin: $OriginClass = $OriginModule.None",
+      true
     )
   )
 

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
@@ -41,6 +41,7 @@ class ReflectionSuite extends FunSuite {
     assertEquals(
       iff.allFields.map(_.toString),
       List(
+        "field Term.If.privateOrigin: scala.meta.trees.Origin",
         "field Term.If.cond: scala.meta.Term",
         "field Term.If.thenp: scala.meta.Term",
         "field Term.If.elsep: scala.meta.Term",
@@ -60,6 +61,7 @@ class ReflectionSuite extends FunSuite {
     assertEquals(
       iff.allFields.map(_.toString),
       List(
+        "field Term.Name.privateOrigin: scala.meta.trees.Origin",
         "field Term.Name.value: String @org.scalameta.invariants.nonEmpty"
       )
     )

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
@@ -44,7 +44,7 @@ class PublicSuite extends TreeSuiteBase {
 
   test("scala.meta.Tree.toString (quasiquotes)") {
     val tree = q"foo + bar // baz"
-    assertEquals(tree.toString, "foo + bar")
+    assertEquals(tree.toString, "foo + bar // baz")
   }
 
   test("scala.meta.Tree.structure (quasiquoted)") {
@@ -54,7 +54,7 @@ class PublicSuite extends TreeSuiteBase {
 
   test("scala.meta.Tree.syntax (quasiquoted)") {
     val tree = q"foo + bar // baz"
-    assertWithOriginalSyntax(tree, "foo + bar", "foo + bar")
+    assertWithOriginalSyntax(tree, "foo + bar // baz", "foo + bar")
   }
 
   test("scala.meta.classifiers.Classifiable.toString") {

--- a/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -649,7 +649,7 @@ class SuccessSuite extends TreeSuiteBase {
       q"foo match { case bar => baz; case _ => foo ; case q => w }"
     assertTree(expr)(Term.Name("foo"))
     assertWithOriginalSyntax(casez: _*)(
-      "case _ => foo"
+      "case _ => foo ;"
     )(
       "case _ => foo"
     )
@@ -667,7 +667,7 @@ class SuccessSuite extends TreeSuiteBase {
     val q"$expr match { ..case $casez }" = q"foo match { case bar => baz; case _ => foo }"
     assertTree(expr)(Term.Name("foo"))
     assertWithOriginalSyntax(casez: _*)(
-      "case bar => baz",
+      "case bar => baz;",
       "case _ => foo"
     )(
       "case bar => baz",
@@ -699,8 +699,8 @@ class SuccessSuite extends TreeSuiteBase {
       q"try foo catch { case a => b; case _ => bar; case 1 => 2; case q => w} finally baz"
     assertTree(expr)(Term.Name("foo"))
     assertWithOriginalSyntax(cases: _*)(
-      "case _ => bar",
-      "case 1 => 2"
+      "case _ => bar;",
+      "case 1 => 2;"
     )(
       "case _ => bar",
       "case 1 => 2"
@@ -2219,7 +2219,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertTrees(mods: _*)(Mod.Covariant())
     assertTree(tparamname)(Type.Name("Z"))
     assertWithOriginalSyntax(tparams)(
-      "[Q, W]"
+      "[Q,W]"
     )(
       "[Q, W]"
     )
@@ -2576,7 +2576,7 @@ class SuccessSuite extends TreeSuiteBase {
   test("1 source\"..stats\"") {
     val source"..$stats" = source"class A { val a = 'a'}"
     assertWithOriginalSyntax(stats: _*)(
-      "class A { val a = 'a' }"
+      "class A { val a = 'a'}"
     )(
       "class A { val a = 'a' }"
     )
@@ -2601,7 +2601,7 @@ class SuccessSuite extends TreeSuiteBase {
     val source"class B { val b = 'b'}; ..$stats" =
       source"class B { val b = 'b'}; class A { val a = 'a'}"
     assertWithOriginalSyntax(stats: _*)(
-      "class A { val a = 'a' }"
+      "class A { val a = 'a'}"
     )(
       "class A { val a = 'a' }"
     )
@@ -3047,7 +3047,11 @@ class SuccessSuite extends TreeSuiteBase {
   test("#3409") {
     val code: Tree = source"object Generated {}"
     code.privateOrigin match {
-      case Origin.None =>
+      case x: Origin.Parsed =>
+        x.input match {
+          case Input.String("object Generated {}") =>
+          case y => fail(s"origin input doesn't match: $y")
+        }
       case x => fail(s"origin doesn't match: $x")
     }
   }
@@ -3056,7 +3060,7 @@ class SuccessSuite extends TreeSuiteBase {
     val valX = q"x // X"
     val fOfX = q"func( $valX )"
 
-    assertWithOriginalSyntax(valX, "x", "x")
+    assertWithOriginalSyntax(valX, "x // X", "x")
     assertWithOriginalSyntax(fOfX, "func(x)", "func(x)")
 
     def assertOriginType(obtained: Tree, expected: Class[_ <: Origin]): Unit =
@@ -3065,7 +3069,7 @@ class SuccessSuite extends TreeSuiteBase {
         expected.asInstanceOf[Class[Origin]]
       )
 
-    assertOriginType(valX, Origin.None.getClass)
+    assertOriginType(valX, classOf[Origin.Parsed])
     assertOriginType(fOfX, Origin.None.getClass)
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/transversers/SimpleTraverserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/transversers/SimpleTraverserSuite.scala
@@ -25,7 +25,7 @@ class SimpleTraverserSuite extends FunSuite {
     assertEquals(
       log.mkString("\n").replace("\r", ""),
       """
-      |{   def foo(x: x)(x: Int) = x + x   class C(x: x) { def bar(x: x) = ??? } }
+      |def foo(x: x)(x: Int) = x + x       class C(x: x) {         def bar(x: x) = ???       }
       |def foo(x: x)(x: Int) = x + x
       |foo
       |(x: x)(x: Int)
@@ -42,9 +42,9 @@ class SimpleTraverserSuite extends FunSuite {
       |x
       |+
       |
-      |(x)
       |x
-      |class C(x: x) { def bar(x: x) = ??? }
+      |x
+      |class C(x: x) {         def bar(x: x) = ???       }
       |C
       |
       |def this(x: x)
@@ -53,7 +53,7 @@ class SimpleTraverserSuite extends FunSuite {
       |x: x
       |x
       |x
-      |{ def bar(x: x) = ??? }
+      |{         def bar(x: x) = ???       }
       |
       |
       |def bar(x: x) = ???

--- a/tests/shared/src/test/scala/scala/meta/tests/transversers/TraverserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/transversers/TraverserSuite.scala
@@ -24,7 +24,7 @@ class TraverserSuite extends FunSuite {
     assertEquals(
       log.mkString("\n").replace("\r", ""),
       """
-      |{   def foo(x: x)(x: Int) = x + x   class C(x: x) { def bar(x: x) = ??? } }
+      |def foo(x: x)(x: Int) = x + x       class C(x: x) {         def bar(x: x) = ???       }
       |def foo(x: x)(x: Int) = x + x
       |foo
       |(x: x)(x: Int)
@@ -41,9 +41,9 @@ class TraverserSuite extends FunSuite {
       |x
       |+
       |
-      |(x)
       |x
-      |class C(x: x) { def bar(x: x) = ??? }
+      |x
+      |class C(x: x) {         def bar(x: x) = ???       }
       |C
       |
       |def this(x: x)
@@ -52,7 +52,7 @@ class TraverserSuite extends FunSuite {
       |x: x
       |x
       |x
-      |{ def bar(x: x) = ??? }
+      |{         def bar(x: x) = ???       }
       |
       |
       |def bar(x: x) = ???


### PR DESCRIPTION
This is one of key changes enabling storing of origin for quasiquotes. Helps with #3425.