### PR TITLE
LegacyScanner: refactor interpolation part parsing

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/Scala210Suite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/Scala210Suite.scala
@@ -8,7 +8,7 @@ class Scala210Suite extends ParseSuite {
   test("$_") {
     val error = """|<input>:1: error: Not one of: `$$', `$'ident, `$'this, `$'BlockExpr
                    | val q"x + $_" = tree 
-                   |       ^""".stripMargin.lf2nl
+                   |            ^""".stripMargin.lf2nl
     interceptMessage[TokenizeException](error)(stat(""" val q"x + $_" = tree """))
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
@@ -1960,7 +1960,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
     interceptMessage[TokenizeException](
       """|<input>:2: error: Not one of: `$$', `$'ident, `$'this, `$'BlockExpr, `$'_
          |  def foo = s"b$"
-         |              ^""".stripMargin.lf2nl
+         |                ^""".stripMargin.lf2nl
     )(tokenize(code, dialects.Scala213))
 
     // scala3


### PR DESCRIPTION
Split part and splice methods and invoke them separately. This approach also allows us to return splice identifiers in the `curr` token instead of `next`, which frees `next` to contain any possible parsing errors.