### PR TITLE
ScannerTokens: check end marker for try/for/while

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -453,7 +453,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
       case _: KwEnum => currRef(RegionTemplateMark :: sepRegions)
       case _: KwObject | _: KwClass | _: KwTrait | _: KwPackage | _: KwNew
           if dialect.allowSignificantIndentation => currRef(RegionTemplateMark :: sepRegions)
-      case _: KwTry => currRef(RegionTry :: dropRegionLine(sepRegions))
+      case _: KwTry if !isPrevEndMarker() => currRef(RegionTry :: dropRegionLine(sepRegions))
       case _: KwMatch if !isPrevEndMarker() => getCaseIntro(sepRegions)
       case _: KwCatch => getCaseIntro(dropWhile(sepRegions)(_ ne RegionTry))
       case _: KwCase if !next.isClassOrObject =>
@@ -520,8 +520,9 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
             new RegionCaseBody(bodyIndent, curr) :: rs
           case _ => sepRegions
         })
-      case _: KwFor => currRef(RegionFor(next) :: sepRegions)
-      case _: KwWhile if dialect.allowQuietSyntax => currRef(RegionWhile(next) :: sepRegions)
+      case _: KwFor if !isPrevEndMarker() => currRef(RegionFor(next) :: sepRegions)
+      case _: KwWhile if dialect.allowQuietSyntax && !isPrevEndMarker() =>
+        currRef(RegionWhile(next) :: sepRegions)
       case _: KwIf if dialect.allowQuietSyntax =>
         currRef(dropRegionLine(sepRegions) match {
           case rs @ (_: RegionCaseExpr | _: RegionFor) :: _ => rs

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -538,10 +538,34 @@ class ControlSyntaxSuite extends BaseDottySuite {
                   |   catch
                   |      case f =>
                   |""".stripMargin
-    val error = """|<input>:9: error: `;` expected but `catch` found
-                   |   catch
-                   |   ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = """|object a {
+                    |  try {
+                    |    for (i <- foo) foo
+                    |    end for
+                    |    foo match {
+                    |      case foo =>
+                    |    }
+                    |    end match
+                    |  } catch {
+                    |    case f =>
+                    |  }
+                    |}
+                    |""".stripMargin
+    val tree = Defn.Object(
+      Nil,
+      tname("a"),
+      tpl(Term.Try(
+        blk(
+          Term.For(List(Enumerator.Generator(Pat.Var(tname("i")), tname("foo"))), tname("foo")),
+          Term.EndMarker(tname("for")),
+          Term.Match(tname("foo"), List(Case(Pat.Var(tname("foo")), None, blk())), Nil),
+          Term.EndMarker(tname("match"))
+        ),
+        List(Case(Pat.Var(tname("f")), None, blk())),
+        None
+      ))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("#3532 nested try-finally on same line") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -526,6 +526,24 @@ class ControlSyntaxSuite extends BaseDottySuite {
     ))))
   }
 
+  test("catch after `end for` and `end match`") {
+    val code = """|object a:
+                  |   try
+                  |      for (i <- foo)
+                  |        foo
+                  |      end for
+                  |      foo match
+                  |         case foo =>
+                  |      end match
+                  |   catch
+                  |      case f =>
+                  |""".stripMargin
+    val error = """|<input>:9: error: `;` expected but `catch` found
+                   |   catch
+                   |   ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
   test("#3532 nested try-finally on same line") {
     val code = """|try try Right(f()) finally iter.close()
                   |finally arena.close()


### PR DESCRIPTION
We already check `match` but these additional keywords went undetected. Helps with scalameta/scalafmt#4133.