### PR TITLE
ScannerTokens: add RegionLine if indented further

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
@@ -653,4 +653,102 @@ class InfixSuite extends BaseDottySuite {
     runTestAssert[Stat](code, Some(layout))(tree)
   }
 
+  test("scalafmt #3825 1") {
+    val code =
+      """|object a:
+         |  foo
+         |    .map: i =>
+         |      i + 1
+         |    *> bar
+         |""".stripMargin
+    val layout =
+      """|object a {
+         |  foo.map {
+         |    i => i + 1 *> bar
+         |  }
+         |}
+         |""".stripMargin
+    val tree = Defn.Object(
+      Nil,
+      tname("a"),
+      tpl(
+        Term.Apply(
+          Term.Select(tname("foo"), tname("map")),
+          blk(
+            Term.Function(
+              List(tparam("i")),
+              Term.ApplyInfix(
+                tname("i"),
+                tname("+"),
+                Nil,
+                List(Term.ApplyInfix(int(1), tname("*>"), Nil, List(tname("bar"))))
+              )
+            )
+          ) :: Nil
+        )
+      )
+    )
+    runTestAssert[Stat](code, layout)(tree)
+  }
+
+  test("scalafmt #3825 2") {
+    val code =
+      """|object a:
+         |  object b:
+         |    foo
+         |      .map: i =>
+         |        i + 1
+         |          + 2
+         |        + 3
+         |      *> bar
+         |    baz
+         |  qux
+         |""".stripMargin
+    val layout =
+      """|object a {
+         |  object b {
+         |    foo.map {
+         |      i => i + 1 + 2 + 3 *> bar
+         |    }
+         |    baz
+         |  }
+         |  qux
+         |}
+         |""".stripMargin
+    val tree = Defn.Object(
+      Nil,
+      tname("a"),
+      tpl(
+        Defn.Object(
+          Nil,
+          tname("b"),
+          tpl(
+            Term.Apply(
+              Term.Select(tname("foo"), tname("map")),
+              blk(
+                Term.Function(
+                  List(tparam("i")),
+                  Term.ApplyInfix(
+                    Term.ApplyInfix(
+                      Term.ApplyInfix(tname("i"), tname("+"), Nil, List(int(1))),
+                      tname("+"),
+                      Nil,
+                      List(int(2))
+                    ),
+                    tname("+"),
+                    Nil,
+                    List(Term.ApplyInfix(int(3), tname("*>"), Nil, List(tname("bar"))))
+                  )
+                )
+              ) :: Nil
+            ),
+            tname("baz")
+          )
+        ),
+        tname("qux")
+      )
+    )
+    runTestAssert[Stat](code, layout)(tree)
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
@@ -664,27 +664,27 @@ class InfixSuite extends BaseDottySuite {
     val layout =
       """|object a {
          |  foo.map {
-         |    i => i + 1 *> bar
-         |  }
+         |    i => i + 1
+         |  } *> bar
          |}
          |""".stripMargin
     val tree = Defn.Object(
       Nil,
       tname("a"),
       tpl(
-        Term.Apply(
-          Term.Select(tname("foo"), tname("map")),
-          blk(
-            Term.Function(
-              List(tparam("i")),
-              Term.ApplyInfix(
-                tname("i"),
-                tname("+"),
-                Nil,
-                List(Term.ApplyInfix(int(1), tname("*>"), Nil, List(tname("bar"))))
+        Term.ApplyInfix(
+          Term.Apply(
+            Term.Select(tname("foo"), tname("map")),
+            blk(
+              Term.Function(
+                List(tparam("i")),
+                Term.ApplyInfix(tname("i"), tname("+"), Nil, List(int(1)))
               )
-            )
-          ) :: Nil
+            ) :: Nil
+          ),
+          tname("*>"),
+          Nil,
+          List(tname("bar"))
         )
       )
     )
@@ -708,8 +708,8 @@ class InfixSuite extends BaseDottySuite {
       """|object a {
          |  object b {
          |    foo.map {
-         |      i => i + 1 + 2 + 3 *> bar
-         |    }
+         |      i => i + 1 + 2 + 3
+         |    } *> bar
          |    baz
          |  }
          |  qux
@@ -723,24 +723,29 @@ class InfixSuite extends BaseDottySuite {
           Nil,
           tname("b"),
           tpl(
-            Term.Apply(
-              Term.Select(tname("foo"), tname("map")),
-              blk(
-                Term.Function(
-                  List(tparam("i")),
-                  Term.ApplyInfix(
+            Term.ApplyInfix(
+              Term.Apply(
+                Term.Select(tname("foo"), tname("map")),
+                blk(
+                  Term.Function(
+                    List(tparam("i")),
                     Term.ApplyInfix(
-                      Term.ApplyInfix(tname("i"), tname("+"), Nil, List(int(1))),
+                      Term.ApplyInfix(
+                        Term.ApplyInfix(tname("i"), tname("+"), Nil, List(int(1))),
+                        tname("+"),
+                        Nil,
+                        List(int(2))
+                      ),
                       tname("+"),
                       Nil,
-                      List(int(2))
-                    ),
-                    tname("+"),
-                    Nil,
-                    List(Term.ApplyInfix(int(3), tname("*>"), Nil, List(tname("bar"))))
+                      List(int(3))
+                    )
                   )
-                )
-              ) :: Nil
+                ) :: Nil
+              ),
+              tname("*>"),
+              Nil,
+              List(tname("bar"))
             ),
             tname("baz")
           )


### PR DESCRIPTION
Fixes scalameta/scalafmt#3825.