### PR TITLE
ScalametaParser: simplify {Decl,Defn}.Type parsing

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -3788,30 +3788,9 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
     newLinesOpt()
     val name = typeName()
     val tparams = typeParamClauseOpt(ownerIsType = true)
-
-    def aliasType() = {
-      // empty bounds also need to have origin
-      val emptyBounds = atCurPosEmpty(Type.Bounds(None, None))
-      Defn.Type(mods, name, tparams, typeIndentedOpt(), emptyBounds)
-    }
-
-    def abstractType() = {
-      val bounds = typeBounds()
-      if (acceptOpt[Equals]) {
-        val tpe = typeIndentedOpt()
-        if (tpe.is[Type.Match]) Defn.Type(mods, name, tparams, tpe, bounds)
-        else syntaxError("cannot combine bound and alias", at = tpe.pos)
-      } else Decl.Type(mods, name, tparams, bounds)
-    }
-    if (mods.exists(_.is[Mod.Opaque])) {
-      val bounds = typeBounds()
-      accept[Equals]
-      Defn.Type(mods, name, tparams, typeIndentedOpt(), bounds)
-    } else currToken match {
-      case _: Equals => next(); aliasType()
-      case _: Supertype | _: Subtype | _: Comma | StatSep() | StatSeqEnd() => abstractType()
-      case _ => syntaxError("`=', `>:', or `<:' expected", at = currToken)
-    }
+    val bounds = typeBounds()
+    if (acceptOpt[Equals]) Defn.Type(mods, name, tparams, typeIndentedOpt(), bounds)
+    else Decl.Type(mods, name, tparams, bounds)
   }
 
   /** Hook for IDE, for top-level classes/objects. */

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -243,7 +243,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |TypeCase case Array[t] => t
        |Type.Apply Array[t]
        |Type.ArgClause [t]
-       |Type.Bounds type T = @@A match {
+       |Type.Bounds type T @@= A match {
        |""".stripMargin
   )
   checkPositions[Stat](
@@ -326,7 +326,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |Type.ArgClause [T]
        |Type.Apply Option[T]
        |Type.ArgClause [T]
-       |Type.Bounds type F0 = @@[T] => List[T] ?=> Option[T]
+       |Type.Bounds type F0 @@= [T] => List[T] ?=> Option[T]
        |""".stripMargin
   )
   checkPositions[Stat](
@@ -1200,11 +1200,11 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |Stat.Block { type U = T }
        |Defn.Type type U = T
        |Type.ParamClause val x: (C { type U @@= T } { type T = String }) # U
-       |Type.Bounds val x: (C { type U = @@T } { type T = String }) # U
+       |Type.Bounds val x: (C { type U @@= T } { type T = String }) # U
        |Stat.Block { type T = String }
        |Defn.Type type T = String
        |Type.ParamClause val x: (C { type U = T } { type T @@= String }) # U
-       |Type.Bounds val x: (C { type U = T } { type T = @@String }) # U
+       |Type.Bounds val x: (C { type U = T } { type T @@= String }) # U
        |""".stripMargin
   )
 
@@ -1219,7 +1219,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |Decl.Type type T>: Null
        |Type.ParamClause   type T@@>: Null
        |Type.Bounds >: Null
-       |Type.Bounds type A = @@AnyRef with
+       |Type.Bounds type A @@= AnyRef with
        |""".stripMargin
   )
 
@@ -1235,7 +1235,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |Decl.Type type T>: Null
        |Type.ParamClause   type T@@>: Null
        |Type.Bounds >: Null
-       |Type.Bounds type A = @@AnyRef:
+       |Type.Bounds type A @@= AnyRef:
        |""".stripMargin
   )
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/BasicPositionSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/BasicPositionSuite.scala
@@ -455,7 +455,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
     """type foo = (a -> b)""",
     """|Type.ParamClause type foo @@= (a -> b)
        |Type.ApplyInfix a -> b
-       |Type.Bounds type foo = @@(a -> b)
+       |Type.Bounds type foo @@= (a -> b)
        |""".stripMargin
   )
 
@@ -464,7 +464,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
     """|Type.ParamClause type foo @@= (a -> b) -> c
        |Type.ApplyInfix (a -> b) -> c
        |Type.ApplyInfix a -> b
-       |Type.Bounds type foo = @@(a -> b) -> c
+       |Type.Bounds type foo @@= (a -> b) -> c
        |""".stripMargin
   )
 
@@ -472,7 +472,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
     """type foo = (a :+ b)""",
     """|Type.ParamClause type foo @@= (a :+ b)
        |Type.ApplyInfix a :+ b
-       |Type.Bounds type foo = @@(a :+ b)
+       |Type.Bounds type foo @@= (a :+ b)
        |""".stripMargin
   )
 
@@ -481,7 +481,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
     """|Type.ParamClause type foo @@= (a :+ b) :+ c
        |Type.ApplyInfix (a :+ b) :+ c
        |Type.ApplyInfix a :+ b
-       |Type.Bounds type foo = @@(a :+ b) :+ c
+       |Type.Bounds type foo @@= (a :+ b) :+ c
        |""".stripMargin
   )
 
@@ -489,7 +489,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
     """type foo = (a +: b)""",
     """|Type.ParamClause type foo @@= (a +: b)
        |Type.ApplyInfix a +: b
-       |Type.Bounds type foo = @@(a +: b)
+       |Type.Bounds type foo @@= (a +: b)
        |""".stripMargin
   )
 
@@ -498,7 +498,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
     """|Type.ParamClause type foo @@= (a +: b) +: c
        |Type.ApplyInfix (a +: b) +: c
        |Type.ApplyInfix a +: b
-       |Type.Bounds type foo = @@(a +: b) +: c
+       |Type.Bounds type foo @@= (a +: b) +: c
        |""".stripMargin
   )
 
@@ -506,7 +506,7 @@ class BasicPositionSuite extends BasePositionSuite(dialects.Scala213) {
     """type foo = (a, b)""",
     """|Type.ParamClause type foo @@= (a, b)
        |Type.Tuple (a, b)
-       |Type.Bounds type foo = @@(a, b)
+       |Type.Bounds type foo @@= (a, b)
        |""".stripMargin
   )
 


### PR DESCRIPTION
Remove syntax error checks. Helps with #4093.