### PR TITLE
Replace scalafiddle reference with scastie

### DIFF
--- a/docs/trees/guide.md
+++ b/docs/trees/guide.md
@@ -50,10 +50,10 @@ Welcome to the Ammonite Repl 2.3.8 (Scala 2.13.5 Java 11.0.7)
 @ import $ivy.`org.scalameta::scalameta:@VERSION@`, scala.meta._
 ```
 
-### ScalaFiddle
+### Scastie
 
 You can try out Scalameta online with the
-[ScalaFiddle playground](scalafiddle.html).
+[Scastie playground](scastie.html).
 
 ## What is a syntax tree?
 

--- a/docs/trees/scalafiddle.md
+++ b/docs/trees/scalafiddle.md
@@ -1,8 +1,0 @@
----
-id: scalafiddle
-title: ScalaFiddle Playground
----
-
-Scalameta runs in the browser thanks to [Scala.js](http://www.scala-js.org/).
-
-<iframe height="400px" frameborder="0" style="width: 100%" src="https://embed.scalafiddle.io/embed?sfid=73hv0Cv/0&layout=v43"></iframe>

--- a/docs/trees/scastie.md
+++ b/docs/trees/scastie.md
@@ -1,0 +1,6 @@
+---
+id: scastie
+title: Scastie Playground
+---
+
+You can try Scalameta in the browser with [Scastie](https://scastie.scala-lang.org/w2zX3RPiSkeK5gIGlDO1Mw/).

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,6 +1,6 @@
 {
   "docs": {
-    "Trees": ["trees/guide", "trees/quasiquotes", "trees/examples", "trees/scalafiddle", "trees/astexplorer", "trees/scaladoc"],
+    "Trees": ["trees/guide", "trees/quasiquotes", "trees/examples", "trees/scastie", "trees/astexplorer", "trees/scaladoc"],
     "SemanticDB": ["semanticdb/guide", "semanticdb/specification"],
     "Community": ["misc/built-with-scalameta", "misc/presentations"]
   }


### PR DESCRIPTION
Seems like the good-old (dead now) ScalaFiddle redirects to https://bee-line.dk/ for some reason...  

https://scalameta.org/docs/trees/scalafiddle.html shows an iframe of this site: https://bee-line.dk/ :sweat: 

This PR replaces it with a Scastie playground.