### PR TITLE
fix build on JDK 23

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,8 @@
 import org.scalameta.build.Versions._
 import org.scalameta.build._
 
+import sbt.io.IO
+
 import java.io._
 
 import scala.xml.transform.RewriteRule

--- a/project/os.scala
+++ b/project/os.scala
@@ -1,6 +1,8 @@
 package org.scalameta
 package os
 
+import sbt.io.IO
+
 import java.io._
 
 import scala.compat.Platform.EOL


### PR DESCRIPTION
JDK 23 adds `java.io.IO` to stdlib, causing an import conflict with `sbt.io.IO`

this came up in the Scala 2 community build: https://scala-ci.typesafe.com/view/scala-2.13.x/job/scala-2.13.x-jdk23-integrate-community-build/222/artifact/logs/scalameta-extract.log