### PR TITLE
ScalametaParser: support named type arguments

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -676,6 +676,11 @@ object Type {
   }
 
   @ast
+  class Assign(name: Name, rhs: Type) extends Type with Tree.WithBody {
+    override def body: Tree = rhs
+  }
+
+  @ast
   class Param(
       mods: List[Mod],
       name: meta.Name,

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -688,6 +688,7 @@ object TreeSyntax {
       case t: Type.Var => m(SimpleTyp, s(t.name.value))
       case t: Type.FunctionArg => m(ParamTyp, w(t.mods, " "), p(Typ, t.tpe))
       case t: Type.TypedParam => m(SimpleTyp, w(t.mods, " "), s(t.name.value), ": ", p(Typ, t.typ))
+      case t: Type.Assign => m(SimpleTyp, s(t.name.value), " ", kw("="), " ", p(Typ, t.rhs))
       case t: Type.ParamClause => r(t.values, "[", ", ", "]")
       case t: Type.BoundsAlias => m(SimpleTyp, s(t.bounds, " ", "as", " ", t.name))
       case t: Type.Param =>

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -488,6 +488,7 @@ class SurfaceSuite extends TreeSuiteBase {
          |scala.meta.Type.Apply
          |scala.meta.Type.ApplyInfix
          |scala.meta.Type.ArgClause
+         |scala.meta.Type.Assign
          |scala.meta.Type.Block
          |scala.meta.Type.Bounds
          |scala.meta.Type.BoundsAlias

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
@@ -24,7 +24,7 @@ class ReflectionSuite extends TreeSuiteBase {
     val sym = symbolOf[scala.meta.Tree]
     assert(sym.isRoot)
     val root = sym.asRoot
-    assertEquals((root.allBranches.length, root.allLeafs.length), (63, 443))
+    assertEquals((root.allBranches.length, root.allLeafs.length), (63, 445))
   }
 
   test("If") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
@@ -576,10 +576,19 @@ class TypeSuite extends BaseDottySuite {
 
   test("#3998") {
     val code = "val xs1 = construct[Coll = List, Elem = Int](1, 2, 3)"
-    val error = """|<input>:1: error: `]` expected but `=` found
-                   |val xs1 = construct[Coll = List, Elem = Int](1, 2, 3)
-                   |                         ^""".stripMargin
-    runTestError[Stat](code, error)
+    val tree = Defn.Val(
+      Nil,
+      List(Pat.Var(tname("xs1"))),
+      None,
+      Term.Apply(
+        Term.ApplyType(
+          tname("construct"),
+          List(Type.Assign(pname("Coll"), pname("List")), Type.Assign(pname("Elem"), pname("Int")))
+        ),
+        List(lit(1), lit(2), lit(3))
+      )
+    )
+    runTestAssert[Stat](code)(tree)
   }
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
@@ -574,4 +574,12 @@ class TypeSuite extends BaseDottySuite {
 
   test("#3672 [scala3] ***")(runTestAssert[Type]("***")(pname("***")))
 
+  test("#3998") {
+    val code = "val xs1 = construct[Coll = List, Elem = Int](1, 2, 3)"
+    val error = """|<input>:1: error: `]` expected but `=` found
+                   |val xs1 = construct[Coll = List, Elem = Int](1, 2, 3)
+                   |                         ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
 }


### PR DESCRIPTION
Fixes #3998.