### PR TITLE
ScalametaParser: allow named types within `types()`

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NamedTuplesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NamedTuplesSuite.scala
@@ -29,6 +29,28 @@ class NamedTuplesSuite extends BaseDottySuite {
 
   }
 
+  test("simple-named-type-assign") {
+    runTestAssert[Stat]("type T = (a: Int, b: String)")(Defn.Type(
+      Nil,
+      pname("T"),
+      Nil,
+      Type.Tuple(List(
+        Type.TypedParam(pname("a"), pname("Int"), Nil),
+        Type.TypedParam(pname("b"), pname("String"), Nil)
+      )),
+      noBounds
+    ))
+  }
+
+  test("named-tuple-summon") {
+    val code = """|val y = summon[Tuple2[Int, String] <:< (x: Int, y: String)]
+                  |""".stripMargin
+    val error = """|<input>:1: error: `)` expected but `:` found
+                   |val y = summon[Tuple2[Int, String] <:< (x: Int, y: String)]
+                   |                                         ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
   test("complex-named-type") {
     runTestAssert[Type]("(a: Int, b: String, c: (a: Int, d: Double))")(Type.Tuple(List(
       Type.TypedParam(pname("a"), pname("Int"), Nil),

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NamedTuplesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NamedTuplesSuite.scala
@@ -45,10 +45,22 @@ class NamedTuplesSuite extends BaseDottySuite {
   test("named-tuple-summon") {
     val code = """|val y = summon[Tuple2[Int, String] <:< (x: Int, y: String)]
                   |""".stripMargin
-    val error = """|<input>:1: error: `)` expected but `:` found
-                   |val y = summon[Tuple2[Int, String] <:< (x: Int, y: String)]
-                   |                                         ^""".stripMargin
-    runTestError[Stat](code, error)
+    runTestAssert[Stat](code)(Defn.Val(
+      Nil,
+      List(Pat.Var(tname("y"))),
+      None,
+      Term.ApplyType(
+        tname("summon"),
+        List(Type.ApplyInfix(
+          Type.Apply(pname("Tuple2"), List(pname("Int"), pname("String"))),
+          pname("<:<"),
+          Type.Tuple(List(
+            Type.TypedParam(pname("x"), pname("Int"), Nil),
+            Type.TypedParam(pname("y"), pname("String"), Nil)
+          ))
+        ))
+      )
+    ))
   }
 
   test("complex-named-type") {


### PR DESCRIPTION
Fixes #4007. Alternative to #4009.