### PR TITLE
Add tests for type `***`

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TypeSuite.scala
@@ -268,4 +268,8 @@ class TypeSuite extends ParseSuite {
     assertNoDiff(err.shortMessage, "can't have multiple parameter lists in function types")
   }
 
+  test("#3672 [scala213] ***") {
+    runTestAssert[Type]("***")(pname("***"))
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
@@ -678,4 +678,8 @@ class TypeSuite extends BaseDottySuite {
     )
   }
 
+  test("#3672 [scala3] ***") {
+    parseAndCheckTree[Type]("***", "*")(Type.AnonymousParam(None))
+  }
+
 }


### PR DESCRIPTION
Helps with #3672.