### PR TITLE
bugfix: Fix publishing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -506,7 +506,6 @@ lazy val mergeSettings = Def.settings(
 )
 
 lazy val protobufSettings = Def.settings(
-  sharedSettings,
   Compile / packageSrc / mappings ++= {
     val base = (Compile / sourceManaged).value
     val files = (Compile / managedSources).value


### PR DESCRIPTION
The issue was that protobuf settings were adding shared settings, which only set the cross versions to latest and not all. I removed it from protobuf settings since it's already contained in the project.