### PR TITLE
Trees: save tokens and positions as lazy

### DIFF
--- a/scalameta/inputs/shared/src/main/scala/scala/meta/inputs/Position.scala
+++ b/scalameta/inputs/shared/src/main/scala/scala/meta/inputs/Position.scala
@@ -36,11 +36,11 @@ object Position {
   }
 
   final case class Range(input: Input, start: Int, end: Int) extends Position {
-    def startLine: Int = input.offsetToLine(start)
+    lazy val startLine: Int = input.offsetToLine(start)
     def startColumn: Int = start - input.lineToOffset(startLine)
-    def endLine: Int = input.offsetToLine(end)
+    lazy val endLine: Int = input.offsetToLine(end)
     def endColumn: Int = end - input.lineToOffset(endLine)
-    override def text = new String(input.chars, start, end - start)
+    lazy val text = new String(input.chars, start, end - start)
     override def toString = s"[$start..$end) in $input"
   }
 

--- a/scalameta/trees/shared/src/main/scala/scala/meta/trees/Origin.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/trees/Origin.scala
@@ -24,10 +24,10 @@ object Origin {
   // `begTokenIdx` and `endTokenIdx` are half-open interval of index range
   @adt.leaf
   class Parsed(source: ParsedSource, begTokenIdx: Int, endTokenIdx: Int) extends Origin {
-    @inline private def tokenize() = source.tokens
+    @inline def allInputTokens() = source.tokens
 
-    def position: Position = {
-      val tokens = tokenize()
+    lazy val position: Position = {
+      val tokens = allInputTokens()
       val start = tokens(begTokenIdx).start
       val end = tokens(endTokenIdx - 1).end
       Position.Range(input, start, end)
@@ -36,7 +36,7 @@ object Origin {
     def dialectOpt: Option[Dialect] = Some(dialect)
 
     def tokens: Tokens = {
-      tokenize().slice(begTokenIdx, endTokenIdx)
+      allInputTokens().slice(begTokenIdx, endTokenIdx)
     }
 
     @inline def input: Input = source.input


### PR DESCRIPTION
Need to make Parsed.position lazy as well, otherwise its own lazy vals would not persist.