### PR TITLE
ScalametaParser: in fewer braces, limit type parse

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2435,8 +2435,10 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
       autoPos(getParam(mods, fullTypeOK))
     @tailrec
     def getParam(mods: List[Mod], fullTypeOK: Boolean): Term.Param = {
-      def afterName(name: Name) =
-        Term.Param(mods, name, getDeclTpeOpt(fullTypeOK = fullTypeOK), None)
+      def afterName(name: Name) = {
+        val tpe = if (fullTypeOK || mods.nonEmpty) getDeclTpeOpt(fullTypeOK = fullTypeOK) else None
+        Term.Param(mods, name, tpe, None)
+      }
       token match {
         case t: Ellipsis => ellipsis[Term.Param](t, 1)
         case t: Ident =>

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
@@ -2409,4 +2409,30 @@ class FewerBracesSuite extends BaseDottySuite {
     runTestAssert[Stat](code, layout)(tree)
   }
 
+  test("scalafmt #3785") {
+    val code =
+      """|val foo = bar(): loader =>
+         |  baz:
+         |    loader: _ => 
+         |      qux
+         |""".stripMargin
+    val layout = "val foo = bar()(loader => baz((loader: _) => qux))"
+    val tree = Defn.Val(
+      Nil,
+      List(Pat.Var(tname("foo"))),
+      None,
+      Term.Apply(
+        Term.Apply(tname("bar"), Nil),
+        Term.Function(
+          List(tparam("loader")),
+          Term.Apply(
+            tname("baz"),
+            List(Term.Function(List(tparam("loader", Type.Wildcard(noBounds))), tname("qux")))
+          )
+        ) :: Nil
+      )
+    )
+    runTestAssert[Stat](code, layout)(tree)
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
@@ -2416,7 +2416,7 @@ class FewerBracesSuite extends BaseDottySuite {
          |    loader: _ => 
          |      qux
          |""".stripMargin
-    val layout = "val foo = bar()(loader => baz((loader: _) => qux))"
+    val layout = "val foo = bar()(loader => baz(loader(_ => qux)))"
     val tree = Defn.Val(
       Nil,
       List(Pat.Var(tname("foo"))),
@@ -2427,7 +2427,10 @@ class FewerBracesSuite extends BaseDottySuite {
           List(tparam("loader")),
           Term.Apply(
             tname("baz"),
-            List(Term.Function(List(tparam("loader", Type.Wildcard(noBounds))), tname("qux")))
+            Term.Apply(
+              tname("loader"),
+              Term.Function(List(tparam("_")), tname("qux")) :: Nil
+            ) :: Nil
           )
         ) :: Nil
       )


### PR DESCRIPTION
Fixes scalameta/scalafmt#3785.