### PR TITLE
InternalTrees: require origin dialect in `tokens`

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/InternalTrees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/InternalTrees.scala
@@ -57,8 +57,10 @@ trait InternalTree extends Product {
   // Tokens
   // ==============================================================
 
-  def tokens(implicit dialect: Dialect): Tokens = {
-    tokensOpt.getOrElse(lookupOrTokenizeFor(dialect))
+  def tokens(implicit dialect: Dialect): Tokens = tokensOpt.getOrElse {
+    throw new Error.MissingDialectException(
+      "Tree missing a dialect; update root tree `.withDialectIfRootAndNotSet` first, or call `.tokenizeFor`."
+    )
   }
 
   def tokenizeFor(dialect: Dialect): Tokens =

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
@@ -955,7 +955,9 @@ class TokenizerSuite extends BaseTokenizerSuite {
     val tree = Term.ApplyInfix(Term.Name("foo"), Term.Name("+"), Nil, List(Term.Name("bar")))
     assert(tree.pos == Position.None)
     val tokens = tree.tokenizeFor(implicitly[Dialect])
-    assertEquals(tree.tokens, tokens)
+    interceptMessage[trees.Error.MissingDialectException](
+      "Tree missing a dialect; update root tree `.withDialectIfRootAndNotSet` first, or call `.tokenizeFor`."
+    )(tree.tokens)
     assertEquals(
       tokens.structure,
       "Tokens(BOF [0..0), foo [0..3),   [3..4), + [4..5),   [5..6), bar [6..9), EOF [9..9))"

--- a/tests/shared/src/test/scala/scala/meta/tests/trees/TokensSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/trees/TokensSuite.scala
@@ -27,7 +27,9 @@ class TokensSuite extends TreeSuiteBase {
     assertEquals(tree.syntax, "foo + bar")
     assert(tree.origin eq trees.Origin.None)
     val tokens = tree.tokenizeFor(implicitly[Dialect])
-    assertEquals(tree.tokens, tokens)
+    interceptMessage[trees.Error.MissingDialectException](
+      "Tree missing a dialect; update root tree `.withDialectIfRootAndNotSet` first, or call `.tokenizeFor`."
+    )(tree.tokens)
     assertEquals(tokens.syntax, "foo + bar")
     assert(tokens.forall(_.input.isInstanceOf[Input.VirtualFile]))
     val dialectTree = tree.withDialectIfRootAndNotSet


### PR DESCRIPTION
That way, we will not incur hidden syntax-generation and tokenization costs implicitly; for that, we have the `tokenizeFor` method.
