### PR TITLE
ScannerTokens: allow breaks within `for()`

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -660,6 +660,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
           case RegionTry :: xs
               if !next.isAny[KwCatch, KwFinally] && isLeadingInfix != LeadingInfix.Yes => strip(xs)
           case Nil | (_: CanProduceLF) :: _ => Some(rs)
+          case RegionParen :: RegionForMaybeParens :: _ => Some(rs)
           case _ => None
         }
         val ok = lastNewlinePos >= 0 && !CantStartStat(next) &&

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -1341,10 +1341,16 @@ class TermSuite extends ParseSuite {
                   |  if a === b
                   |) yield a
                   |""".stripMargin
-    val error = """|<input>:3: error: `)` expected but `<-` found
-                   |  b <- foob
-                   |    ^""".stripMargin
-    runTestError[Term](code, error)
+    val layout = "for (a <- fooa; b <- foob; if a === b) yield a"
+    val tree = Term.ForYield(
+      List(
+        Enumerator.Generator(Pat.Var(tname("a")), tname("fooa")),
+        Enumerator.Generator(Pat.Var(tname("b")), tname("foob")),
+        Enumerator.Guard(Term.ApplyInfix(tname("a"), tname("==="), Nil, List(tname("b"))))
+      ),
+      tname("a")
+    )
+    runTestAssert[Term](code, layout)(tree)
   }
 
   test("scalafmt #3911 for in parens, NL after `(`, `;` between") {
@@ -1371,10 +1377,16 @@ class TermSuite extends ParseSuite {
                   |     b <- foob
                   |     if a === b) yield a
                   |""".stripMargin
-    val error = """|<input>:2: error: `)` expected but `<-` found
-                   |     b <- foob
-                   |       ^""".stripMargin
-    runTestError[Term](code, error)
+    val layout = "for (a <- fooa; b <- foob; if a === b) yield a"
+    val tree = Term.ForYield(
+      List(
+        Enumerator.Generator(Pat.Var(tname("a")), tname("fooa")),
+        Enumerator.Generator(Pat.Var(tname("b")), tname("foob")),
+        Enumerator.Guard(Term.ApplyInfix(tname("a"), tname("==="), Nil, List(tname("b"))))
+      ),
+      tname("a")
+    )
+    runTestAssert[Term](code, layout)(tree)
   }
 
   test("scalafmt #3911 for in parens, no NL after `(`, `;` between") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -1334,4 +1334,94 @@ class TermSuite extends ParseSuite {
     runTestAssert[Term](code, Some(layout))(tree)
   }
 
+  test("scalafmt #3911 for in parens, NL after `(`, NL between") {
+    val code = """|for (
+                  |  a <- fooa
+                  |  b <- foob
+                  |  if a === b
+                  |) yield a
+                  |""".stripMargin
+    val error = """|<input>:3: error: `)` expected but `<-` found
+                   |  b <- foob
+                   |    ^""".stripMargin
+    runTestError[Term](code, error)
+  }
+
+  test("scalafmt #3911 for in parens, NL after `(`, `;` between") {
+    val code = """|for (
+                  |  a <- fooa;
+                  |  b <- foob;
+                  |  if a === b
+                  |) yield a
+                  |""".stripMargin
+    val layout = "for (a <- fooa; b <- foob; if a === b) yield a"
+    val tree = Term.ForYield(
+      List(
+        Enumerator.Generator(Pat.Var(tname("a")), tname("fooa")),
+        Enumerator.Generator(Pat.Var(tname("b")), tname("foob")),
+        Enumerator.Guard(Term.ApplyInfix(tname("a"), tname("==="), Nil, List(tname("b"))))
+      ),
+      tname("a")
+    )
+    runTestAssert[Term](code, layout)(tree)
+  }
+
+  test("scalafmt #3911 for in parens, no NL after `(`, NL between") {
+    val code = """|for (a <- fooa
+                  |     b <- foob
+                  |     if a === b) yield a
+                  |""".stripMargin
+    val error = """|<input>:2: error: `)` expected but `<-` found
+                   |     b <- foob
+                   |       ^""".stripMargin
+    runTestError[Term](code, error)
+  }
+
+  test("scalafmt #3911 for in parens, no NL after `(`, `;` between") {
+    val code = """|for (a <- fooa;
+                  |     b <- foob;
+                  |     if a === b) yield a
+                  |""".stripMargin
+    val layout = "for (a <- fooa; b <- foob; if a === b) yield a"
+    val tree = Term.ForYield(
+      List(
+        Enumerator.Generator(Pat.Var(tname("a")), tname("fooa")),
+        Enumerator.Generator(Pat.Var(tname("b")), tname("foob")),
+        Enumerator.Guard(Term.ApplyInfix(tname("a"), tname("==="), Nil, List(tname("b"))))
+      ),
+      tname("a")
+    )
+    runTestAssert[Term](code, layout)(tree)
+  }
+
+  test("scalafmt #3911 for in parens, no NL after `(`, NL between, no NL before guard") {
+    val code = """|for (a <- fooa if
+                  |       a > 0) yield a
+                  |""".stripMargin
+    val layout = "for (a <- fooa; if a > 0) yield a"
+    val tree = Term.ForYield(
+      List(
+        Enumerator.Generator(Pat.Var(tname("a")), tname("fooa")),
+        Enumerator.Guard(Term.ApplyInfix(tname("a"), tname(">"), Nil, List(lit(0))))
+      ),
+      tname("a")
+    )
+    runTestAssert[Term](code, layout)(tree)
+  }
+
+  test("scalafmt #3911 for in parens, no NL after `(`, `;` between, no NL before guard op") {
+    val code = """|for (a <- fooa if a >
+                  |       0) yield a
+                  |""".stripMargin
+    val layout = "for (a <- fooa; if a > 0) yield a"
+    val tree = Term.ForYield(
+      List(
+        Enumerator.Generator(Pat.Var(tname("a")), tname("fooa")),
+        Enumerator.Guard(Term.ApplyInfix(tname("a"), tname(">"), Nil, List(lit(0))))
+      ),
+      tname("a")
+    )
+    runTestAssert[Term](code, layout)(tree)
+  }
+
 }


### PR DESCRIPTION
Fixes scalameta/scalafmt#3911.