### PR TITLE
ScannerTokens: improve handling of `finally`

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SepRegion.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SepRegion.scala
@@ -33,7 +33,7 @@ case object RegionBracket extends RegionDelimNonIndented
 case class RegionBrace(override val indent: Int) extends RegionDelimNonIndented with CanProduceLF
 
 case object RegionCaseMark extends RegionNonDelimNonIndented
-final class RegionCaseExpr(override val indent: Int) extends RegionNonDelimNonIndented
+final class RegionCaseExpr(override val indent: Int) extends SepRegionNonIndented
 final class RegionCaseBody(override val indent: Int, val arrow: Token)
     extends SepRegionNonIndented with CanProduceLF
 
@@ -181,4 +181,4 @@ case object RegionForOther extends RegionFor {
   def isTerminatingTokenRequired(): Boolean = true
 }
 
-final class RegionIndentTry(override val indent: Int) extends SepRegionIndented
+case object RegionTry extends SepRegionNonIndented with CanProduceLF

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -470,12 +470,19 @@ object TreeSyntax {
           )
         )
       case t: Term.Try =>
+        val showExpr = p(Expr, t.expr)
+        val needParensAroundExpr = t.expr match {
+          case e: Term.Try if e.finallyp.isEmpty =>
+            if (e.catchp.isEmpty) t.catchp.nonEmpty || t.finallyp.isDefined
+            else t.catchp.isEmpty && t.finallyp.isDefined
+          case _ => false
+        }
         m(
           Expr1,
           s(
             kw("try"),
             " ",
-            p(Expr, t.expr),
+            if (needParensAroundExpr) s("(", i(showExpr), n(")")) else showExpr,
             if (t.catchp.nonEmpty) s(" ", kw("catch"), " {", t.catchp, n("}"))
             else s(""),
             t.finallyp

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -688,7 +688,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |finally arena.close()
          |""".stripMargin
     val layout =
-      """|try try Right(f()) catch {
+      """|try (
+         |  try Right(f())
+         |) catch {
          |  case NonFatal(ex) =>
          |    Left(???)
          |} finally arena.close()
@@ -706,7 +708,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
       ) :: Nil,
       Some(Term.Apply(Term.Select(tname("arena"), tname("close")), Nil))
     )
-    parseAndCheckTree[Stat](code, layout)(tree)
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("#3532 nested try-finally, try with multiline non-indented expr 1") {
@@ -761,13 +763,17 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |    + 2
          |finally foo
          |""".stripMargin
-    val layout = "try try 1 + 2 finally foo"
+    val layout =
+      """|try (
+         |  try 1 + 2
+         |) finally foo
+         |""".stripMargin
     val tree = Term.Try(
       Term.Try(Term.ApplyInfix(int(1), tname("+"), Nil, List(int(2))), Nil, None),
       Nil,
       Some(tname("foo"))
     )
-    parseAndCheckTree[Stat](code, layout)(tree)
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("#3532 nested bare try, outer with catch") {
@@ -780,7 +786,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |finally foo
          |""".stripMargin
     val layout =
-      """|try try 1 + 2 catch {
+      """|try (
+         |  try 1 + 2
+         |) catch {
          |  case NonFatal(ex) => 3
          |} finally foo
          |""".stripMargin
@@ -789,7 +797,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
       List(Case(Pat.Extract(tname("NonFatal"), List(Pat.Var(tname("ex")))), None, int(3))),
       Some(tname("foo"))
     )
-    parseAndCheckTree[Stat](code, layout)(tree)
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   // --------------------------

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -600,6 +600,198 @@ class ControlSyntaxSuite extends BaseDottySuite {
     )
   }
 
+  test("#3532 nested try-finally on same line") {
+    val code =
+      """|try try Right(f()) finally iter.close()
+         |finally arena.close()
+         |""".stripMargin
+    val layout = "try try Right(f()) finally iter.close() finally arena.close()"
+    val tree = Term.Try(
+      Term.Try(
+        Term.Apply(tname("Right"), List(Term.Apply(tname("f"), Nil))),
+        Nil,
+        Some(Term.Apply(Term.Select(tname("iter"), tname("close")), Nil))
+      ),
+      Nil,
+      Some(Term.Apply(Term.Select(tname("arena"), tname("close")), Nil))
+    )
+    runTestAssert[Stat](code, layout)(tree)
+  }
+
+  test("#3532 nested try-finally without catch") {
+    val code =
+      """|try
+         |  try Right(f())
+         |  finally iter.close()
+         |finally arena.close()
+         |""".stripMargin
+    val error =
+      """|<input>:4: error: ; expected but finally found
+         |finally arena.close()
+         |^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("#3532 nested try-finally, oneline catch") {
+    val code =
+      """|try
+         |  try Right(f())
+         |  catch case NonFatal(ex) => Left(???)
+         |  finally iter.close()
+         |finally arena.close()
+         |""".stripMargin
+    val error =
+      """|<input>:5: error: ; expected but finally found
+         |finally arena.close()
+         |^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("#3532 nested try-finally, catch with non-indented case") {
+    val code =
+      """|try
+         |  try Right(f())
+         |  catch
+         |  case NonFatal(ex) => Left(???)
+         |  finally iter.close()
+         |finally arena.close()
+         |""".stripMargin
+    val error =
+      """|<input>:6: error: ; expected but finally found
+         |finally arena.close()
+         |^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("#3532 nested try-finally, catch with indented case") {
+    val code =
+      """|try
+         |  try Right(f())
+         |  catch
+         |    case NonFatal(ex) => Left(???)
+         |  finally iter.close()
+         |finally arena.close()
+         |""".stripMargin
+    val error =
+      """|<input>:6: error: ; expected but finally found
+         |finally arena.close()
+         |^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("#3532 nested try, inner with catch, outer with finally") {
+    val code =
+      """|try
+         |  try Right(f())
+         |  catch
+         |    case NonFatal(ex) => Left(???)
+         |finally arena.close()
+         |""".stripMargin
+    val layout =
+      """|try try Right(f()) catch {
+         |  case NonFatal(ex) =>
+         |    Left(???)
+         |} finally arena.close()
+         |""".stripMargin
+    val tree = Term.Try(
+      Term.Try(
+        Term.Apply(tname("Right"), List(Term.Apply(tname("f"), Nil))),
+        Nil,
+        None
+      ),
+      Case(
+        Pat.Extract(tname("NonFatal"), List(Pat.Var(tname("ex")))),
+        None,
+        Term.Apply(tname("Left"), List(tname("???")))
+      ) :: Nil,
+      Some(Term.Apply(Term.Select(tname("arena"), tname("close")), Nil))
+    )
+    parseAndCheckTree[Stat](code, layout)(tree)
+  }
+
+  test("#3532 nested try-finally, try with multiline non-indented expr 1") {
+    val code =
+      """|try
+         |  try { 1 + 2 }
+         |    + 3
+         |  finally iter.close()
+         |finally arena.close()
+         |""".stripMargin
+    val error =
+      """|<input>:5: error: ; expected but finally found
+         |finally arena.close()
+         |^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("#3532 nested try-finally, try with multiline non-indented expr 2") {
+    val code =
+      """|try
+         |  try { 1 + 2 }
+         |    .foo
+         |  finally iter.close()
+         |finally arena.close()
+         |""".stripMargin
+    val error =
+      """|<input>:5: error: ; expected but finally found
+         |finally arena.close()
+         |^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("#3532 nested try-finally, try with multiline non-indented expr 3") {
+    val code =
+      """|try
+         |  try { 1 + 2 }
+         |    (foo)
+         |  finally iter.close()
+         |finally arena.close()
+         |""".stripMargin
+    val error =
+      """|<input>:5: error: ; expected but finally found
+         |finally arena.close()
+         |^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("#3532 nested bare try, outer without catch") {
+    val code =
+      """|try
+         |  try 1
+         |    + 2
+         |finally foo
+         |""".stripMargin
+    val layout = "try try 1 + 2 finally foo"
+    val tree = Term.Try(
+      Term.Try(Term.ApplyInfix(int(1), tname("+"), Nil, List(int(2))), Nil, None),
+      Nil,
+      Some(tname("foo"))
+    )
+    parseAndCheckTree[Stat](code, layout)(tree)
+  }
+
+  test("#3532 nested bare try, outer with catch") {
+    val code =
+      """|try
+         |  try 1
+         |    + 2
+         |catch
+         |  case NonFatal(ex) => 3
+         |finally foo
+         |""".stripMargin
+    val layout =
+      """|try try 1 + 2 catch {
+         |  case NonFatal(ex) => 3
+         |} finally foo
+         |""".stripMargin
+    val tree = Term.Try(
+      Term.Try(Term.ApplyInfix(int(1), tname("+"), Nil, List(int(2))), Nil, None),
+      List(Case(Pat.Extract(tname("NonFatal"), List(Pat.Var(tname("ex")))), None, int(3))),
+      Some(tname("foo"))
+    )
+    parseAndCheckTree[Stat](code, layout)(tree)
+  }
+
   // --------------------------
   // FOR
   // --------------------------


### PR DESCRIPTION
Since we allow `finally` to be at the same indent as the `try` body, we could end up with `finally` terminating both the previous `catch` as well as the outer `try`.

Instead, let's introduce a new `RegionTry` and ensure that this region is not removed before the `finally` keyword, so that we won't end up with an exposed outer `RegionTry`.

Fixes #3532.