### PR TITLE
Trees: remove Ref.isStableId, use isPath instead

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -3192,7 +3192,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
     def dotselectors = Importer(sid, importees())
     def name(tn: Term.Name) = copyPos(tn)(Name.Indeterminate(tn.value))
     sid match {
-      case Term.Select(sid: Term.Ref, tn: Term.Name) if sid.isStableId =>
+      case Term.Select(sid: Term.Ref, tn: Term.Name) if sid.isPath =>
         if (acceptOpt[Dot]) dotselectors
         else if (acceptOpt(soft.KwAs(_))) Importer(sid, importeeRename(name(tn)) :: Nil)
         else if (Wildcard.isStar(tn.tokens.head))

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -1234,7 +1234,7 @@ class Export(importers: List[Importer] @nonEmpty) extends ImportExportStat
 
 @ast
 class Importer(ref: Term.Ref, importees: List[Importee] @nonEmpty) extends Tree {
-  checkFields(ref.isStableId)
+  checkFields(ref.isPath)
 }
 
 @branch

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/package.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/package.scala
@@ -80,26 +80,27 @@ package object trees {
   }
 
   implicit class XtensionTreesTerm(private val tree: Term) extends AnyVal {
+    @tailrec
     def isExtractor: Boolean = tree match {
       case quasi: Term.Quasi => true
-      case ref: Term.Ref => ref.isStableId
+      case ref: Term.Ref => ref.isPath
       case t: Term.ApplyType => t.fun.isExtractor
       case _ => false
     }
   }
 
   implicit class XtensionTreesTermRef(private val tree: Term.Ref) extends AnyVal {
-    def isPath: Boolean = tree.isStableId || tree.is[Term.This]
+    @tailrec
     def isQualId: Boolean = tree match {
       case _: Term.Ref.Quasi => true
       case _: Term.Name => true
       case Term.Select(qual: Term.Ref, _) => qual.isQualId
       case _ => false
     }
-    def isStableId: Boolean = tree match {
-      case _: Term.Ref.Quasi => true
-      case _: Term.Name | _: Term.Anonymous | Term.Select(_: Term.Super, _) => true
-      case Term.Select(qual: Term.Quasi, _) => true
+    @tailrec
+    def isPath: Boolean = tree match {
+      case _: Term.Ref.Quasi | _: Term.This | _: Term.Name | _: Term.Anonymous => true
+      case Term.Select(_: Term.Super | _: Term.Quasi, _) => true
       case Term.Select(qual: Term.Ref, _) => qual.isPath
       case _ => false
     }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExportImportSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExportImportSuite.scala
@@ -104,4 +104,15 @@ class ExportImportSuite extends BaseDottySuite {
       List(Importer(Term.Select(tname("A"), tname("b")), List(Importee.Name(Name("*")))))
     ))
   }
+
+  test("#3754 export Type.this.field") {
+    val code = """|case class A():
+                  |  export A.this.value
+                  |""".stripMargin
+    val error = """|<input>:2: error: `.` expected but `outdent` found
+                   |  export A.this.value
+                   |                     ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExportImportSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExportImportSuite.scala
@@ -109,10 +109,15 @@ class ExportImportSuite extends BaseDottySuite {
     val code = """|case class A():
                   |  export A.this.value
                   |""".stripMargin
-    val error = """|<input>:2: error: `.` expected but `outdent` found
-                   |  export A.this.value
-                   |                     ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "case class A() { export A.this.value }"
+    val tree = Defn.Class(
+      List(Mod.Case()),
+      pname("A"),
+      Nil,
+      ctorp(Nil),
+      tpl(Export(List(Importer(Term.This(Name("A")), List(Importee.Name(Name("value")))))))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
 }


### PR DESCRIPTION
The latter also includes `Term.This`. Fixes #3754.