### PR TITLE
SoftKeywords: define KwPureFunctionLikeArrow

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -518,8 +518,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
 
   private object InfixTypeIdent {
     def unapply(tok: Token.Ident): Boolean = tok.text match {
-      case soft.KwPureFunctionArrow() => false
-      case soft.KwPureContextFunctionArrow() => false
+      case soft.KwPureFunctionLikeArrow() => false
       case "*" => // we assume that this is a type specification for a vararg parameter
         peekToken match {
           case _: RightParen | _: Comma | _: Equals | _: RightBrace | _: EOF => false

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SoftKeywords.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SoftKeywords.scala
@@ -24,6 +24,11 @@ class SoftKeywords(dialect: Dialect) {
   object KwPureFunctionArrow extends IsWithName(dialect.allowPureFunctions, Token.pureFunctionArrow)
   object KwPureContextFunctionArrow
       extends IsWithName(dialect.allowPureFunctions, Token.pureContextFunctionArrow)
+  object KwPureFunctionLikeArrow
+      extends IsWithPred(
+        dialect.allowPureFunctions,
+        x => x == Token.pureFunctionArrow || x == Token.pureContextFunctionArrow
+      )
 
   object StarSplice extends IsWithName(dialect.allowPostfixStarVarargSplices, "*")
   object StarAsTypePlaceholder


### PR DESCRIPTION
It matches both "->" and "?->" pure function-like arrows.