### PR TITLE
Trees: revert change to Term.PartialFunction

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -422,10 +422,7 @@ object Term {
     override final def paramClause: Member.SyntaxValuesClause = tparamClause
   }
   @ast
-  class PartialFunction(casesClause: CasesClause @nonEmpty) extends Term with Tree.WithCasesClause {
-    @replacedField("4.9.9")
-    override final def cases: List[Case] = casesClause.cases
-  }
+  class PartialFunction(cases: List[Case] @nonEmpty) extends Term with Tree.WithCases
   @ast
   class While(expr: Term, body: Term) extends Term with Tree.WithCond with Tree.WithBody {
     override final def cond: Term = expr

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
@@ -192,7 +192,6 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
     "(f)({ case a => a })",
     """|Term.ArgClause ({ case a => a })
        |Term.PartialFunction { case a => a }
-       |Term.CasesClause { case a => a }
        |Case case a => a
        |""".stripMargin
   )
@@ -341,8 +340,7 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
   )
   checkPositions[Stat](
     "{ case x => x; case y => y }",
-    """|Term.CasesClause { case x => x; case y => y }
-       |Case case x => x;
+    """|Case case x => x;
        |Case case y => y
        |""".stripMargin
   )


### PR DESCRIPTION
It's pointless when PartialFunction and CasesClause amount to exactly the same tree. Helps with #3913.