### PR TITLE
ParseSuite: don't re-check for empty origins

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
@@ -145,7 +145,6 @@ class ParseSuite extends TreeSuiteBase with CommonTrees {
   )(implicit loc: munit.Location, parser: (String, Dialect) => T, dialect: Dialect): Unit = {
     val expectedStructure = expected.structure
     val obtained: T = parser(code, dialect)
-    MoreHelpers.requireNonEmptyOrigin(obtained)
 
     // check bijection
     val reprintedCode = obtained.reprint
@@ -160,7 +159,6 @@ class ParseSuite extends TreeSuiteBase with CommonTrees {
       expected: Tree
   )(implicit loc: munit.Location, parser: (String, Dialect) => T, dialect: Dialect): Unit = {
     val obtained: T = parser(code, dialect)
-    MoreHelpers.requireNonEmptyOrigin(obtained)
     checkTree(obtained, syntax)(expected)
   }
 


### PR DESCRIPTION
All parse rules defined in ParseSuite use the Input.applyRule extension which calls `requireNonEmptyOrigin` method, so there's no need to do it again.