### PR TITLE
ScalametaParser: less backtrack on ctrl cond, body

### DIFF
--- a/tests/jvm/src/test/scala/scala/meta/tests/parsers/dotty/CtrlExprJVMSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/parsers/dotty/CtrlExprJVMSuite.scala
@@ -1,0 +1,42 @@
+package scala.meta.tests.parsers.dotty
+
+import scala.meta._
+
+class CtrlExprJVMSuite extends BaseDottySuite {
+
+  test("metals#6552: huge nested `if`") {
+    val nestedNum = 100 // was previously failing around 25-30 deep
+    def generateIfs(num: Int, ident: String): String =
+      if (num <= 1) "if (1 >= 10) {}"
+      else s"""|if (1 >= 10) {
+               |$ident  ${generateIfs(num - 1, ident + "  ")}
+               |$ident}""".stripMargin
+
+    val code = s"""|object Test {
+                   |  def apply(): Unit = {
+                   |    ${generateIfs(nestedNum, "    ")}
+                   |  }
+                   |}
+                   |""".stripMargin
+
+    def generateIfsTree(num: Int): Term.If = {
+      val inner = if (num <= 1) Nil else List(generateIfsTree(num - 1))
+      Term.If(Term.ApplyInfix(lit(1), tname(">="), Nil, List(lit(10))), blk(inner), Lit.Unit(), Nil)
+    }
+    val tree = Source(List(Defn.Object(
+      Nil,
+      tname("Test"),
+      tpl(Defn.Def(
+        Nil,
+        tname("apply"),
+        Nil,
+        List(Nil),
+        Some(pname("Unit")),
+        blk(generateIfsTree(nestedNum))
+      ))
+    )))
+
+    runTestAssert[Source](code)(tree)
+  }
+
+}


### PR DESCRIPTION
If a scala3 if/while actually uses scala2 syntax, we might have parsed part of the body while looking for `then` or `do`, which leads to some backtracking.

Specifically, for nested `if` clauses with their `then` part in explicit braces, each will be parsed exactly twice, once as a continuation of the condition expression and second time as the body, thus leading to an exponential time complexity.

Let's instead reduce backtracking by processing what might be both an argument to a condition expression or an initial part of the body, such as a brace expression, and then using it either for condition or for body.

Fixes scalameta/metals#6552. Supersedes #3795.