### PR TITLE
ScalametaParser: add `:` in opt braces, not `with`

### DIFF
--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -1225,6 +1225,21 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |""".stripMargin
   )
 
+  checkPositions[Stat](
+    """|type A = AnyRef:
+       |  type T>: Null
+       |""".stripMargin,
+    """|Type.ParamClause type A @@= AnyRef:
+       |Type.Refine AnyRef:
+       |  type T>: Null
+       |Stat.Block type T>: Null
+       |Decl.Type type T>: Null
+       |Type.ParamClause   type T@@>: Null
+       |Type.Bounds >: Null
+       |Type.Bounds type A = @@AnyRef:
+       |""".stripMargin
+  )
+
   checkPositions[Type](
     """|(x: X, y: Y) => Z
        |""".stripMargin,

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -143,9 +143,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |<inits1>Init Eq[Int]</inits1>
        |<tpe>Type.Apply Eq[Int]</tpe>
        |<argClause>Type.ArgClause [Int]</argClause>
-       |<body>Template.Body with
-       |  // c1
-       |  def f(): Int = 1
+       |<body>Template.Body def f(): Int = 1
        |  // c2</body>
        |<stats0>Defn.Def def f(): Int = 1</stats0>
        |<paramClauseGroups0>Member.ParamClauseGroup ()</paramClauseGroups0>
@@ -1232,7 +1230,8 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
     """|Type.ParamClause type A @@= AnyRef:
        |Type.Refine AnyRef:
        |  type T>: Null
-       |Stat.Block type T>: Null
+       |Stat.Block :
+       |  type T>: Null
        |Decl.Type type T>: Null
        |Type.ParamClause   type T@@>: Null
        |Type.Bounds >: Null


### PR DESCRIPTION
Helps with #3913.