### PR TITLE
Trees: add Term.SelectPostfix

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1702,7 +1702,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
     @tailrec
     def getMod(t: Tree, mods: List[Mod] = Nil): Option[List[Mod]] = t match {
       case t: Term.Name => getModFromName(t).map(_ :: mods)
-      case t: Term.Select => getModFromName(t.name) match {
+      case t: Term.SelectPostfix => getModFromName(t.name) match {
           case Some(mod) => getMod(t.qual, mod :: mods)
           case _ => None
         }
@@ -1723,7 +1723,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
     def getNameAndMod(t: Tree): Option[(Name, List[Mod])] = t match {
       case t: Name => Some((t, Nil))
       case t: Quasi => Some((t.become[Term.Name], Nil))
-      case t: Term.Select => getMod(t.qual).map((t.name, _))
+      case t: Term.SelectPostfix => getMod(t.qual).map((t.name, _))
       case t: Term.ApplyInfix => t.argClause.values match {
           case arg :: Nil if t.targClause.values.isEmpty =>
             for {
@@ -1991,7 +1991,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
         if (targs.nonEmpty)
           syntaxError("type application is not allowed for postfix operators", at = currToken)
         val finQual = getPrevLhs(op)
-        val term: Term = atPos(getLhsStartPos(finQual), op)(Term.Select(finQual, op))
+        val term: Term = atPos(getLhsStartPos(finQual), op)(Term.SelectPostfix(finQual, op))
         Left(term)
       }
 

--- a/scalameta/tokens/shared/src/main/scala/scala/meta/tokens/package.scala
+++ b/scalameta/tokens/shared/src/main/scala/scala/meta/tokens/package.scala
@@ -20,7 +20,7 @@ package object tokens extends tokens.Api {
 
     def isBackquoted: Boolean = value.startsWith("`") && value.endsWith("`")
 
-    def isIdentSymbolicInfixOperator: Boolean = isBackquoted || {
+    def isIdentSymbolicNonBackquotedInfixOperator: Boolean = {
       @tailrec
       def iter(idx: Int, nonEmpty: Boolean): Boolean = {
         val ch = value(idx)
@@ -31,6 +31,9 @@ package object tokens extends tokens.Api {
       val len = value.length
       len == 0 || iter(len - 1, false)
     }
+
+    def isIdentSymbolicInfixOperator: Boolean = isBackquoted ||
+      isIdentSymbolicNonBackquotedInfixOperator
   }
 
 }

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -285,8 +285,15 @@ object Term {
     def value = ""
     checkParent(ParentChecks.AnonymousImport)
   }
+  @branch
+  trait SelectLike extends Term.Ref with Pat {
+    def qual: Term
+    def name: Term.Name
+  }
   @ast
-  class Select(qual: Term, name: Term.Name) extends Term.Ref with Pat
+  class Select(qual: Term, name: Term.Name) extends SelectLike
+  @ast
+  class SelectPostfix(qual: Term, name: Term.Name) extends SelectLike
   @ast
   class Interpolate(prefix: Name, parts: List[Lit] @nonEmpty, args: List[Term]) extends Term {
     checkFields(parts.length == args.length + 1)

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -233,6 +233,7 @@ class SurfaceSuite extends TreeSuiteBase {
          |* String.hashCode(): Int
          |* String.isBackquoted: Boolean
          |* String.isIdentSymbolicInfixOperator: Boolean
+         |* String.isIdentSymbolicNonBackquotedInfixOperator: Boolean
          |* T(implicit scala.meta.classifiers.Classifiable[T]).is(implicit XtensionClassifiable.this.C[U]): Boolean
          |* T(implicit scala.meta.classifiers.Classifiable[T]).isAny(implicit XtensionClassifiable.this.C[U1], XtensionClassifiable.this.C[U2]): Boolean
          |* T(implicit scala.meta.classifiers.Classifiable[T]).isAny(implicit XtensionClassifiable.this.C[U1], XtensionClassifiable.this.C[U2], XtensionClassifiable.this.C[U3]): Boolean
@@ -450,6 +451,8 @@ class SurfaceSuite extends TreeSuiteBase {
          |scala.meta.Term.Repeated
          |scala.meta.Term.Return
          |scala.meta.Term.Select
+         |scala.meta.Term.SelectLike
+         |scala.meta.Term.SelectPostfix
          |scala.meta.Term.SplicedMacroExpr
          |scala.meta.Term.SplicedMacroPat
          |scala.meta.Term.Super

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
@@ -24,7 +24,7 @@ class ReflectionSuite extends TreeSuiteBase {
     val sym = symbolOf[scala.meta.Tree]
     assert(sym.isRoot)
     val root = sym.asRoot
-    assertEquals((root.allBranches.length, root.allLeafs.length), (67, 459))
+    assertEquals((root.allBranches.length, root.allLeafs.length), (68, 462))
   }
 
   test("If") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/BasicPositionSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/BasicPositionSuite.scala
@@ -233,10 +233,10 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
     """(a (b (c d) b) a)""",
     """|Term.Apply a (b (c d) b)
        |Term.ArgClause (b (c d) b)
-       |Term.Select b (c d) b
+       |Term.SelectPostfix b (c d) b
        |Term.Apply b (c d)
        |Term.ArgClause (c d)
-       |Term.Select c d
+       |Term.SelectPostfix c d
        |""".stripMargin
   )
 
@@ -247,7 +247,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
        |Term.ApplyInfix b + (c d)
        |Type.ArgClause (a + (b + @@(c d)))
        |Term.ArgClause (c d)
-       |Term.Select c d
+       |Term.SelectPostfix c d
        |""".stripMargin
   )
 
@@ -256,14 +256,14 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
     """|Term.ArgClause (b (c d))
        |Term.Apply b (c d)
        |Term.ArgClause (c d)
-       |Term.Select c d
+       |Term.SelectPostfix c d
        |""".stripMargin
   )
 
   checkPositions[Stat](
     """(((c d) b) a)""",
-    """|Term.Select (c d) b
-       |Term.Select c d
+    """|Term.SelectPostfix (c d) b
+       |Term.SelectPostfix c d
        |""".stripMargin
   )
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
@@ -99,6 +99,7 @@ trait CommonTrees {
   final def tinfix(lt: Term, op: Term.Name, ta: List[Type], rt: Term*): Term.ApplyInfix = Term
     .ApplyInfix(lt, op, ta, rt.toList)
   final def tinfix(lt: Term, op: Term.Name, rt: Term*): Term.ApplyInfix = tinfix(lt, op, Nil, rt: _*)
+  final def tpostfix(lt: Term, op: Term.Name): Term.SelectPostfix = Term.SelectPostfix(lt, op)
   final def tselect(lt: Term, op: Term.Name): Term.Select = Term.Select(lt, op)
   final def tapply(fun: Term, args: Term*): Term.Apply = Term.Apply(fun, args.toList)
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
@@ -99,6 +99,8 @@ trait CommonTrees {
   final def tinfix(lt: Term, op: Term.Name, ta: List[Type], rt: Term*): Term.ApplyInfix = Term
     .ApplyInfix(lt, op, ta, rt.toList)
   final def tinfix(lt: Term, op: Term.Name, rt: Term*): Term.ApplyInfix = tinfix(lt, op, Nil, rt: _*)
+  final def tselect(lt: Term, op: Term.Name): Term.Select = Term.Select(lt, op)
+  final def tapply(fun: Term, args: Term*): Term.Apply = Term.Apply(fun, args.toList)
 
   final def pname(name: String): Type.Name = Type.Name(name)
   implicit def implicitStringToType(obj: String): Type.Name = pname(obj)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/QuasiquoteSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/QuasiquoteSuite.scala
@@ -7,7 +7,7 @@ class QuasiquoteSuite extends ParseSuite {
   locally {
     implicit val dialect = dialects.Scala211.unquoteTerm(multiline = false)
 
-    test("single-line disallow normal escaping")(assertTree(term("\\n"))(tselect("\\", "n")))
+    test("single-line disallow normal escaping")(assertTree(term("\\n"))(tpostfix("\\", "n")))
 
     test("single-line allow unicode escaping")(assertTree(term("\\u0061"))(tname("a")))
 
@@ -47,7 +47,7 @@ class QuasiquoteSuite extends ParseSuite {
   locally {
     implicit val dialect = dialects.Scala211.unquoteTerm(multiline = true)
 
-    test("multi-line disallow do normal escaping")(assertTree(term("\\n"))(tselect("\\", "n")))
+    test("multi-line disallow do normal escaping")(assertTree(term("\\n"))(tpostfix("\\", "n")))
 
     test("multi-line allow unicode escaping")(assertTree(term("\\u0061"))(tname("a")))
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/QuasiquoteSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/QuasiquoteSuite.scala
@@ -7,9 +7,7 @@ class QuasiquoteSuite extends ParseSuite {
   locally {
     implicit val dialect = dialects.Scala211.unquoteTerm(multiline = false)
 
-    test("single-line disallow normal escaping") {
-      assertTree(term("\\n"))(Term.Select(tname("\\"), tname("n")))
-    }
+    test("single-line disallow normal escaping")(assertTree(term("\\n"))(tselect("\\", "n")))
 
     test("single-line allow unicode escaping")(assertTree(term("\\u0061"))(tname("a")))
 
@@ -49,9 +47,7 @@ class QuasiquoteSuite extends ParseSuite {
   locally {
     implicit val dialect = dialects.Scala211.unquoteTerm(multiline = true)
 
-    test("multi-line disallow do normal escaping") {
-      assertTree(term("\\n"))(Term.Select(tname("\\"), tname("n")))
-    }
+    test("multi-line disallow do normal escaping")(assertTree(term("\\n"))(tselect("\\", "n")))
 
     test("multi-line allow unicode escaping")(assertTree(term("\\u0061"))(tname("a")))
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -27,7 +27,7 @@ class TermSuite extends ParseSuite {
 
   test("a.b.c")(assertTerm("a.b.c")(Select(Select(tname("a"), tname("b")), tname("c"))))
 
-  test("a.b c")(assertTerm("a.b c")(Select(Select(tname("a"), tname("b")), tname("c"))))
+  test("a.b c")(assertTerm("a.b c")(tselect(tselect("a", "b"), "c")))
 
   test("foo.this")(assertTerm("foo.this")(This(Indeterminate("foo"))))
 
@@ -603,17 +603,9 @@ class TermSuite extends ParseSuite {
     }
   }
 
-  test("(a + b) c") {
-    assertTerm("(a + b) c") {
-      Term.Select(Term.ApplyInfix(tname("a"), tname("+"), Nil, List(tname("b"))), tname("c"))
-    }
-  }
+  test("(a + b) c")(assertTerm("(a + b) c")(tselect(tinfix("a", "+", "b"), "c")))
 
-  test("a + b c") {
-    assertTerm("a + b c") {
-      Term.Select(Term.ApplyInfix(tname("a"), tname("+"), Nil, List(tname("b"))), tname("c"))
-    }
-  }
+  test("a + b c")(assertTerm("a + b c")(tselect(tinfix("a", "+", "b"), "c")))
 
   test("disallow parse[Stat] on statseqs")(intercept[ParseException](stat("hello; world")))
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -27,7 +27,7 @@ class TermSuite extends ParseSuite {
 
   test("a.b.c")(assertTerm("a.b.c")(Select(Select(tname("a"), tname("b")), tname("c"))))
 
-  test("a.b c")(assertTerm("a.b c")(tselect(tselect("a", "b"), "c")))
+  test("a.b c")(assertTerm("a.b c")(tpostfix(tselect("a", "b"), "c")))
 
   test("foo.this")(assertTerm("foo.this")(This(Indeterminate("foo"))))
 
@@ -603,9 +603,9 @@ class TermSuite extends ParseSuite {
     }
   }
 
-  test("(a + b) c")(assertTerm("(a + b) c")(tselect(tinfix("a", "+", "b"), "c")))
+  test("(a + b) c")(assertTerm("(a + b) c")(tpostfix(tinfix("a", "+", "b"), "c")))
 
-  test("a + b c")(assertTerm("a + b c")(tselect(tinfix("a", "+", "b"), "c")))
+  test("a + b c")(assertTerm("a + b c")(tpostfix(tinfix("a", "+", "b"), "c")))
 
   test("disallow parse[Stat] on statseqs")(intercept[ParseException](stat("hello; world")))
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
@@ -258,10 +258,10 @@ class InfixSuite extends BaseDottySuite {
          |""".stripMargin,
       """|{
          |  freezing
-         |  |.boiling
+         |  |boiling
          |}
          |""".stripMargin
-    )(blk("freezing", tselect("|", "boiling")))
+    )(blk("freezing", tpostfix("|", "boiling")))
   }
 
   test("scala3 infix syntax 3.2.1") {
@@ -274,10 +274,10 @@ class InfixSuite extends BaseDottySuite {
          |""".stripMargin,
       """|{
          |  freezing
-         |  |.boiling
+         |  |boiling
          |}
          |""".stripMargin
-    )(blk("freezing", tselect("|", "boiling")))
+    )(blk("freezing", tpostfix("|", "boiling")))
   }
 
   test("scala3 infix syntax 3.2.2") {
@@ -290,10 +290,10 @@ class InfixSuite extends BaseDottySuite {
          |""".stripMargin,
       """|{
          |  freezing
-         |  |.!
+         |  `|`!
          |}
          |""".stripMargin
-    )(blk("freezing", tselect("|", "!")))
+    )(blk("freezing", tpostfix("|", "!")))
   }
 
   test("scala3 infix syntax 3.2.3") {
@@ -306,10 +306,10 @@ class InfixSuite extends BaseDottySuite {
          |""".stripMargin,
       """|{
          |  freezing
-         |  |.!
+         |  `|`!
          |}
          |""".stripMargin
-    )(blk("freezing", tselect("|", "!")))
+    )(blk("freezing", tpostfix("|", "!")))
   }
 
   test("scala3 infix syntax 3.2.4") {
@@ -322,10 +322,10 @@ class InfixSuite extends BaseDottySuite {
          |""".stripMargin,
       """|{
          |  freezing
-         |  |.|
+         |  `|`|
          |}
          |""".stripMargin
-    )(blk("freezing", tselect("|", "|")))
+    )(blk("freezing", tpostfix("|", "|")))
   }
 
   test("scala3 infix syntax 3.2.5") {
@@ -338,10 +338,10 @@ class InfixSuite extends BaseDottySuite {
          |""".stripMargin,
       """|{
          |  freezing
-         |  |.|
+         |  `|`|
          |}
          |""".stripMargin
-    )(blk("freezing", tselect("|", "|")))
+    )(blk("freezing", tpostfix("|", "|")))
   }
 
   test("scala3 infix syntax 3.3") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
@@ -256,14 +256,92 @@ class InfixSuite extends BaseDottySuite {
          |    | boiling
          |}
          |""".stripMargin,
-      Some(
-        """|{
-           |  freezing
-           |  |.boiling
-           |}
-           |""".stripMargin
-      )
-    )(Term.Block(List(tname("freezing"), Term.Select(tname("|"), tname("boiling")))))
+      """|{
+         |  freezing
+         |  |.boiling
+         |}
+         |""".stripMargin
+    )(blk("freezing", tselect("|", "boiling")))
+  }
+
+  test("scala3 infix syntax 3.2.1") {
+    runTestAssert[Stat](
+      """|{
+         |  freezing
+         |
+         |    `|` boiling
+         |}
+         |""".stripMargin,
+      """|{
+         |  freezing
+         |  |.boiling
+         |}
+         |""".stripMargin
+    )(blk("freezing", tselect("|", "boiling")))
+  }
+
+  test("scala3 infix syntax 3.2.2") {
+    runTestAssert[Stat](
+      """|{
+         |  freezing
+         |
+         |    | !
+         |}
+         |""".stripMargin,
+      """|{
+         |  freezing
+         |  |.!
+         |}
+         |""".stripMargin
+    )(blk("freezing", tselect("|", "!")))
+  }
+
+  test("scala3 infix syntax 3.2.3") {
+    runTestAssert[Stat](
+      """|{
+         |  freezing
+         |
+         |    `|` !
+         |}
+         |""".stripMargin,
+      """|{
+         |  freezing
+         |  |.!
+         |}
+         |""".stripMargin
+    )(blk("freezing", tselect("|", "!")))
+  }
+
+  test("scala3 infix syntax 3.2.4") {
+    runTestAssert[Stat](
+      """|{
+         |  freezing
+         |
+         |    | |
+         |}
+         |""".stripMargin,
+      """|{
+         |  freezing
+         |  |.|
+         |}
+         |""".stripMargin
+    )(blk("freezing", tselect("|", "|")))
+  }
+
+  test("scala3 infix syntax 3.2.5") {
+    runTestAssert[Stat](
+      """|{
+         |  freezing
+         |
+         |    `|` |
+         |}
+         |""".stripMargin,
+      """|{
+         |  freezing
+         |  |.|
+         |}
+         |""".stripMargin
+    )(blk("freezing", tselect("|", "|")))
   }
 
   test("scala3 infix syntax 3.3") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -648,9 +648,9 @@ class MinorDottySuite extends BaseDottySuite {
 
   test("vararg-wildcard-like-postfix-star") {
     val codeOriginal = "val lst = List(0, arr`*`)"
-    val codeObtained = "val lst = List(0, arr.*)"
+    val codeObtained = "val lst = List(0, arr `*`)"
     runTestAssert[Stat](codeOriginal, codeObtained)(
-      Defn.Val(Nil, List(patvar("lst")), None, tapply("List", lit(0), tselect("arr", "*")))
+      Defn.Val(Nil, List(patvar("lst")), None, tapply("List", lit(0), tpostfix("arr", "*")))
     )
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -647,13 +647,11 @@ class MinorDottySuite extends BaseDottySuite {
   }
 
   test("vararg-wildcard-like-postfix-star") {
-    val tree = Defn.Val(
-      Nil,
-      List(Pat.Var(tname("lst"))),
-      None,
-      Term.Apply(tname("List"), List(lit(0), Term.Select(tname("arr"), tname("*"))))
+    val codeOriginal = "val lst = List(0, arr`*`)"
+    val codeObtained = "val lst = List(0, arr.*)"
+    runTestAssert[Stat](codeOriginal, codeObtained)(
+      Defn.Val(Nil, List(patvar("lst")), None, tapply("List", lit(0), tselect("arr", "*")))
     )
-    runTestAssert[Stat]("val lst = List(0, arr`*`)", "val lst = List(0, arr.*)")(tree)
   }
 
   test("non-vararg-infix-star") {


### PR DESCRIPTION
Just like ApplyInfix, which largely reflects form rather than content, and could have been expressed as a Select followed by an Apply instead, let's introduce SelectPostfix.

This also makes it clear that any Select trees are properly constructed having a dot in their syntax, as recent scala releases started requiring an explicit import to allow `postfixOps`.