### PR TITLE
bugfix: Use earliest Scala version for scalameta, parsers and trees projects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ import munit.sbtmunit.BuildInfo.munitVersion
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
 lazy val LanguageVersions = LatestScalaVersions
-lazy val LanguageVersion = LanguageVersions.head
+lazy val LanguageVersion = EarliestScala213
 def customVersion = sys.props.get("scalameta.version")
 def parseTagVersion: String = {
   import scala.sys.process._
@@ -81,6 +81,7 @@ Global / resolvers +=
 
 val commonJsSettings = Seq(
   crossScalaVersions := List(LatestScala213, LatestScala212),
+  scalaVersion := LatestScala213,
   scalaJSLinkerConfig := StandardConfig().withBatchMode(true),
   scalacOptions ++= {
     if (isSnapshot.value) Seq.empty
@@ -94,6 +95,7 @@ val commonJsSettings = Seq(
 
 lazy val nativeSettings = Seq(
   crossScalaVersions := List(LatestScala213, LatestScala212),
+  scalaVersion := LatestScala213,
   nativeConfig ~= { _.withMode(scalanative.build.Mode.releaseFast) }
 )
 
@@ -751,6 +753,7 @@ def macroDependencies(hardcore: Boolean) = libraryDependencies ++= {
 lazy val docs = project.in(file("scalameta-docs")).settings(
   sharedSettings,
   crossScalaVersions := List(LatestScala213),
+  scalaVersion := LatestScala213,
   nonPublishableSettings,
   buildInfoKeys := Seq[BuildInfoKey]("scalameta" -> scalameta),
   buildInfoPackage := "docs",

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -8,6 +8,7 @@ object Versions {
   val LatestScala211 = Scala211Versions.head
   val LatestScala212 = Scala212Versions.head
   val LatestScala213 = Scala213Versions.head
+  val EarliestScala213 = Scala213Versions.last
   val AllScalaVersions = Scala213Versions ++ Scala212Versions ++ Scala211Versions
   val LatestScalaVersions = Seq(LatestScala213, LatestScala212, LatestScala211)
 


### PR DESCRIPTION
If we use latest by default then the semanticdb parts will also depend on newer Scala versions, which is breaking for anything that might be using it as dependency.

The other option here is to change their suffix to full and publish separate for each version, but I would rather avoid it as it would mean more artifacts to publish and a change for any dependency.

This showed up in https://github.com/scalameta/metals/pull/6608