### PR TITLE
LegacyScanner: allow repeated number separators

### DIFF
--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
@@ -765,12 +765,12 @@ class LegacyScanner(input: Input, dialect: Dialect) {
       putChar(ch)
       nextChar()
       readDigits(base)
-    } else if (wasSeparator) {
-      val pos = if (ch == SU) begCharOffset else begCharOffset - 1
-      syntaxError("trailing number separator", at = pos)
     } else if (isNumberSeparator()) {
       nextChar()
       readDigits(base, true)
+    } else if (wasSeparator) {
+      val pos = if (ch == SU) begCharOffset else begCharOffset - 1
+      syntaxError("trailing number separator", at = pos)
     }
 
   /**

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
@@ -1141,8 +1141,11 @@ class TokenizerSuite extends BaseTokenizerSuite {
     "1_024L",
     "3_14e-2",
     "3_14E-2_1",
+    "3_14E-1__2",
     "0x_1234",
-    "0b_0101"
+    "0b_0101",
+    "123_456__789",
+    "0x__123_456__789"
   ).foreach { value =>
     test(s"numeric literal separator ok scala213: $value") {
       dialects.Scala213(value).tokenize.get // no exception
@@ -1199,12 +1202,6 @@ class TokenizerSuite extends BaseTokenizerSuite {
          |    ^""".stripMargin
     ),
     (
-      "3_14E-1__2",
-      """|<input>:1: error: trailing number separator
-         |3_14E-1__2
-         |       ^""".stripMargin
-    ),
-    (
       "3_14E-2_",
       """|<input>:1: error: trailing number separator
          |3_14E-2_
@@ -1233,18 +1230,6 @@ class TokenizerSuite extends BaseTokenizerSuite {
       """|<input>:1: error: trailing number separator
          |3.1_4_dd
          |     ^""".stripMargin
-    ),
-    (
-      "123_456__789",
-      """|<input>:1: error: trailing number separator
-         |123_456__789
-         |       ^""".stripMargin
-    ),
-    (
-      "0x__123_456__789",
-      """|<input>:1: error: trailing number separator
-         |0x__123_456__789
-         |  ^""".stripMargin
     )
   ).foreach { case (value, error) =>
     test(s"numeric literal separator fail scala213: $value") {

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
@@ -1136,7 +1136,14 @@ class TokenizerSuite extends BaseTokenizerSuite {
     }
   }
 
-  Seq("1_024", "1_024L", "3_14e-2", "3_14E-2_1").foreach { value =>
+  Seq(
+    "1_024",
+    "1_024L",
+    "3_14e-2",
+    "3_14E-2_1",
+    "0x_1234",
+    "0b_0101"
+  ).foreach { value =>
     test(s"numeric literal separator ok scala213: $value") {
       dialects.Scala213(value).tokenize.get // no exception
     }
@@ -1226,6 +1233,18 @@ class TokenizerSuite extends BaseTokenizerSuite {
       """|<input>:1: error: trailing number separator
          |3.1_4_dd
          |     ^""".stripMargin
+    ),
+    (
+      "123_456__789",
+      """|<input>:1: error: trailing number separator
+         |123_456__789
+         |       ^""".stripMargin
+    ),
+    (
+      "0x__123_456__789",
+      """|<input>:1: error: trailing number separator
+         |0x__123_456__789
+         |  ^""".stripMargin
     )
   ).foreach { case (value, error) =>
     test(s"numeric literal separator fail scala213: $value") {


### PR DESCRIPTION
Partial undo of #3593 where this logic was accidentally removed.