### PR TITLE
bugfix: Fix named tuples in types

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -1081,6 +1081,33 @@ class MinorDottySuite extends BaseDottySuite {
     )))
   }
 
+  test("annots") {
+    runTestAssert[Stat]("def aa(@(transient @param) tracker: MapOutputTrackerMaster = null) = ???")(
+      Defn.Def(
+        Nil,
+        Term.Name("aa"),
+        List(Member.ParamClauseGroup(
+          Type.ParamClause(Nil),
+          List(Term.ParamClause(List(Term.Param(
+            List(Mod.Annot(Init(
+              Type.Annotate(
+                Type.Name("transient"),
+                List(Mod.Annot(Init(Type.Name("param"), Name.Anonymous(), Nil)))
+              ),
+              Name.Anonymous(),
+              Nil
+            ))),
+            Term.Name("tracker"),
+            Some(Type.Name("MapOutputTrackerMaster")),
+            Some(Lit.Null())
+          ))))
+        )),
+        None,
+        Term.Name("???")
+      )
+    )
+  }
+
   test("class Baz1 @deprecated(implicit c: C)") {
     runTestAssert[Stat](
       "class Baz1 @deprecated(implicit c: C)",

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NamedTuplesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NamedTuplesSuite.scala
@@ -31,6 +31,41 @@ class NamedTuplesSuite extends BaseDottySuite {
     )))
 
   }
+  test("simple-named-type-assign") {
+    runTestAssert[Stat]("type T = (a: Int, b: String)")(Defn.Type(
+      Nil,
+      Type.Name("T"),
+      Type.ParamClause(Nil),
+      Type.Tuple(List(
+        Type.TypedParam(Type.Name("a"), Type.Name("Int"), Nil),
+        Type.TypedParam(Type.Name("b"), Type.Name("String"), Nil)
+      )),
+      Type.Bounds(None, None)
+    ))
+
+  }
+
+  test("named-tuple-summon") {
+    val code = """|val y = summon[Tuple2[Int, String] <:< (x: Int, y: String)]
+                  |""".stripMargin
+    runTestAssert[Stat](code)(Defn.Val(
+      Nil,
+      List(Pat.Var(Term.Name("y"))),
+      None,
+      Term.ApplyType(
+        Term.Name("summon"),
+        Type.ArgClause(List(Type.ApplyInfix(
+          Type
+            .Apply(Type.Name("Tuple2"), Type.ArgClause(List(Type.Name("Int"), Type.Name("String")))),
+          Type.Name("<:<"),
+          Type.Tuple(List(
+            Type.TypedParam(Type.Name("x"), Type.Name("Int"), Nil),
+            Type.TypedParam(Type.Name("y"), Type.Name("String"), Nil)
+          ))
+        )))
+      )
+    ))
+  }
 
   test("complex-named-type") {
     runTestAssert[Type]("(a: Int, b: String, c: (a: Int, d: Double))")(Type.Tuple(List(


### PR DESCRIPTION
The reason here was that we have a separate way of creating tuple types.

Fixes https://github.com/scalameta/scalameta/issues/4007