### PR TITLE
Show: carefully filter None values early

### DIFF
--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/prettyprinters/ShowMacros.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/prettyprinters/ShowMacros.scala
@@ -20,17 +20,6 @@ class ShowMacros(val c: Context) {
     }
   }
 
-  def sequence(xs: c.Tree*) = {
-    val results = mkResults(xs)
-    if (xs.isEmpty) q"$ShowObj.None"
-    else if (xs.length == 1) results.head
-    else q"$ShowObj.Sequence(..$results)"
-  }
-
-  def meta(data: c.Tree, xs: c.Tree*) = {
-    val results = mkResults(xs)
-    if (xs.isEmpty) q"$ShowObj.None"
-    else if (xs.length == 1) q"$ShowObj.Meta($data, ${results.head})"
-    else q"$ShowObj.Meta($data, $ShowObj.Sequence(..$results))"
-  }
+  def sequence(xs: c.Tree*) = q"$ShowObj.mkseq(..${mkResults(xs)})"
+  def meta(data: c.Tree, xs: c.Tree*) = q"$ShowObj.meta($data, ${sequence(xs: _*)})"
 }

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -224,8 +224,13 @@ object TreeSyntax {
         }
       }
       s(t) match {
-        case Show.Meta(ig: SyntacticGroup, res) if force || groupNeedsParens(og, ig) =>
-          s("(", res, ")")
+        case x: Show.Meta =>
+          val needParens = force ||
+            (x.data match {
+              case ig: SyntacticGroup => groupNeedsParens(og, ig)
+              case _ => false
+            })
+          w("(", x.res, ")", needParens)
         case res => res
       }
     }


### PR DESCRIPTION
Otherwise, our checks on intermediate results being None are incorrect. For this, turn most Result into regular classes, and add companion apply definitions doing the filtering. Helps with #3913.