### PR TITLE
ScalametaParser: allow Enum.Val before generator

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2444,14 +2444,14 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
     case _: KwIf if !isFirst => enumeratorGuardOnIf()
     case t: Ellipsis => ellipsis[Enumerator](t, 1)
     case t: Unquote if !peekToken.isAny[Equals, LeftArrow] => unquote[Enumerator](t) // support for q"for ($enum1; ..$enums; $enum2)"
-    case _ => generator(!isFirst)
+    case _ => generator()
   }
 
   def quasiquoteEnumerator(): Enumerator = entrypointEnumerator()
 
   def entrypointEnumerator(): Enumerator = enumerator()
 
-  private def generator(eqOK: Boolean): Enumerator with Tree.WithBody = {
+  private def generator(): Enumerator with Tree.WithBody = {
     val startPos = tokenPos
     val hasVal = acceptOpt[KwVal]
     val isCase = acceptOpt[KwCase]
@@ -2463,7 +2463,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
       if (hasEq) deprecationWarning("val keyword in for comprehension is deprecated", at = token)
       else syntaxError("val in for comprehension must be followed by assignment", at = token)
 
-    if (hasEq && eqOK) next() else accept[LeftArrow]
+    if (hasEq) next() else accept[LeftArrow]
     val rhs = expr()
 
     autoEndPos(startPos) {

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/package.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/package.scala
@@ -236,9 +236,6 @@ package object trees {
   }
 
   private[meta] def checkValidEnumerators(enums: List[Enumerator]): Boolean =
-    enums.headOption match {
-      case Some(_: Enumerator.Generator | _: Enumerator.CaseGenerator | _: Enumerator.Quasi) => true
-      case _ => false
-    }
+    !enums.headOption.forall(_.is[Enumerator.Guard])
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -1171,6 +1171,237 @@ class ControlSyntaxSuite extends BaseDottySuite {
     runTestAssert[Stat](code, layout)(tree)
   }
 
+  test("enum-val-first-ok-1") {
+    val code = """|for {
+                  |  a = 1
+                  |  b <- Some(2)
+                  |} yield a + b
+                  |""".stripMargin
+    val layout = "for (a = 1; b <- Some(2)) yield a + b"
+    val tree = Term.ForYield(
+      List(
+        Enumerator.Val(Pat.Var(tname("a")), lit(1)),
+        Enumerator.Generator(Pat.Var(tname("b")), Term.Apply(tname("Some"), List(lit(2))))
+      ),
+      Term.ApplyInfix(tname("a"), tname("+"), Nil, List(tname("b")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
+  }
+
+  test("enum-val-first-ok-2") {
+    val code = """|for {
+                  |  a = 1
+                  |  b <- Some(2)
+                  |  c = 3
+                  |} yield a + b + c
+                  |""".stripMargin
+    val layout = "for (a = 1; b <- Some(2); c = 3) yield a + b + c"
+    val tree = Term.ForYield(
+      List(
+        Enumerator.Val(Pat.Var(tname("a")), lit(1)),
+        Enumerator.Generator(Pat.Var(tname("b")), Term.Apply(tname("Some"), List(lit(2)))),
+        Enumerator.Val(Pat.Var(tname("c")), lit(3))
+      ),
+      Term.ApplyInfix(
+        Term.ApplyInfix(tname("a"), tname("+"), Nil, List(tname("b"))),
+        tname("+"),
+        Nil,
+        List(tname("c"))
+      )
+    )
+    runTestAssert[Stat](code, layout)(tree)
+  }
+
+  test("enum-val-first-ok-3") {
+    val code = """|for {
+                  |  a = 1
+                  |  b = 3
+                  |  c <- Some(4)
+                  |} yield a + b + c
+                  |""".stripMargin
+    val layout = "for (a = 1; b = 3; c <- Some(4)) yield a + b + c"
+    val tree = Term.ForYield(
+      List(
+        Enumerator.Val(Pat.Var(tname("a")), lit(1)),
+        Enumerator.Val(Pat.Var(tname("b")), lit(3)),
+        Enumerator.Generator(Pat.Var(tname("c")), Term.Apply(tname("Some"), List(lit(4))))
+      ),
+      Term.ApplyInfix(
+        Term.ApplyInfix(tname("a"), tname("+"), Nil, List(tname("b"))),
+        tname("+"),
+        Nil,
+        List(tname("c"))
+      )
+    )
+    runTestAssert[Stat](code, layout)(tree)
+  }
+
+  test("enum-val-first-ok-4") {
+    val code = """|for {
+                  |  a = 1
+                  |  b <- Some(2)
+                  |  c = 3
+                  |  d <- Some(4)
+                  |} yield a + b + c + d
+                  |""".stripMargin
+    val layout = "for (a = 1; b <- Some(2); c = 3; d <- Some(4)) yield a + b + c + d"
+    val tree = Term.ForYield(
+      List(
+        Enumerator.Val(Pat.Var(tname("a")), lit(1)),
+        Enumerator.Generator(Pat.Var(tname("b")), Term.Apply(tname("Some"), List(lit(2)))),
+        Enumerator.Val(Pat.Var(tname("c")), lit(3)),
+        Enumerator.Generator(Pat.Var(tname("d")), Term.Apply(tname("Some"), List(lit(4))))
+      ),
+      Term.ApplyInfix(
+        Term.ApplyInfix(
+          Term.ApplyInfix(tname("a"), tname("+"), Nil, List(tname("b"))),
+          tname("+"),
+          Nil,
+          List(tname("c"))
+        ),
+        tname("+"),
+        Nil,
+        List(tname("d"))
+      )
+    )
+    runTestAssert[Stat](code, layout)(tree)
+  }
+
+  test("enum-val-first-ok-5") {
+    val code = """|for {
+                  |  a = 1
+                  |  b <- Some(2)
+                  |  if b > 0
+                  |  c = 3
+                  |  d <- Some(4)
+                  |} yield a + b + c + d
+                  |""".stripMargin
+    val layout = "for (a = 1; b <- Some(2); if b > 0; c = 3; d <- Some(4)) yield a + b + c + d"
+    val tree = Term.ForYield(
+      List(
+        Enumerator.Val(Pat.Var(tname("a")), lit(1)),
+        Enumerator.Generator(Pat.Var(tname("b")), Term.Apply(tname("Some"), List(lit(2)))),
+        Enumerator.Guard(Term.ApplyInfix(tname("b"), tname(">"), Nil, List(lit(0)))),
+        Enumerator.Val(Pat.Var(tname("c")), lit(3)),
+        Enumerator.Generator(Pat.Var(tname("d")), Term.Apply(tname("Some"), List(lit(4))))
+      ),
+      Term.ApplyInfix(
+        Term.ApplyInfix(
+          Term.ApplyInfix(tname("a"), tname("+"), Nil, List(tname("b"))),
+          tname("+"),
+          Nil,
+          List(tname("c"))
+        ),
+        tname("+"),
+        Nil,
+        List(tname("d"))
+      )
+    )
+    runTestAssert[Stat](code, layout)(tree)
+  }
+
+  test("enum-val-first-ok-6") {
+    val code = """|for {
+                  |  a = 1
+                  |  b <- Some(2)
+                  |  c = 3
+                  |  if b > 0
+                  |  d <- Some(4)
+                  |} yield a + b + c + d
+                  |""".stripMargin
+    val layout = "for (a = 1; b <- Some(2); c = 3; if b > 0; d <- Some(4)) yield a + b + c + d"
+    val tree = Term.ForYield(
+      List(
+        Enumerator.Val(Pat.Var(tname("a")), lit(1)),
+        Enumerator.Generator(Pat.Var(tname("b")), Term.Apply(tname("Some"), List(lit(2)))),
+        Enumerator.Val(Pat.Var(tname("c")), lit(3)),
+        Enumerator.Guard(Term.ApplyInfix(tname("b"), tname(">"), Nil, List(lit(0)))),
+        Enumerator.Generator(Pat.Var(tname("d")), Term.Apply(tname("Some"), List(lit(4))))
+      ),
+      Term.ApplyInfix(
+        Term.ApplyInfix(
+          Term.ApplyInfix(tname("a"), tname("+"), Nil, List(tname("b"))),
+          tname("+"),
+          Nil,
+          List(tname("c"))
+        ),
+        tname("+"),
+        Nil,
+        List(tname("d"))
+      )
+    )
+    runTestAssert[Stat](code, layout)(tree)
+  }
+
+  test("enum-val-first-ok-7") {
+    val code = """|for {
+                  |  a = 1
+                  |  if b > 0
+                  |  b <- Some(2)
+                  |} yield a + b
+                  |""".stripMargin
+    val layout = "for (a = 1; if b > 0; b <- Some(2)) yield a + b"
+    val tree = Term.ForYield(
+      List(
+        Enumerator.Val(Pat.Var(tname("a")), lit(1)),
+        Enumerator.Guard(Term.ApplyInfix(tname("b"), tname(">"), Nil, List(lit(0)))),
+        Enumerator.Generator(Pat.Var(tname("b")), Term.Apply(tname("Some"), List(lit(2))))
+      ),
+      Term.ApplyInfix(tname("a"), tname("+"), Nil, List(tname("b")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
+  }
+
+  test("enum-val-first-ok-8") {
+    val code = """|for {
+                  |  if a > 0
+                  |  b <- Some(2)
+                  |} yield b
+                  |""".stripMargin
+    runTestError[Stat](
+      code,
+      """|error: illegal start of simple pattern
+         |  if a > 0
+         |  ^""".stripMargin
+    )
+  }
+
+  test("enum-val-first-ok-9") {
+    val code = """|for {
+                  |  a = 1
+                  |  b = 3
+                  |  if b > 0
+                  |  c <- Some(2)
+                  |} yield a + b + c
+                  |""".stripMargin
+    val layout = "for (a = 1; b = 3; if b > 0; c <- Some(2)) yield a + b + c"
+    val tree = Term.ForYield(
+      List(
+        Enumerator.Val(Pat.Var(tname("a")), lit(1)),
+        Enumerator.Val(Pat.Var(tname("b")), lit(3)),
+        Enumerator.Guard(Term.ApplyInfix(tname("b"), tname(">"), Nil, List(lit(0)))),
+        Enumerator.Generator(Pat.Var(tname("c")), Term.Apply(tname("Some"), List(lit(2))))
+      ),
+      Term.ApplyInfix(
+        Term.ApplyInfix(tname("a"), tname("+"), Nil, List(tname("b"))),
+        tname("+"),
+        Nil,
+        List(tname("c"))
+      )
+    )
+    runTestAssert[Stat](code, layout)(tree)
+  }
+
+  test("enum-val-first-ok-10") {
+    val code = """|for {
+                  |  a = 1
+                  |} yield a
+                  |""".stripMargin
+    val layout = "for (a = 1) yield a"
+    val tree = Term.ForYield(List(Enumerator.Val(Pat.Var(tname("a")), lit(1))), tname("a"))
+    runTestAssert[Stat](code, layout)(tree)
+  }
+
   // --------------------------
   // WHILE
   // --------------------------


### PR DESCRIPTION
This is described in SIP-62.