### PR TITLE
ScannerTokens: move comma past outdents in parens

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/LazyTokenIterator.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/LazyTokenIterator.scala
@@ -22,8 +22,7 @@ private[parsers] class LazyTokenIterator private (
   import scannerTokens._
 
   private def getNextTokenRef(): TokenRef = {
-    if (curr.next eq null) curr.next = nextToken(curr)
-    curr.next
+    if (curr.next eq null) nextToken(curr) else curr.next
   }
 
   override def next(): Unit = {

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -346,8 +346,11 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
   }
 
   @inline
-  private[parsers] def nextToken(ref: TokenRef): TokenRef =
-    nextToken(ref.token, ref.pos, ref.nextPos, ref.regions)
+  private[parsers] def nextToken(ref: TokenRef): TokenRef = {
+    val next = nextToken(ref.token, ref.pos, ref.nextPos, ref.regions)
+    ref.next = next
+    next
+  }
 
   @tailrec
   private[parsers] def nextToken(

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -1641,11 +1641,32 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |  b = "xxx"
          |)
          |""".stripMargin
-    val error =
-      """|<input>:4: error: ; expected but , found
-         |    case _ => None,
-         |                  ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout =
+      """|Request(value = true match {
+         |  case true =>
+         |    Some(1)
+         |  case _ =>
+         |    None
+         |}, b = "xxx")
+         |""".stripMargin
+    val tree = Term.Apply(
+      tname("Request"),
+      List(
+        Term.Assign(
+          tname("value"),
+          Term.Match(
+            bool(true),
+            List(
+              Case(bool(true), None, Term.Apply(tname("Some"), List(int(1)))),
+              Case(Pat.Wildcard(), None, tname("None"))
+            ),
+            Nil
+          )
+        ),
+        Term.Assign(tname("b"), str("xxx"))
+      )
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("indented-double-apply") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -1632,6 +1632,22 @@ class SignificantIndentationSuite extends BaseDottySuite {
     )
   }
 
+  test("#3531 apply with optional braces and trailing comma") {
+    val code =
+      """|Request(
+         |  value = true match
+         |    case true => Some(1)
+         |    case _ => None,
+         |  b = "xxx"
+         |)
+         |""".stripMargin
+    val error =
+      """|<input>:4: error: ; expected but , found
+         |    case _ => None,
+         |                  ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
   test("indented-double-apply") {
     runTestAssert[Stat](
       """|def method = 


### PR DESCRIPTION
Fixes #3531.