### PR TITLE
InternalTrees: rename dialectText, add tokenizeFor

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
@@ -954,8 +954,11 @@ class TokenizerSuite extends BaseTokenizerSuite {
   test("synthetic trees don't have BOF/EOF in their tokens") {
     val tree = Term.ApplyInfix(Term.Name("foo"), Term.Name("+"), Nil, List(Term.Name("bar")))
     assert(tree.pos == Position.None)
-    assert(
-      tree.tokens.structure == "Tokens(BOF [0..0), foo [0..3),   [3..4), + [4..5),   [5..6), bar [6..9), EOF [9..9))"
+    val tokens = tree.tokenizeFor(implicitly[Dialect])
+    assertEquals(tree.tokens, tokens)
+    assertEquals(
+      tokens.structure,
+      "Tokens(BOF [0..0), foo [0..3),   [3..4), + [4..5),   [5..6), bar [6..9), EOF [9..9))"
     )
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/trees/InfrastructureSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/trees/InfrastructureSuite.scala
@@ -38,6 +38,6 @@ class InfrastructureSuite extends TreeSuiteBase {
     val x1 = "foo".parse[Term].get.asInstanceOf[Term.Name]
     val x2 = x1.copy()
     assert(x1.tokens.nonEmpty == true)
-    assert(x2.tokens.nonEmpty == true)
+    assertEquals(x2.tokenizeFor(implicitly[Dialect]).nonEmpty, true)
   }
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/trees/TokensSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/trees/TokensSuite.scala
@@ -23,16 +23,17 @@ class TokensSuite extends TreeSuiteBase {
     interceptMessage[trees.Error.MissingDialectException](
       "Tree missing a dialect; update root tree `.withDialectIfRootAndNotSet` first, or call `.dialectText`."
     )(tree.text)
-    assertEquals(tree.dialectText, "foo + bar")
+    assertEquals(tree.printSyntaxFor(implicitly[Dialect]), "foo + bar")
     assertEquals(tree.syntax, "foo + bar")
     assert(tree.origin eq trees.Origin.None)
-    val tokens = tree.tokens
+    val tokens = tree.tokenizeFor(implicitly[Dialect])
+    assertEquals(tree.tokens, tokens)
     assertEquals(tokens.syntax, "foo + bar")
     assert(tokens.forall(_.input.isInstanceOf[Input.VirtualFile]))
     val dialectTree = tree.withDialectIfRootAndNotSet
     assertNotEquals(dialectTree, tree)
     assertEquals(dialectTree.text, "foo + bar")
-    assertEquals(dialectTree.dialectText, "foo + bar")
+    assertEquals(dialectTree.printSyntaxFor(implicitly[Dialect]), "foo + bar")
     assert(dialectTree.origin ne trees.Origin.None)
     val dialectTokens = dialectTree.tokens
     assertEquals(dialectTokens.syntax, "foo + bar")


### PR DESCRIPTION
Make both methods take explicit dialect parameter, and make their names reflect that they are doing non-trivial work potentially.