### PR TITLE
Dialects: add explicit `allowQuietSyntax` flag

### DIFF
--- a/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
@@ -158,6 +158,8 @@ final class Dialect private[meta] (
      * It wasn't available in Scala 3.0 and got introduced later.
      */
     val allowFewerBraces: Boolean,
+    // https://docs.scala-lang.org/scala3/reference/other-new-features/control-syntax.html
+    val allowQuietSyntax: Boolean,
     // Are binary literals allowed? SIP-42.
     val allowBinaryLiterals: Boolean
 ) extends Product with Serializable {
@@ -253,6 +255,7 @@ final class Dialect private[meta] (
     allowInfixOperatorAfterNL = false,
     allowParamClauseInterleaving = false,
     allowFewerBraces = false,
+    allowQuietSyntax = false,
     allowBinaryLiterals = false
     // NOTE(olafur): declare the default value for new fields above this comment.
   )
@@ -385,6 +388,8 @@ final class Dialect private[meta] (
 
   def withAllowFewerBraces(newValue: Boolean): Dialect = privateCopy(allowFewerBraces = newValue)
 
+  def withAllowQuietSyntax(newValue: Boolean): Dialect = privateCopy(allowQuietSyntax = newValue)
+
   def withAllowBinaryLiterals(newValue: Boolean): Dialect =
     privateCopy(allowBinaryLiterals = newValue)
 
@@ -452,6 +457,7 @@ final class Dialect private[meta] (
       allowInfixOperatorAfterNL: Boolean = this.allowInfixOperatorAfterNL,
       allowParamClauseInterleaving: Boolean = this.allowParamClauseInterleaving,
       allowFewerBraces: Boolean = this.allowFewerBraces,
+      allowQuietSyntax: Boolean = this.allowQuietSyntax,
       allowBinaryLiterals: Boolean = this.allowBinaryLiterals
       // NOTE(olafur): add the next parameter above this comment.
   ): Dialect = {
@@ -514,6 +520,7 @@ final class Dialect private[meta] (
       allowInfixOperatorAfterNL = allowInfixOperatorAfterNL,
       allowParamClauseInterleaving = allowParamClauseInterleaving,
       allowFewerBraces = allowFewerBraces,
+      allowQuietSyntax = allowQuietSyntax,
       allowBinaryLiterals = allowBinaryLiterals
     )
     if (equivalent) return this // RETURN!
@@ -578,6 +585,7 @@ final class Dialect private[meta] (
       allowInfixOperatorAfterNL = allowInfixOperatorAfterNL,
       allowParamClauseInterleaving = allowParamClauseInterleaving,
       allowFewerBraces = allowFewerBraces,
+      allowQuietSyntax = allowQuietSyntax,
       allowBinaryLiterals = allowBinaryLiterals,
       // NOTE(olafur): add the next argument above this comment.
       unquoteType = unquoteType,
@@ -665,6 +673,7 @@ final class Dialect private[meta] (
       allowInfixOperatorAfterNL: Boolean,
       allowParamClauseInterleaving: Boolean,
       allowFewerBraces: Boolean,
+      allowQuietSyntax: Boolean,
       allowBinaryLiterals: Boolean
   ): Boolean =
     // do not include deprecated values in this comparison
@@ -716,6 +725,7 @@ final class Dialect private[meta] (
       this.useInfixTypePrecedence == useInfixTypePrecedence &&
       this.allowInfixOperatorAfterNL == allowInfixOperatorAfterNL &&
       this.allowParamClauseInterleaving == allowParamClauseInterleaving &&
+      this.allowQuietSyntax == allowQuietSyntax && // separated from "significant indentation"
       this.allowFewerBraces == allowFewerBraces && this.allowBinaryLiterals == allowBinaryLiterals
 
   @inline
@@ -778,6 +788,7 @@ final class Dialect private[meta] (
       allowInfixOperatorAfterNL = that.allowInfixOperatorAfterNL,
       allowParamClauseInterleaving = that.allowParamClauseInterleaving,
       allowFewerBraces = that.allowFewerBraces,
+      allowQuietSyntax = that.allowQuietSyntax,
       allowBinaryLiterals = that.allowBinaryLiterals
     )
 

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -95,7 +95,7 @@ package object dialects {
     .withAllowAsForImportRename(true).withAllowStarWildcardImport(true)
     .withAllowProcedureSyntax(false).withAllowDoWhile(false).withAllowStarAsTypePlaceholder(true)
     .withUseInfixTypePrecedence(true).withAllowInfixOperatorAfterNL(true)
-    .withAllowBinaryLiterals(false)
+    .withAllowBinaryLiterals(false).withAllowQuietSyntax(true)
 
   implicit val Scala31: Dialect = Scala30.withAllowErasedDefs(true)
 

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1414,7 +1414,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
   }
 
   private def condExprInParens[T <: Token: ClassTag]: Term =
-    if (dialect.allowSignificantIndentation) {
+    if (dialect.allowQuietSyntax) {
       val startPos = tokenPos
       val simpleExpr = condExpr()
       tryParse {
@@ -1496,7 +1496,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
           if (acceptOpt[LeftBrace]) inBracesAfterOpen(enumerators())
           else if (token.is[LeftParen]) {
             def parseInParens() = inParensOnOpen(enumerators())
-            if (dialect.allowSignificantIndentation)
+            if (dialect.allowQuietSyntax)
               // Dotty retry in case of `for (a,b) <- list1.zip(list2) yield (a, b)`
               tryParse(Try(parseInParens()).toOption).getOrElse(enumerators())
             else parseInParens()

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -528,9 +528,8 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
           case _ => sepRegions
         })
       case _: KwFor => currRef(RegionFor(next) :: sepRegions)
-      case _: KwWhile if dialect.allowSignificantIndentation =>
-        currRef(RegionWhile(next) :: sepRegions)
-      case _: KwIf if dialect.allowSignificantIndentation =>
+      case _: KwWhile if dialect.allowQuietSyntax => currRef(RegionWhile(next) :: sepRegions)
+      case _: KwIf if dialect.allowQuietSyntax =>
         currRef(dropRegionLine(sepRegions) match {
           case rs @ (_: RegionCaseExpr | _: RegionFor) :: _ => rs
           case rs @ (_: RegionDelim) :: (_: RegionFor) :: _ => rs
@@ -541,7 +540,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
           case (_: RegionIf) :: rs => currRef(RegionThen :: rs)
           case _ => currRef(RegionThen :: sepRegions)
         }
-      case _: KwElse if dialect.allowSignificantIndentation =>
+      case _: KwElse if dialect.allowQuietSyntax =>
         dropRegionLine(sepRegions) match {
           case (r: RegionIndent) :: RegionThen :: rs => outdentThenCurrRef(r, rs)
           case (_: RegionControl) :: rs => currRef(rs)
@@ -588,7 +587,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
               case _: Dot | _: KwMatch => rc.asCond() :: rs
               // might continue cond or start body
               case _: Ident | _: LeftBrace | _: LeftBracket | _: LeftParen | _: Underscore
-                  if dialect.allowSignificantIndentation => rc.asCondOrBody() :: rs
+                  if dialect.allowQuietSyntax => rc.asCondOrBody() :: rs
               case _ => rc.asBody().fold(rs)(_ :: rs)
             }
           case RegionForMaybeParens if prev.is[RightParen] =>

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyTokenData.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyTokenData.scala
@@ -102,7 +102,7 @@ trait LegacyTokenData {
       case ENUM if !dialect.allowEnums =>
       case GIVEN if !dialect.allowGivenUsing =>
       case EXPORT if !dialect.allowExportClause =>
-      case THEN if !dialect.allowSignificantIndentation =>
+      case THEN if !dialect.allowQuietSyntax =>
       case TYPELAMBDAARROW if !dialect.allowTypeLambdas =>
       case CTXARROW if !dialect.allowGivenUsing =>
       case x =>

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/package.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/package.scala
@@ -70,7 +70,7 @@ package object tokenizers {
       dialectKeywords += "given"
       dialectKeywords += "?=>"
     }
-    if (dialect.allowSignificantIndentation) dialectKeywords += "then"
+    if (dialect.allowQuietSyntax) dialectKeywords += "then"
 
     baseKeywords ++ dialectKeywords.result()
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -3683,4 +3683,78 @@ class ControlSyntaxSuite extends BaseDottySuite {
     runTestAssert[Stat](code, layout)(tree)
   }
 
+  test("scalafmt #3941 no significant indentation with quiet syntax: if-then 1") {
+    implicit val dialect = dialects.Scala3.withAllowSignificantIndentation(false)
+    val code = """|def demo() = {
+                  |  if true then greet()
+                  |  else
+                  |    sayGoodbye()
+                  |    openDoor()
+                  |}
+                  |""".stripMargin
+    val error = """|<input>:3: error: `then` expected but `else` found
+                   |  else
+                   |  ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("scalafmt #3941 no significant indentation with quiet syntax: if-then 2") {
+    implicit val dialect = dialects.Scala3.withAllowSignificantIndentation(false)
+    val code = """|def demo() = {
+                  |  if (a + b)
+                  |    == (c + d)
+                  |  then greet()
+                  |  else
+                  |    sayGoodbye()
+                  |    openDoor()
+                  |}
+                  |""".stripMargin
+    val error = """|<input>:5: error: `;` expected but `else` found
+                   |  else
+                   |  ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("scalafmt #3941 no significant indentation with quiet syntax: while-do 1") {
+    implicit val dialect = dialects.Scala3.withAllowSignificantIndentation(false)
+    val code = """|def demo() = {
+                  |  while true do
+                  |    sayGoodbye()
+                  |    openDoor()
+                  |}
+                  |""".stripMargin
+    val layout = """|def demo() = {
+                    |  while (true) sayGoodbye()
+                    |  openDoor()
+                    |}""".stripMargin
+    val tree = Defn.Def(
+      Nil,
+      tname("demo"),
+      Nil,
+      List(Nil),
+      None,
+      blk(
+        Term.While(lit(true), Term.Apply(tname("sayGoodbye"), Nil)),
+        Term.Apply(tname("openDoor"), Nil)
+      )
+    )
+    runTestAssert[Stat](code, layout)(tree)
+  }
+
+  test("scalafmt #3941 no significant indentation with quiet syntax: while-do 2") {
+    implicit val dialect = dialects.Scala3.withAllowSignificantIndentation(false)
+    val code = """|def demo() = {
+                  |  while (a + b)
+                  |    == (c + d)
+                  |  do
+                  |    sayGoodbye()
+                  |    openDoor()
+                  |}
+                  |""".stripMargin
+    val error = """|<input>:4: error: do {...} while (...) syntax is no longer supported
+                   |  do
+                   |  ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -3692,10 +3692,23 @@ class ControlSyntaxSuite extends BaseDottySuite {
                   |    openDoor()
                   |}
                   |""".stripMargin
-    val error = """|<input>:3: error: `then` expected but `else` found
-                   |  else
-                   |  ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = """|def demo() = {
+                    |  if (true) greet() else sayGoodbye()
+                    |  openDoor()
+                    |}""".stripMargin
+    val tree = Defn.Def(
+      Nil,
+      tname("demo"),
+      Nil,
+      List(Nil),
+      None,
+      blk(
+        Term
+          .If(lit(true), Term.Apply(tname("greet"), Nil), Term.Apply(tname("sayGoodbye"), Nil), Nil),
+        Term.Apply(tname("openDoor"), Nil)
+      )
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("scalafmt #3941 no significant indentation with quiet syntax: if-then 2") {
@@ -3709,10 +3722,32 @@ class ControlSyntaxSuite extends BaseDottySuite {
                   |    openDoor()
                   |}
                   |""".stripMargin
-    val error = """|<input>:5: error: `;` expected but `else` found
-                   |  else
-                   |  ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = """|def demo() = {
+                    |  if (a + b == c + d) greet() else sayGoodbye()
+                    |  openDoor()
+                    |}""".stripMargin
+    val tree = Defn.Def(
+      Nil,
+      tname("demo"),
+      Nil,
+      List(Nil),
+      None,
+      blk(
+        Term.If(
+          Term.ApplyInfix(
+            Term.ApplyInfix(tname("a"), tname("+"), Nil, List(tname("b"))),
+            tname("=="),
+            Nil,
+            List(Term.ApplyInfix(tname("c"), tname("+"), Nil, List(tname("d"))))
+          ),
+          Term.Apply(tname("greet"), Nil),
+          Term.Apply(tname("sayGoodbye"), Nil),
+          Nil
+        ),
+        Term.Apply(tname("openDoor"), Nil)
+      )
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("scalafmt #3941 no significant indentation with quiet syntax: while-do 1") {
@@ -3751,10 +3786,30 @@ class ControlSyntaxSuite extends BaseDottySuite {
                   |    openDoor()
                   |}
                   |""".stripMargin
-    val error = """|<input>:4: error: do {...} while (...) syntax is no longer supported
-                   |  do
-                   |  ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = """|def demo() = {
+                    |  while (a + b == c + d) sayGoodbye()
+                    |  openDoor()
+                    |}""".stripMargin
+    val tree = Defn.Def(
+      Nil,
+      tname("demo"),
+      Nil,
+      List(Nil),
+      None,
+      blk(
+        Term.While(
+          Term.ApplyInfix(
+            Term.ApplyInfix(tname("a"), tname("+"), Nil, List(tname("b"))),
+            tname("=="),
+            Nil,
+            List(Term.ApplyInfix(tname("c"), tname("+"), Nil, List(tname("d"))))
+          ),
+          Term.Apply(tname("sayGoodbye"), Nil)
+        ),
+        Term.Apply(tname("openDoor"), Nil)
+      )
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
 }


### PR DESCRIPTION
Previously, this logic was unlocked with `allowSignificantIndentation` implicitly. Use `.allowQuietSyntax` for `if-then`/`while-do`. Helps with scalameta/scalafmt#3941.