### PR TITLE
Add tests with syntax-like backquoted identifiers

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
@@ -538,6 +538,18 @@ class ModSuite extends ParseSuite {
     }
   }
 
+  test("covariant-like in type") {
+    runTestAssert[Stat]("type A[`+`T] = B[T]", "type A[+T] = B[T]") {
+      Defn.Type(
+        Nil,
+        pname("A"),
+        pparam(List(Mod.Covariant()), "T") :: Nil,
+        Type.Apply(pname("B"), List(pname("T"))),
+        noBounds
+      )
+    }
+  }
+
   test("covariant in def") {
     interceptParseError(
       "def foo[+T](t: T): Int"
@@ -562,6 +574,22 @@ class ModSuite extends ParseSuite {
 
   test("contravariant in class") {
     assertTree(templStat("class A[-T](t: T)")) {
+      Defn.Class(
+        Nil,
+        pname("A"),
+        pparam(List(Mod.Contravariant()), "T") :: Nil,
+        Ctor.Primary(
+          Nil,
+          anon,
+          List(tparam("t", "T")) :: Nil
+        ),
+        EmptyTemplate()
+      )
+    }
+  }
+
+  test("contravariant-like in class") {
+    runTestAssert[Stat]("class A[`-`T](t: T)", "class A[-T](t: T)") {
       Defn.Class(
         Nil,
         pname("A"),

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/PatSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/PatSuite.scala
@@ -182,12 +182,18 @@ class PatSuite extends ParseSuite {
     assertPat("a :: ()")(
       ExtractInfix(Var(tname("a")), tname("::"), Nil)
     )
+    val error =
+      """|<input>:1: error: infix patterns cannot have type arguments
+         |a ::[T] ()
+         |    ^""".stripMargin
+    runTestError[Pat]("a ::[T] ()", error)
   }
 
   test("1 | 2 | 3") {
     assertPat("1 | 2 | 3")(
       Alternative(int(1), Alternative(int(2), int(3)))
     )
+    runTestAssert[Pat]("1 `|` 2", "1 | 2")(Alternative(int(1), int(2)))
   }
 
   test("()") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -913,6 +913,12 @@ class TermSuite extends ParseSuite {
     }
   }
 
+  test("x = (ys: _`*`)") {
+    runTestAssert[Stat]("x = (ys: _`*`)", "x = ys: _*") {
+      Term.Assign(tname("x"), Term.Repeated(tname("ys")))
+    }
+  }
+
   test("!(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length") {
     assertTerm("!(arr.cast[Ptr[Byte]] + sizeof[Ptr[_]]).cast[Ptr[Int]] = length") {
       Term.Assign(

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/VarargParameterSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/VarargParameterSuite.scala
@@ -105,6 +105,24 @@ class VarargParameterSuite extends ParseSuite {
     )
   }
 
+  test("vararg-like parameters") {
+    check(
+      "def obj(fa: Int, fb: Int`*`) = true",
+      Defn.Def(
+        Nil,
+        tname("obj"),
+        Nil,
+        List(List(tparam("fa", "Int"), tparam("fb", Type.Repeated(pname("Int"))))),
+        None,
+        lit(true)
+      )
+    )
+    checkError(
+      "def obj(fa: Int`*`, fb: Int) = true",
+      "error: *-parameter must come last"
+    )
+  }
+
   private def check(definition: String, expected: scala.meta.Stat): Unit = {
     checkTree(templStat(definition))(expected)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/PatSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/PatSuite.scala
@@ -191,11 +191,17 @@ class PatSuite extends ParseSuite {
 
   test("a :: ()") {
     assertPat("a :: ()")(ExtractInfix(Var(tname("a")), tname("::"), Nil))
+    val error =
+      """|<input>:1: error: infix patterns cannot have type arguments
+         |a ::[T] ()
+         |    ^""".stripMargin
+    runTestError[Pat]("a ::[T] ()", error)
   }
 
   test("1 | 2 | 3") {
     assertPat("1 | 2")(Alternative(int(1), int(2)))
     assertPat("1 | 2 | 3")(Alternative(int(1), Alternative(int(2), int(3))))
+    runTestAssert[Pat]("1 `|` 2", "1 | 2")(Alternative(int(1), int(2)))
   }
 
   test("()") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
@@ -453,6 +453,20 @@ class TypeSuite extends BaseDottySuite {
     }
   }
 
+  test("F[`*`]") {
+    // will be deprecated in later versions
+    implicit val dialect: Dialect = dialects.Scala31
+    runTestAssert[Type]("F[`*`]", "F[*]") {
+      AnonymousLambda(Apply(TypeName("F"), List(AnonymousParam(None))))
+    }
+    runTestAssert[Type]("F[`+*`]", "F[+*]") {
+      AnonymousLambda(Apply(TypeName("F"), List(AnonymousParam(Some(Mod.Covariant())))))
+    }
+    runTestAssert[Type]("F[`-*`]", "F[-*]") {
+      AnonymousLambda(Apply(TypeName("F"), List(AnonymousParam(Some(Mod.Contravariant())))))
+    }
+  }
+
   test("F[T] forSome { type T }") {
     assertTpe("F[T] forSome { type T }") {
       Existential(


### PR DESCRIPTION
Helps with #3631.