### PR TITLE
LegacyScanner: remove unused float parsing logic

### DIFF
--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
@@ -875,31 +875,7 @@ class LegacyScanner(input: Input, dialect: Dialect) {
       if (!Character.isDigit(c))
         return setStrVal()
 
-      val isDefinitelyNumber = (c: @switch) match {
-        /** Another digit is a giveaway. */
-        case '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' =>
-          true
-
-        /* Backquoted idents like 22.`foo`. */
-        case '`' =>
-          return setStrVal()
-        /** Note the early return */
-
-        /* These letters may be part of a literal, or a method invocation on an Int.
-         */
-        case 'd' | 'D' | 'f' | 'F' =>
-          !isIdentifierPart(lookahead.getc())
-
-        /* A little more special handling for e.g. 5e7 */
-        case 'e' | 'E' =>
-          val ch = lookahead.getc()
-          !isIdentifierPart(ch) || (Character.isDigit(ch) || ch == '+' || ch == '-')
-
-        case x =>
-          !isIdentifierStart(x)
-      }
-      if (isDefinitelyNumber) restOfNumber()
-      else restOfUncertainToken()
+      restOfNumber()
     }
   }
 

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyTokenData.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyTokenData.scala
@@ -82,23 +82,11 @@ trait LegacyTokenData {
    */
   private def floatingVal: BigDecimal = {
     val text = strVal
-    def isDeprecatedForm = {
-      val idx = text indexOf '.'
-      (idx == text.length - 1) || (
-        (idx >= 0)
-          && (idx + 1 < text.length)
-          && (!Character.isDigit(text charAt (idx + 1)))
-      )
-    }
-    if (isDeprecatedForm) {
-      syntaxError("floating point number is missing digit after dot", at = offset)
-    } else {
-      val designatorSuffixes = List('d', 'D', 'f', 'F')
-      val parsee =
-        if (text.nonEmpty && designatorSuffixes.contains(text.last)) text.dropRight(1) else text
-      try BigDecimal(parsee)
-      catch { case _: Exception => syntaxError("malformed floating point number", at = offset) }
-    }
+    val designatorSuffixes = List('d', 'D', 'f', 'F')
+    val parsee =
+      if (text.nonEmpty && designatorSuffixes.contains(text.last)) text.dropRight(1) else text
+    try BigDecimal(parsee)
+    catch { case _: Exception => syntaxError("malformed floating point number", at = offset) }
   }
 
   def intVal: BigInt = integerVal


### PR DESCRIPTION
Since we already established that the next character is a digit, let's remove obsolete code which tries to consider other possibilities after that. Let's also remove the check for failure this logic has ruled out.