### PR TITLE
bugfix: Set earlier versions as only cross versions for scalameta projects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           - '2.13.14'
         java:
           - '8'
-          - '21'
+          - '17'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ import munit.sbtmunit.BuildInfo.munitVersion
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
 lazy val LanguageVersions = LatestScalaVersions
-lazy val LanguageVersion = EarliestScala213
+lazy val LanguageVersion = LatestScala213
 def customVersion = sys.props.get("scalameta.version")
 def parseTagVersion: String = {
   import scala.sys.process._
@@ -152,7 +152,6 @@ lazy val semanticdbMetac = project.in(file("semanticdb/metac")).settings(
   sharedSettings,
   publishJVMSettings,
   fullCrossVersionSettings,
-  crossScalaVersions := LanguageVersions,
   mimaPreviousArtifacts := Set.empty,
   description := "Scalac 2.x launcher that generates SemanticDB on compile",
   libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value,
@@ -164,7 +163,6 @@ lazy val semanticdbMetap = project.in(file("semanticdb/metap")).settings(
   sharedSettings,
   publishJVMSettings,
   fullCrossVersionSettings,
-  crossScalaVersions := LanguageVersions,
   mimaPreviousArtifacts := Set.empty,
   description := "Prints SemanticDB files",
   mainClass := Some("scala.meta.cli.Metap")
@@ -175,7 +173,6 @@ lazy val semanticdbMetacp = project.in(file("semanticdb/metacp")).settings(
   sharedSettings,
   publishJVMSettings,
   fullCrossVersionSettings,
-  crossScalaVersions := LanguageVersions,
   mimaPreviousArtifacts := Set.empty,
   description := "Generates SemanticDB files for a classpath",
   mainClass := Some("scala.meta.cli.Metacp")
@@ -193,7 +190,7 @@ lazy val common = crossProject(allPlatforms: _*).in(file("scalameta/common")).se
   enableMacros,
   buildInfoPackage := "scala.meta.internal",
   buildInfoKeys := Seq[BuildInfoKey](version),
-  crossScalaVersions := AllScalaVersions
+  crossScalaVersions := EarliestScalaVersions
 ).configureCross(crossPlatformPublishSettings).jsSettings(commonJsSettings)
   .enablePlugins(BuildInfoPlugin).nativeSettings(nativeSettings)
 
@@ -201,7 +198,7 @@ lazy val trees = crossProject(allPlatforms: _*).in(file("scalameta/trees")).sett
   moduleName := "trees",
   sharedSettings,
   description := "Scalameta abstract syntax trees",
-  crossScalaVersions := AllScalaVersions,
+  crossScalaVersions := EarliestScalaVersions,
   // NOTE: uncomment this to update ast.md
   // scalacOptions += "-Xprint:typer",
   enableHardcoreMacros,
@@ -231,7 +228,7 @@ lazy val parsers = crossProject(allPlatforms: _*).in(file("scalameta/parsers")).
   sharedSettings,
   description := "Scalameta APIs for parsing and their baseline implementation",
   enableHardcoreMacros,
-  crossScalaVersions := AllScalaVersions,
+  crossScalaVersions := EarliestScalaVersions,
   mergedModule { base =>
     List(base / "scalameta" / "quasiquotes", base / "scalameta" / "transversers")
   }
@@ -272,7 +269,7 @@ lazy val scalameta = crossProject(allPlatforms: _*).in(file("scalameta/scalameta
   moduleName := "scalameta",
   sharedSettings,
   description := "Scalameta umbrella module that includes all public APIs",
-  crossScalaVersions := AllScalaVersions,
+  crossScalaVersions := EarliestScalaVersions,
   libraryDependencies ++= List("org.scala-lang" % "scalap" % scalaVersion.value),
   mergedModule(base => List(base / "scalameta" / "contrib"))
 ).configureCross(crossPlatformPublishSettings).configureCross(crossPlatformShading)
@@ -282,6 +279,7 @@ lazy val scalameta = crossProject(allPlatforms: _*).in(file("scalameta/scalameta
 lazy val semanticdbIntegration = project.in(file("semanticdb/integration")).settings(
   description := "Sources to compile to build SemanticDB for tests.",
   sharedSettings,
+  crossScalaVersions := AllScalaVersions,
   nonPublishableSettings,
   // the sources in this project intentionally produce warnings to test the
   // diagnostics pipeline in semanticdb-scalac.
@@ -312,12 +310,17 @@ lazy val semanticdbIntegration = project.in(file("semanticdb/integration")).sett
   javacOptions += "-parameters"
 ).dependsOn(semanticdbIntegrationMacros, semanticdbScalacPlugin)
 
-lazy val semanticdbIntegrationMacros = project.in(file("semanticdb/integration-macros"))
-  .settings(sharedSettings, nonPublishableSettings, enableMacros)
+lazy val semanticdbIntegrationMacros = project.in(file("semanticdb/integration-macros")).settings(
+  sharedSettings,
+  crossScalaVersions := AllScalaVersions,
+  nonPublishableSettings,
+  enableMacros
+)
 
 lazy val testkit = crossProject(allPlatforms: _*).in(file("scalameta/testkit")).settings(
   moduleName := "testkit",
   sharedSettings,
+  crossScalaVersions := EarliestScalaVersions,
   hasLargeIntegrationTests,
   libraryDependencies += munitLibrary.value,
   testFrameworks := List(new TestFramework("munit.Framework")),
@@ -336,6 +339,7 @@ lazy val testkit = crossProject(allPlatforms: _*).in(file("scalameta/testkit")).
 
 lazy val tests = crossProject(allPlatforms: _*).in(file("tests")).configs(Slow, All).settings(
   sharedSettings,
+  crossScalaVersions := AllScalaVersions,
   testFrameworks := List(new TestFramework("munit.Framework")),
   Test / unmanagedSourceDirectories ++= {
     val base = (Compile / baseDirectory).value
@@ -396,6 +400,7 @@ lazy val testSettings: List[Def.SettingsDefinition] = List(
 lazy val communitytest = project.in(file("community-test")).settings(
   nonPublishableSettings,
   sharedSettings,
+  crossScalaVersions := LanguageVersions,
   libraryDependencies += munitLibrary.value,
   testFrameworks := List(new TestFramework("munit.Framework"))
 ).dependsOn(scalameta.jvm)
@@ -404,6 +409,7 @@ lazy val communitytest = project.in(file("community-test")).settings(
 lazy val bench = project.in(file("bench/suite")).enablePlugins(BuildInfoPlugin)
   .enablePlugins(JmhPlugin).settings(
     sharedSettings,
+    crossScalaVersions := LanguageVersions,
     nonPublishableSettings,
     libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value,
     buildInfoKeys := Seq[BuildInfoKey]("sourceroot" -> (ThisBuild / baseDirectory).value),
@@ -487,7 +493,6 @@ lazy val sharedSettings = Def.settings(
     }
   },
   scalaVersion := LanguageVersion,
-  crossScalaVersions := LanguageVersions,
   organization := "org.scalameta",
   libraryDependencies ++= {
     if (isScala213.value) Nil

--- a/build.sbt
+++ b/build.sbt
@@ -14,8 +14,6 @@ import complete.DefaultParsers._
 import munit.sbtmunit.BuildInfo.munitVersion
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
-lazy val LanguageVersions = LatestScalaVersions
-lazy val LanguageVersion = LatestScala213
 def customVersion = sys.props.get("scalameta.version")
 def parseTagVersion: String = {
   import scala.sys.process._
@@ -400,7 +398,7 @@ lazy val testSettings: List[Def.SettingsDefinition] = List(
 lazy val communitytest = project.in(file("community-test")).settings(
   nonPublishableSettings,
   sharedSettings,
-  crossScalaVersions := LanguageVersions,
+  crossScalaVersions := LatestScalaVersions,
   libraryDependencies += munitLibrary.value,
   testFrameworks := List(new TestFramework("munit.Framework"))
 ).dependsOn(scalameta.jvm)
@@ -409,7 +407,7 @@ lazy val communitytest = project.in(file("community-test")).settings(
 lazy val bench = project.in(file("bench/suite")).enablePlugins(BuildInfoPlugin)
   .enablePlugins(JmhPlugin).settings(
     sharedSettings,
-    crossScalaVersions := LanguageVersions,
+    crossScalaVersions := LatestScalaVersions,
     nonPublishableSettings,
     libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value,
     buildInfoKeys := Seq[BuildInfoKey]("sourceroot" -> (ThisBuild / baseDirectory).value),
@@ -492,7 +490,7 @@ lazy val sharedSettings = Def.settings(
       if (isCI) dynVer else localSnapshotVersion // only for local publishing
     }
   },
-  scalaVersion := LanguageVersion,
+  scalaVersion := LatestScala213,
   organization := "org.scalameta",
   libraryDependencies ++= {
     if (isScala213.value) Nil

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -8,8 +8,11 @@ object Versions {
   val LatestScala211 = Scala211Versions.head
   val LatestScala212 = Scala212Versions.head
   val LatestScala213 = Scala213Versions.head
+  val EarliestScala211 = Scala211Versions.last
+  val EarliestScala212 = Scala212Versions.last
   val EarliestScala213 = Scala213Versions.last
   val AllScalaVersions = Scala213Versions ++ Scala212Versions ++ Scala211Versions
+  val EarliestScalaVersions = Seq(EarliestScala213, EarliestScala212, EarliestScala211)
   val LatestScalaVersions = Seq(LatestScala213, LatestScala212, LatestScala211)
 
   // returns versions from newest to oldest


### PR DESCRIPTION
Turns out, the previous approach didn't work and we still published with the newest Scala version. I changed it to only use the earliest versions, so that it's not even possible to set newer versions. I also changed sharedSettings to not include cross settings by default as they should be defined per project (or with fullCrossSettings).