### PR TITLE
Add Scala35 dialect

### DIFF
--- a/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
@@ -917,6 +917,7 @@ object Dialect extends InternalDialect {
     Scala32,
     Scala33,
     Scala34,
+    Scala35,
     Paradise211,
     Paradise212,
     ParadiseTypelevel211,

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -106,10 +106,12 @@ package object dialects {
 
   implicit val Scala34: Dialect = Scala33.withAllowQuotedTypeVariables(true)
 
-  implicit val Scala3: Dialect = Scala34
+  implicit val Scala35: Dialect = Scala34.withAllowBinaryLiterals(true)
+
+  implicit val Scala3: Dialect = Scala35
 
   implicit val Scala3Future: Dialect = Scala3.withAllowUnderscoreAsTypePlaceholder(true)
-    .withAllowBinaryLiterals(true).withAllowTrackedParameters(true)
+    .withAllowTrackedParameters(true)
 
   @deprecated("Use Scala3 instead", "4.4.2")
   implicit val Dotty: Dialect = Scala3

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -103,6 +103,7 @@ class SurfaceSuite extends TreeSuiteBase {
          |scala.meta.dialects.Scala32 *
          |scala.meta.dialects.Scala33 *
          |scala.meta.dialects.Scala34 *
+         |scala.meta.dialects.Scala35 *
          |scala.meta.dialects.Scala3Future *
          |scala.meta.dialects.Typelevel211 *
          |scala.meta.dialects.Typelevel212 *

--- a/tests/shared/src/test/scala/scala/meta/tests/DialectSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/DialectSuite.scala
@@ -38,14 +38,14 @@ class DialectSuite extends FunSuite {
     assert(!Scala213.isEquivalentTo(Scala213Source3))
   }
 
-  test("scala3 toString")(assertEquals(Scala3.toString, "Scala34"))
+  test("scala3 toString")(assertEquals(Scala3.toString, "Scala35"))
 
-  test("scala3copy toString")(assertEquals(scala3copy.toString, "Scala34"))
+  test("scala3copy toString")(assertEquals(scala3copy.toString, "Scala35"))
 
   test("scala3 without indentation toString") {
     assertEquals(Scala3.withAllowSignificantIndentation(false).toString, "Dialect()")
   }
 
-  test("scala3.unquoteTerm toString")(assertEquals(Scala3.unquoteTerm(true).toString, "Scala34"))
+  test("scala3.unquoteTerm toString")(assertEquals(Scala3.unquoteTerm(true).toString, "Scala35"))
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/AndOrTypesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/AndOrTypesSuite.scala
@@ -12,7 +12,7 @@ class AndOrTypesSuite extends BaseDottySuite {
    */
   test("view bounds not allowed") {
     interceptMessage[IllegalArgumentException](
-      "requirement failed: Scala34 doesn't support view bounds"
+      "requirement failed: Scala35 doesn't support view bounds"
     )(dialects.Scala3("{ def foo[T <% Int](t: T) = ??? }").parse[Term].get)
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
@@ -54,7 +54,7 @@ class PublicSuite extends TreeSuiteBase {
   }
 
   test("scala.meta.dialects.Scala3.toString") {
-    assertNoDiff(scala.meta.dialects.Scala3.toString, "Scala34")
+    assertNoDiff(scala.meta.dialects.Scala3.toString, "Scala35")
   }
 
   test("scala.meta.dialects.Scala30.toString") {
@@ -75,6 +75,10 @@ class PublicSuite extends TreeSuiteBase {
 
   test("scala.meta.dialects.Scala34.toString") {
     assertNoDiff(scala.meta.dialects.Scala34.toString, "Scala34")
+  }
+
+  test("scala.meta.dialects.Scala35.toString") {
+    assertNoDiff(scala.meta.dialects.Scala35.toString, "Scala35")
   }
 
   test("scala.meta.dialects.Scala3Future.toString") {


### PR DESCRIPTION
It looks like from the parser perspective the only change was binary literals going non experimental in 3.5.0