### PR TITLE
ScalametaParser: new given can use `name[type] =>`

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -3557,10 +3557,10 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
         if (!tryAheadNot[Indentation.Indent]) None
         else if (newSyntax) givenSigAfterColon(name)
         else Some(GivenSig(name))
-      else if (tryAhead[LeftBracket]) givenSigOnBracket(name) // only with old syntax
+      else if (tryAhead[LeftBracket]) givenSigOnBracket(name)
       else if (tryAhead[LeftParen]) givenSigOnParen(name) // only with old syntax
       else if (tryAhead[EOL])
-        if (tryAhead[LeftBracket]) givenSigOnBracket(name) // only with old syntax
+        if (tryAhead[LeftBracket]) givenSigOnBracket(name)
         else if (tryAhead[LeftParen]) givenSigOnParen(name) // only with old syntax
         else None
       else if (newSyntax)
@@ -3589,7 +3589,10 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
     else if (!name.isAnonymous) {
       val typeName = copyPos(name)(Type.Name(name.value))
       val tpe = convertNameTypeParamClauseToType(typeName, pcg.tparamClause)
-      Some(GivenSig(anonNameAt(name), declType = Some(tpe)))
+      val anon = anonNameAt(name)
+      if (dialect.allowImprovedTypeClassesSyntax && acceptOpt[RightArrow])
+        givenSigAfterArrow(anon, convertTypeToTermParamClause(tpe))
+      else Some(GivenSig(anon, declType = Some(tpe)))
     } else if (dialect.allowImprovedTypeClassesSyntax && acceptOpt[RightArrow])
       givenSigAfterArrow(name, pcg.tparamClause)
     else None

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenSyntax36Suite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenSyntax36Suite.scala
@@ -960,4 +960,12 @@ class GivenSyntax36Suite extends BaseDottySuite {
     runTestAssert[Stat](code, layout)(tree)
   }
 
+  test("#4091 given") {
+    val code = "given List[Int] => Object {}"
+    val error = """|<input>:1: error: abstract givens cannot be anonymous
+                   |given List[Int] => Object {}
+                   |      ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenSyntax36Suite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenSyntax36Suite.scala
@@ -962,10 +962,15 @@ class GivenSyntax36Suite extends BaseDottySuite {
 
   test("#4091 given") {
     val code = "given List[Int] => Object {}"
-    val error = """|<input>:1: error: abstract givens cannot be anonymous
-                   |given List[Int] => Object {}
-                   |      ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given (List[Int]) => Object {}"
+    val tree = Defn.Given(
+      Nil,
+      anon,
+      Nil,
+      List(List(tparam("", papply("List", "Int")))),
+      tpl(List(init("Object")), Nil)
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
 }


### PR DESCRIPTION
Fixes #4091.