### PR TITLE
ScannerTokens: improve handling within `case` body

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -785,7 +785,8 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
               case (rc: RegionCaseBody) :: (r: RegionIndent) :: rs =>
                 if (nextIndent > r.indent) null
                 else if (next.is[KwFinally]) OutdentInfo(r, rs, noOutdent(rs))
-                else if (nextIndent < r.indent || rc.arrow.ne(prev) && !next.is[KwCase])
+                else if (nextIndent < r.indent || rc.arrow.ne(prev) &&
+                  (!next.is[KwCase]) || getNextToken(nextPos).isClassOrObject)
                   OutdentInfo(r, rs)
                 else null
               case (r: RegionIndent) :: (rs @ RegionTry :: xs) =>

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -724,9 +724,6 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
           case RegionTry :: xs
               if !next.isAny[KwCatch, KwFinally] && isLeadingInfix != LeadingInfix.Yes =>
             strip(xs)
-          case (_: RegionCaseBody) :: xs
-              if !next.isAny[KwCase, KwFinally] && isLeadingInfix != LeadingInfix.Yes =>
-            strip(xs)
           case Nil | (_: CanProduceLF) :: _ => Some(rs)
           case _ => None
         }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -4046,12 +4046,16 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin
     val layout =
       """|case 1 =>
-         |  println(2)(3, 4)
+         |  println(2)
+         |  (3, 4)
          |""".stripMargin
     val tree = Case(
       int(1),
       None,
-      Term.Apply(Term.Apply(tname("println"), List(int(2))), List(int(3), int(4)))
+      blk(
+        Term.Apply(tname("println"), List(int(2))),
+        Term.Tuple(List(int(3), int(4)))
+      )
     )
     runTestAssert[Case](code, layout)(tree)
   }
@@ -4096,7 +4100,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
         tname("baz")
       )
     )
-    parseAndCheckTree[Stat](code, layout)(tree)
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("scalafmt #3790 match optional braces, and case class following in case body") {
@@ -4141,7 +4145,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
         Nil
       )
     )
-    parseAndCheckTree[Stat](code, layout)(tree)
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("scalafmt #3790 match optional braces, and case class following after case body") {
@@ -4172,7 +4176,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
     val layout =
       """|def foo = bar match {
          |  case 1 =>
-         |    println(2)(3, 4)
+         |    println(2)
+         |    (3, 4)
          |    baz
          |}
          |""".stripMargin
@@ -4187,7 +4192,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
           int(1),
           None,
           blk(
-            Term.Apply(Term.Apply(tname("println"), List(int(2))), List(int(3), int(4))),
+            Term.Apply(tname("println"), List(int(2))),
+            Term.Tuple(List(int(3), int(4))),
             tname("baz")
           )
         ) :: Nil,

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -4157,11 +4157,44 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |    (3, 4)
          |  case class A(a: Int)
          |""".stripMargin
-    val error =
-      """|<input>:6: error: outdent expected but case found
+    val layout =
+      """|def foo = {
+         |  bar match {
+         |    case 1 =>
+         |      println(2)
+         |      (3, 4)
+         |  }
          |  case class A(a: Int)
-         |  ^""".stripMargin
-    runTestError[Stat](code, error)
+         |}
+         |""".stripMargin
+    val tree = Defn.Def(
+      Nil,
+      tname("foo"),
+      Nil,
+      None,
+      blk(
+        Term.Match(
+          tname("bar"),
+          Case(
+            int(1),
+            None,
+            blk(
+              Term.Apply(tname("println"), List(int(2))),
+              Term.Tuple(List(int(3), int(4)))
+            )
+          ) :: Nil,
+          Nil
+        ),
+        Defn.Class(
+          List(Mod.Case()),
+          pname("A"),
+          Nil,
+          ctorp(List(tparam("a", "Int"))),
+          tpl()
+        )
+      )
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("scalafmt #3790 match actual braces") {


### PR DESCRIPTION
- Remove wrong LF check for `case`
- Detect `case class` in `case` body
Fixes scalameta/scalafmt#3790. Fixes scalameta/scalafmt#3789.