### PR TITLE
Lit.{Float,Double}: disallow NaN and Infinity

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1342,17 +1342,9 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
         else if (value < min) syntaxError("integer number too small", at = token)
         Lit.Long(value.toLong)
       case tok @ Constant.Float(rawValue) =>
-        if (rawValue > Float.MaxValue)
-          syntaxError("floating point number too large", at = token)
-        else if (rawValue < Float.MinValue)
-          syntaxError("floating point number too small", at = token)
         val value = tok.text
         Lit.Float(if (isNegated) s"-$value" else value)
       case tok @ Constant.Double(rawValue) =>
-        if (rawValue > Double.MaxValue)
-          syntaxError("floating point number too large", at = token)
-        else if (rawValue < Double.MinValue)
-          syntaxError("floating point number too small", at = token)
         val value = tok.text
         Lit.Double(if (isNegated) s"-$value" else value)
       case Constant.Char(value) =>

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -87,10 +87,24 @@ object Lit {
   // 1.4f.toString == "1.399999976158142" // in JS
   // 1.4f.toString == "1.4"               // in JVM
   // See https://www.scala-js.org/doc/semantics.html#tostring-of-float-double-and-unit
-  @ast class Double(format: scala.Predef.String) extends Lit { val value = format.toDouble }
-  object Double { def apply(double: scala.Double): Double = Lit.Double(double.toString) }
-  @ast class Float(format: scala.Predef.String) extends Lit { val value = format.toFloat }
-  object Float { def apply(float: scala.Float): Float = Lit.Float(float.toString) }
+  @ast class Double(format: scala.Predef.String) extends Lit {
+    val value = format.toDouble
+  }
+  object Double {
+    def apply(value: scala.Double): Double = {
+      org.scalameta.invariants.require(java.lang.Double.isFinite(value))
+      apply(value.toString)
+    }
+  }
+  @ast class Float(format: scala.Predef.String) extends Lit {
+    val value = format.toFloat
+  }
+  object Float {
+    def apply(value: scala.Float): Float = {
+      org.scalameta.invariants.require(java.lang.Float.isFinite(value))
+      apply(value.toString)
+    }
+  }
   @ast class Byte(value: scala.Byte) extends Lit
   @ast class Short(value: scala.Short) extends Lit
   @ast class Char(value: scala.Char) extends Lit

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -787,30 +787,12 @@ object TreeSyntax {
         )
       case Lit.Int(value) => m(Literal, s(value.toString))
       case Lit.Long(value) => m(Literal, s(value.toString + "L"))
-      case Lit.Float(value) =>
-        val n = value.toFloat
-        if (java.lang.Float.isNaN(n)) s("Float.NaN")
-        else {
-          n match {
-            case Float.PositiveInfinity => s("Float.PositiveInfinity")
-            case Float.NegativeInfinity => s("Float.NegativeInfinity")
-            case _ if Character.toLowerCase(value.last) == 'f' => s(value)
-            case _ =>
-              s(value, "f")
-          }
-        }
-      case Lit.Double(value) =>
-        val n = value.toDouble
-        if (java.lang.Double.isNaN(n)) s("Double.NaN")
-        else {
-          n match {
-            case Double.PositiveInfinity => s("Double.PositiveInfinity")
-            case Double.NegativeInfinity => s("Double.NegativeInfinity")
-            case _ if Character.toLowerCase(value.last) == 'd' => s(value)
-            case _ =>
-              s(value, "d")
-          }
-        }
+      case t: Lit.Float =>
+        val format = t.format
+        w(s(format), "f", Character.toLowerCase(format.last) != 'f')
+      case t: Lit.Double =>
+        val format = t.format
+        w(s(format), "d", Character.toLowerCase(format.last) != 'd')
       case t @ Lit.Char(value) =>
         val syntax = t.pos match {
           case Position.None => SingleQuotes(value)

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -1,6 +1,8 @@
 package scala.meta.tests
 package prettyprinters
 
+import org.scalameta.invariants.InvariantFailedException
+
 import scala.meta._
 import scala.meta.prettyprinters.Show
 import scala.meta.trees.Origin
@@ -424,23 +426,33 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     // assertEquals(Lit.Double(1.40d).structure, "Lit.Double(1.4d)") // trailing 0 is lost
     // assertEquals(Lit.Double(1.4d).structure, "Lit.Double(1.4d)")
     // assertEquals(Lit.Double(1.40d).structure, "Lit.Double(1.4d)") // trailing 0 is lost
-    assertEquals(Lit.Double(Double.NaN).syntax, "Double.NaN")
-    assertEquals(Lit.Double(Double.PositiveInfinity).syntax, "Double.PositiveInfinity")
-    assertEquals(Lit.Double(Double.NegativeInfinity).syntax, "Double.NegativeInfinity")
-    assertTree(Lit.Double(Double.NaN))(Lit.Double(Double.NaN))
-    assertTree(Lit.Double(Double.PositiveInfinity))(Lit.Double(Double.PositiveInfinity))
-    assertTree(Lit.Double(Double.NegativeInfinity))(Lit.Double(Double.NegativeInfinity))
+    def assertFiniteError(value: Double, what: String) =
+      interceptMessage[InvariantFailedException](
+        s"""|invariant failed:
+            |when verifying java.lang.Double.isFinite(value)
+            |found that java.lang.Double.isFinite(value) is false
+            |where value = $what
+            |""".stripMargin.replace("\n", EOL)
+      )(Lit.Double(value))
+    assertFiniteError(Double.NaN, "NaN")
+    assertFiniteError(Double.PositiveInfinity, "Infinity")
+    assertFiniteError(Double.NegativeInfinity, "-Infinity")
   }
 
   test("Lit.Float") {
     assertTree(templStat("1.4f"))(Lit.Float("1.4"))
     assertTree(templStat("1.40f"))(Lit.Float("1.40"))
-    assertEquals(Lit.Float(Float.NaN).syntax, "Float.NaN")
-    assertEquals(Lit.Float(Float.PositiveInfinity).syntax, "Float.PositiveInfinity")
-    assertEquals(Lit.Float(Float.NegativeInfinity).syntax, "Float.NegativeInfinity")
-    assertTree(Lit.Float(Float.NaN))(Lit.Float(Float.NaN))
-    assertTree(Lit.Float(Float.PositiveInfinity))(Lit.Float(Float.PositiveInfinity))
-    assertTree(Lit.Float(Float.NegativeInfinity))(Lit.Float(Float.NegativeInfinity))
+    def assertFiniteError(value: Float, what: String) =
+      interceptMessage[InvariantFailedException](
+        s"""|invariant failed:
+            |when verifying java.lang.Float.isFinite(value)
+            |found that java.lang.Float.isFinite(value) is false
+            |where value = $what
+            |""".stripMargin.replace("\n", EOL)
+      )(Lit.Float(value))
+    assertFiniteError(Float.NaN, "NaN")
+    assertFiniteError(Float.PositiveInfinity, "Infinity")
+    assertFiniteError(Float.NegativeInfinity, "-Infinity")
   }
 
   test("context and view bounds") {


### PR DESCRIPTION
These values cannot be specified using the scala numeric literal format and only using predefined constants like `Double.PositiveInfinity` and `Float.NaN`.

However, these constants would not be parsed as `Lit.Float` anyway, and instead as `Term.Select(...)`.