### PR TITLE
ScalametaParser: keep pos if dropping outer block

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -92,6 +92,14 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
   @inline
   private def isFollowedByNL(index: Int): Boolean = tokens(getStrictNext(index)).is[AtEOLorF]
 
+  @tailrec
+  final def isPrecededByDetachedComment(idx: Int, end: Int): Boolean = idx > end &&
+    (tokens(idx) match {
+      case _: Comment => isPrecededByNL(idx)
+      case _: Whitespace => isPrecededByDetachedComment(idx - 1, end)
+      case _ => false
+    })
+
   @inline
   private def isEndMarkerIdentifier(token: Token) = soft.KwEnd(token)
 

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -705,9 +705,9 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |    else
        |      gx
        |      // c2
-       |Term.Name fx
+       |Term.Block fx
        |      // c1
-       |Term.Name gx
+       |Term.Block gx
        |      // c2
        |""".stripMargin
   )
@@ -738,13 +738,18 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |    else
        |      gx
        |    // c2
-       |Term.If if cond then
+       |Term.Block if cond then
        |      fx
        |      // c1
        |    else
        |      gx
        |    // c2
-       |Term.Name fx
+       |Term.If if cond then
+       |      fx
+       |      // c1
+       |    else
+       |      gx
+       |Term.Block fx
        |      // c1
        |""".stripMargin
   )
@@ -782,9 +787,9 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |    else
        |      gx
        |      // c2
-       |Term.Name fx
+       |Term.Block fx
        |      // c1
-       |Term.Name gx
+       |Term.Block gx
        |      // c2
        |""".stripMargin
   )
@@ -816,13 +821,18 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |    else
        |      gx
        |    // c2
-       |Term.If if cond then
+       |Term.Block if cond then
        |      fx
        |      // c1
        |    else
        |      gx
        |    // c2
-       |Term.Name fx
+       |Term.If if cond then
+       |      fx
+       |      // c1
+       |    else
+       |      gx
+       |Term.Block fx
        |      // c1
        |""".stripMargin
   )
@@ -854,13 +864,18 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |    else
        |      gx
        |    // c2
-       |Term.If if cond then
+       |Term.Block if cond then
        |      fx
        |      // c1
        |    else
        |      gx
        |    // c2
-       |Term.Name fx
+       |Term.If if cond then
+       |      fx
+       |      // c1
+       |    else
+       |      gx
+       |Term.Block fx
        |      // c1
        |""".stripMargin
   )
@@ -890,13 +905,18 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |    else
        |      gx
        |    /* c2 */
-       |Term.If if cond then
+       |Term.Block if cond then
        |      fx
        |      // c1
        |    else
        |      gx
        |    /* c2 */
-       |Term.Name fx
+       |Term.If if cond then
+       |      fx
+       |      // c1
+       |    else
+       |      gx
+       |Term.Block fx
        |      // c1
        |""".stripMargin
   )
@@ -1147,7 +1167,6 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |""".stripMargin,
     """|Defn.Val val b =
        |    1 // comment
-       |Lit.Int 1 // comment
        |""".stripMargin
   )
 
@@ -1177,7 +1196,6 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |""".stripMargin,
     """|Defn.Val val b = // comment1
        |    1 // comment2
-       |Lit.Int 1 // comment2
        |""".stripMargin
   )
 
@@ -1209,7 +1227,6 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
     """|Defn.Val val b =
        |    // comment1
        |    1 // comment2
-       |Lit.Int 1 // comment2
        |""".stripMargin
   )
 
@@ -1307,7 +1324,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
     """|Defn.Val val b =
        |    1
        |    // comment
-       |Lit.Int 1
+       |Term.Block 1
        |    // comment
        |""".stripMargin
   )
@@ -1343,7 +1360,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
     """|Defn.Val val b = // comment1
        |    1
        |    // comment2
-       |Lit.Int 1
+       |Term.Block 1
        |    // comment2
        |""".stripMargin
   )
@@ -1381,7 +1398,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |    // comment1
        |    1
        |    // comment2
-       |Lit.Int 1
+       |Term.Block 1
        |    // comment2
        |""".stripMargin
   )

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -1128,4 +1128,285 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |""".stripMargin
   )
 
+  // #3689 1
+  checkPositions[Term](
+    """|{
+       |  val a = 1 // comment
+       |}
+       |""".stripMargin,
+    """|Defn.Val val a = 1
+       |""".stripMargin
+  )
+
+  // #3689 2
+  checkPositions[Term](
+    """|{
+       |  val b =
+       |    1 // comment
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b =
+       |    1 // comment
+       |Lit.Int 1 // comment
+       |""".stripMargin
+  )
+
+  // #3689 2.1
+  checkPositions[Term](
+    """|{
+       |  val b = {
+       |    1 // comment
+       |  }
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b = {
+       |    1 // comment
+       |  }
+       |Term.Block {
+       |    1 // comment
+       |  }
+       |""".stripMargin
+  )
+
+  // #3689 3
+  checkPositions[Term](
+    """|{
+       |  val b = // comment1
+       |    1 // comment2
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b = // comment1
+       |    1 // comment2
+       |Lit.Int 1 // comment2
+       |""".stripMargin
+  )
+
+  // #3689 3.1
+  checkPositions[Term](
+    """|{
+       |  val b = /* comment1 */ {
+       |    1 // comment2
+       |  }
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b = /* comment1 */ {
+       |    1 // comment2
+       |  }
+       |Term.Block {
+       |    1 // comment2
+       |  }
+       |""".stripMargin
+  )
+
+  // #3689 4
+  checkPositions[Term](
+    """|{
+       |  val b =
+       |    // comment1
+       |    1 // comment2
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b =
+       |    // comment1
+       |    1 // comment2
+       |Lit.Int 1 // comment2
+       |""".stripMargin
+  )
+
+  // #3689 4.1
+  checkPositions[Term](
+    """|{
+       |  val b = {
+       |    // comment1
+       |    1 // comment2
+       |  }
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b = {
+       |    // comment1
+       |    1 // comment2
+       |  }
+       |Term.Block {
+       |    // comment1
+       |    1 // comment2
+       |  }
+       |""".stripMargin
+  )
+
+  // #3689 5
+  checkPositions[Term](
+    """|{
+       |  val b = // comment
+       |    1
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b = // comment
+       |    1
+       |""".stripMargin
+  )
+
+  // #3689 5.1
+  checkPositions[Term](
+    """|{
+       |  val b = /* comment */ {
+       |    1
+       |  }
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b = /* comment */ {
+       |    1
+       |  }
+       |Term.Block {
+       |    1
+       |  }
+       |""".stripMargin
+  )
+
+  // #3689 6
+  checkPositions[Term](
+    """|{
+       |  val b =
+       |    // comment
+       |    1
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b =
+       |    // comment
+       |    1
+       |""".stripMargin
+  )
+
+  // #3689 6.1
+  checkPositions[Term](
+    """|{
+       |  val b = {
+       |    // comment
+       |    1
+       |  }
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b = {
+       |    // comment
+       |    1
+       |  }
+       |Term.Block {
+       |    // comment
+       |    1
+       |  }
+       |""".stripMargin
+  )
+
+  // #3689 7
+  checkPositions[Term](
+    """|{
+       |  val b =
+       |    1
+       |    // comment
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b =
+       |    1
+       |    // comment
+       |Lit.Int 1
+       |    // comment
+       |""".stripMargin
+  )
+
+  // #3689 7.1
+  checkPositions[Term](
+    """|{
+       |  val b = {
+       |    1
+       |    // comment
+       |  }
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b = {
+       |    1
+       |    // comment
+       |  }
+       |Term.Block {
+       |    1
+       |    // comment
+       |  }
+       |""".stripMargin
+  )
+
+  // #3689 8
+  checkPositions[Term](
+    """|{
+       |  val b = // comment1
+       |    1
+       |    // comment2
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b = // comment1
+       |    1
+       |    // comment2
+       |Lit.Int 1
+       |    // comment2
+       |""".stripMargin
+  )
+
+  // #3689 8.1
+  checkPositions[Term](
+    """|{
+       |  val b = /* comment1 */ {
+       |    1
+       |    // comment2
+       |  }
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b = /* comment1 */ {
+       |    1
+       |    // comment2
+       |  }
+       |Term.Block {
+       |    1
+       |    // comment2
+       |  }
+       |""".stripMargin
+  )
+
+  // #3689 9
+  checkPositions[Term](
+    """|{
+       |  val b =
+       |    // comment1
+       |    1
+       |    // comment2
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b =
+       |    // comment1
+       |    1
+       |    // comment2
+       |Lit.Int 1
+       |    // comment2
+       |""".stripMargin
+  )
+
+  // #3689 9.1
+  checkPositions[Term](
+    """|{
+       |  val b = {
+       |    // comment1
+       |    1
+       |    // comment2
+       |  }
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b = {
+       |    // comment1
+       |    1
+       |    // comment2
+       |  }
+       |Term.Block {
+       |    // comment1
+       |    1
+       |    // comment2
+       |  }
+       |""".stripMargin
+  )
+
 }

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
@@ -804,4 +804,274 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
        |Type.ArgClause (10) + @@1 toInt
        |""".stripMargin
   )
+
+  // #3689 1
+  checkPositions[Term](
+    """|{
+       |  val a = 1 // comment
+       |}
+       |""".stripMargin,
+    """|Defn.Val val a = 1
+       |""".stripMargin
+  )
+
+  // #3689 2
+  checkPositions[Term](
+    """|{
+       |  val b =
+       |    1 // comment
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b =
+       |    1
+       |""".stripMargin
+  )
+
+  // #3689 2.1
+  checkPositions[Term](
+    """|{
+       |  val b = {
+       |    1 // comment
+       |  }
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b = {
+       |    1 // comment
+       |  }
+       |Term.Block {
+       |    1 // comment
+       |  }
+       |""".stripMargin
+  )
+
+  // #3689 3
+  checkPositions[Term](
+    """|{
+       |  val b = // comment1
+       |    1 // comment2
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b = // comment1
+       |    1
+       |""".stripMargin
+  )
+
+  // #3689 3.1
+  checkPositions[Term](
+    """|{
+       |  val b = /* comment1 */ {
+       |    1 // comment2
+       |  }
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b = /* comment1 */ {
+       |    1 // comment2
+       |  }
+       |Term.Block {
+       |    1 // comment2
+       |  }
+       |""".stripMargin
+  )
+
+  // #3689 4
+  checkPositions[Term](
+    """|{
+       |  val b =
+       |    // comment1
+       |    1 // comment2
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b =
+       |    // comment1
+       |    1
+       |""".stripMargin
+  )
+
+  // #3689 4.1
+  checkPositions[Term](
+    """|{
+       |  val b = {
+       |    // comment1
+       |    1 // comment2
+       |  }
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b = {
+       |    // comment1
+       |    1 // comment2
+       |  }
+       |Term.Block {
+       |    // comment1
+       |    1 // comment2
+       |  }
+       |""".stripMargin
+  )
+
+  // #3689 5
+  checkPositions[Term](
+    """|{
+       |  val b = // comment
+       |    1
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b = // comment
+       |    1
+       |""".stripMargin
+  )
+
+  // #3689 5.1
+  checkPositions[Term](
+    """|{
+       |  val b = /* comment */ {
+       |    1
+       |  }
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b = /* comment */ {
+       |    1
+       |  }
+       |Term.Block {
+       |    1
+       |  }
+       |""".stripMargin
+  )
+
+  // #3689 6
+  checkPositions[Term](
+    """|{
+       |  val b =
+       |    // comment
+       |    1
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b =
+       |    // comment
+       |    1
+       |""".stripMargin
+  )
+
+  // #3689 6.1
+  checkPositions[Term](
+    """|{
+       |  val b = {
+       |    // comment
+       |    1
+       |  }
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b = {
+       |    // comment
+       |    1
+       |  }
+       |Term.Block {
+       |    // comment
+       |    1
+       |  }
+       |""".stripMargin
+  )
+
+  // #3689 7
+  checkPositions[Term](
+    """|{
+       |  val b =
+       |    1
+       |    // comment
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b =
+       |    1
+       |""".stripMargin
+  )
+
+  // #3689 7.1
+  checkPositions[Term](
+    """|{
+       |  val b = {
+       |    1
+       |    // comment
+       |  }
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b = {
+       |    1
+       |    // comment
+       |  }
+       |Term.Block {
+       |    1
+       |    // comment
+       |  }
+       |""".stripMargin
+  )
+
+  // #3689 8
+  checkPositions[Term](
+    """|{
+       |  val b = // comment1
+       |    1
+       |    // comment2
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b = // comment1
+       |    1
+       |""".stripMargin
+  )
+
+  // #3689 8.1
+  checkPositions[Term](
+    """|{
+       |  val b = /* comment1 */ {
+       |    1
+       |    // comment2
+       |  }
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b = /* comment1 */ {
+       |    1
+       |    // comment2
+       |  }
+       |Term.Block {
+       |    1
+       |    // comment2
+       |  }
+       |""".stripMargin
+  )
+
+  // #3689 9
+  checkPositions[Term](
+    """|{
+       |  val b =
+       |    // comment1
+       |    1
+       |    // comment2
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b =
+       |    // comment1
+       |    1
+       |""".stripMargin
+  )
+
+  // #3689 9.1
+  checkPositions[Term](
+    """|{
+       |  val b = {
+       |    // comment1
+       |    1
+       |    // comment2
+       |  }
+       |}
+       |""".stripMargin,
+    """|Defn.Val val b = {
+       |    // comment1
+       |    1
+       |    // comment2
+       |  }
+       |Term.Block {
+       |    // comment1
+       |    1
+       |    // comment2
+       |  }
+       |""".stripMargin
+  )
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExtensionMethodsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExtensionMethodsSuite.scala
@@ -170,18 +170,20 @@ class ExtensionMethodsSuite extends BaseDottySuite {
          |    
          |    /** */
          |""".stripMargin,
-      assertLayout = Some("extension (a: Int) def double = a * 2")
+      """|extension (a: Int) {
+         |  def double = a * 2
+         |}""".stripMargin
     )(Defn.ExtensionGroup(
       Nil,
       List(List(tparam("a", "Int"))),
-      Defn.Def(
+      blk(Defn.Def(
         Nil,
         tname("double"),
         Nil,
         Nil,
         None,
         Term.ApplyInfix(tname("a"), tname("*"), Nil, List(int(2)))
-      )
+      ))
     ))
   }
 


### PR DESCRIPTION
Also, retain a significant-indentation block if it ends in a detached comment, as otherwise the comment's indentation would be lost. Fixes #3689.