### PR TITLE
ScalametaParser: keep block around func with mods

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
@@ -1668,7 +1668,11 @@ class FewerBracesSuite extends BaseDottySuite {
         |   implicit bar =>
         |      baz
         |""".stripMargin
-    val layout = "def a = foo { implicit bar => baz }"
+    val layout =
+      """|def a = foo {
+         |  implicit bar => baz
+         |}
+         |""".stripMargin
     val tree = Defn.Def(
       Nil,
       tname("a"),
@@ -1676,13 +1680,18 @@ class FewerBracesSuite extends BaseDottySuite {
       None,
       Term.Apply(
         tname("foo"),
-        Term.Function(
-          Term.ParamClause(List(tparam(List(Mod.Implicit()), "bar")), Some(Mod.Implicit())),
-          tname("baz")
+        Term.Block(
+          Term.Function(
+            Term.ParamClause(
+              List(tparam(List(Mod.Implicit()), "bar")),
+              Some(Mod.Implicit())
+            ),
+            tname("baz")
+          ) :: Nil
         ) :: Nil
       )
     )
-    parseAndCheckTree[Stat](code, layout)(tree)
+    runTestAssert[Stat](code, Some(layout))(tree)
   }
 
   test("scalafmt #3763 implicit in braces, no fewer") {


### PR DESCRIPTION
Helps with scalameta/scalafmt#3763.