### PR TITLE
token: override definition of `text()` for fixed

### DIFF
--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/tokens/token.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/tokens/token.scala
@@ -91,9 +91,11 @@ class TokenNamerMacros(val c: Context) extends TokenNamerMacroHelpers {
         stats1 += q"private[meta] def name: _root_.scala.Predef.String = $tokenName"
 
         // step 5: generate implementation of `def end: String` for fixed tokens
-        if (isFixed && !hasMethod("end")) {
-          val code = providedTokenName // as simple as that
-          stats1 += q"def end: _root_.scala.Int = this.start + ${code.length}"
+        if (isFixed) {
+          if (!hasMethod("end")) // for fixed, as simple as adding length of name
+            stats1 += q"def end: _root_.scala.Int = this.start + ${providedTokenName.length}"
+          if (!hasMethod("text"))
+            stats1 += q"override def text: _root_.scala.Predef.String = $providedTokenName"
         }
 
         // step 6: generate implementation of `Companion.unapply`


### PR DESCRIPTION
There's no need to look up the underlying text from position and input when the token is fixed.