### PR TITLE
chore: Also release semanticdbMetap when releasing semanticdb

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
             VERSION=$(echo $GITHUB_REF_NAME | cut -d "_" -f2 | cut -c2-)
             SCALA_VERSION=$(echo $GITHUB_REF_NAME | cut -d "_" -f3)
             if [ ! -z $VERSION ] && [ ! -z $SCALA_VERSION ]; then
-              export CI_RELEASE="++$SCALA_VERSION; semanticdbShared/publishSigned; semanticdbScalacCore/publishSigned; semanticdbScalacPlugin/publishSigned; semanticdbMetac/publishSigned"
+              export CI_RELEASE="++$SCALA_VERSION; semanticdbShared/publishSigned; semanticdbScalacCore/publishSigned; semanticdbScalacPlugin/publishSigned; semanticdbMetac/publishSigned; semanticdbMetap/publishSigned"
               COMMAND="; set ThisBuild/version :=\"$VERSION\"; $COMMAND"
             else
               echo 'Invalid tag name. Expected: semanticdb_v${existing-release}_${scala-version}'


### PR DESCRIPTION
This is currently used by metals.