### PR TITLE
bugfix: Don't throw when broken string interpolation

### DIFF
--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
@@ -277,10 +277,7 @@ class ScalametaTokenizer(input: Input, dialect: Dialect)(implicit options: Token
 
       case EOF => new Token.EOF(input, dialect)
       case SHEBANG => new Token.Shebang(input, dialect, curr.offset, curr.endOffset, curr.strVal)
-      case INVALID => getInvalid(curr, curr.strVal)
-
-      // the rest of tokens shouldn't be obtained via this method
-      case _ => unreachable(debug(curr))
+      case _ => getInvalid(curr, curr.strVal)
     }
   }
 

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
@@ -60,11 +60,13 @@ class ScalametaTokenizer(input: Input, dialect: Dialect)(implicit options: Token
           pushPart(beg)
           pushToken(Token.Interpolation.SpliceStart(input, dialect, dollarOffset, dollarOffset + 1))
           val splice = nextToken()
-          pushToken(getToken(splice))
-          if (splice.token == LBRACE) loop(braceBalance = 1)
-          val end = nextToken()
-          pushToken(Token.Interpolation.SpliceEnd(input, dialect, end.offset, end.offset))
-          emitContents(end)
+          if (splice.token != STRINGPART) {
+            pushToken(getToken(splice))
+            if (splice.token == LBRACE) loop(braceBalance = 1)
+            val end = nextToken()
+            pushToken(Token.Interpolation.SpliceEnd(input, dialect, end.offset, end.offset))
+            emitContents(end)
+          } else emitContents(splice)
         } else beg
 
       // NOTE: before emitStart, curr is the first token that follows INTERPOLATIONID

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
@@ -2122,6 +2122,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
          |Interpolation.Part(|Available languages (default = ) [5..37)
          |Interpolation.SpliceStart [37..38)
          |Invalid(Not one of: `$'_, `$$', `$'ident, `$'this, `$'BlockExpr) [38..38)
+         |Interpolation.SpliceEnd [38..38)
          |Interpolation.Part():\nverilog - Verilog or SystemVerilog dialects\nvhdl    - VHDL dialects\n\nAvailable Verilog/SystemVerilog dialects (default = ) [38..162)
          |Interpolation.SpliceStart [162..163)
          |Ident(defaultDialect) [163..177)

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
@@ -2114,27 +2114,25 @@ class TokenizerSuite extends BaseTokenizerSuite {
                   |'''.stripMargin
                   |""".stripMargin.replace("'''", "\"\"\"")
 
-    val struct = """|BOF [0..0)
-                    |LF [0..1)
-                    |Interpolation.Id(s) [1..2)
-                    |Interpolation.Start(''') [2..5)
-                    |Interpolation.Part(|Available languages (default = ) [5..37)
-                    |Interpolation.SpliceStart [37..38)
-                    |Invalid(Not one of: `$'_, `$$', `$'ident, `$'this, `$'BlockExpr) [38..38)
-                    |Invalid():
-                    |verilog - Verilog or SystemVerilog dialects
-                    |vhdl    - VHDL dialects
-                    |
-                    |Available Verilog/SystemVerilog dialects (default = ) [38..162)
-                    |Interpolation.SpliceEnd [163..163)
-                    |Interpolation.Part(defaultDialect) [163..177)
-                    |Interpolation.End() [177..177)
-                    |Constant.String():\nv2001   - Verilog 2001\nsv2005  - \n) [177..214)
-                    |Dot [217..218)
-                    |Ident(stripMargin) [218..229)
-                    |LF [229..230)
-                    |EOF [230..230)
-                    |""".stripMargin.replace("'''", "\"\"\"").nl2lf
+    val struct =
+      """|BOF [0..0)
+         |LF [0..1)
+         |Interpolation.Id(s) [1..2)
+         |Interpolation.Start(''') [2..5)
+         |Interpolation.Part(|Available languages (default = ) [5..37)
+         |Interpolation.SpliceStart [37..38)
+         |Invalid(Not one of: `$'_, `$$', `$'ident, `$'this, `$'BlockExpr) [38..38)
+         |Interpolation.Part():\nverilog - Verilog or SystemVerilog dialects\nvhdl    - VHDL dialects\n\nAvailable Verilog/SystemVerilog dialects (default = ) [38..162)
+         |Interpolation.SpliceStart [162..163)
+         |Ident(defaultDialect) [163..177)
+         |Interpolation.SpliceEnd [177..177)
+         |Interpolation.Part():\nv2001   - Verilog 2001\nsv2005  - \n) [177..214)
+         |Interpolation.End(''') [214..217)
+         |Dot [217..218)
+         |Ident(stripMargin) [218..229)
+         |LF [229..230)
+         |EOF [230..230)
+         |""".stripMargin.replace("'''", "\"\"\"").nl2lf
     assertTokenizedAsStructureLines(code, struct)
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
@@ -2102,5 +2102,40 @@ class TokenizerSuite extends BaseTokenizerSuite {
                     |""".stripMargin.nl2lf
     assertTokenizedAsStructureLines(code, struct)
   }
+  test("broken-interpolator") {
+    val code = """|
+                  |s'''|Available languages (default = $):
+                  |verilog - Verilog or SystemVerilog dialects
+                  |vhdl    - VHDL dialects
+                  |
+                  |Available Verilog/SystemVerilog dialects (default = $defaultDialect):
+                  |v2001   - Verilog 2001
+                  |sv2005  - 
+                  |'''.stripMargin
+                  |""".stripMargin.replace("'''", "\"\"\"")
+
+    val struct = """|BOF [0..0)
+                    |LF [0..1)
+                    |Interpolation.Id(s) [1..2)
+                    |Interpolation.Start(''') [2..5)
+                    |Interpolation.Part(|Available languages (default = ) [5..37)
+                    |Interpolation.SpliceStart [37..38)
+                    |Invalid(Not one of: `$'_, `$$', `$'ident, `$'this, `$'BlockExpr) [38..38)
+                    |Invalid():
+                    |verilog - Verilog or SystemVerilog dialects
+                    |vhdl    - VHDL dialects
+                    |
+                    |Available Verilog/SystemVerilog dialects (default = ) [38..162)
+                    |Interpolation.SpliceEnd [163..163)
+                    |Interpolation.Part(defaultDialect) [163..177)
+                    |Interpolation.End() [177..177)
+                    |Constant.String():\nv2001   - Verilog 2001\nsv2005  - \n) [177..214)
+                    |Dot [217..218)
+                    |Ident(stripMargin) [218..229)
+                    |LF [229..230)
+                    |EOF [230..230)
+                    |""".stripMargin.replace("'''", "\"\"\"").nl2lf
+    assertTokenizedAsStructureLines(code, struct)
+  }
 
 }


### PR DESCRIPTION
Related to https://github.com/scalameta/metals/issues/6699

It seems the code is perfectly reachable after all, so maybe it's better to default to invalid.

The other option I was thinking about (or an additional) is to finish interpolation splice right away with and End, but that might be too complex for a case that might not pop up that often.