### PR TITLE
ScannerTokens: yet another leading infix fix

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -969,8 +969,8 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
   private def isLeadingInfixArg(afterOpPos: Int, nextIndent: Int) = {
     // we don't check for pos to be within bounds since we would exit on EOF first
     @tailrec def iter(pos: Int, indent: Int, prevNoNL: Boolean): LeadingInfix = tokens(pos) match {
-      case _: EOL => if (prevNoNL) iter(pos + 1, 0, false) else LeadingInfix.InvalidArg
-      case _: Whitespace => iter(pos + 1, if (prevNoNL) indent else indent + 1, prevNoNL)
+      case _: EOL => if (prevNoNL) iter(pos + 1, 0, false) else LeadingInfix.No
+      case _: HSpace => iter(pos + 1, if (prevNoNL) indent else indent + 1, prevNoNL)
       case c: Comment =>
         val commentIndent = multilineCommentIndent(c)
         iter(pos + 1, if (commentIndent < 0) indent else commentIndent, true)
@@ -981,7 +981,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
     }
     tokens(afterOpPos) match {
       case _: EOL => iter(afterOpPos + 1, 0, false)
-      case _: Whitespace => iter(afterOpPos + 1, -1, true)
+      case _: HSpace => iter(afterOpPos + 1, -1, true)
       case _: Comment => LeadingInfix.InvalidArg
       case _ => LeadingInfix.No
     }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
@@ -379,6 +379,26 @@ class DefnSuite extends ParseSuite {
     runTestAssert[Stat](code, layout)(tree)
   }
 
+  test("#3605 scala213") {
+    val code =
+      """|new A {
+         |  def b: C =
+         |    ???
+         |
+         |}
+         |""".stripMargin
+    val layout =
+      """|new A { def b: C = ??? }
+         |""".stripMargin
+    val tree = Term.NewAnonymous(
+      tpl(
+        List(Init(pname("A"), anon, Nil)),
+        List(Defn.Def(Nil, tname("b"), Nil, Some(pname("C")), tname("???")))
+      )
+    )
+    runTestAssert[Stat](code, layout)(tree)
+  }
+
   test("#3571 scala213source3") {
     implicit val Scala213 = scala.meta.dialects.Scala213Source3
     val code =
@@ -397,6 +417,22 @@ class DefnSuite extends ParseSuite {
       )
     )
     runTestAssert[Stat](code, layout)(tree)
+  }
+
+  test("#3605 scala213source3") {
+    implicit val Scala213 = scala.meta.dialects.Scala213Source3
+    val code =
+      """|new A {
+         |  def b: C =
+         |    ???
+         |
+         |}
+         |""".stripMargin
+    val error =
+      """|<input>:2: error: illegal start of simple expression
+         |  def b: C =
+         |            ^""".stripMargin
+    runTestError[Stat](code, error)
   }
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
@@ -428,11 +428,16 @@ class DefnSuite extends ParseSuite {
          |
          |}
          |""".stripMargin
-    val error =
-      """|<input>:2: error: illegal start of simple expression
-         |  def b: C =
-         |            ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout =
+      """|new A { def b: C = ??? }
+         |""".stripMargin
+    val tree = Term.NewAnonymous(
+      tpl(
+        List(Init(pname("A"), anon, Nil)),
+        List(Defn.Def(Nil, tname("b"), Nil, Some(pname("C")), tname("???")))
+      )
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -3361,4 +3361,24 @@ class SignificantIndentationSuite extends BaseDottySuite {
     runTestAssert[Stat](code, layout)(tree)
   }
 
+  test("#3605 scala3") {
+    val code =
+      """|new A {
+         |  def b: C =
+         |    ???
+         |
+         |}
+         |""".stripMargin
+    val layout =
+      """|new A { def b: C = ??? }
+         |""".stripMargin
+    val tree = Term.NewAnonymous(
+      tpl(
+        List(Init(pname("A"), anon, Nil)),
+        List(Defn.Def(Nil, tname("b"), Nil, Some(pname("C")), tname("???")))
+      )
+    )
+    runTestAssert[Stat](code, layout)(tree)
+  }
+
 }


### PR DESCRIPTION
- first, match HSpace instead of Whitespace, to exclude LFLF
- second, on double EOL, return No instead of InvalidArg (which is used
   to indicate incorrectly indented infix arguments).

Fixes #3605.