### PR TITLE
Fix invalid check: empty or nested Member.Tuple

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -154,7 +154,7 @@ object Term {
   @ast class Tuple(args: List[Term] @nonEmpty) extends Term with Member.Tuple {
     // tuple may have one element (see scala.Tuple1)
     // however, this element may not be another single-element Tuple
-    checkParent(ParentChecks.MemberTuple)
+    checkFields(ParentChecks.MemberTuple(args))
   }
   @ast class Block(stats: List[Stat]) extends Term {
     checkParent(ParentChecks.TermBlock)
@@ -311,7 +311,7 @@ object Type {
   @ast class Tuple(args: List[Type] @nonEmpty) extends Type with Member.Tuple {
     // tuple may have one element (see scala.Tuple1)
     // however, this element may not be another single-element Tuple
-    checkParent(ParentChecks.MemberTuple)
+    checkFields(ParentChecks.MemberTuple(args))
   }
   @ast class With(lhs: Type, rhs: Type) extends Type
   @deprecated("And unused, replaced by ApplyInfix", "4.5.1")
@@ -423,7 +423,7 @@ object Pat {
   @ast class Tuple(args: List[Pat] @nonEmpty) extends Pat with Member.Tuple {
     // tuple may have one element (see scala.Tuple1)
     // however, this element may not be another single-element Tuple
-    checkParent(ParentChecks.MemberTuple)
+    checkFields(ParentChecks.MemberTuple(args))
   }
   @ast class Repeated(name: Term.Name) extends Pat
   @ast class Extract(fun: Term, argClause: ArgClause) extends Pat with Member.Apply {

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/ParentChecks.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/ParentChecks.scala
@@ -129,9 +129,9 @@ object ParentChecks {
     }
   }
 
-  private[meta] def MemberTuple(tree: Member.Tuple, parent: Tree, dest: String): Boolean = {
-    tree.args match {
-      case Nil | Member.Tuple(_ :: Nil) => false
+  private[meta] def MemberTuple(args: List[Tree]): Boolean = {
+    args match {
+      case Member.Tuple(_ :: Nil) :: Nil => false
       case _ => true
     }
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/trees/InvariantSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/trees/InvariantSuite.scala
@@ -6,7 +6,6 @@ import org.scalameta.invariants._
 
 import scala.meta._
 import scala.meta.dialects.Scala211
-import scala.util.Try
 
 class InvariantSuite extends TreeSuiteBase {
   test("secondary constructors in templates") {
@@ -96,8 +95,13 @@ class InvariantSuite extends TreeSuiteBase {
   }
   test("nested Term.Tuple") {
     def tuple = Term.Tuple(Term.Tuple(Lit.Unit() :: Nil) :: Nil)
-    // no exception
-    assert(Try(tuple).isSuccess)
+    interceptMessage[InvariantFailedException](
+      """|invariant failed:
+         |when verifying scala.meta.internal.trees.ParentChecks.MemberTuple(args)
+         |found that scala.meta.internal.trees.ParentChecks.MemberTuple(args) is false
+         |where args = List((()))
+         |""".stripMargin.replace("\n", EOL)
+    )(tuple)
   }
 
   test("empty Pat.Tuple") {
@@ -113,8 +117,13 @@ class InvariantSuite extends TreeSuiteBase {
   }
   test("nested Pat.Tuple") {
     def tuple = Pat.Tuple(Pat.Tuple(Lit.Unit() :: Nil) :: Nil)
-    // no exception
-    assert(Try(tuple).isSuccess)
+    interceptMessage[InvariantFailedException](
+      """|invariant failed:
+         |when verifying scala.meta.internal.trees.ParentChecks.MemberTuple(args)
+         |found that scala.meta.internal.trees.ParentChecks.MemberTuple(args) is false
+         |where args = List((()))
+         |""".stripMargin.replace("\n", EOL)
+    )(tuple)
   }
 
   test("empty Type.Tuple") {
@@ -130,8 +139,13 @@ class InvariantSuite extends TreeSuiteBase {
   }
   test("nested Type.Tuple") {
     def tuple = Type.Tuple(Type.Tuple(Lit.Unit() :: Nil) :: Nil)
-    // no exception
-    assert(Try(tuple).isSuccess)
+    interceptMessage[InvariantFailedException](
+      """|invariant failed:
+         |when verifying scala.meta.internal.trees.ParentChecks.MemberTuple(args)
+         |found that scala.meta.internal.trees.ParentChecks.MemberTuple(args) is false
+         |where args = List((()))
+         |""".stripMargin.replace("\n", EOL)
+    )(tuple)
   }
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/trees/InvariantSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/trees/InvariantSuite.scala
@@ -1,9 +1,12 @@
 package scala.meta.tests
 package trees
 
+import org.scalameta.internal.ScalaCompat.EOL
 import org.scalameta.invariants._
+
 import scala.meta._
 import scala.meta.dialects.Scala211
+import scala.util.Try
 
 class InvariantSuite extends TreeSuiteBase {
   test("secondary constructors in templates") {
@@ -79,4 +82,56 @@ class InvariantSuite extends TreeSuiteBase {
     intercept[InvariantFailedException] { mod"private[$ref]" }
     intercept[InvariantFailedException] { mod"protected[$ref]" }
   }
+
+  test("empty Term.Tuple") {
+    def tuple = Term.Tuple(Nil)
+    interceptMessage[InvariantFailedException](
+      """|invariant failed (args should be non-empty):
+         |when verifying args.!=(null).&&(args.isInstanceOf[scala.meta.internal.trees.Quasi].||(args.nonEmpty))
+         |found that args.isInstanceOf[scala.meta.internal.trees.Quasi] is false
+         |and also args.nonEmpty is false
+         |where args = List()
+         |""".stripMargin.replace("\n", EOL)
+    )(tuple)
+  }
+  test("nested Term.Tuple") {
+    def tuple = Term.Tuple(Term.Tuple(Lit.Unit() :: Nil) :: Nil)
+    // no exception
+    assert(Try(tuple).isSuccess)
+  }
+
+  test("empty Pat.Tuple") {
+    def tuple = Pat.Tuple(Nil)
+    interceptMessage[InvariantFailedException](
+      """|invariant failed (args should be non-empty):
+         |when verifying args.!=(null).&&(args.isInstanceOf[scala.meta.internal.trees.Quasi].||(args.nonEmpty))
+         |found that args.isInstanceOf[scala.meta.internal.trees.Quasi] is false
+         |and also args.nonEmpty is false
+         |where args = List()
+         |""".stripMargin.replace("\n", EOL)
+    )(tuple)
+  }
+  test("nested Pat.Tuple") {
+    def tuple = Pat.Tuple(Pat.Tuple(Lit.Unit() :: Nil) :: Nil)
+    // no exception
+    assert(Try(tuple).isSuccess)
+  }
+
+  test("empty Type.Tuple") {
+    def tuple = Type.Tuple(Nil)
+    interceptMessage[InvariantFailedException](
+      """|invariant failed (args should be non-empty):
+         |when verifying args.!=(null).&&(args.isInstanceOf[scala.meta.internal.trees.Quasi].||(args.nonEmpty))
+         |found that args.isInstanceOf[scala.meta.internal.trees.Quasi] is false
+         |and also args.nonEmpty is false
+         |where args = List()
+         |""".stripMargin.replace("\n", EOL)
+    )(tuple)
+  }
+  test("nested Type.Tuple") {
+    def tuple = Type.Tuple(Type.Tuple(Lit.Unit() :: Nil) :: Nil)
+    // no exception
+    assert(Try(tuple).isSuccess)
+  }
+
 }


### PR DESCRIPTION
The new version of scala 2.13 has finally discovered these issues, so let's fix them before adding support for that version.

First, we were using a parent check whereas we should have used a field check.

Second, the pattern was incorrect and didn't match the case of a single nested single-element tuple.

Finally, the only case that would have matched if it had been used as a field check was unnecessary, since the `@nonEmpty` notation covered it.