### PR TITLE
ScannerTokens: keep multiple outdents to swap `,`

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/LazyTokenIterator.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/LazyTokenIterator.scala
@@ -21,9 +21,9 @@ private[parsers] class LazyTokenIterator private (
 
   import scannerTokens._
 
-  private def getNextTokenRef(): TokenRef = {
-    if (curr.next eq null) nextToken(curr) else curr.next
-  }
+  @inline
+  private def getNextTokenRef(): TokenRef =
+    nextToken(curr)
 
   override def next(): Unit = {
     prev = curr

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -325,15 +325,16 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
     }
   }
 
-  @inline
-  private[parsers] def nextToken(ref: TokenRef): TokenRef = {
-    val next = nextToken(ref.token, ref.pos, ref.nextPos, ref.regions)
-    ref.next = next
-    next
+  private[parsers] def nextToken(ref: TokenRef): TokenRef = ref.next match {
+    case null =>
+      val next = nextToken(ref.token, ref.pos, ref.nextPos, ref.regions)
+      ref.next = next
+      next
+    case nref => nref
   }
 
   @tailrec
-  private[parsers] def nextToken(
+  private def nextToken(
       prevToken: Token,
       prevPos: Int,
       currPos: Int,

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -1675,6 +1675,22 @@ class SignificantIndentationSuite extends BaseDottySuite {
     runTestAssert[Stat](code, layout)(tree)
   }
 
+  test("#3542 apply with optional braces in intermediate arg, with multiple outdents") {
+    val code =
+      """|A(
+         |  foo = x =>
+         |    x match
+         |      case baz => baz,
+         |  bar = bar
+         |)
+         |""".stripMargin
+    val error =
+      """|<input>:4: error: `;` expected but `,` found
+         |      case baz => baz,
+         |                     ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
   test("indented-double-apply") {
     runTestAssert[Stat](
       """|def method = 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -1684,11 +1684,25 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |  bar = bar
          |)
          |""".stripMargin
-    val error =
-      """|<input>:4: error: `;` expected but `,` found
-         |      case baz => baz,
-         |                     ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout =
+      """|A(foo = x => x match {
+         |  case baz => baz
+         |}, bar = bar)
+         |""".stripMargin
+    val tree = Term.Apply(
+      tname("A"),
+      List(
+        Term.Assign(
+          tname("foo"),
+          Term.Function(
+            List(tparam("x")),
+            Term.Match(tname("x"), List(Case(Pat.Var(tname("baz")), None, tname("baz"))), Nil)
+          )
+        ),
+        Term.Assign(tname("bar"), tname("bar"))
+      )
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("indented-double-apply") {


### PR DESCRIPTION
`nextToken` ignored the `.next` field and tried to recompute the next token; instead, we should not do that if that field is already set.

Fixes #3664. Follow-up to #3542.
