### PR TITLE
TreeSyntax: omit `()` around partial function

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -1059,7 +1059,7 @@ object TreeSyntax {
     // Multiples and optionals
     private def printApplyArgs(args: Term.ArgClause, beforeBrace: String): Show.Result =
       args.values match {
-        case Seq(b: Term.Block) => s(beforeBrace, b)
+        case Seq(b @ (_: Term.Block | _: Term.PartialFunction)) => s(beforeBrace, b)
         case Seq(f: Term.Function) if f.paramClause.mod.isDefined =>
           s(beforeBrace, "{ ", f, " }")
         case _ => s(args)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -1740,9 +1740,9 @@ class TermSuite extends ParseSuite {
          |  }
          |""".stripMargin
     val layout =
-      """|for (x2 <- x1) yield x2.x3({
+      """|for (x2 <- x1) yield x2.x3 {
          |  case x4 if x5.x6.x7(x8) => x9
-         |})
+         |}
          |""".stripMargin
     runTestAssert[Term](code, Some(layout))(
       Term.ForYield(

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -2746,9 +2746,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
     val output =
       """|object a {
          |  constraint.contains(tl) || other.isRemovable(tl) || {
-         |    val tvars = tl.paramRefs.map(other.typeVarOfParam(_)).collect({
+         |    val tvars = tl.paramRefs.map(other.typeVarOfParam(_)).collect {
          |      case tv: TypeVar => tv
-         |    })
+         |    }
          |    if (this.isCommittable) tvars.foreach(tvar => if (!tvar.inst.exists && !isOwnedAnywhere(this, tvar)) includeVar(tvar))
          |    typeComparer.addToConstraint(tl, tvars)
          |  }
@@ -3042,9 +3042,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |}
          |""".stripMargin,
       assertLayout = Some(
-        """|val tvars = targs.filter(_.isInstanceOf[InferredTypeTree]).tpes.collect({
+        """|val tvars = targs.filter(_.isInstanceOf[InferredTypeTree]).tpes.collect {
            |  case tvar: TypeVar if !tvar.isInstantiated && ctx.typerState.ownedVars.contains(tvar) && !locked.contains(tvar) => tvar
-           |})
+           |}
            |""".stripMargin
       )
     )(
@@ -3290,12 +3290,12 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |    }
          |""".stripMargin
     val output =
-      """|classDef.foreach({
+      """|classDef.foreach {
          |  case typeSymbol: Symbol =>
          |    if (typ) {}
          |    if (typeDef) if (typJava) {}
          |  case _ =>
-         |})
+         |}
          |""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(
       Term.Apply(
@@ -3691,9 +3691,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |  }
          |""".stripMargin
     val layout =
-      """|for (x2 <- x1) yield x2.x3({
+      """|for (x2 <- x1) yield x2.x3 {
          |  case x4 if x5.x6.x7(x8) => x9
-         |})
+         |}
          |""".stripMargin
     runTestAssert[Stat](code, Some(layout))(
       Term.ForYield(

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
@@ -121,9 +121,9 @@ class FewerBracesSuite extends BaseDottySuite {
          |    a
          |""".stripMargin,
       assertLayout = Some(
-        """|val firstLine = files.map({
+        """|val firstLine = files.map {
            |  case (a, b) => a
-           |})
+           |}
            |""".stripMargin
       )
     )(
@@ -161,10 +161,10 @@ class FewerBracesSuite extends BaseDottySuite {
          |""".stripMargin,
       assertLayout = Some(
         """|def main = {
-           |  val firstLine = files.map({
+           |  val firstLine = files.map {
            |    case A(a) => a
            |    case B(b) => b
-           |  })
+           |  }
            |  def hello = ???
            |}
            |""".stripMargin


### PR DESCRIPTION
It already contains `{}`. Fixes #3544.