### PR TITLE
Scalac: move Position/Range implicit to semanticdb

### DIFF
--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DiagnosticOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/DiagnosticOps.scala
@@ -1,7 +1,7 @@
 package scala.meta.internal.semanticdb.scalac
 
 import org.scalameta.unreachable
-import scala.meta.internal.inputs._
+import scala.meta.internal.semanticdb.Implicits._
 import scala.meta.internal.{semanticdb => s}
 
 import scala.{meta => m}

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SyntheticOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SyntheticOps.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.semanticdb.scalac
 
 import scala.meta.internal.inputs._
+import scala.meta.internal.semanticdb.Implicits._
 import scala.meta.internal.semanticdb.Scala._
 import scala.meta.internal.{semanticdb => s}
 

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
@@ -5,6 +5,7 @@ import scala.meta.Dialect
 import scala.meta.internal.inputs._
 import scala.meta.internal.io.PathIO
 import scala.meta.internal.scalacp._
+import scala.meta.internal.semanticdb.Implicits._
 import scala.meta.internal.semanticdb.Scala._
 import scala.meta.internal.{semanticdb => s}
 

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/package.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/package.scala
@@ -1,7 +1,5 @@
 package scala.meta.internal.semanticdb
 
-import scala.meta.inputs.Input
-import scala.meta.inputs.Position
 import scala.meta.internal.{semanticdb => s}
 import scala.meta.io.AbsolutePath
 
@@ -21,25 +19,6 @@ package object scalac {
     }
     def save(targetroot: AbsolutePath): Unit = write(targetroot, append = false)
     def append(targetroot: AbsolutePath): Unit = write(targetroot, append = true)
-  }
-
-  implicit class XtensionPositionToRange(private val pos: Position) extends AnyVal {
-    def toRange: s.Range = s.Range(
-      startLine = pos.startLine,
-      startCharacter = pos.startColumn,
-      endLine = pos.endLine,
-      endCharacter = pos.endColumn
-    )
-  }
-
-  implicit class XtensionRangeToPosition(private val range: s.Range) extends AnyVal {
-    def toPosition(input: Input): Position = Position.Range(
-      input = input,
-      startLine = range.startLine,
-      startColumn = range.startCharacter,
-      endLine = range.endLine,
-      endColumn = range.endCharacter
-    )
   }
 
 }

--- a/semanticdb/semanticdb/src/main/scala/scala/meta/internal/metap/RangePrinter.scala
+++ b/semanticdb/semanticdb/src/main/scala/scala/meta/internal/metap/RangePrinter.scala
@@ -1,6 +1,7 @@
 package scala.meta.internal.metap
 
 import scala.meta.inputs._
+import scala.meta.internal.semanticdb.Implicits._
 import scala.meta.internal.semanticdb._
 
 import scala.collection.mutable
@@ -21,13 +22,11 @@ trait RangePrinter extends BasePrinter {
 
   private val inputCache = new mutable.HashMap[TextDocument, Input]
   implicit class DocumentOps(doc: TextDocument) {
-    def substring(range: Option[Range]): Option[String] = range.flatMap { range =>
-      if (doc.text.nonEmpty) {
-        val input = inputCache.getOrElseUpdate(doc, Input.String(doc.text))
-        val pos = Position
-          .Range(input, range.startLine, range.startCharacter, range.endLine, range.endCharacter)
-        Some(pos.text)
-      } else None
+    def substring(range: Option[Range]): Option[String] = range match {
+      case Some(range) if doc.text.nonEmpty =>
+        val pos = range.toPosition(inputCache.getOrElseUpdate(doc, Input.String(doc.text)))
+        Some(if (pos.isEmpty) "" else pos.text)
+      case _ => None
     }
   }
 

--- a/semanticdb/semanticdb/src/main/scala/scala/meta/internal/semanticdb/Implicits.scala
+++ b/semanticdb/semanticdb/src/main/scala/scala/meta/internal/semanticdb/Implicits.scala
@@ -1,0 +1,27 @@
+package scala.meta.internal.semanticdb
+
+import scala.meta.inputs.Input
+import scala.meta.inputs.Position
+
+object Implicits {
+
+  implicit class XtensionPositionToRange(private val pos: Position) extends AnyVal {
+    def toRange: Range = Range(
+      startLine = pos.startLine,
+      startCharacter = pos.startColumn,
+      endLine = pos.endLine,
+      endCharacter = pos.endColumn
+    )
+  }
+
+  implicit class XtensionRangeToPosition(private val range: Range) extends AnyVal {
+    def toPosition(input: Input): Position = Position.Range(
+      input = input,
+      startLine = range.startLine,
+      startColumn = range.startCharacter,
+      endLine = range.endLine,
+      endColumn = range.endCharacter
+    )
+  }
+
+}

--- a/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/SemanticdbSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/semanticdb/SemanticdbSuite.scala
@@ -2,7 +2,7 @@ package scala.meta.tests
 package semanticdb
 
 import org.scalameta.internal.ScalaCompat.EOL
-import scala.meta.internal.inputs._
+import scala.meta.internal.semanticdb.Implicits._
 import scala.meta.internal.semanticdb.scalac.CommandLineParser
 import scala.meta.internal.semanticdb.scalac._
 import scala.meta.internal.{semanticdb => s}


### PR DESCRIPTION
That way, we don't need to duplicate this simple code in RangePrinter.