### PR TITLE
Transversers: skip Quasi before other trees

### DIFF
--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/transversers/transverser.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/transversers/transverser.scala
@@ -75,10 +75,11 @@ trait TransverserMacros extends MacroHelpers with AstReflection {
     val defnBuilder = List.newBuilder[Leaf]
     val restBuilder = List.newBuilder[Leaf]
     TreeAdt.allLeafs.foreach { l =>
-      if (l <:< TermAdt) termBuilder += l
+      if (l <:< QuasiAdt) {} // do nothing
+      else if (l <:< TermAdt) termBuilder += l
       else if (l <:< TypeAdt) typeBuilder += l
       else if (l <:< DefnAdt) defnBuilder += l
-      else if (!(l <:< QuasiAdt)) restBuilder += l
+      else restBuilder += l
     }
 
     val termPriority = Seq("Term.Name", "Term.Apply", "Lit", "Term.Param", "Term.ApplyInfix")


### PR DESCRIPTION
Since every Quasi tree in reality derives from one of the other types, and the declaration of a Quasi tree follows that of its parent, the case for the parent happens before the case for the quasi, and hence the quasi code is unreachable.

Since the intention was likely to exclude Quasi trees altogether, let's skip them at the beginning rather than the end.