### PR TITLE
Revert "Origin: add flag enabling unquotes to ParsedSource"

### DIFF
--- a/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
@@ -757,13 +757,6 @@ final class Dialect private[meta] (
     allowMultilinePrograms = true
   )
 
-  private[meta] def unquotesEnabled: Dialect =
-    privateCopy(
-      allowTermUnquotes = true,
-      allowMultilinePrograms = true,
-      allowTypeLambdas = true
-    )
-
   private[meta] def unquoteTerm(multiline: Boolean): Dialect = {
     require(!allowUnquotes)
     privateCopy(

--- a/scalameta/quasiquotes/shared/src/main/scala/scala/meta/internal/quasiquotes/ReificationMacros.scala
+++ b/scalameta/quasiquotes/shared/src/main/scala/scala/meta/internal/quasiquotes/ReificationMacros.scala
@@ -61,8 +61,7 @@ class ReificationMacros(val c: Context) extends AstReflection with AdtLiftables 
     val skeleton = parseSkeleton(parser, input, dialect)
     val sourceTree = q"""
       new _root_.scala.meta.internal.trees.Origin.ParsedSource(
-        _root_.scala.meta.inputs.Input.String(${input.text}),
-        unquote = true
+        _root_.scala.meta.inputs.Input.String(${input.text})
       )($dialectTree)
     """
     reifySkeleton(skeleton, mode, sourceTree)

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/Origin.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/Origin.scala
@@ -40,9 +40,8 @@ object Origin {
     @inline def dialect: Dialect = source.dialect
   }
 
-  class ParsedSource(val input: Input, unquote: Boolean = false)(implicit val dialect: Dialect) {
-    lazy val tokenized =
-      implicitly[Tokenize].apply(input, if (unquote) dialect.unquotesEnabled else dialect)
+  class ParsedSource(val input: Input)(implicit val dialect: Dialect) {
+    lazy val tokenized = implicitly[Tokenize].apply(input, dialect)
     @inline def tokens = tokenized.get
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -1083,10 +1083,6 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     val source2 = new Origin.ParsedSource(input)
     val tree2 = tree1.withOrigin(new Origin.Parsed(source2, 0, numTokens))
     assertNotEquals(tree2.tokens.length, numTokens)
-
-    val source3 = new Origin.ParsedSource(input, unquote = true)
-    val tree3 = tree1.withOrigin(new Origin.Parsed(source3, 0, numTokens))
-    assertEquals(tree3.tokens.length, numTokens)
   }
 
   test("interpolator braces for plain identifiers") {


### PR DESCRIPTION
Perhaps this solution was rather masking the problem with TreeSyntax.
Reverts scalameta/scalameta#3460