### PR TITLE
Origin: internally expose possible input

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/InternalTrees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/InternalTrees.scala
@@ -81,7 +81,7 @@ trait InternalTree extends Product {
     case Lit.String(value) =>
       val input = Input.VirtualFile("<InternalTrees.tokens>", value)
       Tokens(Array(Constant.String(input, dialect, 0, value.length, value)))
-    case _ => tokenize(textAsInput, dialect).get
+    case _ => tokenize(origin.inputOpt.fold(textAsInput)(_.withTokenizerOptions), dialect).get
   }
 
   private[meta] def textAsInput(implicit

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/InternalTrees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/InternalTrees.scala
@@ -64,19 +64,24 @@ trait InternalTree extends Product {
   }
 
   def tokenizeFor(dialect: Dialect): Tokens =
-    if (origin.dialectOpt.contains(dialect)) tokensOpt.get else retokenize(dialect, None)
+    if (origin.dialectOpt.contains(dialect)) tokensOpt.get else retokenizeFor(dialect)
 
   private def tokensOpt: Option[Tokens] = origin.tokensOpt.orElse(syntaxTokensOpt)
-  private lazy val syntaxTokensOpt: Option[Tokens] = origin.dialectOpt.map(retokenize(_, None))
+  private lazy val syntaxTokensOpt: Option[Tokens] = origin.dialectOpt.map(retokenizeFor)
 
   private[meta] def retokenize(implicit
+      tokenize: Tokenize,
       dialect: Dialect,
       tokenizerOptions: Option[TokenizerOptions]
-  ): Tokens = this match {
+  ): Tokens = retokenizeFor(dialect)
+
+  private[meta] def retokenizeFor(
+      dialect: Dialect
+  )(implicit tokenize: Tokenize, tokenizerOptions: Option[TokenizerOptions]): Tokens = this match {
     case Lit.String(value) =>
       val input = Input.VirtualFile("<InternalTrees.tokens>", value)
       Tokens(Array(Constant.String(input, dialect, 0, value.length, value)))
-    case _ => implicitly[Tokenize].apply(textAsInput, dialect).get
+    case _ => tokenize(textAsInput, dialect).get
   }
 
   private[meta] def textAsInput(implicit

--- a/scalameta/trees/shared/src/main/scala/scala/meta/trees/Origin.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/trees/Origin.scala
@@ -11,6 +11,7 @@ import scala.meta.tokens._
 trait Origin extends Optional {
   def position: Position
   def dialectOpt: Option[Dialect]
+  private[meta] def inputOpt: Option[Input]
   private[meta] def textOpt: Option[String]
   private[meta] def tokensOpt: Option[Tokens]
 }
@@ -20,6 +21,7 @@ object Origin {
   object None extends Origin {
     val position: Position = Position.None
     val dialectOpt: Option[Dialect] = scala.None
+    private[meta] val inputOpt: Option[Input] = scala.None
     private[meta] val textOpt: Option[String] = scala.None
     private[meta] val tokensOpt: Option[Tokens] = scala.None
   }
@@ -38,6 +40,7 @@ object Origin {
     }
 
     def dialectOpt: Option[Dialect] = Some(dialect)
+    private[meta] def inputOpt: Option[Input] = Some(input)
     private[meta] def textOpt: Option[String] = Some(text)
     private[meta] def tokensOpt: Option[Tokens] = Some(tokens)
 
@@ -60,6 +63,7 @@ object Origin {
   class DialectOnly(dialect: Dialect) extends Origin {
     val position: Position = Position.None
     def dialectOpt: Option[Dialect] = Some(dialect)
+    private[meta] val inputOpt: Option[Input] = scala.None
     private[meta] val textOpt: Option[String] = scala.None
     private[meta] val tokensOpt: Option[Tokens] = scala.None
   }


### PR DESCRIPTION
In InternalTree, use it to tokenize, before resorting to syntax parsing. Also, if that Input contained any TokenizerOptions, they would naturally be used. Follow-on to #3786.