### PR TITLE
TreeSuiteBase: move `tokenize` method centrally

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/TreeSuiteBase.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/TreeSuiteBase.scala
@@ -3,6 +3,7 @@ package scala.meta.tests
 import org.scalameta.internal.ScalaCompat
 import scala.meta._
 import scala.meta.tests.parsers.CommonTrees
+import scala.meta.tokenizers.Tokenize
 import scala.meta.trees.Origin
 
 import munit._
@@ -163,5 +164,8 @@ abstract class TreeSuiteBase extends FunSuite with CommonTrees {
       dialect: Dialect,
       conv: TestHelpers.Tokenize
   ): Unit = assertTokenizedAsSyntax(code, expected, dialect)
+
+  protected def tokenize(code: String)(implicit dialect: Dialect): Tokens = Tokenize
+    .scalametaTokenize.apply(Input.String(code), dialect).get
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/XmlSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/XmlSuite.scala
@@ -14,12 +14,6 @@ class XmlSuite extends ParseSuite {
     def tokensStructure(tokenized: Tokens): String = tokenized.map(_.structure)
       .mkString("", "\n", "\n")
 
-    def tokenize(code: String): Tokens = {
-      val convert = scala.meta.inputs.Input.stringToInput
-      val tokenize = scala.meta.tokenizers.Tokenize.scalametaTokenize
-      code.tokenize(convert, tokenize, dialect).get
-    }
-
     test(logger.revealWhitespace(original)) {
       val obtained = tokensStructure(tokenize(original))
       assertEquals(obtained, expected)

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/BaseTokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/BaseTokenizerSuite.scala
@@ -8,9 +8,6 @@ import munit.Location
 
 abstract class BaseTokenizerSuite extends TreeSuiteBase {
 
-  def tokenize(code: String)(implicit dialect: Dialect): Tokens = tokenizers.Tokenize
-    .scalametaTokenize.apply(inputs.Input.stringToInput(code), dialect).get
-
   implicit def implicitTokenize: TestHelpers.Tokenize = new TestHelpers.Tokenize {
     override def apply(code: String)(implicit dialect: Dialect): Iterable[Token] = tokenize(code)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
@@ -1291,7 +1291,8 @@ class TokenizerSuite extends BaseTokenizerSuite {
     "0x__123_456__789"
   ).foreach { value =>
     test(s"numeric literal separator ok scala213: $value") {
-      dialects.Scala213(value).tokenize.get // no exception
+      implicit val dialect: Dialect = dialects.Scala213
+      tokenize(value) // no exception
     }
   }
 
@@ -1388,8 +1389,9 @@ class TokenizerSuite extends BaseTokenizerSuite {
   }
 
   test("numeric literal separator scala213: check positions") {
-    val intConstant = dialects.Scala213(" 1_000_000 ").tokenize.get(2)
-      .asInstanceOf[Token.Constant.Int]
+    implicit val dialect: Dialect = dialects.Scala213
+    val tokens = tokenize(" 1_000_000 ")
+    val intConstant = tokens(2).asInstanceOf[Token.Constant.Int]
     assertEquals(intConstant.pos.text, "1_000_000") // assert token position includes underscores
     assertEquals(intConstant.value, BigInt(1000000))
   }
@@ -1449,8 +1451,8 @@ class TokenizerSuite extends BaseTokenizerSuite {
 
   test("#3328") {
     val code = "val \\uD835\\uDF11: Double"
-    val res = dialects.Scala212(code).tokenize
-    assertEquals(res.get.toString, code)
+    implicit val dialect: Dialect = dialects.Scala212
+    assertEquals(tokenize(code).toString, code)
   }
 
   test("#3328 2") {
@@ -1471,8 +1473,8 @@ class TokenizerSuite extends BaseTokenizerSuite {
 
   test("#3402") {
     val code = "val MIN_HIGH_SURROGATE = '\\uD800'"
-    val res = dialects.Scala212(code).tokenize
-    assertEquals(res.get.toString, code)
+    implicit val dialect: Dialect = dialects.Scala212
+    assertEquals(tokenize(code).toString, code)
   }
 
   test("binary literals") {
@@ -1480,8 +1482,8 @@ class TokenizerSuite extends BaseTokenizerSuite {
                   |val v2 = 0B_0010_1010
                   |val v3 = 0b_0010_1010L
                   |""".stripMargin
-    val res = dialects.Scala213(code).tokenize
-    assertEquals(res.get.toString, code)
+    implicit val dialect: Dialect = dialects.Scala213
+    assertEquals(tokenize(code).toString, code)
   }
 
   Seq(

--- a/tests/shared/src/test/scala/scala/meta/tests/tokens/TokensSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokens/TokensSuite.scala
@@ -48,11 +48,8 @@ class TokensApiSuite extends FunSuite {
 
   implicit val dialect: Dialect = dialects.Scala211
 
-  def tokenize(code: String): Tokens = {
-    val convert = scala.meta.inputs.Input.stringToInput
-    val tokenize = scala.meta.tokenizers.Tokenize.scalametaTokenize
-    code.tokenize(convert, tokenize, dialect).get
-  }
+  def tokenize(code: String): Tokens = tokenizers.Tokenize.scalametaTokenize
+    .apply(inputs.Input.String(code), dialect).get
 
   test("Maintains Tokens type when implementing collections API methods") {
     // Drop BOF and EOF to make tests more readable


### PR DESCRIPTION
Follow-on to #3786.