### PR TITLE
ScannerTokens: finish support for CR, expand tests

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -934,7 +934,7 @@ object ScannerTokens {
     def loop(idx: Int, indent: Int): Int =
       if (idx <= 0) -1
       else str.charAt(idx) match {
-        case '\n' => indent
+        case '\n' | '\r' => indent
         case ' ' | '\t' => loop(idx - 1, indent + 1)
         case _ => loop(idx - 1, 0)
       }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
@@ -304,8 +304,6 @@ class InfixSuite extends BaseDottySuite {
                     |""".stripMargin
     val tree = blk(Term.ApplyInfix(tname("freezing"), tname("|"), Nil, List(tname("boiling"))))
     runTestAssert[Stat](code, Some(layout))(tree)
-    // now use CRLF
-    runTestAssert[Stat](code.replace("\n", "\r\n"), layout)(tree)
   }
 
   test("scala3 infix syntax 3.5") {


### PR DESCRIPTION
In ParseSuite, test and compare LF, CR and CRLF code.