### PR TITLE
Lit.{Float,Double}: preserve parsed numeric value

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1342,19 +1342,27 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
         else if (value < min) syntaxError("integer number too small", at = token)
         Lit.Long(value.toLong)
       case tok @ Constant.Float(rawValue) =>
-        if (rawValue > Float.MaxValue)
+        val floatValue = rawValue.floatValue
+        if (floatValue == Float.PositiveInfinity)
           syntaxError("floating point number too large", at = token)
-        else if (rawValue < Float.MinValue)
+        else if (floatValue == Float.NegativeInfinity)
           syntaxError("floating point number too small", at = token)
         val value = tok.text
-        Lit.Float(if (isNegated) s"-$value" else value)
+        if (isNegated)
+          Lit.Float(s"-$value", -floatValue)
+        else
+          Lit.Float(value, floatValue)
       case tok @ Constant.Double(rawValue) =>
-        if (rawValue > Double.MaxValue)
+        val floatValue = rawValue.doubleValue
+        if (floatValue == Double.PositiveInfinity)
           syntaxError("floating point number too large", at = token)
-        else if (rawValue < Double.MinValue)
+        else if (floatValue == Double.NegativeInfinity)
           syntaxError("floating point number too small", at = token)
         val value = tok.text
-        Lit.Double(if (isNegated) s"-$value" else value)
+        if (isNegated)
+          Lit.Double(s"-$value", -floatValue)
+        else
+          Lit.Double(value, floatValue)
       case Constant.Char(value) =>
         Lit.Char(value)
       case Constant.String(value) =>

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -87,10 +87,26 @@ object Lit {
   // 1.4f.toString == "1.399999976158142" // in JS
   // 1.4f.toString == "1.4"               // in JVM
   // See https://www.scala-js.org/doc/semantics.html#tostring-of-float-double-and-unit
-  @ast class Double(format: scala.Predef.String) extends Lit { val value = format.toDouble }
-  object Double { def apply(double: scala.Double): Double = Lit.Double(double.toString) }
-  @ast class Float(format: scala.Predef.String) extends Lit { val value = format.toFloat }
-  object Float { def apply(float: scala.Float): Float = Lit.Float(float.toString) }
+  @ast class Double(
+      format: scala.Predef.String,
+      @newField("4.9.0") number: scala.Double = scala.Double.NaN
+  ) extends Lit {
+    final val scalar = if (java.lang.Double.isNaN(number)) format.toDouble else number
+    override def value: Any = scalar
+  }
+  object Double {
+    def apply(value: scala.Double): Double = Double(value.toString, value)
+  }
+  @ast class Float(
+      format: scala.Predef.String,
+      @newField("4.9.0") number: scala.Float = scala.Float.NaN
+  ) extends Lit {
+    final val scalar = if (java.lang.Float.isNaN(number)) format.toFloat else number
+    override def value: Any = scalar
+  }
+  object Float {
+    def apply(value: scala.Float): Float = Float(value.toString, value)
+  }
   @ast class Byte(value: scala.Byte) extends Lit
   @ast class Short(value: scala.Short) extends Lit
   @ast class Char(value: scala.Char) extends Lit

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -787,28 +787,28 @@ object TreeSyntax {
         )
       case Lit.Int(value) => m(Literal, s(value.toString))
       case Lit.Long(value) => m(Literal, s(value.toString + "L"))
-      case Lit.Float(value) =>
-        val n = value.toFloat
-        if (java.lang.Float.isNaN(n)) s("Float.NaN")
+      case t: Lit.Float =>
+        val number = t.scalar
+        if (java.lang.Float.isNaN(number)) s("Float.NaN")
         else {
-          n match {
+          number match {
             case Float.PositiveInfinity => s("Float.PositiveInfinity")
             case Float.NegativeInfinity => s("Float.NegativeInfinity")
-            case _ if Character.toLowerCase(value.last) == 'f' => s(value)
             case _ =>
-              s(value, "f")
+              val format = t.format
+              w(s(format), "f", Character.toLowerCase(format.last) != 'f')
           }
         }
-      case Lit.Double(value) =>
-        val n = value.toDouble
-        if (java.lang.Double.isNaN(n)) s("Double.NaN")
+      case t: Lit.Double =>
+        val number = t.scalar
+        if (java.lang.Double.isNaN(number)) s("Double.NaN")
         else {
-          n match {
+          number match {
             case Double.PositiveInfinity => s("Double.PositiveInfinity")
             case Double.NegativeInfinity => s("Double.NegativeInfinity")
-            case _ if Character.toLowerCase(value.last) == 'd' => s(value)
             case _ =>
-              s(value, "d")
+              val format = t.format
+              w(s(format), "d", Character.toLowerCase(format.last) != 'd')
           }
         }
       case t @ Lit.Char(value) =>

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
@@ -85,6 +85,8 @@ class ReflectionSuite extends FunSuite {
       |Boolean
       |Byte
       |Char
+      |Double
+      |Float
       |Int
       |List[meta.Term.ParamClause]
       |List[scala.meta.Case]

--- a/tests/jvm/src/test/scala/scala/meta/tests/prettyprinters/PlatformSyntacticSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/prettyprinters/PlatformSyntacticSuite.scala
@@ -6,10 +6,10 @@ import scala.meta._
 class PlatformSyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
   test("JVM has proper floats") {
     // this gives different results work in a JS runtime
-    assert(Lit.Float(1.40f).syntax == "1.4f") // trailing zero is lost
-    assert(Lit.Float(1.4f).syntax == "1.4f")
+    assertSyntax(lit(1.40f))(flt("1.4f")) // trailing zero is lost
+    assertSyntax(lit(1.4f))(flt("1.4f"))
     // cross-platform way to accomplish the same
-    assert(Lit.Float("1.40").syntax == "1.40f")
-    assert(Lit.Float("1.4").syntax == "1.4f")
+    assertSyntax(flt("1.40"))(flt("1.40f"))
+    assertSyntax(flt("1.4"))(flt("1.4f"))
   }
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
@@ -119,8 +119,10 @@ trait CommonTrees {
   final def lit(v: Long) = Lit.Long(v)
   final def dbl(v: String) = Lit.Double(v)
   final def lit(v: Double) = Lit.Double(v)
+  final def lit(f: String, v: Double) = Lit.Double(f, v)
   final def flt(v: String) = Lit.Float(v)
   final def lit(v: Float) = Lit.Float(v)
+  final def lit(f: String, v: Float) = Lit.Float(f, v)
   final def str(v: String) = Lit.String(v)
   final def init(name: String, args: List[Term.ArgClause] = Nil): Init =
     Init(pname(name), anon, args)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
@@ -113,7 +113,14 @@ trait CommonTrees {
     Type.Bounds(Option(lo).map(pname), Option(hi).map(pname))
 
   final def bool(v: Boolean) = Lit.Boolean(v)
+  final def lit(v: Boolean) = Lit.Boolean(v)
   final def int(v: Int) = Lit.Int(v)
+  final def lit(v: Int) = Lit.Int(v)
+  final def lit(v: Long) = Lit.Long(v)
+  final def dbl(v: String) = Lit.Double(v)
+  final def lit(v: Double) = Lit.Double(v)
+  final def flt(v: String) = Lit.Float(v)
+  final def lit(v: Float) = Lit.Float(v)
   final def str(v: String) = Lit.String(v)
   final def init(name: String, args: List[Term.ArgClause] = Nil): Init =
     Init(pname(name), anon, args)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/LitSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/LitSuite.scala
@@ -187,4 +187,22 @@ class LitSuite extends ParseSuite {
     )
 
   }
+
+  test("numeric literals with separators") {
+    implicit val Scala211 = scala.meta.dialects.Scala213
+    interceptMessage[NumberFormatException](
+      """|For input string: "1_000_000_000.0"""".stripMargin
+    )(term("1_000_000_000.0"))
+    interceptMessage[NumberFormatException](
+      """|For input string: "1_000_000_000d"""".stripMargin
+    )(term("1_000_000_000d"))
+    interceptMessage[NumberFormatException](
+      """|For input string: "1_000_000_000D"""".stripMargin
+    )(term("1_000_000_000D"))
+    runTestAssert[Stat]("1000000000d")(dbl("1000000000d"))
+    runTestAssert[Stat]("1000000000D")(dbl("1000000000d"))
+    runTestAssert[Stat]("1_000_000_000l", "1000000000L")(lit(1000000000L))
+    runTestAssert[Stat]("1_000_000_000L", "1000000000L")(lit(1000000000L))
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/LitSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/LitSuite.scala
@@ -190,15 +190,9 @@ class LitSuite extends ParseSuite {
 
   test("numeric literals with separators") {
     implicit val Scala211 = scala.meta.dialects.Scala213
-    interceptMessage[NumberFormatException](
-      """|For input string: "1_000_000_000.0"""".stripMargin
-    )(term("1_000_000_000.0"))
-    interceptMessage[NumberFormatException](
-      """|For input string: "1_000_000_000d"""".stripMargin
-    )(term("1_000_000_000d"))
-    interceptMessage[NumberFormatException](
-      """|For input string: "1_000_000_000D"""".stripMargin
-    )(term("1_000_000_000D"))
+    runTestAssert[Stat]("1_000_000_000.0", "1_000_000_000.0d")(lit("1_000_000_000d", 1000000000d))
+    runTestAssert[Stat]("1_000_000_000d", "1_000_000_000d")(lit("1_000_000_000d", 1000000000d))
+    runTestAssert[Stat]("1_000_000_000D", "1_000_000_000D")(lit("1_000_000_000d", 1000000000d))
     runTestAssert[Stat]("1000000000d")(dbl("1000000000d"))
     runTestAssert[Stat]("1000000000D")(dbl("1000000000d"))
     runTestAssert[Stat]("1_000_000_000l", "1000000000L")(lit(1000000000L))


### PR DESCRIPTION
It might handle things like numeric separators. Fixes scalameta/sbt-scalafmt#299.
