### PR TITLE
ast: implicit dialect in apply(), store in origin

### DIFF
--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/NamerMacros.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/NamerMacros.scala
@@ -26,6 +26,7 @@ trait CommonNamerMacros extends MacroHelpers {
   lazy val PointModule = q"_root_.scala.meta.inputs.Point"
   lazy val OriginClass = tq"_root_.scala.meta.trees.Origin"
   lazy val OriginModule = q"_root_.scala.meta.trees.Origin"
+  lazy val DialectClass = tq"_root_.scala.meta.Dialect"
 
   def mkClassifier(name: TypeName): List[Tree] = {
     val q"..$classifierBoilerplate" = q"""

--- a/scalameta/quasiquotes/shared/src/main/scala/scala/meta/internal/quasiquotes/ReificationMacros.scala
+++ b/scalameta/quasiquotes/shared/src/main/scala/scala/meta/internal/quasiquotes/ReificationMacros.scala
@@ -50,6 +50,8 @@ class ReificationMacros(val c: Context) extends AstReflection with AdtLiftables 
   val InternalUnlift = c.mirror.staticModule("scala.meta.internal.quasiquotes.Unlift")
   val QuasiquotePrefix = c.freshName("quasiquote")
 
+  private val OriginModule = q"_root_.scala.meta.trees.Origin"
+
   def apply(args: ReflectTree*)(dialect: ReflectTree): ReflectTree = expand(dialect)
   def unapply(scrutinee: ReflectTree)(dialect: ReflectTree): ReflectTree = expand(dialect)
   def expand(dialectTree: ReflectTree): ReflectTree = {
@@ -367,8 +369,7 @@ class ReificationMacros(val c: Context) extends AstReflection with AdtLiftables 
       val liftOrigin: Origin => ReflectTree =
         if (sourceName ne null)
           _ match {
-            case Origin.Parsed(_, beg, end) =>
-              q"_root_.scala.meta.trees.Origin.Parsed($sourceName, $beg, $end)"
+            case Origin.Parsed(_, beg, end) => q"$OriginModule.Parsed($sourceName, $beg, $end)"
             case _ => dialectOnlyNameTree
           }
         else _ => dialectOnlyNameTree
@@ -398,11 +399,11 @@ class ReificationMacros(val c: Context) extends AstReflection with AdtLiftables 
       q"val $dialectName = $dialectTree",
       q"""
         val $dialectOnlyName =
-          new _root_.scala.meta.trees.Origin.DialectOnly($dialectName)
+          new $OriginModule.DialectOnly($dialectName)
       """,
       if (sourceName eq null) null
       else q"""
-        val $sourceName = new _root_.scala.meta.trees.Origin.ParsedSource(
+        val $sourceName = new $OriginModule.ParsedSource(
           _root_.scala.meta.inputs.Input.String(${input.text.replace("$$", "$")})
         )($dialectName)
       """

--- a/scalameta/quasiquotes/shared/src/main/scala/scala/meta/internal/quasiquotes/ReificationMacros.scala
+++ b/scalameta/quasiquotes/shared/src/main/scala/scala/meta/internal/quasiquotes/ReificationMacros.scala
@@ -398,7 +398,7 @@ class ReificationMacros(val c: Context) extends AstReflection with AdtLiftables 
     val valDefns = List(
       q"val $dialectName = $dialectTree",
       q"""
-        val $dialectOnlyName =
+        implicit val $dialectOnlyName: $OriginModule.DialectOnly =
           new $OriginModule.DialectOnly($dialectName)
       """,
       if (sourceName eq null) null

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/SyntacticTrees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/SyntacticTrees.scala
@@ -10,7 +10,7 @@ import scala.annotation.tailrec
 object Syntactic {
   object TermApply {
     object ArgList {
-      def apply(fun: Term, argss: List[Term.ArgClause]): Term =
+      def apply(fun: Term, argss: List[Term.ArgClause])(implicit dialect: Dialect): Term =
         argss.foldLeft(fun)((curr, args) => Term.Apply(curr, args))
 
       def unapply(tree: Tree): Option[(Term, List[Term.ArgClause])] =
@@ -31,8 +31,8 @@ object Syntactic {
     }
 
     object ArgListList {
-      def apply(fun: Term, argss: List[List[Term]]): Term =
-        ArgList(fun, argss.map(Term.ArgClause(_)))
+      def apply(fun: Term, argss: List[List[Term]])(implicit dialect: Dialect): Term =
+        ArgList(fun, argss.map(Term.ArgClause(_, None)))
 
       def unapply(tree: Tree): Option[(Term, List[List[Term]])] =
         tree match {

--- a/scalameta/trees/shared/src/main/scala/scala/meta/trees/Api.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/trees/Api.scala
@@ -4,32 +4,72 @@ package trees
 import scala.collection.mutable
 import scala.language.implicitConversions
 
-private[meta] trait Api {
-  implicit def typeParamClauseToValues(v: Type.ParamClause): List[Type.Param] = v.values
+private[meta] trait ApiLowPriority {
   implicit def typeValuesToParamClause(v: List[Type.Param]): Type.ParamClause = Type.ParamClause(v)
 
-  implicit def termParamClauseToValues(v: Term.ParamClause): List[Term.Param] = v.values
   implicit def termValuesToParamClause(v: List[Term.Param]): Term.ParamClause =
     Term.ParamClause(v, Term.ParamClause.getMod(v))
   implicit def termListValuesToListParamClause(v: List[List[Term.Param]]): List[Term.ParamClause] =
     v.map(termValuesToParamClause)
 
-  implicit def typeArgsToValues(v: Type.ArgClause): List[Type] = v.values
   implicit def typeValuesToArgClause(v: List[Type]): Type.ArgClause = Type.ArgClause(v)
 
-  implicit def typeFuncParamsToValues(v: Type.FuncParamClause): List[Type] = v.values
   implicit def typeValuesToFuncParamClause(v: List[Type]): Type.FuncParamClause =
     Type.FuncParamClause(v)
 
-  implicit def termArgsToValues(v: Term.ArgClause): List[Term] = v.values
-  implicit def termValuesToArgClause(v: List[Term]): Term.ArgClause = Term.ArgClause(v)
+  implicit def termValuesToArgClause(v: List[Term]): Term.ArgClause = Term.ArgClause(v, None)
   implicit def termListValuesToListArgClause(v: List[List[Term]]): List[Term.ArgClause] =
     v.map(termValuesToArgClause)
 
-  implicit def patArgsToValues(v: Pat.ArgClause): List[Pat] = v.values
   implicit def patValuesToArgClause(v: List[Pat]): Pat.ArgClause = Pat.ArgClause(v)
   implicit def patListValuesToListArgClause(v: List[List[Pat]]): List[Pat.ArgClause] =
     v.map(patValuesToArgClause)
+}
+
+private[meta] trait Api extends ApiLowPriority {
+  implicit def typeParamClauseToValues(v: Type.ParamClause): List[Type.Param] = v.values
+  implicit def typeValuesToParamClauseWithDialect(v: List[Type.Param])(
+      implicit dialect: Dialect
+  ): Type.ParamClause = Type.ParamClause(v)
+
+  implicit def termParamClauseToValues(v: Term.ParamClause): List[Term.Param] = v.values
+  implicit def termValuesToParamClauseWithDialect(v: List[Term.Param])(
+      implicit dialect: Dialect
+  ): Term.ParamClause =
+    Term.ParamClause(v, Term.ParamClause.getMod(v))
+  implicit def termListValuesToListParamClauseWithDialect(v: List[List[Term.Param]])(
+      implicit dialect: Dialect
+  ): List[Term.ParamClause] =
+    v.map(termValuesToParamClauseWithDialect)
+
+  implicit def typeArgsToValues(v: Type.ArgClause): List[Type] = v.values
+  implicit def typeValuesToArgClauseWithDialect(v: List[Type])(
+      implicit dialect: Dialect
+  ): Type.ArgClause = Type.ArgClause(v)
+
+  implicit def typeFuncParamsToValues(v: Type.FuncParamClause): List[Type] = v.values
+  implicit def typeValuesToFuncParamClauseWithDialect(v: List[Type])(
+      implicit dialect: Dialect
+  ): Type.FuncParamClause =
+    Type.FuncParamClause(v)
+
+  implicit def termArgsToValues(v: Term.ArgClause): List[Term] = v.values
+  implicit def termValuesToArgClauseWithDialect(v: List[Term])(
+      implicit dialect: Dialect
+  ): Term.ArgClause = Term.ArgClause(v, None)
+  implicit def termListValuesToListArgClauseWithDialect(v: List[List[Term]])(
+      implicit dialect: Dialect
+  ): List[Term.ArgClause] =
+    v.map(termValuesToArgClauseWithDialect)
+
+  implicit def patArgsToValues(v: Pat.ArgClause): List[Pat] = v.values
+  implicit def patValuesToArgClauseWithDialect(v: List[Pat])(
+      implicit dialect: Dialect
+  ): Pat.ArgClause = Pat.ArgClause(v)
+  implicit def patListValuesToListArgClauseWithDialect(v: List[List[Pat]])(
+      implicit dialect: Dialect
+  ): List[Pat.ArgClause] =
+    v.map(patValuesToArgClauseWithDialect)
 }
 
 private[meta] trait Aliases {

--- a/scalameta/trees/shared/src/main/scala/scala/meta/trees/Origin.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/trees/Origin.scala
@@ -54,4 +54,37 @@ object Origin {
     def dialectOpt: Option[Dialect] = Some(dialect)
   }
 
+  object DialectOnly {
+    implicit def fromDialect(implicit dialect: Dialect): DialectOnly =
+      new DialectOnly(dialect)
+
+    private[meta] def getFromArgs(args: Any*): DialectOnly = {
+      val queue = scala.collection.mutable.Queue.empty[Iterator[Any]]
+      @scala.annotation.tailrec
+      def loop(iterator: Iterator[Any]): DialectOnly =
+        if (!iterator.hasNext) {
+          if (queue.isEmpty)
+            implicitly[DialectOnly]
+          else
+            loop(queue.dequeue())
+        } else {
+          iterator.next() match {
+            case x: scala.meta.Tree =>
+              x.origin.dialectOpt match {
+                case Some(dialect) => fromDialect(dialect)
+                case _ => loop(iterator)
+              }
+            case x: Iterable[_] =>
+              queue.enqueue(x.iterator)
+              loop(iterator)
+            case _ => loop(iterator)
+          }
+        }
+      loop(Iterator(args))
+    }
+  }
+
+  private[meta] def first(one: Origin, two: Origin): Origin =
+    if (one ne None) one else two
+
 }

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -63,6 +63,7 @@ class SurfaceSuite extends FunSuite {
 
   test("statics (core)") {
     val diagnostic = core.keys.toList.sorted
+      .filter(!_.endsWith("LowPriority"))
       .map(fullName => {
         val suffix = if (core(fullName)) "" else " *"
         s"$fullName$suffix"
@@ -189,9 +190,8 @@ class SurfaceSuite extends FunSuite {
     val prettyprinterTests =
       new scala.meta.tests.prettyprinters.PublicSuite().munitTests().map(_.name)
     val nonPackageStatics = core.keys.filter(_.exists(_.isUpper))
-    val untested = nonPackageStatics.collect {
-      case name if !prettyprinterTests.exists(testName => testName.startsWith(name)) =>
-        name
+    val untested = nonPackageStatics.filter { name =>
+      !name.endsWith("LowPriority") && !prettyprinterTests.exists(_.startsWith(name))
     }
     assertEquals(
       untested,

--- a/tests/jvm/src/test/scala/scala/meta/tests/dialects/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/dialects/ReflectionSuite.scala
@@ -18,6 +18,6 @@ class ReflectionSuite extends FunSuite {
     val reflectiveStandards =
       dialectGetters.map(m => (m.getName, m.invoke(dialects).asInstanceOf[Dialect]))
     val mismatch = reflectiveStandards.toSet -- Dialect.standards.toSet -- aliases
-    assert(mismatch.isEmpty)
+    assertEquals(mismatch, Set.empty[(String, Dialect)])
   }
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/TreeSuiteBase.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/TreeSuiteBase.scala
@@ -16,7 +16,7 @@ abstract class TreeSuiteBase extends FunSuite with CommonTrees {
   protected def assertTree(obtained: Tree)(expected: Tree)(implicit loc: munit.Location): Unit = {
     assertStruct(obtained)(expected.structure)
     expected.origin match {
-      case _: Origin.DialectOnly => fail("origin should not be DialectOnly")
+      case Origin.None => fail("origin should not be None")
       case _ =>
     }
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/TreeSuiteBase.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/TreeSuiteBase.scala
@@ -4,6 +4,7 @@ import munit._
 
 import scala.meta._
 import scala.meta.tests.parsers.CommonTrees
+import scala.meta.trees.Origin
 
 abstract class TreeSuiteBase extends FunSuite with CommonTrees {
 
@@ -12,8 +13,13 @@ abstract class TreeSuiteBase extends FunSuite with CommonTrees {
   protected def assertStruct(obtained: Tree)(expected: String)(implicit loc: munit.Location): Unit =
     assertNoDiff(obtained.structure, expected)
 
-  protected def assertTree(obtained: Tree)(expected: Tree)(implicit loc: munit.Location): Unit =
+  protected def assertTree(obtained: Tree)(expected: Tree)(implicit loc: munit.Location): Unit = {
     assertStruct(obtained)(expected.structure)
+    expected.origin match {
+      case _: Origin.DialectOnly => fail("origin should not be DialectOnly")
+      case _ =>
+    }
+  }
 
   protected def assertTrees(
       obtained: Tree*

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TypeSuite.scala
@@ -9,7 +9,7 @@ import scala.meta.parsers.ParseException
 
 class TypeSuite extends ParseSuite {
 
-  private def assertTpe(expr: String)(tree: Tree)(implicit dialect: Dialect): Unit = {
+  private def assertTpe(expr: String)(tree: => Tree)(implicit dialect: Dialect): Unit = {
     assertTree(tpe(expr))(tree)
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TypeSuite.scala
@@ -13,8 +13,6 @@ class TypeSuite extends ParseSuite {
     assertTree(tpe(expr))(tree)
   }
 
-  import scala.meta.dialects.Scala211
-
   test("T") {
     assertTpe("T")(TypeName("T"))
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
@@ -955,11 +955,12 @@ class TokenizerSuite extends BaseTokenizerSuite {
     val tree = Term.ApplyInfix(Term.Name("foo"), Term.Name("+"), Nil, List(Term.Name("bar")))
     assert(tree.pos == Position.None)
     val tokens = tree.tokenizeFor(implicitly[Dialect])
+    val tokensStructure = tokens.structure
     interceptMessage[trees.Error.MissingDialectException](
       "Tree missing a dialect; update root tree `.withDialectIfRootAndNotSet` first, or call `.tokenizeFor`."
     )(tree.tokens)
     assertEquals(
-      tokens.structure,
+      tokensStructure,
       "Tokens(BOF [0..0), foo [0..3),   [3..4), + [4..5),   [5..6), bar [6..9), EOF [9..9))"
     )
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
@@ -956,9 +956,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
     assert(tree.pos == Position.None)
     val tokens = tree.tokenizeFor(implicitly[Dialect])
     val tokensStructure = tokens.structure
-    interceptMessage[trees.Error.MissingDialectException](
-      "Tree missing a dialect; update root tree `.withDialectIfRootAndNotSet` first, or call `.tokenizeFor`."
-    )(tree.tokens)
+    assertEquals(tree.tokens.structure, tokensStructure)
     assertEquals(
       tokensStructure,
       "Tokens(BOF [0..0), foo [0..3),   [3..4), + [4..5),   [5..6), bar [6..9), EOF [9..9))"

--- a/tests/shared/src/test/scala/scala/meta/tests/trees/TokensSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/trees/TokensSuite.scala
@@ -21,20 +21,17 @@ class TokensSuite extends TreeSuiteBase {
   test("Tree.tokens: manual") {
     val dialect = implicitly[Dialect]
     val tree = Term.ApplyInfix(Term.Name("foo"), Term.Name("+"), Nil, List(Term.Name("bar")))
-    interceptMessage[trees.Error.MissingDialectException](
-      "Tree missing a dialect; update root tree `.withDialectIfRootAndNotSet` first, or call `.printSyntaxFor`."
-    )(tree.text)
+    assertEquals(tree.text, "foo + bar")
     assertEquals(tree.printSyntaxFor(dialect), "foo + bar")
     assertEquals(tree.syntax, "foo + bar")
-    assert(tree.origin eq trees.Origin.None)
+    assert(tree.origin ne trees.Origin.None)
+    assertEquals(tree.origin.dialectOpt, Some(dialect))
     val tokens = tree.tokenizeFor(dialect)
-    interceptMessage[trees.Error.MissingDialectException](
-      "Tree missing a dialect; update root tree `.withDialectIfRootAndNotSet` first, or call `.tokenizeFor`."
-    )(tree.tokens)
+    assertEquals(tree.tokens.structure, tokens.structure)
     assertEquals(tokens.syntax, "foo + bar")
     assert(tokens.forall(_.input.isInstanceOf[Input.VirtualFile]))
     val dialectTree = tree.withDialectIfRootAndNotSet
-    assertNotEquals(dialectTree, tree)
+    assertEquals(dialectTree, tree)
     assertEquals(dialectTree.text, "foo + bar")
     assertEquals(dialectTree.printSyntaxFor(dialect), "foo + bar")
     assert(dialectTree.origin ne trees.Origin.None)

--- a/tests/shared/src/test/scala/scala/meta/tests/trees/TokensSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/trees/TokensSuite.scala
@@ -19,14 +19,15 @@ class TokensSuite extends TreeSuiteBase {
   }
 
   test("Tree.tokens: manual") {
+    val dialect = implicitly[Dialect]
     val tree = Term.ApplyInfix(Term.Name("foo"), Term.Name("+"), Nil, List(Term.Name("bar")))
     interceptMessage[trees.Error.MissingDialectException](
       "Tree missing a dialect; update root tree `.withDialectIfRootAndNotSet` first, or call `.printSyntaxFor`."
     )(tree.text)
-    assertEquals(tree.printSyntaxFor(implicitly[Dialect]), "foo + bar")
+    assertEquals(tree.printSyntaxFor(dialect), "foo + bar")
     assertEquals(tree.syntax, "foo + bar")
     assert(tree.origin eq trees.Origin.None)
-    val tokens = tree.tokenizeFor(implicitly[Dialect])
+    val tokens = tree.tokenizeFor(dialect)
     interceptMessage[trees.Error.MissingDialectException](
       "Tree missing a dialect; update root tree `.withDialectIfRootAndNotSet` first, or call `.tokenizeFor`."
     )(tree.tokens)
@@ -35,7 +36,7 @@ class TokensSuite extends TreeSuiteBase {
     val dialectTree = tree.withDialectIfRootAndNotSet
     assertNotEquals(dialectTree, tree)
     assertEquals(dialectTree.text, "foo + bar")
-    assertEquals(dialectTree.printSyntaxFor(implicitly[Dialect]), "foo + bar")
+    assertEquals(dialectTree.printSyntaxFor(dialect), "foo + bar")
     assert(dialectTree.origin ne trees.Origin.None)
     val dialectTokens = dialectTree.tokens
     assertEquals(dialectTokens.syntax, "foo + bar")
@@ -43,7 +44,7 @@ class TokensSuite extends TreeSuiteBase {
 
     val parsedTree = tree.maybeParseAs[Stat].get
     assert(parsedTree eq parsedTree.maybeParse.get)
-    assertEquals(parsedTree.printSyntaxFor(implicitly[Dialect]), "foo + bar")
+    assertEquals(parsedTree.printSyntaxFor(dialect), "foo + bar")
     assertEquals(parsedTree.syntax, "foo + bar")
     assert(parsedTree.origin.isInstanceOf[trees.Origin.Parsed])
     val parsedTokens = parsedTree.tokens


### PR DESCRIPTION
That way, all our trees will have a proper origin containing a dialect.

Move previous versions of apply, those without dialect, to a new trait, and extend companion object from that trait. That way, MIMA is satisfied and compiler doesn't complain of similar methods matching invocation.

One complexity arises for trees which are defined at the package level rather than within an object. In that case, we can't use that new trait as the macro is not allowed to emit extraneous types at top level.

In that case, we will not pass the implicit dialect but will determine it from one of the trees which were passed as arguments to apply().