### PR TITLE
ScalametaTokenizer: check for INVALID after space

### DIFF
--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
@@ -39,12 +39,13 @@ class ScalametaTokenizer(input: Input, dialect: Dialect)(implicit options: Optio
 
     @tailrec
     def emitTokenWhitespace(token: Token.Whitespace): Token = {
+      val next = nextToken() // might output INVALID token for current whitespace
       token match {
         case t: Token.HSpace => whitespaceTokenizer.pushHS(t)
         case t: Token.EOL => whitespaceTokenizer.pushVS(t)
-        case _ => unreachable
+        case t => unreachable(debug(t), "not a whitespace token")
       }
-      getToken(nextToken()) match {
+      getToken(next) match {
         case nt: Token.Whitespace => emitTokenWhitespace(nt)
         case nt => whitespaceTokenizer.flush(); nt
       }


### PR DESCRIPTION
INVALID legacy tokens are frequently output after the token they intend to invalidate, including whitespace tokens.

This particular issue was masked by the previous whitespace-grouping change which didn't flush whitespace tokens immediately.

Fixes interop between #3835 and #3786.