### PR TITLE
ScannerTokens: RegionTemplateMark can also have LF

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SepRegion.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SepRegion.scala
@@ -47,7 +47,7 @@ case object RegionDefType extends RegionDefDecl
 sealed trait RegionTemplateDecl extends RegionNonDelimNonIndented
 
 /** the initial part of declaration, before the template */
-case object RegionTemplateMark extends RegionTemplateDecl
+case object RegionTemplateMark extends RegionTemplateDecl with CanProduceLF
 
 /** the initial part of the template, containing any inherit clauses */
 case object RegionTemplateInherit extends RegionTemplateDecl

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -2978,4 +2978,55 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
     showFieldName = true
   )
 
+  checkPositions[Stat](
+    """|object Hello {
+       |  buffer
+       |    += new Object()
+       |    += new Object
+       |}
+       |""".stripMargin,
+    """|<templ>Template {
+       |  buffer
+       |    += new Object()
+       |    += new Object
+       |}</templ>
+       |<body>Template.Body {
+       |  buffer
+       |    += new Object()
+       |    += new Object
+       |}</body>
+       |<stats0>Term.ApplyInfix buffer
+       |    += new Object()
+       |    += new Object</stats0>
+       |<lhs>Term.ApplyInfix buffer
+       |    += new Object()</lhs>
+       |<targClause>Type.ArgClause     += @@new Object()</targClause>
+       |<values0>Term.New new Object()</values0>
+       |<init>Init Object()</init>
+       |<argClauses0>Term.ArgClause ()</argClauses0>
+       |<targClause>Type.ArgClause     += @@new Object</targClause>
+       |<values0>Term.New new Object</values0>
+       |""".stripMargin,
+    """|BOF [0..0)
+       |KwObject [0..6)
+       |Ident(Hello) [7..12)
+       |LeftBrace [13..14)
+       |Ident(buffer) [17..23)
+       |InfixLF [23..24)
+       |Ident(+=) [28..30)
+       |KwNew [31..34)
+       |Ident(Object) [35..41)
+       |LeftParen [41..42)
+       |RightParen [42..43)
+       |InfixLF [43..44)
+       |Ident(+=) [48..50)
+       |KwNew [51..54)
+       |Ident(Object) [55..61)
+       |LF [61..62)
+       |RightBrace [62..63)
+       |EOF [64..64)
+       |""".stripMargin,
+    showFieldName = true
+  )
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
@@ -715,7 +715,7 @@ class InfixSuite extends BaseDottySuite {
                        |Ident(Object) [35..41)
                        |LeftParen [41..42)
                        |RightParen [42..43)
-                       |LF [43..44)
+                       |InfixLF [43..44)
                        |Ident(+=) [48..50)
                        |KwNew [51..54)
                        |Ident(Object) [55..61)
@@ -724,10 +724,19 @@ class InfixSuite extends BaseDottySuite {
                        |EOF [64..64)
                        |""".stripMargin
     assertTokenizedAsStructureLines(code, tokenized)
-    val error = """|<input>:4: error: `;` expected but `new` found
-                   |    += new Object
-                   |       ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "object Hello { buffer += (new Object()) += (new Object) }"
+    val tree = Defn.Object(
+      Nil,
+      tname("Hello"),
+      tpl(Term.ApplyInfix(
+        Term
+          .ApplyInfix(tname("buffer"), tname("+="), Nil, List(Term.New(init("Object", List(Nil))))),
+        tname("+="),
+        Nil,
+        List(Term.New(init("Object")))
+      ))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("#3948 2") {


### PR DESCRIPTION
Fixes #3948.