### PR TITLE
SBT: remove circular dependency with mdoc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -843,7 +843,6 @@ def macroDependencies(hardcore: Boolean) = libraryDependencies ++= {
 
 lazy val docs = project
   .in(file("scalameta-docs"))
-  .dependsOn(scalameta.jvm)
   .settings(
     sharedSettings,
     crossScalaVersions := List(LatestScala213),


### PR DESCRIPTION
mdoc currently depends on scalameta and is used here to build scalameta docs. Let's rely on that version of the library which is used by mdoc, rather than trying to substitute the current one (which might not work with mdoc anymore, if binary compat is broken).