### PR TITLE
ScannerTokens: skip RegionLine at indent level

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -625,7 +625,8 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
       def eolRef(rs: List[SepRegion], out: Token) = TokenRef(rs, out, eolPos, nextPos, eolPos, null)
 
       def lastWhitespaceToken(rs: List[SepRegion], lineIndent: Int) = {
-        val regions = if (lineIndent < 0) rs else RegionLine(lineIndent) :: rs
+        val addRegionLine = lineIndent >= 0 && findIndent(rs) < lineIndent
+        val regions = if (addRegionLine) RegionLine(lineIndent) :: rs else rs
         val token = tokens(eolPos)
         val out =
           if (!multiEOL || token.is[MultiEOL]) token

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EndMarkerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EndMarkerSuite.scala
@@ -333,8 +333,8 @@ class EndMarkerSuite extends BaseDottySuite {
                     |    }
                     |    end match
                     |  }
-                    |  end FmtTest
                     |}
+                    |end FmtTest
                     |""".stripMargin
     val tree = Source(List(
       Defn.Class(
@@ -360,10 +360,10 @@ class EndMarkerSuite extends BaseDottySuite {
               ),
               Term.EndMarker(tname("match"))
             )
-          ),
-          Term.EndMarker(tname("FmtTest")) // should not be here
+          )
         )
-      ) // should be end marker here
+      ),
+      Term.EndMarker(tname("FmtTest"))
     ))
     runTestAssert[Source](code, layout)(tree)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EndMarkerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EndMarkerSuite.scala
@@ -311,4 +311,61 @@ class EndMarkerSuite extends BaseDottySuite {
     ))
   }
 
+  test("scalafmt#4098") {
+    val code = """|class FmtTest:
+                  |
+                  |  private val const = 3
+                  |
+                  |  def testBrokenMatch(s: String) =
+                  |    s match
+                  |      case "hello" =>
+                  |        val a = 1
+                  |    end match
+                  |  
+                  |end FmtTest
+                  |""".stripMargin
+    val layout = """|class FmtTest {
+                    |  private val const = 3
+                    |  def testBrokenMatch(s: String) = {
+                    |    s match {
+                    |      case "hello" =>
+                    |        val a = 1
+                    |    }
+                    |    end match
+                    |  }
+                    |  end FmtTest
+                    |}
+                    |""".stripMargin
+    val tree = Source(List(
+      Defn.Class(
+        Nil,
+        pname("FmtTest"),
+        Nil,
+        ctor,
+        tpl(
+          Defn.Val(List(Mod.Private(anon)), List(Pat.Var(tname("const"))), None, lit(3)),
+          Defn.Def(
+            Nil,
+            tname("testBrokenMatch"),
+            Nil,
+            List(List(tparam("s", "String"))),
+            None,
+            blk(
+              Term.Match(
+                tname("s"),
+                List(
+                  Case(lit("hello"), None, blk(Defn.Val(Nil, List(Pat.Var(tname("a"))), None, lit(1))))
+                ),
+                Nil
+              ),
+              Term.EndMarker(tname("match"))
+            )
+          ),
+          Term.EndMarker(tname("FmtTest")) // should not be here
+        )
+      ) // should be end marker here
+    ))
+    runTestAssert[Source](code, layout)(tree)
+  }
+
 }


### PR DESCRIPTION
Fixes scalameta/scalafmt#4098.