### PR TITLE
Origin: add a DialectOnly version

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -330,8 +330,10 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
     atPosWithBody(start, body, end.endTokenPos)
   }
   def atPosOpt[T <: Tree](start: Int, end: EndPos)(body: T): T = {
-    if (body.origin ne Origin.None) body
-    else atPos(start, end)(body)
+    body.origin match {
+      case o: Origin.Parsed if o.source eq originSource => body
+      case _ => atPos(start, end)(body)
+    }
   }
   def atPos[T <: Tree](pos: Int)(body: => T): T = {
     atPosWithBody(pos, body, pos)

--- a/scalameta/trees/shared/src/main/scala/scala/meta/trees/Origin.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/trees/Origin.scala
@@ -48,4 +48,10 @@ object Origin {
     @inline def tokens = tokenized.get
   }
 
+  @adt.leaf
+  class DialectOnly(dialect: Dialect) extends Origin {
+    val position: Position = Position.None
+    def dialectOpt: Option[Dialect] = Some(dialect)
+  }
+
 }

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -173,6 +173,7 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.transversers.Traverser
       |scala.meta.trees
       |scala.meta.trees.Origin *
+      |scala.meta.trees.Origin.DialectOnly *
       |scala.meta.trees.Origin.None *
       |scala.meta.trees.Origin.Parsed *
       |scala.meta.trees.Origin.ParsedSource *

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
@@ -445,6 +445,7 @@ class PublicSuite extends TreeSuiteBase {
   test("scala.meta.XtensionDialectTokensSyntax") {}
 
   test("scala.meta.trees.Origin") {}
+  test("scala.meta.trees.Origin.DialectOnly") {}
   test("scala.meta.trees.Origin.None") {}
   test("scala.meta.trees.Origin.Parsed") {}
   test("scala.meta.trees.Origin.ParsedSource") {}

--- a/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -3070,7 +3070,7 @@ class SuccessSuite extends TreeSuiteBase {
       )
 
     assertOriginType(valX, classOf[Origin.Parsed])
-    assertOriginType(fOfX, Origin.None.getClass)
+    assertOriginType(fOfX, classOf[Origin.DialectOnly])
   }
 
 }


### PR DESCRIPTION
This way, we won't get tokens and positions but `toString` will work.

We can use this origin for quasiquotes which have interpolated values (that we couldn't meaningfully use with Origin.Parsed as its Input would contain interpolation references rather than the values that these references would expand to).

Helps with #3425.