### PR TITLE
ScalametaParser: in implicitClosure, no full type

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1911,7 +1911,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
   private def implicitClosure(location: Location): Term.Function = {
     val implicitPos = prevTokenPos
     val paramName = termName()
-    val paramTpt = getDeclTpeOpt(location.fullTypeOK)
+    val paramTpt = getDeclTpeOpt(fullTypeOK = false)
     val mod = atPos(implicitPos)(Mod.Implicit())
     val param = autoEndPos(implicitPos)(Term.Param(mod :: Nil, paramName, paramTpt, None))
     val params = copyPos(param)(Term.ParamClause(param :: Nil, Some(mod)))


### PR DESCRIPTION
Since it returns a function, it is expecting a `=>` which would be "swallowed" by any infix type.