### PR TITLE
SBT: fail build on warnings, treat some as info

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -556,6 +556,10 @@ lazy val sharedSettings = Def.settings(
     if (isScala213.value) List("-Ymacro-annotations")
     else Nil
   },
+  scalacOptions ++= {
+    if (isScala213.value) List("-Xfatal-warnings", "-Wconf:cat=deprecation:is")
+    else Nil
+  },
   scalacOptions ++= Seq("-feature", "-unchecked"),
   Compile / doc / scalacOptions ++= Seq("-skip-packages", ""),
   Compile / doc / scalacOptions ++= Seq("-implicits", "-implicits-hide:."),


### PR DESCRIPTION
Now that most warnings have been fixed, let's make the build stricter.

Limit these extra checks to scala-2.13 only, as that's sufficient to ensure clean code and avoids running into tooling differences between versions.