### PR TITLE
chore: Add transparent modifier as acceptable for class

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -123,7 +123,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
     }
 
     tokens(index).text match {
-      case soft.KwTransparent() => nextIsDclIntroOrModifierOr(_.is[KwTrait])
+      case soft.KwTransparent() => nextIsDclIntroOrModifierOr(_.isAny[KwTrait, KwClass])
       case soft.KwOpaque() => nextIsDclIntroOrModifierOr(_ => false)
       case soft.KwInline() => nextIsDclIntroOrModifierOr(matchesAfterInlineMatchMod)
       case soft.KwOpen() | soft.KwInfix() | soft.KwErased() => isDefIntro(getNextIndex(index))

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InlineSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InlineSuite.scala
@@ -340,6 +340,12 @@ class InlineSuite extends BaseDottySuite {
     )
   }
 
+  test("transparent-class") {
+    runTestAssert[Stat]("transparent class S")(
+      Defn.Class(List(Mod.Transparent()), pname("S"), Nil, ctor, tplNoBody())
+    )
+  }
+
   test("transparent-trait-newlines") {
     runTestAssert[Stat](
       """|transparent 


### PR DESCRIPTION
Fixes https://github.com/scalameta/scalameta/issues/3947

I don't think we need to add a dialect for it, since the error isn't really important for parser