### PR TITLE
ScannerTokens: check right delim in CantStartStat

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2289,7 +2289,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
     inParensOnOpenOr(token match {
       case t @ Ellipsis(2) => (ellipsis[Term](t) :: Nil).reduceWith(Term.ArgClause(_))
       case x =>
-        val using = x.text == soft.KwUsing.name && !CantStartStat(peekToken)
+        val using = x.text == soft.KwUsing.name && mightStartStat(peekToken, closeDelimOK = false)
         val mod = if (using) Some(atCurPosNext(Mod.Using())) else None
         argumentExprsInParens(location).reduceWith(Term.ArgClause(_, mod))
     })(Term.ArgClause(Nil))
@@ -2422,7 +2422,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
 
   def enumerators(): List[Enumerator] = listBy[Enumerator] { enums =>
     enumeratorBuf(enums, isFirst = true)
-    while (StatSep(token) && nextIf(!peekToken.isAny[Indentation.Outdent, KwDo]))
+    while (StatSep(token) && nextIf(!peekToken.isAny[Indentation.Outdent, KwDo, CloseDelim]))
       enumeratorBuf(enums, isFirst = false)
   }
 

--- a/tests/jvm/src/test/resources/metac.expect_2.12
+++ b/tests/jvm/src/test/resources/metac.expect_2.12
@@ -4656,7 +4656,7 @@ Occurrences:
 [15:9..15:9):  <= types/P#X#`<init>`().
 [16:6..16:7): x <= types/P#x.
 [16:14..16:15): X => types/P#X#
-[17:0..17:0):  => types/P#X#`<init>`().
+[16:15..16:15):  => types/P#X#`<init>`().
 [19:6..19:7): T <= types/T#
 [19:8..19:8):  <= types/T#`<init>`().
 [20:8..20:9): C <= types/T#C#
@@ -4665,7 +4665,7 @@ Occurrences:
 [21:9..21:9):  <= types/T#X#`<init>`().
 [22:6..22:7): x <= types/T#x.
 [22:14..22:15): X => types/T#X#
-[23:0..23:0):  => types/T#X#`<init>`().
+[22:15..22:15):  => types/T#X#`<init>`().
 [25:7..25:11): Test <= types/Test.
 [26:8..26:9): M <= types/Test.M#
 [26:10..26:10):  <= types/Test.M#`<init>`().

--- a/tests/jvm/src/test/resources/metac.expect_2.13
+++ b/tests/jvm/src/test/resources/metac.expect_2.13
@@ -4721,7 +4721,7 @@ Occurrences:
 [15:9..15:9):  <= types/P#X#`<init>`().
 [16:6..16:7): x <= types/P#x.
 [16:14..16:15): X => types/P#X#
-[17:0..17:0):  => types/P#X#`<init>`().
+[16:15..16:15):  => types/P#X#`<init>`().
 [19:6..19:7): T <= types/T#
 [19:8..19:8):  <= types/T#`<init>`().
 [20:8..20:9): C <= types/T#C#
@@ -4730,7 +4730,7 @@ Occurrences:
 [21:9..21:9):  <= types/T#X#`<init>`().
 [22:6..22:7): x <= types/T#x.
 [22:14..22:15): X => types/T#X#
-[23:0..23:0):  => types/T#X#`<init>`().
+[22:15..22:15):  => types/T#X#`<init>`().
 [25:7..25:11): Test <= types/Test.
 [26:8..26:9): M <= types/Test.M#
 [26:10..26:10):  <= types/Test.M#`<init>`().


### PR DESCRIPTION
This allows explicit LF before right delims if present.