### PR TITLE
Input: add WithTokenizerOptions wrapper

### DIFF
--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
@@ -291,8 +291,8 @@ class ScalametaTokenizer(input: Input, dialect: Dialect)(implicit options: Optio
 object ScalametaTokenizer {
   def toTokenize: Tokenize = new Tokenize {
     def apply(input: Input, dialect: Dialect): Tokenized = {
-      implicit val options: Option[TokenizerOptions] = None
-      val tokenizer = new ScalametaTokenizer(input, dialect)
+      implicit val options: Option[TokenizerOptions] = input.tokenizerOptions
+      val tokenizer = new ScalametaTokenizer(input.withoutTokenizerOptions, dialect)
       try Tokenized.Success(tokenizer.tokenize())
       catch {
         case details @ TokenizeException(pos, message) => Tokenized.Error(pos, message, details)

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -121,6 +121,7 @@ class SurfaceSuite extends TreeSuiteBase {
          |scala.meta.inputs.Input.String *
          |scala.meta.inputs.Input.Text *
          |scala.meta.inputs.Input.VirtualFile *
+         |scala.meta.inputs.Input.WithTokenizerOptions *
          |scala.meta.inputs.InputException *
          |scala.meta.inputs.InputRange *
          |scala.meta.inputs.Position

--- a/tests/shared/src/test/scala/scala/meta/tests/TreeSuiteBase.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/TreeSuiteBase.scala
@@ -169,6 +169,6 @@ abstract class TreeSuiteBase extends FunSuite with CommonTrees {
   ): Unit = assertTokenizedAsSyntax(code, expected, dialect)
 
   protected def tokenize(code: String)(implicit dialect: Dialect): Tokens = Tokenize
-    .scalametaTokenize.apply(Input.String(code), dialect).get
+    .scalametaTokenize.apply(Input.String(code).withTokenizerOptions, dialect).get
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/BasePositionSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/BasePositionSuite.scala
@@ -9,6 +9,7 @@ import munit.TestOptions
 
 abstract class BasePositionSuite(defaultDialect: Dialect) extends ParseSuite {
   import scala.meta._
+  import scala.meta.tests.parsers.MoreHelpers._
 
   def checkPositions[T <: Tree: Parse](code: TestOptions)(implicit loc: Location): Unit =
     checkPositions[T](code, "")
@@ -54,7 +55,7 @@ abstract class BasePositionSuite(defaultDialect: Dialect) extends ParseSuite {
   )(implicit loc: Location): Unit = test(code) {
     implicit val D = defaultDialect
     if (expectedTokens.nonEmpty) assertTokenizedAsStructureLines(code.name, expectedTokens)
-    val tree = code.name.parse[T]
+    val tree = code.name.asInput.parse[T]
       .fold(x => fail("parse failure", x.details), MoreHelpers.requireNonEmptyOrigin(_))
     val sb = new StringBuilder
     tree.traverse {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/MoreHelpers.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/MoreHelpers.scala
@@ -2,6 +2,7 @@ package scala.meta.tests.parsers
 
 import scala.meta._
 import scala.meta.internal.parsers._
+import scala.meta.tokenizers.TokenizerOptions
 import scala.meta.trees.Origin
 
 import munit._
@@ -19,11 +20,17 @@ object MoreHelpers {
     tree
   }
   implicit class XtensionCode(private val code: String) extends AnyVal {
-    def asInput: Input = Input.String(code)
-    def asAmmoniteInput: Input = Input.Ammonite(asInput)
-    def applyRule[T <: Tree](rule: ScalametaParser => T)(implicit dialect: Dialect): T = asInput
+    def asInput(implicit tokenizerOptions: Option[TokenizerOptions]): Input = Input.String(code)
+      .withTokenizerOptions(tokenizerOptions)
+    def asAmmoniteInput(implicit tokenizerOptions: Option[TokenizerOptions]): Input = Input
+      .Ammonite(asInput)
+    def applyRule[T <: Tree](
+        rule: ScalametaParser => T
+    )(implicit dialect: Dialect, tokenizerOptions: Option[TokenizerOptions]): T = asInput
       .applyRule(rule)
-    def parseRule[T <: Tree](rule: ScalametaParser => T)(implicit dialect: Dialect): T = asInput
+    def parseRule[T <: Tree](
+        rule: ScalametaParser => T
+    )(implicit dialect: Dialect, tokenizerOptions: Option[TokenizerOptions]): T = asInput
       .parseRule(rule)
   }
   implicit class XtensionInput(private val input: Input) extends AnyVal {

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
@@ -203,6 +203,7 @@ class PublicSuite extends TreeSuiteBase {
 
   test("scala.meta.inputs.Input.Proxy.toString") {}
   test("scala.meta.inputs.Input.Text.toString") {}
+  test("scala.meta.inputs.Input.WithTokenizerOptions.toString") {}
 
   test("scala.meta.dialects.AllowEverything.toString") {
     // Satisfy surface suite.

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
@@ -1048,7 +1048,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
   }
 
   test("parsed trees don't have BOF/EOF in their tokens") {
-    val tree = "foo + bar".parse[Term].get
+    val tree = "foo + bar".asInput.parse[Term].get
     assert(tree.pos != Position.None)
     assertEquals(
       tree.tokens.structure,
@@ -1069,13 +1069,13 @@ class TokenizerSuite extends BaseTokenizerSuite {
   }
 
   test("Ident.value for normal") {
-    "foo".parse[Term].get.tokens match {
+    "foo".asInput.parse[Term].get.tokens match {
       case Tokens(bof, foo: Ident, eof) => assertEquals(foo.value, "foo")
     }
   }
 
   test("Ident.value for backquoted") {
-    "`foo`".parse[Term].get.tokens match {
+    "`foo`".asInput.parse[Term].get.tokens match {
       case Tokens(bof, foo: Ident, eof) =>
         assertEquals(foo.value, "foo")
         assertEquals(foo.syntax, "`foo`")


### PR DESCRIPTION
Since our public code signatures take Input and Dialect, the only way to provide TokenizerOptions without breaking MIMA compatibility is by using either of those types.

Neither of them in reality is perfect for this task, but since Dialect is a final class and adding tokenizer options as a field to it seems a bit illogical, let's implement it as a wrapper of the Input type.

Follow-on to #3786.