### PR TITLE
Trees: move context bounds Type.{Param -> Bounds}

### DIFF
--- a/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -70,6 +70,7 @@ class SurfaceSuite extends FunSuite {
          |scala.meta.Tree
          |scala.meta.Tree.ImplicitOptionTree
          |scala.meta.Tree.ImplicitTree
+         |scala.meta.Type.ParamBoundsCtor
          |scala.meta.VersionSpecificApis
          |scala.meta.XtensionDialectApply
          |scala.meta.XtensionDialectTokenSyntax

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -3086,7 +3086,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |Type.ParamClause [A : Ord]
        |Type.Param A : Ord
        |Type.ParamClause given [A @@: Ord] => Ord[List[A]] = ???
-       |Type.Bounds given [A @@: Ord] => Ord[List[A]] = ???
+       |Type.Bounds : Ord
        |Type.Apply Ord[List[A]]
        |Type.ArgClause [List[A]]
        |Type.Apply List[A]
@@ -3101,7 +3101,7 @@ class Scala3PositionSuite extends BasePositionSuite(dialects.Scala3) {
        |Type.ParamClause [A : Ord]
        |Type.Param A : Ord
        |Type.ParamClause given ord: [A @@: Ord] => Ord[List[A]] = ???
-       |Type.Bounds given ord: [A @@: Ord] => Ord[List[A]] = ???
+       |Type.Bounds : Ord
        |Type.Apply Ord[List[A]]
        |Type.ArgClause [List[A]]
        |Type.Apply List[A]

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
@@ -159,7 +159,7 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
        |Type.ParamClause [A: B]
        |Type.Param A: B
        |Type.ParamClause def f[A@@: B]: C
-       |Type.Bounds def f[A@@: B]: C
+       |Type.Bounds : B
        |""".stripMargin
   )
   checkPositions[Stat](
@@ -168,7 +168,7 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
        |Type.ParamClause [A : B : C]
        |Type.Param A : B : C
        |Type.ParamClause def f[A @@: B : C]: D
-       |Type.Bounds def f[A @@: B : C]: D
+       |Type.Bounds : B : C
        |""".stripMargin
   )
 

--- a/tests/shared/src/test/scala-2/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/tests/shared/src/test/scala-2/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -1723,9 +1723,8 @@ class SuccessSuite extends TreeSuiteBase {
       List(Mod.Covariant()),
       "Z",
       List(pparam("Q"), pparam("W")),
-      bounds("E", "R"),
-      List(Type.With(pname("T"), pname("Y"))),
-      List(Type.With(pname("U"), pname("I")))
+      bounds("E", "R", List(Type.With(pname("U"), pname("I")))),
+      List(Type.With(pname("T"), pname("Y")))
     ))
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
@@ -141,15 +141,14 @@ trait CommonTrees extends CommonTrees.LowPriorityDefinitions {
       s: String,
       params: List[Type.Param] = Nil,
       bounds: Type.Bounds = noBounds,
-      vb: List[Type] = Nil,
-      cb: List[Type] = Nil
+      vb: List[Type] = Nil
   ): Type.Param = {
     val nameTree = s match {
       case "" => anon
       case "_" => phName
       case _ => pname(s)
     }
-    Type.Param(mods, nameTree, params, bounds, vb, cb)
+    Type.Param(mods, nameTree, params, bounds, vb)
   }
 
   final def pinfix(lt: Type, op: String, rt: Type): Type.ApplyInfix = Type.ApplyInfix(lt, op, rt)
@@ -188,11 +187,11 @@ trait CommonTrees extends CommonTrees.LowPriorityDefinitions {
     .ExtractInfix(lt, tname(op), rt.toList)
   final val patwildcard = Pat.Wildcard()
 
-  final val noBounds = Type.Bounds(None, None)
+  final val noBounds = Type.Bounds.empty
   final def loBound(bound: Type): Type.Bounds = Type.Bounds(Some(bound), None)
   final def hiBound(bound: Type): Type.Bounds = Type.Bounds(None, Some(bound))
-  final def bounds(lo: Type = null, hi: Type = null): Type.Bounds = Type
-    .Bounds(Option(lo), Option(hi))
+  final def bounds(lo: Type = null, hi: Type = null, cb: List[Type] = Nil): Type.Bounds = Type
+    .Bounds(Option(lo), Option(hi), cb)
 
   final def pwildcard(bounds: Type.Bounds): Type.Wildcard = Type.Wildcard(bounds)
   final val pwildcard: Type.Wildcard = pwildcard(noBounds)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
@@ -97,7 +97,7 @@ class DefnSuite extends ParseSuite {
 
   test("def x[A: B] = 2") {
     assertTree(templStat("def x[A: B] = 2")) {
-      Defn.Def(Nil, tname("x"), pparam(Nil, "A", cb = pname("B") :: Nil) :: Nil, Nil, None, int(2))
+      Defn.Def(Nil, tname("x"), List(pparam("A", bounds(cb = List(pname("B"))))), Nil, None, int(2))
     }
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EnumSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EnumSuite.scala
@@ -278,7 +278,7 @@ class EnumSuite extends BaseDottySuite {
   }
 
   test("case-generic") {
-    val generic = pparam(Nil, "X", vb = Nil, cb = List(pname("Ord")))
+    val generic = pparam("X", bounds(cb = List(pname("Ord"))))
     runTestAssert[Stat]("enum E { case A[X: Ord]() }")(
       enumWithCase("E", Defn.EnumCase(Nil, tname("A"), List(generic), ctorp(Nil), Nil))
     )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenSyntax36Suite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenSyntax36Suite.scala
@@ -10,7 +10,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
     runTestAssert[Stat](code)(Defn.Def(
       Nil,
       "reduce",
-      List(pparam(Nil, "A", cb = List(Type.BoundsAlias("mm", "Monoid")))),
+      List(pparam("A", bounds(cb = List(Type.BoundsAlias("mm", "Monoid"))))),
       List(List(tparam("xs", "A"))),
       Some("A"),
       "???"
@@ -30,7 +30,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       tpl(Decl.Def(
         Nil,
         "showMax",
-        List(pparam(Nil, "X", cb = List("Ordering", "Show"))),
+        List(pparam("X", bounds(cb = List("Ordering", "Show")))),
         List(List(tparam("x", "X"), tparam("y", "X"))),
         "String"
       ))
@@ -51,9 +51,8 @@ class GivenSyntax36Suite extends BaseDottySuite {
         Nil,
         "showMax",
         List(pparam(
-          Nil,
           "X",
-          cb = List(Type.BoundsAlias("ordering", "Ordering"), Type.BoundsAlias("show", "Show"))
+          bounds(cb = List(Type.BoundsAlias("ordering", "Ordering"), Type.BoundsAlias("show", "Show")))
         )),
         List(List(tparam("x", "X"), tparam("y", "X"))),
         "String"
@@ -94,7 +93,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       Nil,
       pname("Comparer"),
       Nil,
-      ppolyfunc(pparam(Nil, "X", cb = List("Ord")))(
+      ppolyfunc(pparam("X", bounds(cb = List("Ord"))))(
         pfunc(Type.TypedParam("x", "X", Nil), Type.TypedParam("y", "X", Nil))("Boolean")
       ),
       noBounds
@@ -112,7 +111,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       Nil,
       List(patvar("less")),
       Some("Comparer"),
-      tpolyfunc(pparam(Nil, "X", cb = List(Type.BoundsAlias("ord", "Ord"))))(
+      tpolyfunc(pparam("X", bounds(cb = List(Type.BoundsAlias("ord", "Ord")))))(
         tfunc(tparam("x", "X"), tparam("y", "X"))(
           tinfix(tapply(tselect("ord", "compare"), "x", "y"), "<", lit(0))
         )
@@ -152,7 +151,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
          |""".stripMargin,
       assertLayout =
         Some("given [A: Ord]: Ord[List[A]] with { def compare(x: List[A], y: List[A]) = ??? }")
-    )(Defn.Given(Nil, anon, List(pparam(Nil, "A", cb = List("Ord"))), Nil, bodyBounds))
+    )(Defn.Given(Nil, anon, List(pparam("A", bounds(cb = List("Ord")))), Nil, bodyBounds))
   }
 
   test("given-context-using") {
@@ -197,7 +196,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
     runTestAssert[Stat]("given [A: Ord]: Ord[List[A]] = ListOrd[A]")(Defn.GivenAlias(
       Nil,
       anon,
-      List(pparam(Nil, "A", cb = List("Ord"))),
+      List(pparam("A", bounds(cb = List("Ord")))),
       Nil,
       papply("Ord", papply("List", "A")),
       tapplytype("ListOrd", "A")
@@ -238,7 +237,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       assertLayout = Some(
         "given listOrd[A: Ord]: Ord[List[A]] with { def compare(x: List[A], y: List[A]) = ??? }"
       )
-    )(Defn.Given(Nil, "listOrd", List(pparam(Nil, "A", cb = List("Ord"))), Nil, bodyBounds))
+    )(Defn.Given(Nil, "listOrd", List(pparam("A", bounds(cb = List("Ord")))), Nil, bodyBounds))
   }
 
   test("given-context-using") {
@@ -283,7 +282,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
     runTestAssert[Stat]("given listOrd[A: Ord]: Ord[List[A]] = ListOrd[A]")(Defn.GivenAlias(
       Nil,
       "listOrd",
-      List(pparam(Nil, "A", cb = List("Ord"))),
+      List(pparam("A", bounds(cb = List("Ord")))),
       Nil,
       papply("Ord", papply("List", "A")),
       tapplytype("ListOrd", "A")
@@ -380,7 +379,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
     val tree = Defn.Given(
       Nil,
       anon,
-      List(pparam(Nil, "A", cb = List("Ord"))),
+      List(pparam("A", bounds(cb = List("Ord")))),
       Nil,
       tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
     )
@@ -396,7 +395,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
     val tree = Defn.Given(
       Nil,
       anon,
-      List(pparam(Nil, "A", cb = List("Ord"))),
+      List(pparam("A", bounds(cb = List("Ord")))),
       Nil,
       tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
     )
@@ -411,7 +410,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
     val tree = Defn.Given(
       Nil,
       tname("ord"),
-      List(pparam(Nil, "A", cb = List("Ord"))),
+      List(pparam("A", bounds(cb = List("Ord")))),
       Nil,
       tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
     )
@@ -427,7 +426,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
     val tree = Defn.Given(
       Nil,
       tname("ord"),
-      List(pparam(Nil, "A", cb = List("Ord"))),
+      List(pparam("A", bounds(cb = List("Ord")))),
       Nil,
       tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
     )
@@ -443,7 +442,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
     val tree = Defn.Given(
       Nil,
       anon,
-      List(pparam(Nil, "A", cb = List("Ord"))),
+      List(pparam("A", bounds(cb = List("Ord")))),
       Nil,
       tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
     )
@@ -459,7 +458,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
     val tree = Defn.Given(
       Nil,
       anon,
-      List(pparam(Nil, "A", cb = List("Ord"))),
+      List(pparam("A", bounds(cb = List("Ord")))),
       Nil,
       tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
     )
@@ -474,7 +473,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
     val tree = Defn.Given(
       Nil,
       tname("ord"),
-      List(pparam(Nil, "A", cb = List("Ord"))),
+      List(pparam("A", bounds(cb = List("Ord")))),
       Nil,
       tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
     )
@@ -490,7 +489,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
     val tree = Defn.Given(
       Nil,
       tname("ord"),
-      List(pparam(Nil, "A", cb = List("Ord"))),
+      List(pparam("A", bounds(cb = List("Ord")))),
       Nil,
       tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
     )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InterleavedDefnSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InterleavedDefnSuite.scala
@@ -20,7 +20,7 @@ class InterleavedDefnSuite extends BaseDottySuite {
 
   test("def x[A: B] = 2") {
     checkTree(templStat("def x[A: B] = 2")) {
-      Defn.Def(Nil, tname("x"), pparam(Nil, "A", cb = pname("B") :: Nil) :: Nil, Nil, None, int(2))
+      Defn.Def(Nil, tname("x"), List(pparam("A", bounds(cb = List(pname("B"))))), Nil, None, int(2))
     }
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -171,13 +171,10 @@ class MinorDottySuite extends BaseDottySuite {
   }
 
   test("trait-parameters-context-bounds") {
-    runTestAssert[Stat]("trait Foo[T: Eq]")(Defn.Trait(
-      Nil,
-      pname("Foo"),
-      List(pparam(Nil, "T", vb = Nil, cb = List(pname("Eq")))),
-      ctor,
-      tplNoBody()
-    ))
+    runTestAssert[Stat]("trait Foo[T: Eq]")(
+      Defn
+        .Trait(Nil, pname("Foo"), List(pparam("T", bounds(cb = List(pname("Eq"))))), ctor, tplNoBody())
+    )
   }
 
   test("class-parameters-using") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NewFunctionsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NewFunctionsSuite.scala
@@ -452,10 +452,12 @@ class NewFunctionsSuite extends BaseDottySuite {
           Nil,
           "F",
           List(pparam("_")),
-          cb = List(Type.Lambda(
-            List(pparam(Nil, "G", List(pparam("_")))),
-            papply("MonadCancel", "G", "Throwable")
-          ))
+          bounds(cb =
+            List(Type.Lambda(
+              List(pparam(Nil, "G", List(pparam("_")))),
+              papply("MonadCancel", "G", "Throwable")
+            ))
+          )
         )),
         ctor,
         tplNoBody()

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
@@ -701,20 +701,37 @@ class TypeSuite extends BaseDottySuite {
     val code = """|trait Foo:
                   |  type Key : cats.Show
                   |""".stripMargin
-    val error = """|<input>:2: error: `;` expected but `:` found
-                   |  type Key : cats.Show
-                   |           ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "trait Foo { type Key: cats.Show }"
+    val tree = Defn.Trait(
+      Nil,
+      pname("Foo"),
+      Nil,
+      ctor,
+      tpl(Decl.Type(Nil, pname("Key"), Nil, bounds(cb = List(pselect("cats", "Show")))))
+    )
+
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("scala36 type member context bounds 2") {
     val code = """|trait Foo:
                   |  type Value : {cats.Show, cats.Traverse}
                   |""".stripMargin
-    val error = """|<input>:2: error: `;` expected but `:` found
-                   |  type Value : {cats.Show, cats.Traverse}
-                   |             ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "trait Foo { type Value: {cats.Show, cats.Traverse} }"
+    val tree = Defn.Trait(
+      Nil,
+      pname("Foo"),
+      Nil,
+      ctor,
+      tpl(Decl.Type(
+        Nil,
+        pname("Value"),
+        Nil,
+        bounds(cb = List(pselect("cats", "Show"), pselect("cats", "Traverse")))
+      ))
+    )
+
+    runTestAssert[Stat](code, layout)(tree)
   }
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
@@ -697,4 +697,24 @@ class TypeSuite extends BaseDottySuite {
     runTestAssert[Stat](code, layout)(tree)
   }
 
+  test("scala36 type member context bounds 1") {
+    val code = """|trait Foo:
+                  |  type Key : cats.Show
+                  |""".stripMargin
+    val error = """|<input>:2: error: `;` expected but `:` found
+                   |  type Key : cats.Show
+                   |           ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("scala36 type member context bounds 2") {
+    val code = """|trait Foo:
+                  |  type Value : {cats.Show, cats.Traverse}
+                  |""".stripMargin
+    val error = """|<input>:2: error: `;` expected but `:` found
+                   |  type Value : {cats.Show, cats.Traverse}
+                   |             ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
 }


### PR DESCRIPTION
Since SIP-64, every case which uses Type.Bounds in existing trees needs to support context bounds (unlike some of the cases which are currently implemented using Type.Param but might not support context bounds). Fixes #4093.