### PR TITLE
ScalametaParser: backquoted pat is var before `:`, `@`

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2639,7 +2639,8 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
               case name: Term.Name.Quasi => name.become[Pat]
               case name: Term.Name =>
                 if (soft.StarSplice(currToken) && tryAheadNot[Ident]) Pat.Repeated(name)
-                else if ((!sidToken.isBackquoted || isForComprehension) && {
+                else if (if (!isForComprehension && sidToken.isBackquoted) currToken.isAny[Colon, At]
+                  else {
                     val first = name.value.head
                     first == '_' || Character.getType(first) == Character.LOWERCASE_LETTER ||
                     dialect.allowUpperCasePatternVarBinding && at[At]

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
@@ -399,4 +399,19 @@ class DefnSuite extends ParseSuite {
     runTestAssert[Stat](code)(tree)
   }
 
+  test("#4133 intellij ScalaImportTypeFix.scala") {
+    val code =
+      """|private def hasApplyMethod(`class`: PsiClass): Boolean = `class` match {
+         |  case `object`: ScObject => `object`.allFunctionsByName(ScFunction.CommonNames.Apply).nonEmpty
+         |  case `class` @ ScClass(`type`) => isCaseOrInScala3File(`class`) // SCL-19992, SCL-21187
+         |  case _ => false
+         |} 
+         |""".stripMargin
+    val error =
+      """|<input>:2: error: `=>` expected but `:` found
+         |  case `object`: ScObject => `object`.allFunctionsByName(ScFunction.CommonNames.Apply).nonEmpty
+         |               ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
 }


### PR DESCRIPTION
Helps with scalameta/scalafmt#4133.