### PR TITLE
Trees: add Term.SelectMatch

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -373,16 +373,26 @@ object Term {
   class SplicedMacroExpr(body: Term) extends Term
   @ast
   class SplicedMacroPat(pat: Pat) extends Term
+
+  @branch
+  trait MatchLike extends Term with Tree.WithCasesBlock {
+    def expr: Term
+    def casesBlock: CasesBlock
+    def mods: List[Mod]
+  }
+
   @ast
   class Match(
       expr: Term,
       casesBlock: CasesBlock,
       @newField("4.4.5")
       mods: List[Mod] = Nil
-  ) extends Term with Tree.WithCasesBlock {
+  ) extends MatchLike {
     @replacedField("4.9.9")
     override final def cases: List[Case] = casesBlock.cases
   }
+  @ast
+  class SelectMatch(expr: Term, casesBlock: CasesBlock, mods: List[Mod] = Nil) extends MatchLike
   @branch
   trait TryClause extends Term {
     def expr: Term

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -536,7 +536,11 @@ object TreeSyntax {
             if (guessHasElsep(t)) s(" ", kw("else"), " ", p(Expr, t.elsep)) else s()
           )
         )
-      case t: Term.Match =>
+      case t: Term.SelectMatch if dialect.allowMatchAsOperator =>
+        val mods = t.mods
+        val pref = if (mods.isEmpty) Path else Expr1
+        m(pref, s(w(mods, " "), printSelectLhs(t.expr), ".", kw("match"), " ", t.casesBlock))
+      case t: Term.MatchLike =>
         m(Expr1, s(w(t.mods, " "), p(PostfixExpr, t.expr), " ", kw("match"), " ", t.casesBlock))
       case t: Term.TryClause =>
         val showExpr = p(Expr, t.expr)

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -437,6 +437,7 @@ class SurfaceSuite extends TreeSuiteBase {
          |scala.meta.Term.If
          |scala.meta.Term.Interpolate
          |scala.meta.Term.Match
+         |scala.meta.Term.MatchLike
          |scala.meta.Term.Name
          |scala.meta.Term.New
          |scala.meta.Term.NewAnonymous
@@ -452,6 +453,7 @@ class SurfaceSuite extends TreeSuiteBase {
          |scala.meta.Term.Return
          |scala.meta.Term.Select
          |scala.meta.Term.SelectLike
+         |scala.meta.Term.SelectMatch
          |scala.meta.Term.SelectPostfix
          |scala.meta.Term.SplicedMacroExpr
          |scala.meta.Term.SplicedMacroPat

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
@@ -24,7 +24,7 @@ class ReflectionSuite extends TreeSuiteBase {
     val sym = symbolOf[scala.meta.Tree]
     assert(sym.isRoot)
     val root = sym.asRoot
-    assertEquals((root.allBranches.length, root.allLeafs.length), (68, 462))
+    assertEquals((root.allBranches.length, root.allLeafs.length), (69, 465))
   }
 
   test("If") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
@@ -102,6 +102,9 @@ trait CommonTrees {
   final def tpostfix(lt: Term, op: Term.Name): Term.SelectPostfix = Term.SelectPostfix(lt, op)
   final def tselect(lt: Term, op: Term.Name): Term.Select = Term.Select(lt, op)
   final def tapply(fun: Term, args: Term*): Term.Apply = Term.Apply(fun, args.toList)
+  final def tmatch(lt: Term, cases: Case*): Term.Match = Term.Match(lt, cases.toList)
+  final def tselectmatch(lt: Term, cases: Case*): Term.SelectMatch = Term
+    .SelectMatch(lt, cases.toList)
 
   final def pname(name: String): Type.Name = Type.Name(name)
   implicit def implicitStringToType(obj: String): Type.Name = pname(obj)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -3026,18 +3026,15 @@ class SignificantIndentationSuite extends BaseDottySuite {
                   |  .qux
                   |""".stripMargin
     val layout = """|object A {
-                    |  (foo match {
+                    |  foo.match {
                     |    case bar => baz
-                    |  }).qux
+                    |  }.qux
                     |}
                     |""".stripMargin
     val tree = Defn.Object(
       Nil,
-      tname("A"),
-      tpl(Term.Select(
-        Term.Match(tname("foo"), List(Case(Pat.Var(tname("bar")), None, tname("baz"))), Nil),
-        tname("qux")
-      ))
+      "A",
+      tpl(tselect(tselectmatch("foo", Case(patvar("bar"), None, "baz")), tname("qux")))
     )
     runTestAssert[Stat](code, layout)(tree)
   }


### PR DESCRIPTION
Similar to #4040, add a separate tree for `match` with a dot.