### PR TITLE
Tokens: use Token.text, not .toString

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2445,7 +2445,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
         case t @ Ellipsis(2) =>
           (ellipsis[Term](t) :: Nil).reduceWith(Term.ArgClause(_))
         case x =>
-          val using = x.toString == soft.KwUsing.name && !CantStartStat(peekToken)
+          val using = x.text == soft.KwUsing.name && !CantStartStat(peekToken)
           val mod = if (using) Some(atCurPosNext(Mod.Using())) else None
           argumentExprsInParens(location).reduceWith(Term.ArgClause(_, mod))
       })(Term.ArgClause(Nil))

--- a/scalameta/tokens/shared/src/main/scala/scala/meta/internal/prettyprinters/TokensToString.scala
+++ b/scalameta/tokens/shared/src/main/scala/scala/meta/internal/prettyprinters/TokensToString.scala
@@ -6,6 +6,8 @@ import scala.meta.tokens._
 
 object TokensToString {
   def apply(tokens: Tokens) = {
-    tokens.mkString("")
+    val sb = new StringBuilder
+    tokens.foreach(t => sb.append(t.text))
+    sb.result()
   }
 }

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeStructure.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeStructure.scala
@@ -46,9 +46,9 @@ object TreeStructure {
               case _: Lit.Unit | _: Lit.Null =>
                 s()
               case x: Lit.Double =>
-                s(x.tokens.mkString)
+                s(x.tokens.toString)
               case x: Lit.Float =>
-                s(x.tokens.mkString)
+                s(x.tokens.toString)
               case x: Lit =>
                 s(x.tokens.filter(isRelevantToken).map(showToken).mkString)
               case _ =>

--- a/tests/jvm/src/test/scala/scala/meta/tests/tokenizers/UnicodeEscapeSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/tokenizers/UnicodeEscapeSuite.scala
@@ -19,7 +19,7 @@ class UnicodeEscapeSuite extends BaseTokenizerSuite {
   def checkRoundtrip(original: String): Unit = {
     test(logger.revealWhitespace(original)) {
       val tokens = tokenize(original)
-      val obtained = tokens.mkString
+      val obtained = tokens.toString
       assertNoDiff(obtained, original)
     }
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/tokens/TokensSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokens/TokensSuite.scala
@@ -152,8 +152,8 @@ class TokensApiSuite extends FunSuite {
     val (beforeL, afterL) = tokens.span(_.name != "identifier")
     val (beforeR, afterR) = tokens.spanRight(_.name != "identifier")
 
-    assertEquals(afterL.head.toString, "foo")
-    assertEquals(beforeR.last.toString, "foo")
+    assertEquals(afterL.head.text, "foo")
+    assertEquals(beforeR.last.text, "foo")
 
     assertEquals(afterL.tail, afterR)
     assertEquals(beforeL, beforeR.dropRight(1))


### PR DESCRIPTION
`.toString` ultimately calls `.text` but first checks whether the token is consistent with its dialect.