### PR TITLE
Token: requalify CR as an EOL token

### DIFF
--- a/scalameta/tokens/shared/src/main/scala/scala/meta/tokens/Token.scala
+++ b/scalameta/tokens/shared/src/main/scala/scala/meta/tokens/Token.scala
@@ -284,7 +284,7 @@ object Token {
   @fixed("\t")
   class Tab extends HSpace
   @fixed("\r")
-  class CR extends AtEOL
+  class CR extends EOL
   @fixed("\n")
   class LF extends EOL
   @fixed("\f")


### PR DESCRIPTION
Since we detect CRLF sequences as a single token, CR will only appear as a standalone token, hence can be treated as EOL.