### PR TITLE
chore: Disable BSP for Native and JS

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,6 +82,7 @@ Global / resolvers +=
 val commonJsSettings = Seq(
   crossScalaVersions := List(LatestScala213, LatestScala212),
   scalaVersion := LatestScala213,
+  bspEnabled := false,
   scalaJSLinkerConfig := StandardConfig().withBatchMode(true),
   scalacOptions ++= {
     if (isSnapshot.value) Seq.empty
@@ -96,6 +97,7 @@ val commonJsSettings = Seq(
 lazy val nativeSettings = Seq(
   crossScalaVersions := List(LatestScala213, LatestScala212),
   scalaVersion := LatestScala213,
+  bspEnabled := false,
   nativeConfig ~= { _.withMode(scalanative.build.Mode.releaseFast) }
 )
 


### PR DESCRIPTION
There is not a lot of actual code here for native and JS and we don't need to compile it for BSP. It's easy enable it if needed, but by default it hugely limits the first compilation times.