### PR TITLE
SBT: add shading to the common package

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -173,6 +173,7 @@ lazy val common = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     protobufSettings
   )
   .configureCross(crossPlatformPublishSettings)
+  .configureCross(crossPlatformShading)
   .jsSettings(
     commonJsSettings
   )
@@ -882,7 +883,8 @@ lazy val shadingSettings = Def.settings(
         ShadingRule.moveUnder(x.namespace, "scala.meta.shaded.internal")
       }
   },
-  validNamespaces ++= Set("scala.meta", "org.scalameta", "scala", "java")
+  validEntries ++= Set("semanticdb.proto", "semanticidx.proto"),
+  validNamespaces ++= Set("org", "scala", "java")
 )
 
 def platformPublishSettings(platform: sbtcrossproject.Platform) =

--- a/project/ShadedDependency.scala
+++ b/project/ShadedDependency.scala
@@ -7,6 +7,9 @@ case class ShadedDependency(
 
 object ShadedDependency {
 
+  /* make sure that `.configureCross(crossPlatformShading)`
+   * is added to the respective project in build.sbt */
+
   val all = Seq(
     ShadedDependency("com.lihaoyi", "geny", "geny", true),
     ShadedDependency("com.lihaoyi", "fastparse", "fastparse", true),


### PR DESCRIPTION
It was earlier set up to rename symbols from the sourcecode library but not included in the jar. Let's fix it. Follow-on to #3468.