### PR TITLE
ScalametaParser: parse `into` param type modifier

### DIFF
--- a/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
@@ -165,6 +165,8 @@ final class Dialect private[meta] (
     val allowBinaryLiterals: Boolean,
     // Are tracked parameters allowed? docs: https://dotty.epfl.ch/docs/reference/experimental/modularity.html
     val allowTrackedParameters: Boolean,
+    // https://www.scala-lang.org/api/3.3.3/docs/docs/reference/experimental/into-modifier.html
+    val allowParameterTypeConversions: Boolean,
     // https://docs3.scala-lang.org/sips/sips/typeclasses-syntax.html?
     val allowImprovedTypeClassesSyntax: Boolean
 ) extends Product with Serializable {
@@ -263,6 +265,7 @@ final class Dialect private[meta] (
     allowQuietSyntax = false,
     allowBinaryLiterals = false,
     allowTrackedParameters = false,
+    allowParameterTypeConversions = false,
     allowImprovedTypeClassesSyntax = false
     // NOTE(olafur): declare the default value for new fields above this comment.
   )
@@ -404,6 +407,9 @@ final class Dialect private[meta] (
   def withAllowTrackedParameters(newValue: Boolean): Dialect =
     privateCopy(allowTrackedParameters = newValue)
 
+  def withAllowParameterTypeConversions(newValue: Boolean): Dialect =
+    privateCopy(allowParameterTypeConversions = newValue)
+
   def withAllowImprovedTypeClassesSyntax(newValue: Boolean): Dialect =
     privateCopy(allowImprovedTypeClassesSyntax = newValue)
 
@@ -473,6 +479,7 @@ final class Dialect private[meta] (
       allowQuietSyntax: Boolean = this.allowQuietSyntax,
       allowBinaryLiterals: Boolean = this.allowBinaryLiterals,
       allowTrackedParameters: Boolean = this.allowTrackedParameters,
+      allowParameterTypeConversions: Boolean = this.allowParameterTypeConversions,
       allowImprovedTypeClassesSyntax: Boolean = this.allowImprovedTypeClassesSyntax
       // NOTE(olafur): add the next parameter above this comment.
   ): Dialect = {
@@ -537,6 +544,7 @@ final class Dialect private[meta] (
       allowQuietSyntax = allowQuietSyntax,
       allowBinaryLiterals = allowBinaryLiterals,
       allowTrackedParameters = allowTrackedParameters,
+      allowParameterTypeConversions = allowParameterTypeConversions,
       allowImprovedTypeClassesSyntax = allowImprovedTypeClassesSyntax
     )
     if (equivalent) return this // RETURN!
@@ -604,6 +612,7 @@ final class Dialect private[meta] (
       allowQuietSyntax = allowQuietSyntax,
       allowBinaryLiterals = allowBinaryLiterals,
       allowTrackedParameters = allowTrackedParameters,
+      allowParameterTypeConversions = allowParameterTypeConversions,
       allowImprovedTypeClassesSyntax = allowImprovedTypeClassesSyntax,
       // NOTE(olafur): add the next argument above this comment.
       unquoteType = unquoteType,
@@ -693,6 +702,7 @@ final class Dialect private[meta] (
       allowQuietSyntax: Boolean,
       allowBinaryLiterals: Boolean,
       allowTrackedParameters: Boolean,
+      allowParameterTypeConversions: Boolean,
       allowImprovedTypeClassesSyntax: Boolean
   ): Boolean =
     // do not include deprecated values in this comparison
@@ -747,6 +757,7 @@ final class Dialect private[meta] (
       this.allowFewerBraces == allowFewerBraces &&
       this.allowBinaryLiterals == allowBinaryLiterals &&
       this.allowTrackedParameters == allowTrackedParameters &&
+      this.allowParameterTypeConversions == allowParameterTypeConversions &&
       this.allowImprovedTypeClassesSyntax == allowImprovedTypeClassesSyntax
 
   @inline
@@ -811,6 +822,7 @@ final class Dialect private[meta] (
       allowQuietSyntax = that.allowQuietSyntax,
       allowBinaryLiterals = that.allowBinaryLiterals,
       allowTrackedParameters = that.allowTrackedParameters,
+      allowParameterTypeConversions = that.allowParameterTypeConversions,
       allowImprovedTypeClassesSyntax = that.allowImprovedTypeClassesSyntax
     )
 

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -101,7 +101,7 @@ package object dialects {
   implicit val Scala32: Dialect = Scala31
 
   implicit val Scala33: Dialect = Scala32.withAllowFewerBraces(true)
-    .withAllowParamClauseInterleaving(true)
+    .withAllowParamClauseInterleaving(true).withAllowParameterTypeConversions(true)
 
   implicit val Scala34: Dialect = Scala33.withAllowQuotedTypeVariables(true)
 

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -768,7 +768,13 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
       } else t
     }
 
-    private def paramValueType(allowRepeated: Boolean): Type = exactParamType(allowRepeated)
+    private def paramValueType(allowRepeated: Boolean): Type =
+      if (soft.KwInto.matches(currToken)) {
+        val startPos = currIndex
+        val mod = atPos(startPos)(Mod.Into())
+        next()
+        autoEndPos(startPos)(Type.FunctionArg(mod :: Nil, exactParamType(allowRepeated)))
+      } else exactParamType(allowRepeated)
 
     def paramType(): Type = currToken match {
       case _: RightArrow => autoPos {

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -759,24 +759,24 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
       }).getOrElse(t)
     }
 
-    def paramType(): Type = autoPosOpt(currToken match {
-      case _: RightArrow =>
-        val t = autoPos {
+    private def exactParamType(allowRepeated: Boolean): Type = {
+      val startPos = currIndex
+      val t = typ()
+      if (allowRepeated && isStar) {
+        next()
+        autoEndPos(startPos)(Type.Repeated(t))
+      } else t
+    }
+
+    private def paramValueType(allowRepeated: Boolean): Type = exactParamType(allowRepeated)
+
+    def paramType(): Type = currToken match {
+      case _: RightArrow => autoPos {
           next()
-          Type.ByName(typ())
+          Type.ByName(paramValueType(allowRepeated = dialect.allowByNameRepeatedParameters))
         }
-        if (isStar && dialect.allowByNameRepeatedParameters) {
-          next()
-          Type.Repeated(t)
-        } else t
-      case _ =>
-        val t = typ()
-        if (!isStar) t
-        else {
-          next()
-          Type.Repeated(t)
-        }
-    })
+      case _ => paramValueType(allowRepeated = true)
+    }
 
     private def maybeParamType(allowFunctionType: Boolean): Type =
       if (allowFunctionType) paramType() else typ()

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SoftKeywords.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SoftKeywords.scala
@@ -19,6 +19,7 @@ class SoftKeywords(dialect: Dialect) {
   object KwExtension extends IsWithName(dialect.allowExtensionMethods, "extension")
   object KwErased extends IsWithName(dialect.allowErasedDefs, "erased")
   object KwTracked extends IsWithName(dialect.allowTrackedParameters, "tracked")
+  object KwInto extends IsWithName(dialect.allowParameterTypeConversions, "into")
 
   object StarSplice extends IsWithName(dialect.allowPostfixStarVarargSplices, "*")
   object StarAsTypePlaceholder

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -1343,6 +1343,8 @@ object Mod {
   class Erased() extends Mod
   @ast
   class Tracked() extends Mod
+  @ast
+  class Into() extends Mod
 }
 
 @branch

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -938,6 +938,7 @@ object TreeSyntax {
         if (!dialect.allowInfixMods)
           throw new UnsupportedOperationException(s"$dialect doesn't support infix modifiers")
         kw("infix")
+      case _: Mod.Into => kw("into")
 
       // Enumerator
       case t: Enumerator.Val => s(p(Pattern1, t.pat), " = ", p(Expr, t.rhs))

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/ParentChecks.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/ParentChecks.scala
@@ -43,6 +43,7 @@ object ParentChecks {
     case _: Type.FuncParamClause => true
     case _: Type.ByName => !tree.is[Type.ByName] && destination == "tpe"
     case _: Type.Repeated => !tree.is[Type.Repeated] && destination == "tpe"
+    case _: Type.FunctionArg => !tree.is[Type.FunctionArg] && destination == "tpe"
     case _ => false
   }
 

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/ParentChecks.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/ParentChecks.scala
@@ -41,8 +41,8 @@ object ParentChecks {
   private def typeArgument(tree: Type, parent: Tree, destination: String): Boolean = parent match {
     case _: Term.Param => destination == "decltpe"
     case _: Type.FuncParamClause => true
-    case _: Type.ByName => destination == "tpe"
-    case _: Type.Repeated => tree.is[Type.ByName] && destination == "tpe"
+    case _: Type.ByName => !tree.is[Type.ByName] && destination == "tpe"
+    case _: Type.Repeated => !tree.is[Type.Repeated] && destination == "tpe"
     case _ => false
   }
 

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -355,6 +355,7 @@ class SurfaceSuite extends TreeSuiteBase {
          |scala.meta.Mod.Implicit
          |scala.meta.Mod.Infix
          |scala.meta.Mod.Inline
+         |scala.meta.Mod.Into
          |scala.meta.Mod.Lazy
          |scala.meta.Mod.Opaque
          |scala.meta.Mod.Open

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
@@ -24,7 +24,7 @@ class ReflectionSuite extends TreeSuiteBase {
     val sym = symbolOf[scala.meta.Tree]
     assert(sym.isRoot)
     val root = sym.asRoot
-    assertEquals((root.allBranches.length, root.allLeafs.length), (63, 445))
+    assertEquals((root.allBranches.length, root.allLeafs.length), (63, 447))
   }
 
   test("If") {

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -1253,8 +1253,8 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |""".stripMargin,
     """|Type.FuncParamClause (X*, => Y*)
        |Type.Repeated X*
-       |Type.Repeated => Y*
-       |Type.ByName => Y
+       |Type.ByName => Y*
+       |Type.Repeated Y*
        |""".stripMargin
   )
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -329,19 +329,19 @@ class MinorDottySuite extends BaseDottySuite {
   }
 
   test("repeated-byname-class-parameter") {
-    runTestAssert[Stat]("class Foo(bars: => Int*)")(Defn.Class(
+    runTestAssert[Stat]("class Foo(bars: => Int*)", "class Foo(bars: => (Int*))")(Defn.Class(
       Nil,
       pname("Foo"),
       Nil,
-      ctorp(tparam("bars", Type.Repeated(Type.ByName(pname("Int"))))),
+      ctorp(tparam("bars", Type.ByName(Type.Repeated(pname("Int"))))),
       tplNoBody()
     ))
 
-    runTestAssert[Stat]("def fx(x: => Int*): Int = 3")(Defn.Def(
+    runTestAssert[Stat]("def fx(x: => Int*): Int = 3", "def fx(x: => (Int*)): Int = 3")(Defn.Def(
       Nil,
       tname("fx"),
       Nil,
-      List(List(tparam("x", Type.Repeated(Type.ByName(pname("Int")))))),
+      List(List(tparam("x", Type.ByName(Type.Repeated(pname("Int")))))),
       Some(pname("Int")),
       int(3)
     ))

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
@@ -577,34 +577,76 @@ class TypeSuite extends BaseDottySuite {
   // https://www.scala-lang.org/api/3.3.3/docs/docs/reference/experimental/into-modifier.html
   test("#3995 into type") {
     val code = "def ++ (elems: into IterableOnce[A]): List[A]"
-    val error = """|<input>:1: error: `identifier` expected but `[` found
-                   |def ++ (elems: into IterableOnce[A]): List[A]
-                   |                                ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "def ++(elems: into IterableOnce[A]): List[A]"
+    val tree = Decl.Def(
+      Nil,
+      tname("++"),
+      Nil,
+      List(List(tparam(
+        "elems",
+        Some(Type.FunctionArg(List(Mod.Into()), Type.Apply(pname("IterableOnce"), List(pname("A")))))
+      ))),
+      Type.Apply(pname("List"), List(pname("A")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("#3995 into by-name type") {
     val code = "def ++ (elems: => into IterableOnce[A]): List[A]"
-    val error = """|<input>:1: error: `identifier` expected but `[` found
-                   |def ++ (elems: => into IterableOnce[A]): List[A]
-                   |                                   ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "def ++(elems: => (into IterableOnce[A])): List[A]"
+    val tree = Decl.Def(
+      Nil,
+      tname("++"),
+      Nil,
+      List(List(tparam(
+        "elems",
+        Some(Type.ByName(
+          Type.FunctionArg(List(Mod.Into()), Type.Apply(pname("IterableOnce"), List(pname("A"))))
+        ))
+      ))),
+      Type.Apply(pname("List"), List(pname("A")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("#3995 into func type") {
     val code = "def flatMap[B](f: into A => IterableOnce[B]): List[B]"
-    val error = """|<input>:1: error: `identifier` expected but `=>` found
-                   |def flatMap[B](f: into A => IterableOnce[B]): List[B]
-                   |                         ^""".stripMargin
-    runTestError[Stat](code, error)
+    val tree = Decl.Def(
+      Nil,
+      tname("flatMap"),
+      List(pparam("B")),
+      List(List(tparam(
+        "f",
+        Some(Type.FunctionArg(
+          List(Mod.Into()),
+          Type.Function(
+            Type.FuncParamClause(List(pname("A"))),
+            Type.Apply(pname("IterableOnce"), List(pname("B")))
+          )
+        ))
+      ))),
+      Type.Apply(pname("List"), List(pname("B")))
+    )
+    runTestAssert[Stat](code)(tree)
   }
 
   test("#3995 into vararg type") {
     val code = "def concatAll(xss: into IterableOnce[Char]*): List[Char]"
-    val error = """|<input>:1: error: `identifier` expected but `[` found
-                   |def concatAll(xss: into IterableOnce[Char]*): List[Char]
-                   |                                    ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "def concatAll(xss: into (IterableOnce[Char]*)): List[Char]"
+    val tree = Decl.Def(
+      Nil,
+      tname("concatAll"),
+      Nil,
+      List(List(tparam(
+        "xss",
+        Some(Type.FunctionArg(
+          List(Mod.Into()),
+          Type.Repeated(Type.Apply(pname("IterableOnce"), List(pname("Char"))))
+        ))
+      ))),
+      Type.Apply(pname("List"), List(pname("Char")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("#3998") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
@@ -574,6 +574,39 @@ class TypeSuite extends BaseDottySuite {
 
   test("#3672 [scala3] ***")(runTestAssert[Type]("***")(pname("***")))
 
+  // https://www.scala-lang.org/api/3.3.3/docs/docs/reference/experimental/into-modifier.html
+  test("#3995 into type") {
+    val code = "def ++ (elems: into IterableOnce[A]): List[A]"
+    val error = """|<input>:1: error: `identifier` expected but `[` found
+                   |def ++ (elems: into IterableOnce[A]): List[A]
+                   |                                ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("#3995 into by-name type") {
+    val code = "def ++ (elems: => into IterableOnce[A]): List[A]"
+    val error = """|<input>:1: error: `identifier` expected but `[` found
+                   |def ++ (elems: => into IterableOnce[A]): List[A]
+                   |                                   ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("#3995 into func type") {
+    val code = "def flatMap[B](f: into A => IterableOnce[B]): List[B]"
+    val error = """|<input>:1: error: `identifier` expected but `=>` found
+                   |def flatMap[B](f: into A => IterableOnce[B]): List[B]
+                   |                         ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("#3995 into vararg type") {
+    val code = "def concatAll(xss: into IterableOnce[Char]*): List[Char]"
+    val error = """|<input>:1: error: `identifier` expected but `[` found
+                   |def concatAll(xss: into IterableOnce[Char]*): List[Char]
+                   |                                    ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
   test("#3998") {
     val code = "val xs1 = construct[Coll = List, Elem = Int](1, 2, 3)"
     val tree = Defn.Val(


### PR DESCRIPTION
Fixes #3995.