### PR TITLE
ScalametaParser: support `erased` w/ class params

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -174,9 +174,10 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
 
   def isModifier(index: Int): Boolean = tokens(index).is[ModifierKeyword] || isSoftModifier(index)
 
-  object NonParamsModifier {
-    def unapply(token: Token): Boolean = token.text match {
-      case soft.KwOpen() | soft.KwOpaque() | soft.KwTransparent() | soft.KwInfix() => true
+  object ParamsModifier {
+    def unapply(token: Token): Boolean = matches(token.text)
+    def matches(text: String): Boolean = text match {
+      case soft.KwInline() | soft.KwErased() | soft.KwTracked() => true
       case _ => false
     }
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ErasedDefsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ErasedDefsSuite.scala
@@ -12,10 +12,15 @@ class ErasedDefsSuite extends BaseDottySuite {
 
   test("class with erased params") {
     val code = "class ClassWithErasedEv(erased ev: Ev, x: Int) {}"
-    val error = """|<input>:1: error: `:` expected but `identifier` found
-                   |class ClassWithErasedEv(erased ev: Ev, x: Int) {}
-                   |                               ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "class ClassWithErasedEv(erased ev: Ev, x: Int)"
+    val tree = Defn.Class(
+      Nil,
+      pname("ClassWithErasedEv"),
+      Nil,
+      ctorp(tparam(List(Mod.Erased()), "ev", "Ev"), tparam("x", "Int")),
+      tplNoBody()
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("def with erased params") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ErasedDefsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ErasedDefsSuite.scala
@@ -7,7 +7,16 @@ class ErasedDefsSuite extends BaseDottySuite {
   /**
    * All examples based on dotty documentation:
    *   - [[https://dotty.epfl.ch/docs/reference/experimental/erased-defs.html]]
+   *   - [[https://dotty.epfl.ch/docs/reference/experimental/erased-defs-spec.html]]
    */
+
+  test("class with erased params") {
+    val code = "class ClassWithErasedEv(erased ev: Ev, x: Int) {}"
+    val error = """|<input>:1: error: `:` expected but `identifier` found
+                   |class ClassWithErasedEv(erased ev: Ev, x: Int) {}
+                   |                               ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
 
   test("def with erased params") {
     val code = "def methodWithErasedEv(erased ev: Ev, x: Int): Int = x + 2"


### PR DESCRIPTION
Fixes #3999.