### PR TITLE
ScannerTokens: improve leading infix detection

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -977,9 +977,9 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
         val commentIndent = multilineCommentIndent(c)
         iter(pos + 1, if (commentIndent < 0) indent else commentIndent, true)
       case t =>
-        if (indent >= 0 && indent < nextIndent) LeadingInfix.InvalidArg
-        else if (canBeLeadingInfixArg(t, pos)) LeadingInfix.Yes
-        else LeadingInfix.InvalidArg
+        if (!canBeLeadingInfixArg(t, pos)) LeadingInfix.No
+        else if (indent >= 0 && indent < nextIndent) LeadingInfix.InvalidArg
+        else LeadingInfix.Yes
     }
     tokens(afterOpPos) match {
       case _: EOL => iter(afterOpPos + 1, 0, false)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
@@ -360,4 +360,38 @@ class DefnSuite extends ParseSuite {
     runTestAssert[Stat](code, assertLayout = Some(layout))(tree)
   }
 
+  test("#3571 scala213") {
+    val code =
+      """|new A {
+         |  def b: C =
+         |    ???
+         |}
+         |""".stripMargin
+    val layout =
+      """|new A { def b: C = ??? }
+         |""".stripMargin
+    val tree = Term.NewAnonymous(
+      tpl(
+        List(Init(pname("A"), anon, Nil)),
+        List(Defn.Def(Nil, tname("b"), Nil, Some(pname("C")), tname("???")))
+      )
+    )
+    runTestAssert[Stat](code, layout)(tree)
+  }
+
+  test("#3571 scala213source3") {
+    implicit val Scala213 = scala.meta.dialects.Scala213Source3
+    val code =
+      """|new A {
+         |  def b: C =
+         |    ???
+         |}
+         |""".stripMargin
+    val error =
+      """|<input>:2: error: illegal start of simple expression
+         |  def b: C =
+         |            ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
@@ -387,11 +387,16 @@ class DefnSuite extends ParseSuite {
          |    ???
          |}
          |""".stripMargin
-    val error =
-      """|<input>:2: error: illegal start of simple expression
-         |  def b: C =
-         |            ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout =
+      """|new A { def b: C = ??? }
+         |""".stripMargin
+    val tree = Term.NewAnonymous(
+      tpl(
+        List(Init(pname("A"), anon, Nil)),
+        List(Defn.Def(Nil, tname("b"), Nil, Some(pname("C")), tname("???")))
+      )
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
@@ -440,7 +440,7 @@ class InfixSuite extends BaseDottySuite {
   }
 
   test("scala3 infix syntax 5.2") {
-    runTestError[Stat](
+    val code =
       """|{
          |  println("hello")
          |    ???
@@ -448,11 +448,24 @@ class InfixSuite extends BaseDottySuite {
          |      case 0 => 1
          |    }
          |}
-         |""".stripMargin,
-      """|error: Invalid indented leading infix operator found
-         |    ???
-         |    ^""".stripMargin
+         |""".stripMargin
+    val layout =
+      """|{
+         |  println("hello")
+         |  ???
+         |  ??? match {
+         |    case 0 => 1
+         |  }
+         |}
+         |""".stripMargin
+    val tree = Term.Block(
+      List(
+        Term.Apply(tname("println"), List(str("hello"))),
+        tname("???"),
+        Term.Match(tname("???"), List(Case(int(0), None, int(1))), Nil)
+      )
     )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("scala3 infix syntax 6") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -3328,4 +3328,23 @@ class SignificantIndentationSuite extends BaseDottySuite {
     runTestAssert[Stat](code, Some(layout))(tree)
   }
 
+  test("#3571 scala3") {
+    val code =
+      """|new A {
+         |  def b: C =
+         |    ???
+         |}
+         |""".stripMargin
+    val layout =
+      """|new A { def b: C = ??? }
+         |""".stripMargin
+    val tree = Term.NewAnonymous(
+      tpl(
+        List(Init(pname("A"), anon, Nil)),
+        List(Defn.Def(Nil, tname("b"), Nil, Some(pname("C")), tname("???")))
+      )
+    )
+    runTestAssert[Stat](code, layout)(tree)
+  }
+
 }


### PR DESCRIPTION
This helps with ignoring cases which are not leading infix at the expense of possible syntax error detection.

Fixes #3571. Fixes scalameta/scalafmt#3786.