### PR TITLE
SBT: undo shading of the `sourcecode` dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -173,7 +173,6 @@ lazy val common = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     protobufSettings
   )
   .configureCross(crossPlatformPublishSettings)
-  .configureCross(crossPlatformShading)
   .jsSettings(
     commonJsSettings
   )
@@ -883,7 +882,6 @@ lazy val shadingSettings = Def.settings(
         ShadingRule.moveUnder(x.namespace, "scala.meta.shaded.internal")
       }
   },
-  validEntries ++= Set("semanticdb.proto", "semanticidx.proto"),
   validNamespaces ++= Set("org", "scala", "java")
 )
 

--- a/project/ShadedDependency.scala
+++ b/project/ShadedDependency.scala
@@ -12,8 +12,7 @@ object ShadedDependency {
 
   val all = Seq(
     ShadedDependency("com.lihaoyi", "geny", "geny", true),
-    ShadedDependency("com.lihaoyi", "fastparse", "fastparse", true),
-    ShadedDependency("com.lihaoyi", "sourcecode", "sourcecode", true)
+    ShadedDependency("com.lihaoyi", "fastparse", "fastparse", true)
   )
 
 }


### PR DESCRIPTION
Reverts #3482 and #3468.