### PR TITLE
Transverser: set dialect recursively on root tree

### DIFF
--- a/scalameta/transversers/shared/src/main/scala/scala/meta/transversers/Api.scala
+++ b/scalameta/transversers/shared/src/main/scala/scala/meta/transversers/Api.scala
@@ -40,7 +40,12 @@ private[meta] trait Api {
 
   implicit class XtensionTreeLike[T <: Tree](tree: T) {
     private[meta] def withOriginRecursive(origin: trees.Origin): T =
-      tree.transform { case t: Tree => t.withOrigin(origin) }.asInstanceOf[T]
+      tree.transform { case t: Tree => t.withOrigin(origin) }.withOrigin(origin).asInstanceOf[T]
+
+    def withDialectIfRootAndNotSet(implicit dialect: Dialect): T =
+      if (tree.privateParent ne null) tree // must set on root
+      else if (tree.origin ne trees.Origin.None) tree // only if not set
+      else withOriginRecursive(trees.Origin.DialectOnly(dialect))
   }
 }
 

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -232,6 +232,7 @@ class SurfaceSuite extends FunSuite {
       |* T.parse(implicit scala.meta.common.Convert[T,scala.meta.inputs.Input], scala.meta.parsers.Parse[U], scala.meta.Dialect): scala.meta.parsers.Parsed[U]
       |* T.show(implicit Style[T]): String
       |* T.tokenize(implicit scala.meta.common.Convert[T,scala.meta.inputs.Input], scala.meta.tokenizers.Tokenize, scala.meta.Dialect): scala.meta.tokenizers.Tokenized
+      |* T.withDialectIfRootAndNotSet(implicit scala.meta.Dialect): T
       |* scala.meta.Dialect.apply(T)(implicit scala.meta.common.Convert[T,scala.meta.inputs.Input]): (scala.meta.Dialect, scala.meta.inputs.Input)
       |* scala.meta.Dialect.apply(scala.meta.Tree): (scala.meta.Dialect, scala.meta.Tree)
       |* scala.meta.Dialect.apply(scala.meta.tokens.Token): (scala.meta.Dialect, scala.meta.tokens.Token)

--- a/tests/shared/src/test/scala/scala/meta/tests/trees/TokensSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/trees/TokensSuite.scala
@@ -19,10 +19,18 @@ class TokensSuite extends TreeSuiteBase {
   }
 
   test("Tree.tokens: manual") {
-    val tree = Term.ApplyInfix(Term.Name("foo"), Term.Name("+"), Nil, List(Term.Name("bar")))
-    assert(tree.syntax == "foo + bar")
-    assert(tree.tokens.syntax == "foo + bar")
-    assert(tree.tokens.forall(_.input.isInstanceOf[Input.VirtualFile]))
+    val tree: Term = Term.ApplyInfix(Term.Name("foo"), Term.Name("+"), Nil, List(Term.Name("bar")))
+    assertEquals(tree.syntax, "foo + bar")
+    assert(tree.origin eq trees.Origin.None)
+    val tokens = tree.tokens
+    assertEquals(tokens.syntax, "foo + bar")
+    assert(tokens.forall(_.input.isInstanceOf[Input.VirtualFile]))
+    val dialectTree = tree.withDialectIfRootAndNotSet
+    assertNotEquals(dialectTree, tree)
+    assert(dialectTree.origin ne trees.Origin.None)
+    val dialectTokens = dialectTree.tokens
+    assertEquals(dialectTokens.syntax, "foo + bar")
+    assert(dialectTokens.forall(_.input.isInstanceOf[Input.VirtualFile]))
   }
 
   test("Tree.tokens: empty") {


### PR DESCRIPTION
Also, fix minor bug in `.withOriginRecursive` as `.transform` apparently doesn't apply to the original argument.