### PR TITLE
Add basic support for `tracked` parameters

### DIFF
--- a/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
@@ -161,7 +161,9 @@ final class Dialect private[meta] (
     // https://docs.scala-lang.org/scala3/reference/other-new-features/control-syntax.html
     val allowQuietSyntax: Boolean,
     // Are binary literals allowed? SIP-42.
-    val allowBinaryLiterals: Boolean
+    val allowBinaryLiterals: Boolean,
+    // Are tracked parameters allowed? docs: https://dotty.epfl.ch/docs/reference/experimental/modularity.html
+    val allowTrackedParameters: Boolean
 ) extends Product with Serializable {
 
   // NOTE(olafur) checklist for adding a new dialect field in a binary compatible way:
@@ -256,7 +258,8 @@ final class Dialect private[meta] (
     allowParamClauseInterleaving = false,
     allowFewerBraces = false,
     allowQuietSyntax = false,
-    allowBinaryLiterals = false
+    allowBinaryLiterals = false,
+    allowTrackedParameters = false
     // NOTE(olafur): declare the default value for new fields above this comment.
   )
 
@@ -393,6 +396,9 @@ final class Dialect private[meta] (
   def withAllowBinaryLiterals(newValue: Boolean): Dialect =
     privateCopy(allowBinaryLiterals = newValue)
 
+  def withAllowTrackedParameters(newValue: Boolean): Dialect =
+    privateCopy(allowTrackedParameters = newValue)
+
   // NOTE(olafur): add the next `withX()` method above this comment. Please try
   // to use consistent formatting, use `newValue` as the parameter name and wrap
   // the body inside curly braces.
@@ -458,7 +464,8 @@ final class Dialect private[meta] (
       allowParamClauseInterleaving: Boolean = this.allowParamClauseInterleaving,
       allowFewerBraces: Boolean = this.allowFewerBraces,
       allowQuietSyntax: Boolean = this.allowQuietSyntax,
-      allowBinaryLiterals: Boolean = this.allowBinaryLiterals
+      allowBinaryLiterals: Boolean = this.allowBinaryLiterals,
+      allowTrackedParameters: Boolean = this.allowTrackedParameters
       // NOTE(olafur): add the next parameter above this comment.
   ): Dialect = {
     val notForUnquote = unquoteType eq UnquoteType.None
@@ -521,7 +528,8 @@ final class Dialect private[meta] (
       allowParamClauseInterleaving = allowParamClauseInterleaving,
       allowFewerBraces = allowFewerBraces,
       allowQuietSyntax = allowQuietSyntax,
-      allowBinaryLiterals = allowBinaryLiterals
+      allowBinaryLiterals = allowBinaryLiterals,
+      allowTrackedParameters = allowTrackedParameters
     )
     if (equivalent) return this // RETURN!
     new Dialect(
@@ -587,6 +595,7 @@ final class Dialect private[meta] (
       allowFewerBraces = allowFewerBraces,
       allowQuietSyntax = allowQuietSyntax,
       allowBinaryLiterals = allowBinaryLiterals,
+      allowTrackedParameters = allowTrackedParameters,
       // NOTE(olafur): add the next argument above this comment.
       unquoteType = unquoteType,
       unquoteParentDialect = if (notForUnquote) null else this
@@ -674,7 +683,8 @@ final class Dialect private[meta] (
       allowParamClauseInterleaving: Boolean,
       allowFewerBraces: Boolean,
       allowQuietSyntax: Boolean,
-      allowBinaryLiterals: Boolean
+      allowBinaryLiterals: Boolean,
+      allowTrackedParameters: Boolean
   ): Boolean =
     // do not include deprecated values in this comparison
     this.allowAtForExtractorVarargs == allowAtForExtractorVarargs &&
@@ -726,7 +736,8 @@ final class Dialect private[meta] (
       this.allowInfixOperatorAfterNL == allowInfixOperatorAfterNL &&
       this.allowParamClauseInterleaving == allowParamClauseInterleaving &&
       this.allowQuietSyntax == allowQuietSyntax && // separated from "significant indentation"
-      this.allowFewerBraces == allowFewerBraces && this.allowBinaryLiterals == allowBinaryLiterals
+      this.allowFewerBraces == allowFewerBraces && this.allowBinaryLiterals == allowBinaryLiterals &&
+      this.allowTrackedParameters == allowTrackedParameters
 
   @inline
   private def isEquivalentToInternal(that: Dialect): Boolean = (this eq that) ||
@@ -789,7 +800,8 @@ final class Dialect private[meta] (
       allowParamClauseInterleaving = that.allowParamClauseInterleaving,
       allowFewerBraces = that.allowFewerBraces,
       allowQuietSyntax = that.allowQuietSyntax,
-      allowBinaryLiterals = that.allowBinaryLiterals
+      allowBinaryLiterals = that.allowBinaryLiterals,
+      allowTrackedParameters = that.allowTrackedParameters
     )
 
   @deprecated("Use withX method instead", "4.3.11")

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
@@ -736,7 +736,8 @@ final class Dialect private[meta] (
       this.allowInfixOperatorAfterNL == allowInfixOperatorAfterNL &&
       this.allowParamClauseInterleaving == allowParamClauseInterleaving &&
       this.allowQuietSyntax == allowQuietSyntax && // separated from "significant indentation"
-      this.allowFewerBraces == allowFewerBraces && this.allowBinaryLiterals == allowBinaryLiterals &&
+      this.allowFewerBraces == allowFewerBraces &&
+      this.allowBinaryLiterals == allowBinaryLiterals &&
       this.allowTrackedParameters == allowTrackedParameters
 
   @inline

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -110,6 +110,7 @@ package object dialects {
 
   implicit val Scala3Future: Dialect = Scala3.withAllowUnderscoreAsTypePlaceholder(true)
     .withAllowBinaryLiterals(true)
+    .withAllowTrackedParameters(true)
 
   @deprecated("Use Scala3 instead", "4.4.2")
   implicit val Dotty: Dialect = Scala3

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -109,8 +109,7 @@ package object dialects {
   implicit val Scala3: Dialect = Scala34
 
   implicit val Scala3Future: Dialect = Scala3.withAllowUnderscoreAsTypePlaceholder(true)
-    .withAllowBinaryLiterals(true)
-    .withAllowTrackedParameters(true)
+    .withAllowBinaryLiterals(true).withAllowTrackedParameters(true)
 
   @deprecated("Use Scala3 instead", "4.4.2")
   implicit val Dotty: Dialect = Scala3

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2807,6 +2807,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
           case soft.KwOpaque() => atCurPosNext(Mod.Opaque())
           case soft.KwTransparent() => atCurPosNext(Mod.Transparent())
           case soft.KwErased() => atCurPosNext(Mod.Erased())
+          case soft.KwTracked() => atCurPosNext(Mod.Tracked())
           case n =>
             val local = if (isLocal) "local " else ""
             syntaxError(s"${local}modifier expected but $n found", at = currToken)
@@ -3086,6 +3087,8 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
       case _ => if (hasExplicitMods) syntaxErrorExpected[KwVal]; None
     }
     varOrVarParamMod.foreach(mods += _)
+    if (!mods.has[Mod.ValParam] && !mods.has[Mod.VarParam])
+      rejectMod[Mod.Tracked](mods, "`tracked' modifier can only be used val/var parameters in classes")
 
     def endParamQuasi = currToken.isAny[RightParen, Comma]
     mods.headOption.collect { case q: Mod.Quasi if endParamQuasi => q.become[Term.Param] }

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -3087,8 +3087,6 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
       case _ => if (hasExplicitMods) syntaxErrorExpected[KwVal]; None
     }
     varOrVarParamMod.foreach(mods += _)
-    if (!mods.has[Mod.ValParam] && !mods.has[Mod.VarParam])
-      rejectMod[Mod.Tracked](mods, "`tracked' modifier can only be used val/var parameters in classes")
 
     def endParamQuasi = currToken.isAny[RightParen, Comma]
     mods.headOption.collect { case q: Mod.Quasi if endParamQuasi => q.become[Term.Param] }

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -126,7 +126,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
       case soft.KwTransparent() => nextIsDclIntroOrModifierOr(_.isAny[KwTrait, KwClass])
       case soft.KwOpaque() => nextIsDclIntroOrModifierOr(_ => false)
       case soft.KwInline() => nextIsDclIntroOrModifierOr(matchesAfterInlineMatchMod)
-      case soft.KwOpen() | soft.KwInfix() | soft.KwErased() => isDefIntro(getNextIndex(index))
+      case soft.KwOpen() | soft.KwInfix() | soft.KwErased() | soft.KwTracked() => isDefIntro(getNextIndex(index))
       case _ => false
     }
   }

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -126,7 +126,8 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
       case soft.KwTransparent() => nextIsDclIntroOrModifierOr(_.isAny[KwTrait, KwClass])
       case soft.KwOpaque() => nextIsDclIntroOrModifierOr(_ => false)
       case soft.KwInline() => nextIsDclIntroOrModifierOr(matchesAfterInlineMatchMod)
-      case soft.KwOpen() | soft.KwInfix() | soft.KwErased() | soft.KwTracked() => isDefIntro(getNextIndex(index))
+      case soft.KwOpen() | soft.KwInfix() | soft.KwErased() | soft.KwTracked() =>
+        isDefIntro(getNextIndex(index))
       case _ => false
     }
   }

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SoftKeywords.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SoftKeywords.scala
@@ -18,7 +18,7 @@ class SoftKeywords(dialect: Dialect) {
   object KwInfix extends IsWithName(dialect.allowInfixMods, "infix")
   object KwExtension extends IsWithName(dialect.allowExtensionMethods, "extension")
   object KwErased extends IsWithName(dialect.allowErasedDefs, "erased")
-  object KwTracked extends IsWithName(true, "tracked")
+  object KwTracked extends IsWithName(dialect.allowTrackedParameters, "tracked")
 
   object StarSplice extends IsWithName(dialect.allowPostfixStarVarargSplices, "*")
   object StarAsTypePlaceholder

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SoftKeywords.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SoftKeywords.scala
@@ -18,6 +18,7 @@ class SoftKeywords(dialect: Dialect) {
   object KwInfix extends IsWithName(dialect.allowInfixMods, "infix")
   object KwExtension extends IsWithName(dialect.allowExtensionMethods, "extension")
   object KwErased extends IsWithName(dialect.allowErasedDefs, "erased")
+  object KwTracked extends IsWithName(true, "tracked")
 
   object StarSplice extends IsWithName(dialect.allowPostfixStarVarargSplices, "*")
   object StarAsTypePlaceholder

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -1330,6 +1330,8 @@ object Mod {
   class Transparent() extends Mod
   @ast
   class Erased() extends Mod
+  @ast
+  class Tracked() extends Mod
 }
 
 @branch

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -920,6 +920,7 @@ object TreeSyntax {
       case _: Mod.Opaque => kw("opaque")
       case _: Mod.Using => kw("using")
       case _: Mod.Erased => kw("erased")
+      case _: Mod.Tracked => kw("tracked")
       case _: Mod.Transparent => kw("transparent")
       case _: Mod.Override => kw("override")
       case _: Mod.Case => kw("case")

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -362,6 +362,7 @@ class SurfaceSuite extends TreeSuiteBase {
          |scala.meta.Mod.Protected
          |scala.meta.Mod.Sealed
          |scala.meta.Mod.Super
+         |scala.meta.Mod.Tracked
          |scala.meta.Mod.Transparent
          |scala.meta.Mod.Using
          |scala.meta.Mod.ValParam

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
@@ -24,7 +24,7 @@ class ReflectionSuite extends TreeSuiteBase {
     val sym = symbolOf[scala.meta.Tree]
     assert(sym.isRoot)
     val root = sym.asRoot
-    assertEquals((root.allBranches.length, root.allLeafs.length), (63, 437))
+    assertEquals((root.allBranches.length, root.allLeafs.length), (63, 439))
   }
 
   test("If") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/LanguageExtensionsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/LanguageExtensionsSuite.scala
@@ -1,0 +1,41 @@
+package scala.meta.tests.parsers.dotty
+
+import scala.meta._
+
+class LanguageExtensionsSuite extends BaseDottySuite {
+  test("tracked modifier for val param of class") {
+    val code = """|class Vec(tracked val size: Int)""".stripMargin
+    val tree = Defn.Class(
+      Nil,
+      Type.Name("Vec"),
+      Type.ParamClause(Nil),
+      Ctor.Primary(
+        Nil,
+        Name.Anonymous(),
+        List(Term.ParamClause(List(Term.Param(
+          List(Mod.Tracked(), Mod.ValParam()),
+          Term.Name("size"),
+          Some(Type.Name("Int")),
+          None
+        ))))
+      ),
+      Template(None, Nil, Template.Body(None, Nil), Nil)
+    )
+    runTestAssert[Stat](code)(tree)
+  }
+
+  test("tracked modifier for non-val param of class") {
+    val code = """|class Vec(tracked size: Int)""".stripMargin
+    runTestError[Stat](code, "tracked")
+  }
+
+  test("tracked modifier for a def parameter") {
+    val code = """|def foo(tracked x: Int) = x""".stripMargin
+    runTestError[Stat](code, "tracked")
+  }
+
+  test("tracked modifier for a def") {
+    val code = """|tracked def foo(x: Int) = x""".stripMargin
+    runTestError[Stat](code, "tracked")
+  }
+}

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/LanguageExtensionsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/LanguageExtensionsSuite.scala
@@ -4,8 +4,7 @@ import scala.meta._
 
 class LanguageExtensionsSuite extends BaseDottySuite {
 
-  override protected implicit val dialect: Dialect =
-    dialects.Scala3.withAllowTrackedParameters(true)
+  override protected implicit val dialect: Dialect = dialects.Scala3.withAllowTrackedParameters(true)
 
   test("tracked modifier for val param of class") {
     val code = """|class Vec(tracked val size: Int)""".stripMargin

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/LanguageExtensionsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/LanguageExtensionsSuite.scala
@@ -3,6 +3,10 @@ package scala.meta.tests.parsers.dotty
 import scala.meta._
 
 class LanguageExtensionsSuite extends BaseDottySuite {
+
+  override protected implicit val dialect: Dialect =
+    dialects.Scala3.withAllowTrackedParameters(true)
+
   test("tracked modifier for val param of class") {
     val code = """|class Vec(tracked val size: Int)""".stripMargin
     val tree = Defn.Class(


### PR DESCRIPTION
This PR adds basic support for the experimental `tracked` modifier.

Relevant links:
- https://dotty.epfl.ch/docs/reference/experimental/modularity.html
- https://github.com/scala/scala3/blob/e9d48313a2e11685a148e105f038da368485aa66/docs/_docs/internals/syntax.md?plain=1#L382

Any feedback will be appreciated.
