### PR TITLE
ScannerTokens: don't strip RegionTry if indented

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -657,7 +657,8 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
           case RegionTemplateInherit :: xs =>
             if (blankBraceOr(!derives(next) && !derives(prev))) strip(xs) else None
           case RegionTry :: xs
-              if !next.isAny[KwCatch, KwFinally] && canBeLeadingInfix != LeadingInfix.Yes => strip(xs)
+              if !next.isAny[KwCatch, KwFinally] && canBeLeadingInfix != LeadingInfix.Yes &&
+                !isIndented(xs, nextIndent) => strip(xs)
           case Nil | (_: CanProduceLF) :: _ => Some(rs)
           case _ => None
         }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -4190,4 +4190,31 @@ class ControlSyntaxSuite extends BaseDottySuite {
     runTestAssert[Stat](code, layout)(tree)
   }
 
+  test("outdent inlinw try-finally opt-braces") {
+    val code = """|object a:
+                  |  def foo =
+                  |      try bar &&
+                  |          baz
+                  |      finally qux
+                  |""".stripMargin
+    val error = """|<input>:6: error: `outdent` expected but `end of file` found
+                   |
+                   |^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("outdent inlinw try-finally in braces") {
+    val code = """|object a:
+                  |  def foo = {
+                  |      try bar &&
+                  |          baz
+                  |      finally qux
+                  |  }
+                  |""".stripMargin
+    val error = """|<input>:7: error: `outdent` expected but `end of file` found
+                   |
+                   |^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
 }


### PR DESCRIPTION
Helps with scalameta/scalafmt#4133.