### PR TITLE
ScalametaParser: include BOF/EOF only for `Source`

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -54,13 +54,13 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
   }
 
   private def parseRuleAfterBOF[T <: Tree](rule: => T): T = {
-    val start = prevIndex
+    val bofIndex = prevIndex
+    val begIndex = currIndex
     val t = rule
-    // NOTE: can't have prevTokenPos here
-    // because we need to subsume all the trailing trivia
-    val end = currIndex
+    val endIndex = prevIndex
+    val eofIndex = currIndex
     accept[EOF]
-    atPos(start, end)(t)
+    if (t.is[Source]) atPos(bofIndex, eofIndex)(t) else atPos(begIndex, endIndex)(t)
   }
 
   // Entry points for Parse[T]

--- a/tests/shared/src/test/scala/scala/meta/tests/contrib/EqualSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/contrib/EqualSuite.scala
@@ -14,12 +14,12 @@ class EqualSuite extends FunSuite {
   val e: Defn.Class = q"class Foo { val x = 2 }"
 
   test("syntactic") {
-    assert(!a.isEqual[Syntactically](b))
+    assert(a.isEqual[Syntactically](b))
     assert(b.isEqual[Syntactically](c))
-    assert(!e.contains[Syntactically](a))
+    assert(e.contains[Syntactically](a))
     assert(e.contains[Syntactically](b))
     assert(!e.contains[Structurally](d))
-    assert(Set[Syntactically[Tree]](a, b, c, d).size == 3)
+    assertEquals(Set[Syntactically[Tree]](a, b, c, d).size, 2)
   }
 
   test("structural") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ToplevelTermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ToplevelTermSuite.scala
@@ -3,7 +3,7 @@ package scala.meta.tests.parsers
 import scala.meta._
 import scala.meta.tests.TreeSuiteBase
 
-class ToplevelTermSuite extends TreeSuiteBase {
+class ToplevelTermSuite extends ParseSuite {
   implicit val dialect: Dialect = dialects.Scala3.withAllowToplevelTerms(true)
   test("allowToplevelTerms simple") {
 
@@ -11,15 +11,13 @@ class ToplevelTermSuite extends TreeSuiteBase {
                          |foo(x)
                          |""".stripMargin
 
-    val tree = sourceString.parse[Source].get
-
-    assertEquals(tree.syntax, sourceString)
-    val expected = Source(List(
+    val tree = Source(List(
       Defn
         .Def(Nil, tname("foo"), Nil, List(List(tparam("x", "Int"))), Some(pname("Int")), tname("x")),
       Term.Apply(tname("foo"), List(tname("x")))
     ))
-    assertTree(tree)(expected)
+
+    runTestAssert[Source](sourceString)(tree)
   }
 
   test("allowToplevelTerms and allowPackageStatementsWithToplevelTerms with package") {
@@ -29,10 +27,7 @@ class ToplevelTermSuite extends TreeSuiteBase {
                          |foo(x)
                          |""".stripMargin
 
-    val tree = sourceString.parse[Source].get
-
-    assertEquals(tree.syntax, sourceString)
-    val expected = Source(List(Pkg(
+    val tree = Source(List(Pkg(
       tname("bar"),
       List(
         Defn
@@ -40,7 +35,7 @@ class ToplevelTermSuite extends TreeSuiteBase {
         Term.Apply(tname("foo"), List(tname("x")))
       )
     )))
-    assertTree(tree)(expected)
+    runTestAssert[Source](sourceString)(tree)
   }
 
   test("allowToplevelTerms and allowPackageStatementsWithToplevelTerms no package") {
@@ -48,15 +43,12 @@ class ToplevelTermSuite extends TreeSuiteBase {
                          |foo(x)
                          |""".stripMargin
 
-    val tree = sourceString.parse[Source].get
-
-    assertEquals(tree.syntax, sourceString)
-    val expected = Source(List(
+    val tree = Source(List(
       Defn
         .Def(Nil, tname("foo"), Nil, List(List(tparam("x", "Int"))), Some(pname("Int")), tname("x")),
       Term.Apply(tname("foo"), List(tname("x")))
     ))
-    assertTree(tree)(expected)
+    runTestAssert[Source](sourceString)(tree)
   }
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
@@ -25,7 +25,7 @@ class PublicSuite extends TreeSuiteBase {
 
   test("scala.meta.Tree.toString (parsed)") {
     val tree = "foo + bar // baz".parse[Term].get
-    assertEquals(tree.toString, "foo + bar // baz")
+    assertEquals(tree.toString, "foo + bar")
   }
 
   test("scala.meta.Tree.structure (parsed)") {
@@ -35,12 +35,12 @@ class PublicSuite extends TreeSuiteBase {
 
   test("scala.meta.Tree.syntax (parsed)") {
     val tree = "foo + bar // baz".parse[Term].get
-    assertWithOriginalSyntax(tree, "foo + bar // baz", "foo + bar")
+    assertWithOriginalSyntax(tree, "foo + bar", "foo + bar")
   }
 
   test("scala.meta.Tree.toString (quasiquotes)") {
     val tree = q"foo + bar // baz"
-    assertEquals(tree.toString, "foo + bar // baz")
+    assertEquals(tree.toString, "foo + bar")
   }
 
   test("scala.meta.Tree.structure (quasiquoted)") {
@@ -50,7 +50,7 @@ class PublicSuite extends TreeSuiteBase {
 
   test("scala.meta.Tree.syntax (quasiquoted)") {
     val tree = q"foo + bar // baz"
-    assertWithOriginalSyntax(tree, "foo + bar // baz", "foo + bar")
+    assertWithOriginalSyntax(tree, "foo + bar", "foo + bar")
   }
 
   test("scala.meta.dialects.Scala3.toString") {

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -678,7 +678,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
         )
       )))
     )))
-    assertEquals(tree.syntax, code)
+    assertNoDiff(tree.syntax, code)
     assertEquals(
       tree.reprint,
       s"""package foo1

--- a/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -2434,7 +2434,7 @@ class SuccessSuite extends TreeSuiteBase {
     val valX = q"x // X"
     val fOfX = q"func( $valX )"
 
-    assertWithOriginalSyntax(valX, "x // X", "x")
+    assertWithOriginalSyntax(valX, "x", "x")
     assertWithOriginalSyntax(fOfX, "func(x)", "func(x)")
 
     def assertOriginType(obtained: Tree, expected: Class[_ <: Origin]): Unit = assertEquals(

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/GranularWhitespaceTokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/GranularWhitespaceTokenizerSuite.scala
@@ -1102,7 +1102,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
     assert(tree.pos != Position.None)
     assertEquals(
       tree.tokens.structure,
-      "Tokens(BOF [0..0), Ident(foo) [0..3), Space [3..4), Ident(+) [4..5), Space [5..6), Ident(bar) [6..9), EOF [9..9))"
+      "Tokens(Ident(foo) [0..3), Space [3..4), Ident(+) [4..5), Space [5..6), Ident(bar) [6..9))"
     )
   }
 
@@ -1120,13 +1120,13 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
 
   test("Ident.value for normal") {
     "foo".asInput.parse[Term].get.tokens match {
-      case Tokens(bof, foo: Ident, eof) => assertEquals(foo.value, "foo")
+      case Tokens(foo: Ident) => assertEquals(foo.value, "foo")
     }
   }
 
   test("Ident.value for backquoted") {
     "`foo`".asInput.parse[Term].get.tokens match {
-      case Tokens(bof, foo: Ident, eof) =>
+      case Tokens(foo: Ident) =>
         assertEquals(foo.value, "foo")
         assertEquals(foo.syntax, "`foo`")
     }

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
@@ -1055,7 +1055,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
     assert(tree.pos != Position.None)
     assertEquals(
       tree.tokens.structure,
-      "Tokens(BOF [0..0), Ident(foo) [0..3), Space [3..4), Ident(+) [4..5), Space [5..6), Ident(bar) [6..9), EOF [9..9))"
+      "Tokens(Ident(foo) [0..3), Space [3..4), Ident(+) [4..5), Space [5..6), Ident(bar) [6..9))"
     )
   }
 
@@ -1073,13 +1073,13 @@ class TokenizerSuite extends BaseTokenizerSuite {
 
   test("Ident.value for normal") {
     "foo".asInput.parse[Term].get.tokens match {
-      case Tokens(bof, foo: Ident, eof) => assertEquals(foo.value, "foo")
+      case Tokens(foo: Ident) => assertEquals(foo.value, "foo")
     }
   }
 
   test("Ident.value for backquoted") {
     "`foo`".asInput.parse[Term].get.tokens match {
-      case Tokens(bof, foo: Ident, eof) =>
+      case Tokens(foo: Ident) =>
         assertEquals(foo.value, "foo")
         assertEquals(foo.syntax, "`foo`")
     }

--- a/tests/shared/src/test/scala/scala/meta/tests/trees/TokensSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/trees/TokensSuite.scala
@@ -9,14 +9,41 @@ class TokensSuite extends TreeSuiteBase {
 
   test("Tree.tokens: parsed, same dialect") {
     val tree = dialects.Scala211("foo + bar // baz").parse[Term].get
-    assertEquals(tree.syntax, "foo + bar // baz")
-    assertEquals(tree.tokens.syntax, "foo + bar // baz")
+    assertEquals(tree.syntax, "foo + bar")
+    assertEquals(tree.tokens.syntax, "foo + bar")
   }
 
   test("Tree.tokens: parsed, different dialect") {
     val tree = dialects.Scala210("foo + bar // baz").parse[Term].get
     assertEquals(tree.syntax, "foo + bar")
-    assertEquals(tree.tokens.syntax, "foo + bar // baz")
+    assertEquals(tree.tokens.syntax, "foo + bar")
+  }
+
+  test("Tree.tokens: parsed, infix within block") {
+    val tree = dialects.Scala211(
+      """|{
+         |  foo + bar // baz
+         |} // qux
+         |""".stripMargin
+    ).parse[Term].get
+    assertEquals(
+      tree.syntax,
+      """|{
+         |  foo + bar // baz
+         |}""".stripMargin
+    )
+    assertEquals(
+      tree.tokens.syntax,
+      """|{
+         |  foo + bar // baz
+         |}""".stripMargin
+    )
+    tree match {
+      case Term.Block(term :: Nil) =>
+        assertEquals(term.syntax, "foo + bar")
+        assertEquals(term.tokens.syntax, "foo + bar")
+      case _ =>
+    }
   }
 
   test("Tree.tokens: manual") {


### PR DESCRIPTION
Turns out it isn't very inconvenient to parse, say, a block and discover that its first token is not a left brace but a BOF.

Let's keep these two file-indicator tokens only for actual Source trees and exclude for all other trees (including quasiquotes).

Helps with scalameta/scalafmt#4133.