### PR TITLE
ScalametaParser: remove trailing comment in endpos

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -343,7 +343,9 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
       if (nonSpaceEnd < startPos) return (startPos, if (endPos == startPos) endPos else endExcl)
       val start = tokens.skipIf(_.is[Trivia], startPos, endExcl)
       if (start > endPos) return (startPos, nonSpaceEnd + 1)
-      (start, nonSpaceEnd + 1)
+      if (!tokens(nonSpaceEnd).is[Comment]) return (start, nonSpaceEnd + 1)
+      val end = tokens.rskipIf(_.is[HTrivia], nonSpaceEnd - 1, start)
+      (start, (if (tokens(end).is[AtEOLorF]) nonSpaceEnd else end) + 1)
     }
     val (start, endExcl) = getPosRange()
     body.withOrigin(Origin.Parsed(originSource, start, endExcl))

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -947,9 +947,9 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |  case (false, false) => (baz, qux) // c1""".stripMargin,
     """|Pat.Tuple (x, y)
        |Term.Match (foo, bar) match
-       |  case (false, false) => (baz, qux) // c1
+       |  case (false, false) => (baz, qux)
        |Term.Tuple (foo, bar)
-       |Case case (false, false) => (baz, qux) // c1
+       |Case case (false, false) => (baz, qux)
        |Pat.Tuple (false, false)
        |Term.Tuple (baz, qux)
        |""".stripMargin
@@ -961,9 +961,9 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |""".stripMargin,
     """|Pat.Tuple (x, y)
        |Term.Match (foo, bar) match
-       |  case (false, false) => (baz, qux) // c1
+       |  case (false, false) => (baz, qux)
        |Term.Tuple (foo, bar)
-       |Case case (false, false) => (baz, qux) // c1
+       |Case case (false, false) => (baz, qux)
        |Pat.Tuple (false, false)
        |Term.Tuple (baz, qux)
        |""".stripMargin
@@ -977,12 +977,12 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
     """|Pat.Tuple (x, y)
        |Term.Match (foo, bar) match
        |  case (true, false) => (baz, qux) // c1
-       |  case (false, true) => (baz, qux) // c2
+       |  case (false, true) => (baz, qux)
        |Term.Tuple (foo, bar)
-       |Case case (true, false) => (baz, qux) // c1
+       |Case case (true, false) => (baz, qux)
        |Pat.Tuple (true, false)
        |Term.Tuple (baz, qux)
-       |Case case (false, true) => (baz, qux) // c2
+       |Case case (false, true) => (baz, qux)
        |Pat.Tuple (false, true)
        |Term.Tuple (baz, qux)
        |""".stripMargin
@@ -995,12 +995,12 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
     """|Pat.Tuple (x, y)
        |Term.Match (foo, bar) match
        |  case (true, false) => (baz, qux) // c1
-       |  case (false, true) => (baz, qux) // c2
+       |  case (false, true) => (baz, qux)
        |Term.Tuple (foo, bar)
-       |Case case (true, false) => (baz, qux) // c1
+       |Case case (true, false) => (baz, qux)
        |Pat.Tuple (true, false)
        |Term.Tuple (baz, qux)
-       |Case case (false, true) => (baz, qux) // c2
+       |Case case (false, true) => (baz, qux)
        |Pat.Tuple (false, true)
        |Term.Tuple (baz, qux)
        |""".stripMargin
@@ -1011,10 +1011,10 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |  case (true, false) => (baz, qux) // c1
        |  case (false, true) => (baz, qux) // c2""".stripMargin,
     """|Term.Tuple (foo, bar)
-       |Case case (true, false) => (baz, qux) // c1
+       |Case case (true, false) => (baz, qux)
        |Pat.Tuple (true, false)
        |Term.Tuple (baz, qux)
-       |Case case (false, true) => (baz, qux) // c2
+       |Case case (false, true) => (baz, qux)
        |Pat.Tuple (false, true)
        |Term.Tuple (baz, qux)
        |""".stripMargin
@@ -1025,10 +1025,10 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |case (true, false) => (baz, qux) // c1
        |case (false, true) => (baz, qux) // c2""".stripMargin,
     """|Term.Tuple (foo, bar)
-       |Case case (true, false) => (baz, qux) // c1
+       |Case case (true, false) => (baz, qux)
        |Pat.Tuple (true, false)
        |Term.Tuple (baz, qux)
-       |Case case (false, true) => (baz, qux) // c2
+       |Case case (false, true) => (baz, qux)
        |Pat.Tuple (false, true)
        |Term.Tuple (baz, qux)
        |""".stripMargin
@@ -1040,10 +1040,10 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |case (false, true) => (baz, qux) // c2
        |""".stripMargin,
     """|Term.Tuple (foo, bar)
-       |Case case (true, false) => (baz, qux) // c1
+       |Case case (true, false) => (baz, qux)
        |Pat.Tuple (true, false)
        |Term.Tuple (baz, qux)
-       |Case case (false, true) => (baz, qux) // c2
+       |Case case (false, true) => (baz, qux)
        |Pat.Tuple (false, true)
        |Term.Tuple (baz, qux)
        |""".stripMargin
@@ -1166,7 +1166,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |}
        |""".stripMargin,
     """|Defn.Val val b =
-       |    1 // comment
+       |    1
        |""".stripMargin
   )
 
@@ -1195,7 +1195,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |}
        |""".stripMargin,
     """|Defn.Val val b = // comment1
-       |    1 // comment2
+       |    1
        |""".stripMargin
   )
 
@@ -1226,7 +1226,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |""".stripMargin,
     """|Defn.Val val b =
        |    // comment1
-       |    1 // comment2
+       |    1
        |""".stripMargin
   )
 


### PR DESCRIPTION
Fixes #3689.