### PR TITLE
improvement: Don't use format since it seems to break at some chars

### DIFF
--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
@@ -234,7 +234,7 @@ class LegacyScanner(input: Input, dialect: Dialect) {
 
     @inline
     def reportIllegalCharacter(): Unit = curr
-      .setInvalidToken(s"illegal character '\\u${"%04x".format(ch)}'")
+      .setInvalidToken("illegal unicode codepoint: 0x" + ch.toHexString)
 
     (ch: @switch) match {
       case ' ' =>

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
@@ -2136,6 +2136,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
          |""".stripMargin.replace("'''", "\"\"\"").nl2lf
     assertTokenizedAsStructureLines(code, struct)
   }
+
   test("unexpected-character") {
     val code = """|
                   |val 。 = 123
@@ -2145,7 +2146,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
     val struct = s"""|BOF [0..0)
                      |LF [0..1)
                      |KwVal [1..4)
-                     |Invalid(illegal character '\\u3002') [5..6)
+                     |Invalid(illegal unicode codepoint: 0x3002) [5..6)
                      |MultiHS(3) [4..7)
                      |Equals [7..8)
                      |Space [8..9)


### PR DESCRIPTION
Related to https://github.com/scalameta/metals/issues/7003

Looks like there is at least 6 stack traces formatting error for InvalidToken and this looks like a problem.

We get things like:
```
	at java.util.regex.Pattern$BmpCharProperty.match(java.base@11.0.24/Pattern.java:3966)
	at java.util.regex.Pattern$GroupHead.match(java.base@11.0.24/Pattern.java:4807)
	at java.util.regex.Pattern$Branch.match(java.base@11.0.24/Pattern.java:4752)
	at java.util.regex.Pattern$Branch.match(java.base@11.0.24/Pattern.java:4750)
	at java.util.regex.Pattern$BranchConn.match(java.base@11.0.24/Pattern.java:4716)
	at java.util.regex.Pattern$GroupTail.match(java.base@11.0.24/Pattern.java:4866)
	at java.util.regex.Pattern$BmpCharPropertyGreedy.match(java.base@11.0.24/Pattern.java:4347)
	at java.util.regex.Pattern$GroupHead.match(java.base@11.0.24/Pattern.java:4807)
	at java.util.regex.Pattern$Branch.match(java.base@11.0.24/Pattern.java:4752)
	at java.util.regex.Pattern$BranchConn.match(java.base@11.0.24/Pattern.java:4716)
	at java.util.regex.Pattern$GroupTail.match(java.base@11.0.24/Pattern.java:4866)
	at java.util.regex.Pattern$BmpCharPropertyGreedy.match(java.base@11.0.24/Pattern.java:4347)
	at java.util.regex.Pattern$GroupHead.match(java.base@11.0.24/Pattern.java:4807)
	at java.util.regex.Pattern$Branch.match(java.base@11.0.24/Pattern.java:4752)
	at java.util.regex.Pattern$Branch.match(java.base@11.0.24/Pattern.java:4750)
	at java.util.regex.Pattern$BmpCharProperty.match(java.base@11.0.24/Pattern.java:3967)
	at java.util.regex.Pattern$Start.match(java.base@11.0.24/Pattern.java:3622)
	at java.util.regex.Matcher.search(java.base@11.0.24/Matcher.java:1729)
	at java.util.regex.Matcher.find(java.base@11.0.24/Matcher.java:773)
	at java.util.Formatter.parse(java.base@11.0.24/Formatter.java:2702)
	at java.util.Formatter.format(java.base@11.0.24/Formatter.java:2655)
```

and we should be as efficient as possible when just printing an error. Especially if we have a lot of errors then this might become inefficient.