### PR TITLE
InternalTrees: add tokens overload without dialect

### DIFF
--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -46,6 +46,8 @@ object Mima {
     ProblemFilters.exclude[A]("scala.meta." + metaType)
 
   val apiCompatibilityExceptions: Seq[ProblemFilter] = Seq(
+    // Tree
+    exclude[ReversedMissingMethodProblem]("Tree.tokens"), // new version has it, old doesn't; ok?
     // testkit
     exclude[IncompatibleResultTypeProblem]("testkit.Corpus.files"),
     exclude[IncompatibleResultTypeProblem]("testkit.FileOps.listFiles"),

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/InternalTrees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/InternalTrees.scala
@@ -57,7 +57,10 @@ trait InternalTree extends Product {
   // Tokens
   // ==============================================================
 
-  def tokens(implicit dialect: Dialect): Tokens = tokensOpt.getOrElse {
+  @deprecated("dialect is ignored, use parameterless `tokens` method", "4.9.0")
+  final def tokens(dialect: Dialect): Tokens = tokens
+
+  def tokens: Tokens = tokensOpt.getOrElse {
     throw new Error.MissingDialectException(
       "Tree missing a dialect; update root tree `.withDialectIfRootAndNotSet` first, or call `.tokenizeFor`."
     )


### PR DESCRIPTION
Deprecate the older method, with the dialect parameter.