### PR TITLE
ScalametaParser: adjust `into` implementation

### DIFF
--- a/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
@@ -165,7 +165,7 @@ final class Dialect private[meta] (
     val allowBinaryLiterals: Boolean,
     // Are tracked parameters allowed? docs: https://dotty.epfl.ch/docs/reference/experimental/modularity.html
     val allowTrackedParameters: Boolean,
-    // https://www.scala-lang.org/api/3.3.3/docs/docs/reference/experimental/into-modifier.html
+    // https://dotty.epfl.ch/docs/reference/experimental/into-modifier.html
     val allowParameterTypeConversions: Boolean,
     // https://dotty.epfl.ch/docs/reference/experimental/purefuns.html
     val allowPureFunctions: Boolean,

--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -101,7 +101,7 @@ package object dialects {
   implicit val Scala32: Dialect = Scala31
 
   implicit val Scala33: Dialect = Scala32.withAllowFewerBraces(true)
-    .withAllowParamClauseInterleaving(true).withAllowParameterTypeConversions(true)
+    .withAllowParamClauseInterleaving(true)
 
   implicit val Scala34: Dialect = Scala33.withAllowQuotedTypeVariables(true)
 
@@ -113,6 +113,7 @@ package object dialects {
 
   implicit val Scala3Future: Dialect = Scala3.withAllowUnderscoreAsTypePlaceholder(true)
     .withAllowTrackedParameters(true).withAllowPureFunctions(true).withAllowCaptureChecking(true)
+    .withAllowParameterTypeConversions(true)
 
   @deprecated("Use Scala3 instead", "4.4.2")
   implicit val Dotty: Dialect = Scala3


### PR DESCRIPTION
The previous one was based on an older version of documentation. Follow-on for #3995.