### PR TITLE
ScalametaParser: `for` uses `yield` alongside `do`

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2465,7 +2465,10 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
   private def enumeratorGuardOnIf() = autoPos(Enumerator.Guard(guardOnIf()))
 
   def enumerators(): List[Enumerator] = listBy[Enumerator] { enums =>
-    def notEnumsEnd(token: Token): Boolean = !token.isAny[Indentation.Outdent, KwDo, CloseDelim]
+    def notEnumsEnd(token: Token): Boolean = token match {
+      case _: Indentation.Outdent | _: CloseDelim | _: KwDo | _: KwYield => false
+      case _ => true
+    }
     doWhile {
       enums += enumerator(isFirst = enums.isEmpty)
       while (at[Token.KwIf]) enums += enumeratorGuardOnIf()

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -4179,10 +4179,13 @@ class ControlSyntaxSuite extends BaseDottySuite {
                   |  yield
                   |    foo
                   |""".stripMargin
-    val error = """|<input>:4: error: illegal start of simple pattern
-                   |  yield
-                   |  """.stripMargin
-    runTestError[Stat](code, error)
+    val layout = "object a { for (foo <- bar) yield foo }"
+    val tree = Defn.Object(
+      Nil,
+      tname("a"),
+      tpl(Term.ForYield(List(Enumerator.Generator(Pat.Var(tname("foo")), tname("bar"))), tname("foo")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -4172,4 +4172,17 @@ class ControlSyntaxSuite extends BaseDottySuite {
     runTestAssert[Stat](code, layout)(tree)
   }
 
+  test("break after <- in for-yield") {
+    val code = """|object a:
+                  |  for foo <-
+                  |    bar
+                  |  yield
+                  |    foo
+                  |""".stripMargin
+    val error = """|<input>:4: error: illegal start of simple pattern
+                   |  yield
+                   |  """.stripMargin
+    runTestError[Stat](code, error)
+  }
+
 }


### PR DESCRIPTION
Helps with scalameta/scalafmt#4133.