### PR TITLE
TextDocumentOps: don't index empty names

### DIFF
--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
@@ -73,8 +73,10 @@ trait TextDocumentOps {
       locally {
         object traverser extends m.Traverser {
           private def indexName(mname: m.Name): Unit = {
+            val mpos = mname.pos
+            if (mpos.isEmpty) return // for instance, missing type in method declaration
             todo += mname
-            val range = mname.tokens.findNot(_.is[m.Token.LeftParen]).getOrElse(mname.pos)
+            val range = mname.tokens.findNot(_.is[m.Token.LeftParen]).getOrElse(mpos)
             mstarts.put(range.start, mname).foreach(errorAmbiguous("mStart", mname, _))
             mends.put(range.end, mname).foreach(errorAmbiguous("mEnd", mname, _))
           }

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/SemanticdbSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/SemanticdbSuite.scala
@@ -123,13 +123,20 @@ abstract class SemanticdbSuite extends FunSuite {
     unit.toTextDocument
   }
 
-  private def computeDatabaseSectionFromSnippet(code: String, sectionName: String): String = {
+  protected def computePayloadFromSnippet(code: String): String = {
     val document = computeDatabaseFromSnippet(code)
     val format = scala.meta.metap.Format.Detailed
-    val payload = s.Print.document(format, document).split(EOL)
-    val section = payload.dropWhile(_ != sectionName + ":").drop(1).takeWhile(_ != "")
-    section.mkString(EOL)
+    s.Print.document(format, document)
   }
+
+  protected def computeSectionFromPayload(payload: String, sectionName: String): String = {
+    val sectionLine = sectionName + ":"
+    payload.linesIterator.dropWhile(_ != sectionLine).drop(1).takeWhile(_ != "")
+      .mkString("", EOL, EOL)
+  }
+
+  protected def computeDatabaseSectionFromSnippet(code: String, sectionName: String): String =
+    computeSectionFromPayload(computePayloadFromSnippet(code), sectionName)
 
   def checkSection(code: String, expected: String, section: String)(implicit
       loc: munit.Location

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/TargetedSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/TargetedSuite.scala
@@ -237,4 +237,16 @@ class TargetedSuite extends SemanticdbSuite {
       assertEquals(foo2, "n/ForCompWithFilter.foo.")
     }
   )
+
+  locally { // #3738
+    val code = """|trait AmbiguousMend {
+                  |  def x
+                  |}
+                  |""".stripMargin
+    test(code) {
+      val err = intercept[RuntimeException](computePayloadFromSnippet(code)).getMessage
+      assertEquals(err.substring(0, 19), "ambiguous mEnd: ``[")
+    }
+  }
+
 }

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/TargetedSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/TargetedSuite.scala
@@ -244,8 +244,27 @@ class TargetedSuite extends SemanticdbSuite {
                   |}
                   |""".stripMargin
     test(code) {
-      val err = intercept[RuntimeException](computePayloadFromSnippet(code)).getMessage
-      assertEquals(err.substring(0, 19), "ambiguous mEnd: ``[")
+      assertEquals(
+        computePayloadFromSnippet(code).linesIterator.drop(3).filter(!_.startsWith("Uri => "))
+          .mkString("", "\n", "\n"),
+        """|Summary:
+           |Schema => SemanticDB v4
+           |Text => non-empty
+           |Language => Scala
+           |Symbols => 2 entries
+           |Occurrences => 2 entries
+           |
+           |Symbols:
+           |_empty_/AmbiguousMend# => trait AmbiguousMend extends AnyRef { +1 decls }
+           |  AnyRef => scala/AnyRef#
+           |_empty_/AmbiguousMend#x(). => abstract method x: Unit
+           |  Unit => scala/Unit#
+           |
+           |Occurrences:
+           |[0:6..0:19): AmbiguousMend <= _empty_/AmbiguousMend#
+           |[1:6..1:7): x <= _empty_/AmbiguousMend#x().
+           |""".stripMargin
+      )
     }
   }
 


### PR DESCRIPTION
For instance, we might substitute a `Type.Name("Unit")` when the type is missing in a method declaration, but its input position is empty as it isn't actually present in the itput, which might lead to errors due to hash collisions with a parameterless-method name.

Prior to v4.9.4, it "worked" since the position of the empty name was actually around the newline token rather than the preceding method-name token.

Fixes #3738.