### PR TITLE
ScannerTokens: symbolic infix check to common

### DIFF
--- a/scalameta/tokens/shared/src/main/scala/scala/meta/tokens/package.scala
+++ b/scalameta/tokens/shared/src/main/scala/scala/meta/tokens/package.scala
@@ -1,3 +1,32 @@
 package scala.meta
 
-package object tokens extends tokens.Api
+import scala.annotation.tailrec
+import scala.meta.internal.tokens.Chars
+
+package object tokens extends tokens.Api {
+
+  implicit class TokenExtensions(private val value: Token) extends AnyVal {
+    @inline def isBackquoted: Boolean = value.text.isBackquoted
+    @inline def isSymbolicInfixOperator: Boolean =
+      value.isInstanceOf[Token.Ident] && isIdentSymbolicInfixOperator
+    @inline def isIdentSymbolicInfixOperator: Boolean = value.text.isIdentSymbolicInfixOperator
+  }
+
+  implicit class StringExtensions(private val value: String) extends AnyVal {
+
+    def isBackquoted: Boolean = value.startsWith("`") && value.endsWith("`")
+
+    def isIdentSymbolicInfixOperator: Boolean = isBackquoted || {
+      @tailrec
+      def iter(idx: Int, nonEmpty: Boolean): Boolean = {
+        val ch = value(idx)
+        if (ch == '_') nonEmpty || idx > 0 && iter(idx - 1, false)
+        else Chars.isOperatorPart(ch) && (idx == 0 || iter(idx - 1, true))
+      }
+
+      val len = value.length
+      len == 0 || iter(len - 1, false)
+    }
+  }
+
+}

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -166,9 +166,11 @@ class SurfaceSuite extends FunSuite {
       |scala.meta.tokenizers.Tokenized.Error *
       |scala.meta.tokenizers.Tokenized.Success *
       |scala.meta.tokens
+      |scala.meta.tokens.StringExtensions *
       |scala.meta.tokens.Token
       |scala.meta.tokens.Token.Interpolation *
       |scala.meta.tokens.Token.Xml *
+      |scala.meta.tokens.TokenExtensions *
       |scala.meta.tokens.Tokens
       |scala.meta.transversers
       |scala.meta.transversers.SimpleTraverser *
@@ -229,6 +231,10 @@ class SurfaceSuite extends FunSuite {
       |* A.equals(Any): Boolean
       |* A.hashCode(): Int
       |* A.maybeParse(implicit scala.meta.Dialect, scala.meta.parsers.Parse[A]): scala.meta.package.Parsed[A]
+      |* String.equals(Any): Boolean
+      |* String.hashCode(): Int
+      |* String.isBackquoted: Boolean
+      |* String.isIdentSymbolicInfixOperator: Boolean
       |* T(implicit scala.meta.classifiers.Classifiable[T]).is(implicit XtensionClassifiable.this.C[U]): Boolean
       |* T(implicit scala.meta.classifiers.Classifiable[T]).isAny(implicit XtensionClassifiable.this.C[U1], XtensionClassifiable.this.C[U2]): Boolean
       |* T(implicit scala.meta.classifiers.Classifiable[T]).isAny(implicit XtensionClassifiable.this.C[U1], XtensionClassifiable.this.C[U2], XtensionClassifiable.this.C[U3]): Boolean
@@ -253,6 +259,11 @@ class SurfaceSuite extends FunSuite {
       |* scala.meta.Tree.reparseAs(implicit scala.meta.Dialect, scala.meta.parsers.Parse[A]): scala.meta.package.Parsed[A]
       |* scala.meta.Tree.transform(PartialFunction[scala.meta.Tree,scala.meta.Tree]): scala.meta.Tree
       |* scala.meta.Tree.traverse(PartialFunction[scala.meta.Tree,Unit]): Unit
+      |* scala.meta.tokens.Token.equals(Any): Boolean
+      |* scala.meta.tokens.Token.hashCode(): Int
+      |* scala.meta.tokens.Token.isBackquoted: Boolean
+      |* scala.meta.tokens.Token.isIdentSymbolicInfixOperator: Boolean
+      |* scala.meta.tokens.Token.isSymbolicInfixOperator: Boolean
     """.trim.stripMargin.split('\n').mkString(EOL)
     )
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
@@ -446,6 +446,21 @@ class PublicSuite extends TreeSuiteBase {
   test("scala.meta.XtensionTree") {}
   test("scala.meta.XtensionTreeT") {}
 
+  test("scala.meta.tokens.TokenExtensions") {}
+  test("scala.meta.tokens.StringExtensions") {
+    import scala.meta.tokens.StringExtensions
+    assert(!"foo".isBackquoted)
+    assert(!"`foo".isBackquoted)
+    assert(!"foo`".isBackquoted)
+    assert("`".isBackquoted)
+    assert("`foo`".isBackquoted)
+
+    assert(!"foo".isIdentSymbolicInfixOperator)
+    assert("`foo`".isIdentSymbolicInfixOperator)
+    assert("foo_+".isIdentSymbolicInfixOperator)
+    assert("+".isIdentSymbolicInfixOperator)
+  }
+
   test("scala.meta.trees.Origin") {}
   test("scala.meta.trees.Origin.DialectOnly") {}
   test("scala.meta.trees.Origin.None") {}


### PR DESCRIPTION
This way, this check will be available publically.