### PR TITLE
TreeSyntax: print context bounds using new syntax

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenSyntax36Suite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenSyntax36Suite.scala
@@ -21,10 +21,8 @@ class GivenSyntax36Suite extends BaseDottySuite {
   // class B extends A:
   //   def showMax[X : {Ordering as ordering, Show as show}](x: X, y: X): String =
   test("agregate-bounds") {
-    runTestAssert[Stat](
-      "trait A { def showMax[X: {Ordering, Show}](x: X, y: X): String}",
-      assertLayout = Some("trait A { def showMax[X: Ordering: Show](x: X, y: X): String }")
-    )(Defn.Trait(
+    val code = "trait A { def showMax[X: {Ordering, Show}](x: X, y: X): String }"
+    val tree = Defn.Trait(
       Nil,
       pname("A"),
       Nil,
@@ -36,7 +34,8 @@ class GivenSyntax36Suite extends BaseDottySuite {
         List(List(tparam("x", "X"), tparam("y", "X"))),
         "String"
       ))
-    ))
+    )
+    runTestAssert[Stat](code)(tree)
   }
   test("agregate-bounds-named") {
     runTestAssert[Stat](


### PR DESCRIPTION
Helps with #4093.