### PR TITLE
Tree: remove privateOrigin, ensure origin is valid

### DIFF
--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/NamerMacros.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/NamerMacros.scala
@@ -134,7 +134,7 @@ trait CommonNamerMacros extends MacroHelpers {
       q"private[meta] override val privateParent: $TreeClass = null"
     ),
     PrivateField(
-      q"private[meta] override val privateOrigin: $OriginClass = $OriginModule.None",
+      q"override val origin: $OriginClass = $OriginModule.None",
       true
     )
   )

--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/ast.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/ast.scala
@@ -179,6 +179,7 @@ class AstNamerMacros(val c: Context) extends Reflection with CommonNamerMacros {
             destination: $StringClass = null,
             origin: $OriginClass = ${privateFields.origin.field.name}): Tree = {
           $privateCopyParentChecks
+          $DataTyperMacrosModule.nullCheck(origin)
           new $name(prototype.asInstanceOf[$iname], parent, origin)(..$privateCopyArgs)
         }
       """
@@ -332,7 +333,10 @@ class AstNamerMacros(val c: Context) extends Reflection with CommonNamerMacros {
           q"$CommonTyperMacrosModule.initParam(${p.name})"
         }
         privateParams.foreach { p =>
-          if (!p.persist) internalBody += asValDefn(p.field)
+          if (p.persist)
+            internalBody += q"$DataTyperMacrosModule.nullCheck(${p.field.name})"
+          else
+            internalBody += asValDefn(p.field)
         }
         internalBody += q"""
           val node = new $name(

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/InternalTrees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/InternalTrees.scala
@@ -24,12 +24,11 @@ trait InternalTree extends Product {
 
   private[meta] def privatePrototype: Tree
   private[meta] def privateParent: Tree
-  private[meta] def privateOrigin: Origin
   private[meta] def privateCopy(
       prototype: Tree = this,
       parent: Tree = privateParent,
       destination: String = null,
-      origin: Origin = privateOrigin
+      origin: Origin = origin
   ): Tree
 
   // ==============================================================
@@ -46,10 +45,7 @@ trait InternalTree extends Product {
   // def productIterator: Iterator[Any]
   def productFields: List[String]
 
-  def origin: Origin = {
-    val nullableOrigin = privateOrigin
-    if (nullableOrigin != null) nullableOrigin else Origin.None
-  }
+  def origin: Origin
 
   def pos: Position = origin.position
 
@@ -68,16 +64,6 @@ trait InternalTree extends Product {
   }
 
   // ==============================================================
-  // Setters for pieces of internal state defined above.
-  // Everyone except for scala.meta's core should be using "private"-less versions of these methods,
-  // because those are only available on appropriate trees.
-  // ==============================================================
-
-  private[meta] def privateWithOrigin(origin: Origin): Tree = {
-    this.privateCopy(origin = origin)
-  }
-
-  // ==============================================================
   // Intellij-friendly stubs.
   // See https://github.com/scalameta/scalameta/pull/907#discussion_r120090447.
   // ==============================================================
@@ -88,6 +74,6 @@ trait InternalTree extends Product {
 
 trait InternalTreeXtensions {
   private[meta] implicit class XtensionOriginTree[T <: Tree](tree: T) {
-    def withOrigin(origin: Origin): T = tree.privateWithOrigin(origin).asInstanceOf[T]
+    def withOrigin(origin: Origin): T = tree.privateCopy(origin = origin).asInstanceOf[T]
   }
 }

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
@@ -41,7 +41,7 @@ class ReflectionSuite extends FunSuite {
     assertEquals(
       iff.allFields.map(_.toString),
       List(
-        "field Term.If.privateOrigin: scala.meta.trees.Origin",
+        "field Term.If.origin: scala.meta.trees.Origin",
         "field Term.If.cond: scala.meta.Term",
         "field Term.If.thenp: scala.meta.Term",
         "field Term.If.elsep: scala.meta.Term",
@@ -61,7 +61,7 @@ class ReflectionSuite extends FunSuite {
     assertEquals(
       iff.allFields.map(_.toString),
       List(
-        "field Term.Name.privateOrigin: scala.meta.trees.Origin",
+        "field Term.Name.origin: scala.meta.trees.Origin",
         "field Term.Name.value: String @org.scalameta.invariants.nonEmpty"
       )
     )

--- a/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -3046,7 +3046,7 @@ class SuccessSuite extends TreeSuiteBase {
 
   test("#3409") {
     val code: Tree = source"object Generated {}"
-    code.privateOrigin match {
+    code.origin match {
       case x: Origin.Parsed =>
         x.input match {
           case Input.String("object Generated {}") =>


### PR DESCRIPTION
We could do this now as origin is now a persisted field and could be declared public.