### PR TITLE
ScalametaParser: don't apply Eta if canApply=false

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2119,7 +2119,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
         val arguments = addPos(Term.Apply(t, argClause))
         simpleExprRest(arguments, canApply = true, startPos = startPos)
       case _: Colon if canApply => getFewerBracesApplyOnColon(t, startPos).getOrElse(t)
-      case _: Underscore =>
+      case _: Underscore if canApply =>
         next()
         addPos(Term.Eta(t))
       case _ => t

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -4295,10 +4295,23 @@ class ControlSyntaxSuite extends BaseDottySuite {
                     |""".stripMargin.nl2lf
     assertTokenizedAsStructureLines(code, struct)
 
-    val error = """|<input>:9: error: `}` expected but `<-` found
-                   |  _ <- d
-                   |    ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = """|for (_ <- if (a) {
+                    |  b
+                    |} else {
+                    |  c
+                    |}; _ <- d) yield e
+                    |""".stripMargin
+    val tree = Term.ForYield(
+      Term.EnumeratorsBlock(List(
+        Enumerator.Generator(
+          Pat.Wildcard(),
+          Term.If(tname("a"), Term.Block(List(tname("b"))), Term.Block(List(tname("c"))), Nil)
+        ),
+        Enumerator.Generator(Pat.Wildcard(), tname("d"))
+      )),
+      tname("e")
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("#3979 w/ granular whitespace") {
@@ -4347,10 +4360,21 @@ class ControlSyntaxSuite extends BaseDottySuite {
                     |""".stripMargin.nl2lf
     assertTokenizedAsStructureLines(code, struct)
 
-    val error = """|<input>:9: error: `}` expected but `<-` found
-                   |  _ <- d
-                   |    ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = """|for (_ <- if (a) {
+                    |  b
+                    |} else {
+                    |  c
+                    |}; _ <- d) yield e
+                    |""".stripMargin
+    val tree = Term.ForYield(
+      Term.EnumeratorsBlock(List(
+        Enumerator
+          .Generator(Pat.Wildcard(), Term.If(tname("a"), blk(tname("b")), blk(tname("c")), Nil)),
+        Enumerator.Generator(Pat.Wildcard(), tname("d"))
+      )),
+      tname("e")
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
 }


### PR DESCRIPTION
This change was overlooked in #3883. Fixes #3979.