### PR TITLE
scalafmt: set dialect to 2.12 to reflect our build

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,5 @@
 version = 3.8.2
-runner.dialect = scala213
+runner.dialect = scala212
 align {
   preset = none
   stripMargin = true


### PR DESCRIPTION
Otherwise, rewrite rules are too aggressive for 2.12. See comment to #3803.