### PR TITLE
ScalametaParser: check `$` not backquoted in macro

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -534,7 +534,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) { parser =>
 
   private object MacroSplicedIdent extends MacroIdent {
     protected def ident(token: Token): Option[String] = token match {
-      case Ident(value) if value.length > 1 && value.charAt(0) == '$' => Some(value.substring(1))
+      case Keywords(value) if value.length > 1 && value.charAt(0) == '$' => Some(value.substring(1))
       case _ => None
     }
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
@@ -233,6 +233,7 @@ class MacroSuite extends BaseDottySuite {
     val tree = Term.SplicedMacroExpr(blk(Term.SplicedMacroExpr(tname("x"))))
     runTestAssert[Stat](code)(tree)
     runTestAssert[Stat](code, assertLayout = Some(code))(tree)
+    runTestAssert[Stat]("${ `$x` }", code)(tree)
   }
 
   test("macro-splice: ${ powerCode('x) }") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
@@ -233,7 +233,8 @@ class MacroSuite extends BaseDottySuite {
     val tree = Term.SplicedMacroExpr(blk(Term.SplicedMacroExpr(tname("x"))))
     runTestAssert[Stat](code)(tree)
     runTestAssert[Stat](code, assertLayout = Some(code))(tree)
-    runTestAssert[Stat]("${ `$x` }", code)(tree)
+    val backquoted = Term.SplicedMacroExpr(blk(tname("$x")))
+    parseAndCheckTree[Stat]("${ `$x` }", code)(backquoted)
   }
 
   test("macro-splice: ${ powerCode('x) }") {


### PR DESCRIPTION
Helps with #3631.