### PR TITLE
ScalametaParser: remove EndPosPreOutdent, invalid

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -313,9 +313,6 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
     def begIndex = currIndex
     def endIndex = prevIndex
   }
-  case object EndPosPreOutdent extends EndPos {
-    def endIndex = if (at[Indentation.Outdent]) currIndex else prevIndex
-  }
   implicit def intToIndexPos(index: Int): Pos = new IndexPos(index)
   implicit def treeToTreePos(tree: Tree): Pos = new TreePos(tree)
   implicit def optionTreeToPos(tree: Option[Tree]): Pos = tree.fold[Pos](AutoPos)(treeToTreePos)
@@ -2404,7 +2401,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
     }
   }
 
-  def caseClause(forceSingleExpr: Boolean = false): Case = atPos(prevIndex, EndPosPreOutdent) {
+  def caseClause(forceSingleExpr: Boolean = false): Case = autoEndPos(prevIndex) {
     if (currToken.isNot[KwCase]) {
       def caseBody() = {
         accept[RightArrow]

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -1661,8 +1661,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |<cases0>Case case foo1: Foo1 => foo1</cases0>
        |<pat>Pat.Typed foo1: Foo1</pat>
        |<cases1>Case case foo2: Foo2 =>
-       |       foo2 += " = "
-       |     // foo2</cases1>
+       |       foo2 += " = "</cases1>
        |<pat>Pat.Typed foo2: Foo2</pat>
        |<body>Term.ApplyInfix foo2 += " = "</body>
        |<targClause>Type.ArgClause        foo2 += @@" = "</targClause>

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -1635,4 +1635,140 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
     showFieldName = true
   )
 
+  // comment at end of match but not before case outdent
+  checkPositions[Stat](
+    """|object a:
+       |  bar2 match
+       |     case foo1: Foo1 => foo1
+       |     case foo2: Foo2 =>
+       |       foo2 += " = "
+       |     // foo2
+       |  end match
+       |""".stripMargin,
+    """|<templ>Template :
+       |  bar2 match
+       |     case foo1: Foo1 => foo1
+       |     case foo2: Foo2 =>
+       |       foo2 += " = "
+       |     // foo2
+       |  end match</templ>
+       |<self>Self   @@bar2 match</self>
+       |<stats0>Term.Match bar2 match
+       |     case foo1: Foo1 => foo1
+       |     case foo2: Foo2 =>
+       |       foo2 += " = "
+       |     // foo2</stats0>
+       |<cases0>Case case foo1: Foo1 => foo1</cases0>
+       |<pat>Pat.Typed foo1: Foo1</pat>
+       |<cases1>Case case foo2: Foo2 =>
+       |       foo2 += " = "
+       |     // foo2</cases1>
+       |<pat>Pat.Typed foo2: Foo2</pat>
+       |<body>Term.ApplyInfix foo2 += " = "</body>
+       |<targClause>Type.ArgClause        foo2 += @@" = "</targClause>
+       |<values0>Lit.String " = "</values0>
+       |<stats1>Term.EndMarker end match</stats1>
+       |""".stripMargin,
+    """|BOF [0..0)
+       |KwObject [0..6)
+       |Ident(a) [7..8)
+       |Colon [8..9)
+       |Indentation.Indent [9..9)
+       |Ident(bar2) [12..16)
+       |KwMatch [17..22)
+       |Indentation.Indent [22..22)
+       |KwCase [28..32)
+       |Ident(foo1) [33..37)
+       |Colon [37..38)
+       |Ident(Foo1) [39..43)
+       |RightArrow [44..46)
+       |Ident(foo1) [47..51)
+       |LF [51..52)
+       |KwCase [57..61)
+       |Ident(foo2) [62..66)
+       |Colon [66..67)
+       |Ident(Foo2) [68..72)
+       |RightArrow [73..75)
+       |Indentation.Indent [75..75)
+       |Ident(foo2) [83..87)
+       |Ident(+=) [88..90)
+       |Constant.String( = ) [91..96)
+       |Indentation.Outdent [96..96)
+       |Indentation.Outdent [109..109)
+       |Ident(end) [112..115)
+       |KwMatch [116..121)
+       |Indentation.Outdent [121..121)
+       |EOF [122..122)
+       |""".stripMargin,
+    showFieldName = true
+  )
+
+  // comment at end of match and also at end of case
+  checkPositions[Stat](
+    """|object a:
+       |  bar2 match
+       |     case foo1: Foo1 => foo1
+       |     case foo2: Foo2 =>
+       |       foo2 += " = "
+       |       // foo2
+       |  end match
+       |""".stripMargin,
+    """|<templ>Template :
+       |  bar2 match
+       |     case foo1: Foo1 => foo1
+       |     case foo2: Foo2 =>
+       |       foo2 += " = "
+       |       // foo2
+       |  end match</templ>
+       |<self>Self   @@bar2 match</self>
+       |<stats0>Term.Match bar2 match
+       |     case foo1: Foo1 => foo1
+       |     case foo2: Foo2 =>
+       |       foo2 += " = "
+       |       // foo2</stats0>
+       |<cases0>Case case foo1: Foo1 => foo1</cases0>
+       |<pat>Pat.Typed foo1: Foo1</pat>
+       |<cases1>Case case foo2: Foo2 =>
+       |       foo2 += " = "
+       |       // foo2</cases1>
+       |<pat>Pat.Typed foo2: Foo2</pat>
+       |<body>Term.ApplyInfix foo2 += " = "</body>
+       |<targClause>Type.ArgClause        foo2 += @@" = "</targClause>
+       |<values0>Lit.String " = "</values0>
+       |<stats1>Term.EndMarker end match</stats1>
+       |""".stripMargin,
+    """|BOF [0..0)
+       |KwObject [0..6)
+       |Ident(a) [7..8)
+       |Colon [8..9)
+       |Indentation.Indent [9..9)
+       |Ident(bar2) [12..16)
+       |KwMatch [17..22)
+       |Indentation.Indent [22..22)
+       |KwCase [28..32)
+       |Ident(foo1) [33..37)
+       |Colon [37..38)
+       |Ident(Foo1) [39..43)
+       |RightArrow [44..46)
+       |Ident(foo1) [47..51)
+       |LF [51..52)
+       |KwCase [57..61)
+       |Ident(foo2) [62..66)
+       |Colon [66..67)
+       |Ident(Foo2) [68..72)
+       |RightArrow [73..75)
+       |Indentation.Indent [75..75)
+       |Ident(foo2) [83..87)
+       |Ident(+=) [88..90)
+       |Constant.String( = ) [91..96)
+       |Indentation.Outdent [111..111)
+       |Indentation.Outdent [111..111)
+       |Ident(end) [114..117)
+       |KwMatch [118..123)
+       |Indentation.Outdent [123..123)
+       |EOF [124..124)
+       |""".stripMargin,
+    showFieldName = true
+  )
+
 }


### PR DESCRIPTION
Helps with scalameta/scalafmt#4133.