### PR TITLE
Tree: add `maybeParse` extension, for a parsed tree

### DIFF
--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -78,6 +78,8 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.XtensionDialectTokenSyntax
       |scala.meta.XtensionDialectTokensSyntax
       |scala.meta.XtensionDialectTreeSyntax
+      |scala.meta.XtensionTree
+      |scala.meta.XtensionTreeT
       |scala.meta.classifiers
       |scala.meta.classifiers.Classifiable *
       |scala.meta.classifiers.Classifier
@@ -224,6 +226,9 @@ class SurfaceSuite extends FunSuite {
       |* (scala.meta.Dialect, scala.meta.tokens.Tokens).tokenize(implicit scala.meta.tokenizers.Tokenize): scala.meta.tokenizers.Tokenized
       |* (scala.meta.inputs.Input, scala.meta.Dialect).parse(implicit scala.meta.parsers.Parse[U]): scala.meta.parsers.Parsed[U]
       |* (scala.meta.inputs.Input, scala.meta.Dialect).tokenize(implicit scala.meta.tokenizers.Tokenize): scala.meta.tokenizers.Tokenized
+      |* A.equals(Any): Boolean
+      |* A.hashCode(): Int
+      |* A.maybeParse(implicit scala.meta.Dialect, scala.meta.parsers.Parse[A]): scala.meta.package.Parsed[A]
       |* T(implicit scala.meta.classifiers.Classifiable[T]).is(implicit XtensionClassifiable.this.C[U]): Boolean
       |* T(implicit scala.meta.classifiers.Classifiable[T]).isAny(implicit XtensionClassifiable.this.C[U1], XtensionClassifiable.this.C[U2]): Boolean
       |* T(implicit scala.meta.classifiers.Classifiable[T]).isAny(implicit XtensionClassifiable.this.C[U1], XtensionClassifiable.this.C[U2], XtensionClassifiable.this.C[U3]): Boolean
@@ -242,6 +247,10 @@ class SurfaceSuite extends FunSuite {
       |* scala.meta.Dialect.equals(Any): Boolean
       |* scala.meta.Dialect.hashCode(): Int
       |* scala.meta.Tree.collect(PartialFunction[scala.meta.Tree,T]): List[T]
+      |* scala.meta.Tree.equals(Any): Boolean
+      |* scala.meta.Tree.hashCode(): Int
+      |* scala.meta.Tree.maybeParseAs(implicit scala.meta.Dialect, scala.meta.parsers.Parse[A]): scala.meta.package.Parsed[A]
+      |* scala.meta.Tree.reparseAs(implicit scala.meta.Dialect, scala.meta.parsers.Parse[A]): scala.meta.package.Parsed[A]
       |* scala.meta.Tree.transform(PartialFunction[scala.meta.Tree,scala.meta.Tree]): scala.meta.Tree
       |* scala.meta.Tree.traverse(PartialFunction[scala.meta.Tree,Unit]): Unit
     """.trim.stripMargin.split('\n').mkString(EOL)

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
@@ -443,6 +443,8 @@ class PublicSuite extends TreeSuiteBase {
   test("scala.meta.XtensionDialectApply") {}
   test("scala.meta.XtensionDialectTreeSyntax") {}
   test("scala.meta.XtensionDialectTokensSyntax") {}
+  test("scala.meta.XtensionTree") {}
+  test("scala.meta.XtensionTreeT") {}
 
   test("scala.meta.trees.Origin") {}
   test("scala.meta.trees.Origin.DialectOnly") {}

--- a/tests/shared/src/test/scala/scala/meta/tests/trees/TokensSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/trees/TokensSuite.scala
@@ -19,7 +19,7 @@ class TokensSuite extends TreeSuiteBase {
   }
 
   test("Tree.tokens: manual") {
-    val tree: Term = Term.ApplyInfix(Term.Name("foo"), Term.Name("+"), Nil, List(Term.Name("bar")))
+    val tree = Term.ApplyInfix(Term.Name("foo"), Term.Name("+"), Nil, List(Term.Name("bar")))
     interceptMessage[trees.Error.MissingDialectException](
       "Tree missing a dialect; update root tree `.withDialectIfRootAndNotSet` first, or call `.dialectText`."
     )(tree.text)
@@ -38,6 +38,15 @@ class TokensSuite extends TreeSuiteBase {
     val dialectTokens = dialectTree.tokens
     assertEquals(dialectTokens.syntax, "foo + bar")
     assert(dialectTokens.forall(_.input.isInstanceOf[Input.VirtualFile]))
+
+    val parsedTree = tree.maybeParseAs[Stat].get
+    assert(parsedTree eq parsedTree.maybeParse.get)
+    assertEquals(parsedTree.printSyntaxFor(implicitly[Dialect]), "foo + bar")
+    assertEquals(parsedTree.syntax, "foo + bar")
+    assert(parsedTree.origin.isInstanceOf[trees.Origin.Parsed])
+    val parsedTokens = parsedTree.tokens
+    assertEquals(parsedTokens.syntax, "foo + bar")
+    assert(parsedTokens.forall(_.input.isInstanceOf[Input.VirtualFile]))
   }
 
   test("Tree.tokens: empty") {


### PR DESCRIPTION
If we convert a tree to a parsed tree, the latter will contain proper origin, with input, and will not require regenerating tokens, syntax etc. on every access.