### PR TITLE
doc: quasiquote now preserve comments

### DIFF
--- a/docs/trees/guide.md
+++ b/docs/trees/guide.md
@@ -256,14 +256,6 @@ println(
 )
 ```
 
-> It's important to keep in mind that quasiquotes expand at compile-time into
-> the same program as if you had written normal constructors by hand. This means
-> for example that formatting details or comments are not preserved
-
-```scala mdoc
-println(q"function  (    argument   ) // comment")
-```
-
 Quasiquotes can be composed together like normal string interpolators with
 dollar splices `$`
 
@@ -271,6 +263,16 @@ dollar splices `$`
 val left = q"Left()"
 val right = q"Right()"
 println(q"$left + $right")
+```
+
+> It's important to keep in mind that quasiquotes expand at compile-time into
+> as if you had written normal constructors by hand. This means for example
+> that formatting details or comments are not preserved if interpolated values
+> are used, because the complete source is not available at compile-time.
+
+```scala mdoc
+val argument = 1
+println(q"function  (    $argument   ) // comment")
 ```
 
 A list of trees can be inserted into a quasiquote with double dots `..$`

--- a/docs/trees/guide.md
+++ b/docs/trees/guide.md
@@ -266,9 +266,10 @@ println(q"$left + $right")
 ```
 
 > It's important to keep in mind that quasiquotes expand at compile-time into
-> as if you had written normal constructors by hand. This means for example
-> that formatting details or comments are not preserved if interpolated values
-> are used, because the complete source is not available at compile-time.
+> the same program as if you had written normal constructors by hand.
+> This means for example, that formatting details or comments are not preserved
+> if interpolated values are used, because the complete source is not available
+> at compile-time.
 
 ```scala mdoc
 val argument = 1

--- a/docs/trees/guide.md
+++ b/docs/trees/guide.md
@@ -267,7 +267,7 @@ println(q"$left + $right")
 
 > It's important to keep in mind that quasiquotes expand at compile-time into
 > the same program as if you had written normal constructors by hand.
-> This means for example, that formatting details or comments are not preserved
+> This means, for example, that formatting details or comments are not preserved
 > if interpolated values are used, because the complete source is not available
 > at compile-time.
 


### PR DESCRIPTION
Looks like quasiquotes now preserve comments in the source string.

```
>scala-cli repl --scala 2 --dep org.scalameta::scalameta:4.9.0

scala> import scala.meta._
import scala.meta._

scala> println(q"function  (    argument   ) // comment")
function  (    argument   ) // comment
```