### PR TITLE
CharArrayReader: remove validation of surrogates

### DIFF
--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/CharArrayReader.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/CharArrayReader.scala
@@ -55,21 +55,14 @@ private[meta] case class CharArrayReader private (
     else {
       begCharOffset = endCharOffset
       val (hi, hiEnd) = readUnicodeChar(buf, endCharOffset)
-      val isHiSurrogate = Character.isHighSurrogate(hi)
-      if (isHiSurrogate && hiEnd >= buf.length)
-        readerError("invalid unicode surrogate pair", at = begCharOffset)
-      else if (!isHiSurrogate || ch == '\'' && buf(hiEnd) == '\'' && !wasMultiChar) {
-        ch = hi
-        endCharOffset = hiEnd
-      } else {
+      endCharOffset = hiEnd
+      if (hiEnd < buf.length && Character.isHighSurrogate(hi)) {
         val (lo, loEnd) = readUnicodeChar(buf, hiEnd)
-        if (!Character.isLowSurrogate(lo))
-          readerError("invalid unicode surrogate pair", at = begCharOffset)
-        else {
+        if (Character.isLowSurrogate(lo)) {
           ch = Character.toCodePoint(hi, lo)
           endCharOffset = loEnd
-        }
-      }
+        } else ch = hi
+      } else ch = hi
     }
 
   def nextNonWhitespace = {

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/BaseTokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/BaseTokenizerSuite.scala
@@ -24,11 +24,17 @@ abstract class BaseTokenizerSuite extends TreeSuiteBase {
 
   def assertTokenizedAsStructureLines(code: String, expected: String, dialect: Dialect = Scala211)(
       implicit loc: Location
-  ): Unit = assertNoDiff(tokenize(code, dialect).map(_.structure).mkString("\n"), expected)
+  ): Unit = assertTokensAsStructureLines(tokenize(code, dialect), expected)
+
+  def assertTokensAsStructureLines(tokens: Tokens, expected: String)(implicit loc: Location): Unit =
+    assertNoDiff(tokens.map(_.structure).mkString("\n"), expected)
 
   def assertTokenizedAsSyntax(code: String, expected: String, dialect: Dialect = Scala211)(implicit
       loc: Location
-  ): Unit = assertNoDiff(tokenize(code, dialect).map(_.syntax).mkString, expected)
+  ): Unit = assertTokensAsSyntax(tokenize(code, dialect), expected)
+
+  def assertTokensAsSyntax(tokens: Tokens, expected: String)(implicit loc: Location): Unit =
+    assertNoDiff(tokens.map(_.syntax).mkString, expected)
 
   implicit class ImplicitString(value: String) {
     def tq(repl: String): String = value.replace(repl, "\"\"\"")

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
@@ -1643,26 +1643,11 @@ class TokenizerSuite extends BaseTokenizerSuite {
   }
 
   Seq(
-    // high-surrogate char codes
-    55297
-  ).foreach { ch =>
-    test(s"#3690 high-surrogate with char code $ch") {
-      def tokens = tokenize(
-        s"""|"${ch.toChar}"
-            |""".stripMargin,
-        dialects.Scala213
-      )
-      val exception = intercept[TokenizeException](tokens)
-      val err = "<input>:1: error: invalid unicode surrogate pair"
-      assertEquals(exception.getMessage.substring(0, err.length), err)
-    }
-  }
-
-  Seq(
-    // regular or low-surrogate or char codes
+    // regular or half-surrogate char codes
+    55297,
     56375
   ).foreach { ch =>
-    test(s"#3690 non-high-surrogate with char code $ch") {
+    test(s"#3690 any character with char code $ch") {
       tokenize(
         s"""|"${ch.toChar}"
             |""".stripMargin,


### PR DESCRIPTION
For some reason, invalid or incomplete unicode surrogates are allowed
by the scala compiler. Also, we were only checking for standalone
high surrogates, not the low surrogates.

Therefore, let's remove this validation. If we assume that the code is
compilable, it's not our job to invalidate it.

Fixes #3690. Follow on to #3402.