### PR TITLE
ScannerTokens: move InfixLF to indentPos

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1947,7 +1947,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
 
       def getPrevLhs(op: Term.Name): Term = ctx.reduceStack(base, rhsK, rhsEndK, Some(op))
 
-      def getNextRhs(targs: Type.ArgClause)(op: Term.Name) =
+      def getNextRhs(targs: => Type.ArgClause)(op: Term.Name) =
         getNextRhsWith(op, targs, argumentExprsOrPrefixExpr(PostfixStat))
 
       def getNextRhsWith(op: Term.Name, targs: Type.ArgClause, rhs: Term) = {

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -1497,12 +1497,12 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |    c1
        |  */ |
        |  boiling</stats0>
-       |<targClause>Type.ArgClause   freezing@@</targClause>
+       |<targClause>Type.ArgClause   @@/*</targClause>
        |""".stripMargin,
     """|BOF [0..0)
        |LeftBrace [0..1)
        |Ident(freezing) [4..12)
-       |InfixLF [12..13)
+       |InfixLF [23..37)
        |Ident(|) [38..39)
        |LF [39..40)
        |Ident(boiling) [42..49)
@@ -1531,12 +1531,12 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |  */
        |  |
        |  boiling</stats0>
-       |<targClause>Type.ArgClause   freezing@@</targClause>
+       |<targClause>Type.ArgClause   */@@</targClause>
        |""".stripMargin,
     """|BOF [0..0)
        |LeftBrace [0..1)
        |Ident(freezing) [4..12)
-       |InfixLF [12..13)
+       |InfixLF [37..38)
        |Ident(|) [40..41)
        |LF [41..42)
        |Ident(boiling) [44..51)

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -1453,4 +1453,98 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
     showFieldName = true
   )
 
+  checkPositions[Term](
+    """|{
+       |  freezing /*
+       |    c1 */ // c2
+       |  |
+       |  boiling
+       |}
+       |""".stripMargin,
+    """|<stats0>Term.ApplyInfix freezing /*
+       |    c1 */ // c2
+       |  |
+       |  boiling</stats0>
+       |<targClause>Type.ArgClause     c1 */ // c2@@</targClause>
+       |""".stripMargin,
+    """|BOF [0..0)
+       |LeftBrace [0..1)
+       |Ident(freezing) [4..12)
+       |InfixLF [31..32)
+       |Ident(|) [34..35)
+       |LF [35..36)
+       |Ident(boiling) [38..45)
+       |LF [45..46)
+       |RightBrace [46..47)
+       |EOF [48..48)
+       |""".stripMargin,
+    showFieldName = true
+  )
+
+  checkPositions[Term](
+    """|{
+       |  freezing
+       |  // c1
+       |  /*
+       |    c1
+       |  */ |
+       |  boiling
+       |}
+       |""".stripMargin,
+    """|<stats0>Term.ApplyInfix freezing
+       |  // c1
+       |  /*
+       |    c1
+       |  */ |
+       |  boiling</stats0>
+       |<targClause>Type.ArgClause   freezing@@</targClause>
+       |""".stripMargin,
+    """|BOF [0..0)
+       |LeftBrace [0..1)
+       |Ident(freezing) [4..12)
+       |InfixLF [12..13)
+       |Ident(|) [38..39)
+       |LF [39..40)
+       |Ident(boiling) [42..49)
+       |LF [49..50)
+       |RightBrace [50..51)
+       |EOF [52..52)
+       |""".stripMargin,
+    showFieldName = true
+  )
+
+  checkPositions[Term](
+    """|{
+       |  freezing
+       |  // c1
+       |  /*
+       |    c1
+       |  */
+       |  |
+       |  boiling
+       |}
+       |""".stripMargin,
+    """|<stats0>Term.ApplyInfix freezing
+       |  // c1
+       |  /*
+       |    c1
+       |  */
+       |  |
+       |  boiling</stats0>
+       |<targClause>Type.ArgClause   freezing@@</targClause>
+       |""".stripMargin,
+    """|BOF [0..0)
+       |LeftBrace [0..1)
+       |Ident(freezing) [4..12)
+       |InfixLF [12..13)
+       |Ident(|) [40..41)
+       |LF [41..42)
+       |Ident(boiling) [44..51)
+       |LF [51..52)
+       |RightBrace [52..53)
+       |EOF [54..54)
+       |""".stripMargin,
+    showFieldName = true
+  )
+
 }

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -1465,7 +1465,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |    c1 */ // c2
        |  |
        |  boiling</stats0>
-       |<targClause>Type.ArgClause     c1 */ // c2@@</targClause>
+       |<targClause>Type.ArgClause   @@boiling</targClause>
        |""".stripMargin,
     """|BOF [0..0)
        |LeftBrace [0..1)
@@ -1497,7 +1497,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |    c1
        |  */ |
        |  boiling</stats0>
-       |<targClause>Type.ArgClause   @@/*</targClause>
+       |<targClause>Type.ArgClause   @@boiling</targClause>
        |""".stripMargin,
     """|BOF [0..0)
        |LeftBrace [0..1)
@@ -1531,7 +1531,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |  */
        |  |
        |  boiling</stats0>
-       |<targClause>Type.ArgClause   */@@</targClause>
+       |<targClause>Type.ArgClause   @@boiling</targClause>
        |""".stripMargin,
     """|BOF [0..0)
        |LeftBrace [0..1)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
@@ -320,6 +320,59 @@ class InfixSuite extends BaseDottySuite {
     )
   }
 
+  test("scala3 infix syntax 3.6 comment") {
+    val code = """|{
+                  |  freezing /*
+                  |    c1 */ // c2
+                  |  |
+                  |  boiling
+                  |}
+                  |""".stripMargin
+    val layout = """|{
+                    |  freezing | boiling
+                    |}
+                    |""".stripMargin
+    val tree = blk(Term.ApplyInfix(tname("freezing"), tname("|"), Nil, List(tname("boiling"))))
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
+  test("scala3 infix syntax 3.7 comment") {
+    val code = """|{
+                  |  freezing
+                  |  // c1
+                  |  /*
+                  |    c2
+                  |  */ |
+                  |  boiling
+                  |}
+                  |""".stripMargin
+    val layout = """|{
+                    |  freezing | boiling
+                    |}
+                    |""".stripMargin
+    val tree = blk(Term.ApplyInfix(tname("freezing"), tname("|"), Nil, List(tname("boiling"))))
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
+  test("scala3 infix syntax 3.8 comment") {
+    val code = """|{
+                  |  freezing
+                  |  // c1
+                  |  /*
+                  |    c2
+                  |  */
+                  |  |
+                  |  boiling
+                  |}
+                  |""".stripMargin
+    val layout = """|{
+                    |  freezing | boiling
+                    |}
+                    |""".stripMargin
+    val tree = blk(Term.ApplyInfix(tname("freezing"), tname("|"), Nil, List(tname("boiling"))))
+    runTestAssert[Stat](code, Some(layout))(tree)
+  }
+
   test("scala3 infix syntax 4") {
     runTestAssert[Stat](
       """|{


### PR DESCRIPTION
indentPos is the last newline whereas eolPos is the first. Also, move empty infix targs after op. Helps with #3856.