### PR TITLE
ScalametaParser: allow `lazy` with `given`

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
@@ -1155,11 +1155,8 @@ class GivenUsingSuite extends BaseDottySuite {
 
   test("lazy given") {
     val code = "lazy given foo: Foo = ???"
-    val error =
-      """|<input>:1: error: lazy not allowed here. Only vals can be lazy
-         |lazy given foo: Foo = ???
-         |^""".stripMargin
-    runTestError[Stat](code, error)
+    val tree = Defn.GivenAlias(List(Mod.Lazy()), tname("foo"), None, pname("Foo"), tname("???"))
+    runTestAssert[Stat](code)(tree)
   }
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
@@ -1152,4 +1152,14 @@ class GivenUsingSuite extends BaseDottySuite {
       )
     )
   }
+
+  test("lazy given") {
+    val code = "lazy given foo: Foo = ???"
+    val error =
+      """|<input>:1: error: lazy not allowed here. Only vals can be lazy
+         |lazy given foo: Foo = ???
+         |^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -553,7 +553,7 @@ class MinorDottySuite extends BaseDottySuite {
     )
     runTestError[Stat](
       "trait Foo { protected[this] lazy var from: Int }",
-      "lazy not allowed here. Only vals can be lazy"
+      "lazy not allowed here. Only val/given can be lazy"
     )
   }
 


### PR DESCRIPTION
Fixes #3530.