### PR TITLE
ScalametaParser: detect new `given` syntax

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -3497,33 +3497,10 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
    */
   private def givenDecl(mods: List[Mod]): Stat = autoEndPos(mods) {
     accept[KwGiven]
-    val (sigName, paramClauseGroup) = tryParse {
-      Try {
-        val name: meta.Name = currToken match {
-          case t: Ident => termName(t)
-          case _ => anonName()
-        }
-        val pcg = memberParamClauseGroup(
-          isFirst = true,
-          ownerIsType = false,
-          allowUnderscore = dialect.allowTypeParamUnderscore
-        )
-        if (acceptOpt[Colon]) Some((name, pcg)) else None
-      }.getOrElse {
+    val sig = givenSig()
 
-        /**
-         * We are first trying to parse non-anonymous given, which
-         *   - requires `:` for type, if none is found it means it's anonymous
-         *   - might fail in cases that anonymous type looks like type param
-         *     {{{given Conversion[AppliedName, Expr.Apply[Id]] = ???}}} This will fail because type
-         *     params cannot have `.`
-         */
-        None
-      }
-    }.getOrElse((anonName(), None))
-
-    val initPos = currIndex
-    val decltype = refinement(None).getOrElse(startModType())
+    val initPos = sig.declPos.getOrElse(sig.declType.fold(currIndex)(_.begIndex))
+    val decltype = sig.declType.getOrElse(refinement(None).getOrElse(startModType()))
 
     def getDefnGiven() = {
       val headInit =
@@ -3538,16 +3515,85 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
         else if (inits.lengthCompare(1) > 0) syntaxError("expected 'with' <body>", at = prevToken)
         else emptyTemplateBody()
       val rhs = autoEndPos(initPos)(Template(None, inits, body, Nil))
-      Defn.Given(mods, sigName, paramClauseGroup, rhs)
+      Defn.Given(mods, sig.name, sig.pcg, rhs)
     }
     currToken match {
-      case _: Equals => next(); Defn.GivenAlias(mods, sigName, paramClauseGroup, decltype, expr())
+      case _: Equals => next(); Defn.GivenAlias(mods, sig.name, sig.pcg, decltype, expr())
       case _: KwWith | _: LeftParen => getDefnGiven()
-      case _ => sigName match {
-          case n: Term.Name => Decl.Given(mods, n, paramClauseGroup, decltype)
+      case _ => sig.name match {
+          case n: Term.Name => Decl.Given(mods, n, sig.pcg, decltype)
           case n => syntaxError("abstract givens cannot be anonymous", at = n)
         }
     }
+  }
+
+  /**
+   * We are first trying to parse non-anonymous given, which
+   *   - requires `:` for type, if none is found it means it's anonymous
+   *   - might fail in cases that anonymous type looks like type param
+   *     {{{given Conversion[AppliedName, Expr.Apply[Id]] = ???}}}
+   *
+   * This will fail because type params cannot have `.`
+   */
+  private def givenSig(): GivenSig = tryParse(GivenSigContext.within {
+    val ident = currToken.as[Ident]
+    if (ident ne null) { // possibly named typeclass
+      val identPos = currIndex
+      def name = atPos(identPos)(Term.Name(ident.value))
+      if (tryAhead[Colon])
+        if (!tryAheadNot[Indentation.Indent]) None
+        // TODO: check for new syntax
+        else Some(GivenSig(name))
+      else if (tryAhead[LeftBracket]) givenSigOnBracket(name) // only with old syntax
+      else if (tryAhead[LeftParen]) givenSigOnParen(name) // only with old syntax
+      else if (tryAhead[EOL])
+        if (tryAhead[LeftBracket]) givenSigOnBracket(name) // only with old syntax
+        else if (tryAhead[LeftParen]) givenSigOnParen(name) // only with old syntax
+        else None
+      else None
+    } else // anonymous typeclass or start of decltype
+    if (isAfterOptNewLine[LeftBracket]) givenSigOnBracket(anonName())
+    else if (isAfterOptNewLine[LeftParen]) Try(givenSigOnParen(anonName())).getOrElse(None)
+    else None
+  }).getOrElse(GivenSig(anonName()))
+
+  private def givenOldSyntaxColon(): Boolean = at[Colon] && tryAheadNot[Indentation.Indent]
+
+  private def givenSigOnBracket(name: Name): Option[GivenSig] = Try(memberParamClauseGroupOnBracket(
+    ownerIsType = false,
+    allowUnderscore = dialect.allowTypeParamUnderscore
+  )).toOption.flatMap { pcg =>
+    if (givenOldSyntaxColon()) Some(GivenSig(name, pcg :: Nil))
+    else if (pcg.paramClauses.nonEmpty) None // too hard to convert to init, re-parse
+    else if (!name.isAnonymous) {
+      val typeName = copyPos(name)(Type.Name(name.value))
+      val tpe = convertNameTypeParamClauseToType(typeName, pcg.tparamClause)
+      Some(GivenSig(anonNameAt(name), declType = Some(tpe)))
+    } else None
+  }
+
+  private def givenSigOnParen(name: Name): Option[GivenSig] = {
+    // under the new syntax, this is possible only with anonymous name
+    val useNewSyntax = dialect.allowImprovedTypeClassesSyntax && name.isAnonymous
+    if (!useNewSyntax && !soft.KwUsing(peekToken)) None
+    else {
+      val pcg = memberParamClauseGroupOnParen(ownerIsType = false)
+      if (givenOldSyntaxColon()) Some(GivenSig(name, pcg :: Nil))
+      // TODO: check for new syntax
+      else None
+    }
+  }
+
+  private def convertTypeParamToType(param: Type.Param): Type = param.becomeOr[Type] { x =>
+    convertNameTypeParamClauseToType(copyPos(x.name)(Type.Name(x.name.value)), param.tparamClause)
+  }
+
+  private def convertNameTypeParamClauseToType(name: Type.Name, tpc: Type.ParamClause) = tpc match {
+    case q: Quasi => atPos(name, q)(Type.Apply(name, q.become[Type.ArgClause]))
+    case x if x.nonEmpty =>
+      val args = x.values.map(tp => convertTypeParamToType(tp))
+      atPos(name, x)(Type.Apply(name, copyPos(x)(Type.ArgClause(args))))
+    case _ => name
   }
 
   def funDefOrDclOrExtensionOrSecondaryCtor(mods: List[Mod]): Stat =
@@ -4434,6 +4480,13 @@ object ScalametaParser {
   private object TParamVariant {
     def unapply(ident: Token.Ident): Option[Mod.Variant] = TParamVariantStr.unapply(ident.text)
   }
+
+  private case class GivenSig(
+      name: Name,
+      pcg: List[Member.ParamClauseGroup] = Nil,
+      declType: Option[Type] = None,
+      declPos: Option[Int] = None
+  )
 
 }
 

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -924,11 +924,11 @@ object Member {
       else Some(ParamClauseGroup(tparamClause = tparams, paramClauses = paramss))
   }
 
-  private[meta] object ParamClauseGroupCtorGiven {
+  private[meta] object ParamClauseGroupsCtorGiven {
     def apply(
         tparams: List[sm.Type.Param],
         sparams: List[List[sm.Term.Param]]
-    ): Option[ParamClauseGroup] = ParamClauseGroupCtor(tparams, sparams)
+    ): List[Member.ParamClauseGroup] = ParamClauseGroupsCtor(tparams, sparams)
   }
 
   private[meta] object ParamClauseGroupsCtor {
@@ -1018,8 +1018,9 @@ object Decl {
   class Given(
       mods: List[Mod],
       name: Term.Name,
-      @replacesFields("4.6.0", Member.ParamClauseGroupCtorGiven)
-      paramClauseGroup: Option[Member.ParamClauseGroup],
+      @replacesFields("4.6.0", Member.ParamClauseGroupsCtorGiven)
+      @replacesFields("4.12.0", Member.ParamClauseGroupsCtor)
+      paramClauseGroups: List[Member.ParamClauseGroup],
       decltpe: sm.Type
   ) extends Decl
       with Member.Term
@@ -1027,9 +1028,11 @@ object Decl {
       with Tree.WithParamClauseGroup
       with Tree.WithDeclTpe {
     @replacedField("4.6.0", pos = 2)
-    final def tparams: List[sm.Type.Param] = Member.ParamClauseGroup.toTparams(paramClauseGroup)
+    final def tparams: List[sm.Type.Param] = Member.ParamClauseGroup.toTparams(paramClauseGroups)
     @replacedField("4.6.0", pos = 3)
-    final def sparams: List[List[Term.Param]] = Member.ParamClauseGroup.toParamss(paramClauseGroup)
+    final def sparams: List[List[Term.Param]] = Member.ParamClauseGroup.toParamss(paramClauseGroups)
+    @replacedField("4.12.0")
+    final def paramClauseGroup: Option[Member.ParamClauseGroup] = paramClauseGroups.headOption
   }
 }
 
@@ -1066,15 +1069,18 @@ object Defn {
   @ast
   class Given(
       mods: List[Mod],
-      name: scala.meta.Name,
-      @replacesFields("4.6.0", Member.ParamClauseGroupCtorGiven)
-      paramClauseGroup: Option[Member.ParamClauseGroup],
+      name: Name,
+      @replacesFields("4.6.0", Member.ParamClauseGroupsCtorGiven)
+      @replacesFields("4.12.0", Member.ParamClauseGroupsCtor)
+      paramClauseGroups: List[Member.ParamClauseGroup],
       templ: Template
   ) extends Defn with Stat.WithMods with Tree.WithParamClauseGroup with Stat.WithTemplate {
     @replacedField("4.6.0", pos = 2)
-    final def tparams: List[sm.Type.Param] = Member.ParamClauseGroup.toTparams(paramClauseGroup)
+    final def tparams: List[sm.Type.Param] = Member.ParamClauseGroup.toTparams(paramClauseGroups)
     @replacedField("4.6.0", pos = 3)
-    final def sparams: List[List[Term.Param]] = Member.ParamClauseGroup.toParamss(paramClauseGroup)
+    final def sparams: List[List[Term.Param]] = Member.ParamClauseGroup.toParamss(paramClauseGroups)
+    @replacedField("4.12.0")
+    final def paramClauseGroup: Option[Member.ParamClauseGroup] = paramClauseGroups.headOption
   }
   @ast
   class Enum(
@@ -1111,9 +1117,10 @@ object Defn {
   @ast
   class GivenAlias(
       mods: List[Mod],
-      name: scala.meta.Name,
-      @replacesFields("4.6.0", Member.ParamClauseGroupCtorGiven)
-      paramClauseGroup: Option[Member.ParamClauseGroup],
+      name: Name,
+      @replacesFields("4.6.0", Member.ParamClauseGroupsCtorGiven)
+      @replacesFields("4.12.0", Member.ParamClauseGroupsCtor)
+      paramClauseGroups: List[Member.ParamClauseGroup],
       decltpe: sm.Type,
       body: Term
   ) extends Defn
@@ -1122,9 +1129,11 @@ object Defn {
       with Tree.WithBody
       with Tree.WithDeclTpe {
     @replacedField("4.6.0", pos = 2)
-    final def tparams: List[sm.Type.Param] = Member.ParamClauseGroup.toTparams(paramClauseGroup)
+    final def tparams: List[sm.Type.Param] = Member.ParamClauseGroup.toTparams(paramClauseGroups)
     @replacedField("4.6.0", pos = 3)
-    final def sparams: List[List[Term.Param]] = Member.ParamClauseGroup.toParamss(paramClauseGroup)
+    final def sparams: List[List[Term.Param]] = Member.ParamClauseGroup.toParamss(paramClauseGroups)
+    @replacedField("4.12.0")
+    final def paramClauseGroup: Option[Member.ParamClauseGroup] = paramClauseGroups.headOption
   }
   @ast
   class ExtensionGroup(

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/ParentChecks.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/ParentChecks.scala
@@ -104,12 +104,14 @@ object ParentChecks {
   def EnumCase(tree: Tree, parent: Tree, destination: String): Boolean = parent.is[Template.Body] &&
     parent.parent.parent.isOpt[Defn.Enum]
 
-  def TypeLambda(tree: Type.Lambda, parent: Tree, destination: String): Boolean = parent.is[Type] ||
-    parent.is[Defn.Type] || parent.is[Type.Bounds] || parent.is[Term.ApplyType] ||
-    parent.is[Type.Param] || parent.is[Type.ArgClause]
+  def TypeLambda(tree: Type.Lambda, parent: Tree, destination: String): Boolean = parent match {
+    case _: Type | _: Defn.Type | _: Type.Bounds | _: Term.ApplyType | _: Type.Param | _: Term.Param |
+        _: Type.ArgClause | _: Decl.Given | _: Defn.Given | _: Defn.GivenAlias => true
+    case _ => false
+  }
 
-  def TypeMethod(tree: Type.Method, parent: Tree, destination: String): Boolean = parent.is[Type] ||
-    parent.is[Defn.Type]
+  def TypeMethod(tree: Type.Method, parent: Tree, destination: String): Boolean = parent
+    .isAny[Type, Defn.Type]
 
   def TermBlock(tree: Term.Block, parent: Tree, dest: String): Boolean = tree.stats.forall {
     case _: Decl => true

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
@@ -145,11 +145,16 @@ trait CommonTrees extends CommonTrees.LowPriorityDefinitions {
   final def pinfix(lt: Type, op: Type.Name, rt: Type): Type.ApplyInfix = Type.ApplyInfix(lt, op, rt)
   final def papply(tpe: Type, args: Type*): Type.Apply = Type.Apply(tpe, args.toList)
   final def pfunc(param: List[Type], res: Type): Type.Function = Type.Function(param, res)
+  final def pfunc(res: Type, param: Type*): Type.Function = pfunc(param.toList, res)
   final def pctxfunc(param: List[Type], res: Type): Type.ContextFunction = Type
     .ContextFunction(param, res)
+  final def pctxfunc(res: Type, param: Type*): Type.ContextFunction = pctxfunc(param.toList, res)
   final def purefunc(param: List[Type], res: Type): Type.PureFunction = Type.PureFunction(param, res)
+  final def purefunc(res: Type, param: Type*): Type.PureFunction = purefunc(param.toList, res)
   final def purectxfunc(param: List[Type], res: Type): Type.PureContextFunction = Type
     .PureContextFunction(param, res)
+  final def purectxfunc(res: Type, param: Type*): Type.PureContextFunction =
+    purectxfunc(param.toList, res)
   final def ppolyfunc(body: Type, params: Type.Param*) = Type.PolyFunction(params.toList, body)
 
   final def patvar(name: Term.Name): Pat.Var = Pat.Var(name)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenSyntax36Suite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenSyntax36Suite.scala
@@ -322,9 +322,9 @@ class GivenSyntax36Suite extends BaseDottySuite {
     val code = """|given Ord[Int]:
                   |  def foo = ???
                   |""".stripMargin
-    val error = """|<input>:1: error: `identifier` expected but `indent` found
+    val error = """|<input>:1: error: abstract givens cannot be anonymous
                    |given Ord[Int]:
-                   |               ^""".stripMargin
+                   |      ^""".stripMargin
     runTestError[Stat](code, error)
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenSyntax36Suite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenSyntax36Suite.scala
@@ -322,10 +322,14 @@ class GivenSyntax36Suite extends BaseDottySuite {
     val code = """|given Ord[Int]:
                   |  def foo = ???
                   |""".stripMargin
-    val error = """|<input>:1: error: abstract givens cannot be anonymous
-                   |given Ord[Int]:
-                   |      ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given Ord[Int] { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      anon,
+      Nil,
+      tpl(List(init(papply("Ord", "Int"))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("Simple anonymous typeclass, braces") {
@@ -333,20 +337,28 @@ class GivenSyntax36Suite extends BaseDottySuite {
                   |  def foo = ???
                   |}
                   |""".stripMargin
-    val error = """|<input>:1: error: abstract givens cannot be anonymous
-                   |given Ord[Int] {
-                   |      ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given Ord[Int] { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      anon,
+      Nil,
+      tpl(List(init(papply("Ord", "Int"))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("Simple named typeclass, coloneol") {
     val code = """|given ord: Ord[Int]:
                   |  def foo = ???
                   |""".stripMargin
-    val error = """|<input>:1: error: `;` expected but `:` found
-                   |given ord: Ord[Int]:
-                   |                   ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given ord: Ord[Int] { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      "ord",
+      Nil,
+      tpl(List(init(papply("Ord", "Int"))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("Simple named typeclass, braces") {
@@ -354,10 +366,14 @@ class GivenSyntax36Suite extends BaseDottySuite {
                   |  def foo = ???
                   |}
                   |""".stripMargin
-    val error = """|<input>:1: error: `;` expected but `{` found
-                   |given ord: Ord[Int] {
-                   |                    ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given ord: Ord[Int] { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      "ord",
+      Nil,
+      tpl(List(init(papply("Ord", "Int"))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   // Parameterized typeclass with context bound
@@ -365,10 +381,15 @@ class GivenSyntax36Suite extends BaseDottySuite {
     val code = """|given [A : Ord] => Ord[List[A]]:
                   |  def foo = ???
                   |""".stripMargin
-    val error = """|<input>:1: error: `identifier` expected but `[` found
-                   |given [A : Ord] => Ord[List[A]]:
-                   |      ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given [A: Ord]: Ord[List[A]] with { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      anon,
+      List(pparam(Nil, "A", cb = List("Ord"))),
+      Nil,
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("Parameterized anonymous typeclass with context bound, braces") {
@@ -376,20 +397,30 @@ class GivenSyntax36Suite extends BaseDottySuite {
                   |  def foo = ???
                   |}
                   |""".stripMargin
-    val error = """|<input>:1: error: `identifier` expected but `[` found
-                   |given [A : Ord] => Ord[List[A]] {
-                   |      ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given [A: Ord]: Ord[List[A]] with { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      anon,
+      List(pparam(Nil, "A", cb = List("Ord"))),
+      Nil,
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("Parameterized named typeclass with context bound, coloneol") {
     val code = """|given ord: [A : Ord] => Ord[List[A]]:
                   |  def foo = ???
                   |""".stripMargin
-    val error = """|<input>:1: error: `identifier` expected but `[` found
-                   |given ord: [A : Ord] => Ord[List[A]]:
-                   |           ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given ord[A: Ord]: Ord[List[A]] with { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      tname("ord"),
+      List(pparam(Nil, "A", cb = List("Ord"))),
+      Nil,
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("Parameterized named typeclass with context bound, braces") {
@@ -397,10 +428,15 @@ class GivenSyntax36Suite extends BaseDottySuite {
                   |  def foo = ???
                   |}
                   |""".stripMargin
-    val error = """|<input>:1: error: `identifier` expected but `[` found
-                   |given ord: [A : Ord] => Ord[List[A]] {
-                   |           ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given ord[A: Ord]: Ord[List[A]] with { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      tname("ord"),
+      List(pparam(Nil, "A", cb = List("Ord"))),
+      Nil,
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   // Parameterized typeclass with context bound
@@ -408,10 +444,15 @@ class GivenSyntax36Suite extends BaseDottySuite {
     val code = """|given [A : Ord] => Ord[List[A]]:
                   |  def foo = ???
                   |""".stripMargin
-    val error = """|<input>:1: error: `identifier` expected but `[` found
-                   |given [A : Ord] => Ord[List[A]]:
-                   |      ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given [A: Ord]: Ord[List[A]] with { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      anon,
+      List(pparam(Nil, "A", cb = List("Ord"))),
+      Nil,
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("Parameterized anonymous typeclass with context bound, braces") {
@@ -419,20 +460,30 @@ class GivenSyntax36Suite extends BaseDottySuite {
                   |  def foo = ???
                   |}
                   |""".stripMargin
-    val error = """|<input>:1: error: `identifier` expected but `[` found
-                   |given [A : Ord] => Ord[List[A]] {
-                   |      ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given [A: Ord]: Ord[List[A]] with { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      anon,
+      List(pparam(Nil, "A", cb = List("Ord"))),
+      Nil,
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("Parameterized named typeclass with context bound, coloneol") {
     val code = """|given ord: [A : Ord] => Ord[List[A]]:
                   |  def foo = ???
                   |""".stripMargin
-    val error = """|<input>:1: error: `identifier` expected but `[` found
-                   |given ord: [A : Ord] => Ord[List[A]]:
-                   |           ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given ord[A: Ord]: Ord[List[A]] with { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      tname("ord"),
+      List(pparam(Nil, "A", cb = List("Ord"))),
+      Nil,
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("Parameterized named typeclass with context bound, braces") {
@@ -440,10 +491,15 @@ class GivenSyntax36Suite extends BaseDottySuite {
                   |  def foo = ???
                   |}
                   |""".stripMargin
-    val error = """|<input>:1: error: `identifier` expected but `[` found
-                   |given ord: [A : Ord] => Ord[List[A]] {
-                   |           ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given ord[A: Ord]: Ord[List[A]] with { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      tname("ord"),
+      List(pparam(Nil, "A", cb = List("Ord"))),
+      Nil,
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   // Parameterized typeclass with named context parameter
@@ -451,10 +507,15 @@ class GivenSyntax36Suite extends BaseDottySuite {
     val code = """|given [A] => (ord: Ord[A]) => Ord[List[A]]:
                   |  def foo = ???
                   |""".stripMargin
-    val error = """|<input>:1: error: `identifier` expected but `[` found
-                   |given [A] => (ord: Ord[A]) => Ord[List[A]]:
-                   |      ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given [A] => (ord: Ord[A]) => Ord[List[A]] { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      anon,
+      List(pparam("A")),
+      List(List(tparam("ord", papply("Ord", "A")))),
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("Parameterized anonymous typeclass with named context parameter, braces") {
@@ -462,20 +523,30 @@ class GivenSyntax36Suite extends BaseDottySuite {
                   |  def foo = ???
                   |}
                   |""".stripMargin
-    val error = """|<input>:1: error: `identifier` expected but `[` found
-                   |given [A] => (ord: Ord[A]) => Ord[List[A]] {
-                   |      ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given [A] => (ord: Ord[A]) => Ord[List[A]] { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      anon,
+      List(pparam("A")),
+      List(List(tparam("ord", papply("Ord", "A")))),
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("Parameterized named typeclass with named context parameter, coloneol") {
     val code = """|given ord: [A] => (ord: Ord[A]) => Ord[List[A]]:
                   |  def foo = ???
                   |""".stripMargin
-    val error = """|<input>:1: error: `identifier` expected but `[` found
-                   |given ord: [A] => (ord: Ord[A]) => Ord[List[A]]:
-                   |           ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given ord: [A] => (ord: Ord[A]) => Ord[List[A]] { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      tname("ord"),
+      List(pparam("A")),
+      List(List(tparam("ord", papply("Ord", "A")))),
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("Parameterized named typeclass with named context parameter, braces") {
@@ -483,10 +554,15 @@ class GivenSyntax36Suite extends BaseDottySuite {
                   |  def foo = ???
                   |}
                   |""".stripMargin
-    val error = """|<input>:1: error: `identifier` expected but `[` found
-                   |given ord: [A] => (ord: Ord[A]) => Ord[List[A]] {
-                   |           ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given ord: [A] => (ord: Ord[A]) => Ord[List[A]] { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      tname("ord"),
+      List(pparam("A")),
+      List(List(tparam("ord", papply("Ord", "A")))),
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   // Parameterized typeclass with anonymous context parameter
@@ -494,10 +570,15 @@ class GivenSyntax36Suite extends BaseDottySuite {
     val code = """|given [A] => (Ord[A]) => Ord[List[A]]:
                   |  def foo = ???
                   |""".stripMargin
-    val error = """|<input>:1: error: `identifier` expected but `[` found
-                   |given [A] => (Ord[A]) => Ord[List[A]]:
-                   |      ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given [A] => (Ord[A]) => Ord[List[A]] { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      anon,
+      List(pparam("A")),
+      List(List(tparam("", papply("Ord", "A")))),
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("Parameterized anonymous typeclass with anonymous context parameter, braces") {
@@ -505,20 +586,30 @@ class GivenSyntax36Suite extends BaseDottySuite {
                   |  def foo = ???
                   |}
                   |""".stripMargin
-    val error = """|<input>:1: error: `identifier` expected but `[` found
-                   |given [A] => (Ord[A]) => Ord[List[A]] {
-                   |      ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given [A] => (Ord[A]) => Ord[List[A]] { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      anon,
+      List(pparam("A")),
+      List(List(tparam("", papply("Ord", "A")))),
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("Parameterized named typeclass with anonymous context parameter, coloneol") {
     val code = """|given ord: [A] => (Ord[A]) => Ord[List[A]]:
                   |  def foo = ???
                   |""".stripMargin
-    val error = """|<input>:1: error: `identifier` expected but `[` found
-                   |given ord: [A] => (Ord[A]) => Ord[List[A]]:
-                   |           ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given ord: [A] => (Ord[A]) => Ord[List[A]] { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      tname("ord"),
+      List(pparam("A")),
+      List(List(tparam("", papply("Ord", "A")))),
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("Parameterized named typeclass with anonymous context parameter, braces") {
@@ -526,10 +617,15 @@ class GivenSyntax36Suite extends BaseDottySuite {
                   |  def foo = ???
                   |}
                   |""".stripMargin
-    val error = """|<input>:1: error: `identifier` expected but `[` found
-                   |given ord: [A] => (Ord[A]) => Ord[List[A]] {
-                   |           ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given ord: [A] => (Ord[A]) => Ord[List[A]] { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      tname("ord"),
+      List(pparam("A")),
+      List(List(tparam("", papply("Ord", "A")))),
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   // extra new syntax tests: functions
@@ -538,10 +634,15 @@ class GivenSyntax36Suite extends BaseDottySuite {
     val code = """|given ord: ([A] =>> Ord[A]) => Ord[List[A]]:
                   |  def foo = ???
                   |""".stripMargin
-    val error = """|<input>:1: error: `;` expected but `=>` found
-                   |given ord: ([A] =>> Ord[A]) => Ord[List[A]]:
-                   |                            ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given ord: ([A] =>> Ord[A]) => Ord[List[A]] { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      "ord",
+      Nil,
+      List(List(tparam("", Type.Lambda(List(pparam("A")), papply("Ord", "A"))))),
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("context a lambda function, braces") {
@@ -549,20 +650,33 @@ class GivenSyntax36Suite extends BaseDottySuite {
                   |  def foo = ???
                   |}
                   |""".stripMargin
-    val error = """|<input>:1: error: `;` expected but `=>` found
-                   |given ord: ([A] =>> Ord[A]) => Ord[List[A]] {
-                   |                            ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given ord: ([A] =>> Ord[A]) => Ord[List[A]] { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      "ord",
+      Nil,
+      List(List(tparam("", Type.Lambda(List(pparam(Nil, "A")), papply("Ord", "A"))))),
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("context a poly function, coloneol") {
     val code = """|given ord: ([A] => (Ord[A]) => Ord[List[A]]) => Ord[List[A]]:
                   |  def foo = ???
                   |""".stripMargin
-    val error = """|<input>:1: error: `;` expected but `=>` found
-                   |given ord: ([A] => (Ord[A]) => Ord[List[A]]) => Ord[List[A]]:
-                   |                                             ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given ord: ([A] => Ord[A] => Ord[List[A]]) => Ord[List[A]] { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      "ord",
+      Nil,
+      List(List(tparam(
+        "",
+        ppolyfunc(pfunc(papply("Ord", papply("List", "A")), papply("Ord", "A")), pparam(Nil, "A"))
+      ))),
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("context a poly function, braces") {
@@ -570,20 +684,36 @@ class GivenSyntax36Suite extends BaseDottySuite {
                   |  def foo = ???
                   |}
                   |""".stripMargin
-    val error = """|<input>:1: error: `;` expected but `=>` found
-                   |given ord: ([A] => (Ord[A]) => Ord[List[A]]) => Ord[List[A]] {
-                   |                                             ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given ord: ([A] => Ord[A] => Ord[List[A]]) => Ord[List[A]] { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      "ord",
+      Nil,
+      List(List(tparam(
+        "",
+        ppolyfunc(pfunc(papply("Ord", papply("List", "A")), papply("Ord", "A")), pparam(Nil, "A"))
+      ))),
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("given type a function, coloneol") {
     val code = """|given ord: [A] => (Ord[A] => Ord[List[A]]):
                   |  def foo = ???
                   |""".stripMargin
-    val error = """|<input>:1: error: `identifier` expected but `[` found
-                   |given ord: [A] => (Ord[A] => Ord[List[A]]):
-                   |           ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given ord[A]: (Ord[A] => Ord[List[A]]) with { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      "ord",
+      List(pparam(Nil, "A")),
+      Nil,
+      tpl(
+        List(init(pfunc(papply("Ord", papply("List", "A")), papply("Ord", "A")))),
+        List(Defn.Def(Nil, "foo", Nil, None, "???"))
+      )
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("given type a function, braces") {
@@ -591,10 +721,18 @@ class GivenSyntax36Suite extends BaseDottySuite {
                   |  def foo = ???
                   |}
                   |""".stripMargin
-    val error = """|<input>:1: error: `identifier` expected but `[` found
-                   |given ord: [A] => (Ord[A] => Ord[List[A]]) {
-                   |           ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given ord[A]: (Ord[A] => Ord[List[A]]) with { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      "ord",
+      List(pparam(Nil, "A")),
+      Nil,
+      tpl(
+        List(init(pfunc(papply("Ord", papply("List", "A")), papply("Ord", "A")))),
+        List(Defn.Def(Nil, "foo", Nil, None, "???"))
+      )
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   // extra new syntax tests: param clause first
@@ -603,10 +741,15 @@ class GivenSyntax36Suite extends BaseDottySuite {
     val code = """|given ord: (a: A) => Ord[A] => Ord[List[A]]:
                   |  def foo = ???
                   |""".stripMargin
-    val error = """|<input>:1: error: `;` expected but `=>` found
-                   |given ord: (a: A) => Ord[A] => Ord[List[A]]:
-                   |                  ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given ord: (a: A) => (Ord[A]) => Ord[List[A]] { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      "ord",
+      Nil,
+      List(List(tparam("a", "A")), List(tparam("", papply("Ord", "A")))),
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("named, param clause first, braces") {
@@ -614,20 +757,30 @@ class GivenSyntax36Suite extends BaseDottySuite {
                   |  def foo = ???
                   |}
                   |""".stripMargin
-    val error = """|<input>:1: error: `;` expected but `=>` found
-                   |given ord: (a: A) => Ord[A] => Ord[List[A]] {
-                   |                  ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given ord: (a: A) => (Ord[A]) => Ord[List[A]] { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      "ord",
+      Nil,
+      List(List(tparam("a", "A")), List(tparam("", papply("Ord", "A")))),
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("anonymous, param clause first, coloneol") {
     val code = """|given (a: A) => Ord[A] => Ord[List[A]]:
                   |  def foo = ???
                   |""".stripMargin
-    val error = """|<input>:1: error: abstract givens cannot be anonymous
-                   |given (a: A) => Ord[A] => Ord[List[A]]:
-                   |      ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given (a: A) => (Ord[A]) => Ord[List[A]] { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      anon,
+      Nil,
+      List(List(tparam("a", "A")), List(tparam("", papply("Ord", "A")))),
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("anonymous, param clause first, braces") {
@@ -635,10 +788,15 @@ class GivenSyntax36Suite extends BaseDottySuite {
                   |  def foo = ???
                   |}
                   |""".stripMargin
-    val error = """|<input>:1: error: abstract givens cannot be anonymous
-                   |given (a: A) => Ord[A] => Ord[List[A]] {
-                   |      ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given (a: A) => (Ord[A]) => Ord[List[A]] { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      anon,
+      Nil,
+      List(List(tparam("a", "A")), List(tparam("", papply("Ord", "A")))),
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   // extra new syntax tests: func arg types
@@ -647,10 +805,15 @@ class GivenSyntax36Suite extends BaseDottySuite {
     val code = """|given ord: (A) => Ord[A] => Ord[List[A]]:
                   |  def foo = ???
                   |""".stripMargin
-    val error = """|<input>:1: error: `;` expected but `=>` found
-                   |given ord: (A) => Ord[A] => Ord[List[A]]:
-                   |               ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given ord: (A) => (Ord[A]) => Ord[List[A]] { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      "ord",
+      Nil,
+      List(List(tparam("", "A")), List(tparam("", papply("Ord", "A")))),
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("named, func arg types, braces") {
@@ -658,20 +821,30 @@ class GivenSyntax36Suite extends BaseDottySuite {
                   |  def foo = ???
                   |}
                   |""".stripMargin
-    val error = """|<input>:1: error: `;` expected but `=>` found
-                   |given ord: (A) => Ord[A] => Ord[List[A]] {
-                   |               ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given ord: (A) => (Ord[A]) => Ord[List[A]] { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      "ord",
+      Nil,
+      List(List(tparam("", "A")), List(tparam("", papply("Ord", "A")))),
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("anonymous, func arg types, coloneol") {
     val code = """|given (A) => Ord[A] => Ord[List[A]]:
                   |  def foo = ???
                   |""".stripMargin
-    val error = """|<input>:1: error: abstract givens cannot be anonymous
-                   |given (A) => Ord[A] => Ord[List[A]]:
-                   |      ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given (A) => (Ord[A]) => Ord[List[A]] { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      anon,
+      Nil,
+      List(List(tparam("", "A")), List(tparam("", papply("Ord", "A")))),
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("anonymous, func arg types, braces") {
@@ -679,10 +852,15 @@ class GivenSyntax36Suite extends BaseDottySuite {
                   |  def foo = ???
                   |}
                   |""".stripMargin
-    val error = """|<input>:1: error: abstract givens cannot be anonymous
-                   |given (A) => Ord[A] => Ord[List[A]] {
-                   |      ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given (A) => (Ord[A]) => Ord[List[A]] { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      anon,
+      Nil,
+      List(List(tparam("", "A")), List(tparam("", papply("Ord", "A")))),
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenSyntax36Suite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenSyntax36Suite.scala
@@ -314,4 +314,375 @@ class GivenSyntax36Suite extends BaseDottySuite {
   test("given-abstract-named") {
     runTestAssert[Stat]("given context: Context")(Decl.Given(Nil, "context", None, "Context"))
   }
+
+  // https://docs3.scala-lang.org/sips/sips/typeclasses-syntax.html#7-cleanup-of-given-syntax
+
+  // Simple typeclass
+  test("Simple anonymous typeclass, coloneol") {
+    val code = """|given Ord[Int]:
+                  |  def foo = ???
+                  |""".stripMargin
+    val error = """|<input>:1: error: `identifier` expected but `indent` found
+                   |given Ord[Int]:
+                   |               ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("Simple anonymous typeclass, braces") {
+    val code = """|given Ord[Int] {
+                  |  def foo = ???
+                  |}
+                  |""".stripMargin
+    val error = """|<input>:1: error: abstract givens cannot be anonymous
+                   |given Ord[Int] {
+                   |      ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("Simple named typeclass, coloneol") {
+    val code = """|given ord: Ord[Int]:
+                  |  def foo = ???
+                  |""".stripMargin
+    val error = """|<input>:1: error: `;` expected but `:` found
+                   |given ord: Ord[Int]:
+                   |                   ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("Simple named typeclass, braces") {
+    val code = """|given ord: Ord[Int] {
+                  |  def foo = ???
+                  |}
+                  |""".stripMargin
+    val error = """|<input>:1: error: `;` expected but `{` found
+                   |given ord: Ord[Int] {
+                   |                    ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  // Parameterized typeclass with context bound
+  test("Parameterized anonymous typeclass with context bound, coloneol") {
+    val code = """|given [A : Ord] => Ord[List[A]]:
+                  |  def foo = ???
+                  |""".stripMargin
+    val error = """|<input>:1: error: `identifier` expected but `[` found
+                   |given [A : Ord] => Ord[List[A]]:
+                   |      ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("Parameterized anonymous typeclass with context bound, braces") {
+    val code = """|given [A : Ord] => Ord[List[A]] {
+                  |  def foo = ???
+                  |}
+                  |""".stripMargin
+    val error = """|<input>:1: error: `identifier` expected but `[` found
+                   |given [A : Ord] => Ord[List[A]] {
+                   |      ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("Parameterized named typeclass with context bound, coloneol") {
+    val code = """|given ord: [A : Ord] => Ord[List[A]]:
+                  |  def foo = ???
+                  |""".stripMargin
+    val error = """|<input>:1: error: `identifier` expected but `[` found
+                   |given ord: [A : Ord] => Ord[List[A]]:
+                   |           ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("Parameterized named typeclass with context bound, braces") {
+    val code = """|given ord: [A : Ord] => Ord[List[A]] {
+                  |  def foo = ???
+                  |}
+                  |""".stripMargin
+    val error = """|<input>:1: error: `identifier` expected but `[` found
+                   |given ord: [A : Ord] => Ord[List[A]] {
+                   |           ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  // Parameterized typeclass with context bound
+  test("Parameterized anonymous typeclass with context bound, coloneol") {
+    val code = """|given [A : Ord] => Ord[List[A]]:
+                  |  def foo = ???
+                  |""".stripMargin
+    val error = """|<input>:1: error: `identifier` expected but `[` found
+                   |given [A : Ord] => Ord[List[A]]:
+                   |      ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("Parameterized anonymous typeclass with context bound, braces") {
+    val code = """|given [A : Ord] => Ord[List[A]] {
+                  |  def foo = ???
+                  |}
+                  |""".stripMargin
+    val error = """|<input>:1: error: `identifier` expected but `[` found
+                   |given [A : Ord] => Ord[List[A]] {
+                   |      ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("Parameterized named typeclass with context bound, coloneol") {
+    val code = """|given ord: [A : Ord] => Ord[List[A]]:
+                  |  def foo = ???
+                  |""".stripMargin
+    val error = """|<input>:1: error: `identifier` expected but `[` found
+                   |given ord: [A : Ord] => Ord[List[A]]:
+                   |           ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("Parameterized named typeclass with context bound, braces") {
+    val code = """|given ord: [A : Ord] => Ord[List[A]] {
+                  |  def foo = ???
+                  |}
+                  |""".stripMargin
+    val error = """|<input>:1: error: `identifier` expected but `[` found
+                   |given ord: [A : Ord] => Ord[List[A]] {
+                   |           ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  // Parameterized typeclass with named context parameter
+  test("Parameterized anonymous typeclass with named context parameter, coloneol") {
+    val code = """|given [A] => (ord: Ord[A]) => Ord[List[A]]:
+                  |  def foo = ???
+                  |""".stripMargin
+    val error = """|<input>:1: error: `identifier` expected but `[` found
+                   |given [A] => (ord: Ord[A]) => Ord[List[A]]:
+                   |      ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("Parameterized anonymous typeclass with named context parameter, braces") {
+    val code = """|given [A] => (ord: Ord[A]) => Ord[List[A]] {
+                  |  def foo = ???
+                  |}
+                  |""".stripMargin
+    val error = """|<input>:1: error: `identifier` expected but `[` found
+                   |given [A] => (ord: Ord[A]) => Ord[List[A]] {
+                   |      ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("Parameterized named typeclass with named context parameter, coloneol") {
+    val code = """|given ord: [A] => (ord: Ord[A]) => Ord[List[A]]:
+                  |  def foo = ???
+                  |""".stripMargin
+    val error = """|<input>:1: error: `identifier` expected but `[` found
+                   |given ord: [A] => (ord: Ord[A]) => Ord[List[A]]:
+                   |           ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("Parameterized named typeclass with named context parameter, braces") {
+    val code = """|given ord: [A] => (ord: Ord[A]) => Ord[List[A]] {
+                  |  def foo = ???
+                  |}
+                  |""".stripMargin
+    val error = """|<input>:1: error: `identifier` expected but `[` found
+                   |given ord: [A] => (ord: Ord[A]) => Ord[List[A]] {
+                   |           ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  // Parameterized typeclass with anonymous context parameter
+  test("Parameterized anonymous typeclass with anonymous context parameter, coloneol") {
+    val code = """|given [A] => (Ord[A]) => Ord[List[A]]:
+                  |  def foo = ???
+                  |""".stripMargin
+    val error = """|<input>:1: error: `identifier` expected but `[` found
+                   |given [A] => (Ord[A]) => Ord[List[A]]:
+                   |      ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("Parameterized anonymous typeclass with anonymous context parameter, braces") {
+    val code = """|given [A] => (Ord[A]) => Ord[List[A]] {
+                  |  def foo = ???
+                  |}
+                  |""".stripMargin
+    val error = """|<input>:1: error: `identifier` expected but `[` found
+                   |given [A] => (Ord[A]) => Ord[List[A]] {
+                   |      ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("Parameterized named typeclass with anonymous context parameter, coloneol") {
+    val code = """|given ord: [A] => (Ord[A]) => Ord[List[A]]:
+                  |  def foo = ???
+                  |""".stripMargin
+    val error = """|<input>:1: error: `identifier` expected but `[` found
+                   |given ord: [A] => (Ord[A]) => Ord[List[A]]:
+                   |           ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("Parameterized named typeclass with anonymous context parameter, braces") {
+    val code = """|given ord: [A] => (Ord[A]) => Ord[List[A]] {
+                  |  def foo = ???
+                  |}
+                  |""".stripMargin
+    val error = """|<input>:1: error: `identifier` expected but `[` found
+                   |given ord: [A] => (Ord[A]) => Ord[List[A]] {
+                   |           ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  // extra new syntax tests: functions
+
+  test("context a lambda function, coloneol") {
+    val code = """|given ord: ([A] =>> Ord[A]) => Ord[List[A]]:
+                  |  def foo = ???
+                  |""".stripMargin
+    val error = """|<input>:1: error: `;` expected but `=>` found
+                   |given ord: ([A] =>> Ord[A]) => Ord[List[A]]:
+                   |                            ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("context a lambda function, braces") {
+    val code = """|given ord: ([A] =>> Ord[A]) => Ord[List[A]] {
+                  |  def foo = ???
+                  |}
+                  |""".stripMargin
+    val error = """|<input>:1: error: `;` expected but `=>` found
+                   |given ord: ([A] =>> Ord[A]) => Ord[List[A]] {
+                   |                            ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("context a poly function, coloneol") {
+    val code = """|given ord: ([A] => (Ord[A]) => Ord[List[A]]) => Ord[List[A]]:
+                  |  def foo = ???
+                  |""".stripMargin
+    val error = """|<input>:1: error: `;` expected but `=>` found
+                   |given ord: ([A] => (Ord[A]) => Ord[List[A]]) => Ord[List[A]]:
+                   |                                             ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("context a poly function, braces") {
+    val code = """|given ord: ([A] => (Ord[A]) => Ord[List[A]]) => Ord[List[A]] {
+                  |  def foo = ???
+                  |}
+                  |""".stripMargin
+    val error = """|<input>:1: error: `;` expected but `=>` found
+                   |given ord: ([A] => (Ord[A]) => Ord[List[A]]) => Ord[List[A]] {
+                   |                                             ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("given type a function, coloneol") {
+    val code = """|given ord: [A] => (Ord[A] => Ord[List[A]]):
+                  |  def foo = ???
+                  |""".stripMargin
+    val error = """|<input>:1: error: `identifier` expected but `[` found
+                   |given ord: [A] => (Ord[A] => Ord[List[A]]):
+                   |           ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("given type a function, braces") {
+    val code = """|given ord: [A] => (Ord[A] => Ord[List[A]]) {
+                  |  def foo = ???
+                  |}
+                  |""".stripMargin
+    val error = """|<input>:1: error: `identifier` expected but `[` found
+                   |given ord: [A] => (Ord[A] => Ord[List[A]]) {
+                   |           ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  // extra new syntax tests: param clause first
+
+  test("named, param clause first, coloneol") {
+    val code = """|given ord: (a: A) => Ord[A] => Ord[List[A]]:
+                  |  def foo = ???
+                  |""".stripMargin
+    val error = """|<input>:1: error: `;` expected but `=>` found
+                   |given ord: (a: A) => Ord[A] => Ord[List[A]]:
+                   |                  ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("named, param clause first, braces") {
+    val code = """|given ord: (a: A) => Ord[A] => Ord[List[A]] {
+                  |  def foo = ???
+                  |}
+                  |""".stripMargin
+    val error = """|<input>:1: error: `;` expected but `=>` found
+                   |given ord: (a: A) => Ord[A] => Ord[List[A]] {
+                   |                  ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("anonymous, param clause first, coloneol") {
+    val code = """|given (a: A) => Ord[A] => Ord[List[A]]:
+                  |  def foo = ???
+                  |""".stripMargin
+    val error = """|<input>:1: error: abstract givens cannot be anonymous
+                   |given (a: A) => Ord[A] => Ord[List[A]]:
+                   |      ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("anonymous, param clause first, braces") {
+    val code = """|given (a: A) => Ord[A] => Ord[List[A]] {
+                  |  def foo = ???
+                  |}
+                  |""".stripMargin
+    val error = """|<input>:1: error: abstract givens cannot be anonymous
+                   |given (a: A) => Ord[A] => Ord[List[A]] {
+                   |      ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  // extra new syntax tests: func arg types
+
+  test("named, func arg types, coloneol") {
+    val code = """|given ord: (A) => Ord[A] => Ord[List[A]]:
+                  |  def foo = ???
+                  |""".stripMargin
+    val error = """|<input>:1: error: `;` expected but `=>` found
+                   |given ord: (A) => Ord[A] => Ord[List[A]]:
+                   |               ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("named, func arg types, braces") {
+    val code = """|given ord: (A) => Ord[A] => Ord[List[A]] {
+                  |  def foo = ???
+                  |}
+                  |""".stripMargin
+    val error = """|<input>:1: error: `;` expected but `=>` found
+                   |given ord: (A) => Ord[A] => Ord[List[A]] {
+                   |               ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("anonymous, func arg types, coloneol") {
+    val code = """|given (A) => Ord[A] => Ord[List[A]]:
+                  |  def foo = ???
+                  |""".stripMargin
+    val error = """|<input>:1: error: abstract givens cannot be anonymous
+                   |given (A) => Ord[A] => Ord[List[A]]:
+                   |      ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("anonymous, func arg types, braces") {
+    val code = """|given (A) => Ord[A] => Ord[List[A]] {
+                  |  def foo = ???
+                  |}
+                  |""".stripMargin
+    val error = """|<input>:1: error: abstract givens cannot be anonymous
+                   |given (A) => Ord[A] => Ord[List[A]] {
+                   |      ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
@@ -548,6 +548,24 @@ class GivenUsingSuite extends BaseDottySuite {
     runTestError("given ordered(using Ord[String]): Ord[Int] with Eq[Int]", "expected 'with' <body>")
   }
 
+  test("given without sig and type in parens looking like a param clause") {
+    val code = """|given (using[String]) with Eq[Int] with {
+                  |  def foo = ???
+                  |}
+                  |""".stripMargin
+    val layout = "given using[String] with Eq[Int] with { def foo = ??? }"
+    val tree = Defn.Given(
+      Nil,
+      anon,
+      None,
+      tpl(
+        List(init(papply("using", "String")), init(papply("Eq", "Int"))),
+        List(Defn.Def(Nil, "foo", Nil, None, "???"))
+      )
+    )
+    runTestAssert[Stat](code, layout)(tree)
+  }
+
   // ---------------------------------
   // USING
   // ---------------------------------

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -660,7 +660,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
     ))
   }
 
-  test("given-block-indent-edge-cases") {
+  test("given-block-indent-edge-cases: `with` and no-indent") {
     runTestError[Stat](
       """|given intOrd: Ord[Int] with
          |def fa: Int = 1
@@ -670,7 +670,9 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |def fa: Int = 1
          |^""".stripMargin
     )
+  }
 
+  test("given-block-indent-edge-cases: coloneol") {
     runTestError[Stat](
       """|given intOrd: Ord[Int]:
          |  def fa: Int = 1
@@ -678,7 +680,9 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |""".stripMargin,
       "`;` expected but `:` found"
     )
+  }
 
+  test("given-block-indent-edge-cases: `with` another parent type") {
     runTestAssert[Stat](
       """|class A extends A with 
          |  B

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -673,6 +673,32 @@ class SignificantIndentationSuite extends BaseDottySuite {
   }
 
   test("given-block-indent-edge-cases: coloneol") {
+    runTestAssert[Stat](
+      """|given intOrd: Ord[Int]:
+         |  def fa: Int = 1
+         |  def fb: Int = 2
+         |""".stripMargin,
+      """|given intOrd: Ord[Int] {
+         |  def fa: Int = 1
+         |  def fb: Int = 2
+         |}
+         |""".stripMargin
+    )(Defn.Given(
+      Nil,
+      "intOrd",
+      Nil,
+      tpl(
+        List(init(papply("Ord", "Int"))),
+        List(
+          Defn.Def(Nil, "fa", Nil, Some("Int"), lit(1)),
+          Defn.Def(Nil, "fb", Nil, Some("Int"), lit(2))
+        )
+      )
+    ))
+  }
+
+  test("given-block-indent-edge-cases: coloneol [scala35]") {
+    implicit val dialect: Dialect = dialects.Scala35
     runTestError[Stat](
       """|given intOrd: Ord[Int]:
          |  def fa: Int = 1


### PR DESCRIPTION
The complexity largely arises from having to deal with both old and new. Fixes #4047.