### PR TITLE
SymbolOps: use scala HashMap for caches

### DIFF
--- a/semanticdb/scalac/library/src/main/scala-2.11/scala/meta/internal/scalacp/package.scala
+++ b/semanticdb/scalac/library/src/main/scala-2.11/scala/meta/internal/scalacp/package.scala
@@ -1,0 +1,16 @@
+package scala.meta.internal
+
+import scala.collection.mutable
+
+package object scalacp {
+
+  implicit class ImplicitMap[K, V](private val obj: mutable.Map[K, V]) extends AnyVal {
+    def updateWithRemap(key: K)(remappingFunction: Option[V] => V): V = {
+      val vOldOpt = obj.get(key)
+      val vNew = remappingFunction(vOldOpt)
+      if (!vOldOpt.contains(vNew)) obj.update(key, vNew)
+      vNew
+    }
+  }
+
+}

--- a/semanticdb/scalac/library/src/main/scala-2.12/scala/meta/internal/scalacp/package.scala
+++ b/semanticdb/scalac/library/src/main/scala-2.12/scala/meta/internal/scalacp/package.scala
@@ -1,0 +1,16 @@
+package scala.meta.internal
+
+import scala.collection.mutable
+
+package object scalacp {
+
+  implicit class ImplicitMap[K, V](private val obj: mutable.Map[K, V]) extends AnyVal {
+    def updateWithRemap(key: K)(remappingFunction: Option[V] => V): V = {
+      val vOldOpt = obj.get(key)
+      val vNew = remappingFunction(vOldOpt)
+      if (!vOldOpt.contains(vNew)) obj.update(key, vNew)
+      vNew
+    }
+  }
+
+}

--- a/semanticdb/scalac/library/src/main/scala-2.13/scala/meta/internal/scalacp/package.scala
+++ b/semanticdb/scalac/library/src/main/scala-2.13/scala/meta/internal/scalacp/package.scala
@@ -1,0 +1,12 @@
+package scala.meta.internal
+
+import scala.collection.mutable
+
+package object scalacp {
+
+  implicit class ImplicitMap[K, V](private val obj: mutable.Map[K, V]) extends AnyVal {
+    def updateWithRemap(key: K)(remappingFunction: Option[V] => V): V = obj
+      .updateWith(key)(vOpt => Some(remappingFunction(vOpt))).get
+  }
+
+}

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/scalacp/SymbolOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/scalacp/SymbolOps.scala
@@ -11,23 +11,18 @@ import java.util.HashMap
 import java.util.HashSet
 
 import scala.annotation.tailrec
+import scala.collection.mutable
 import scala.reflect.NameTransformer
 import scala.tools.scalap.scalax.rules.scalasig._
 
 trait SymbolOps {
   _: Scalacp =>
-  lazy val symbolCache = new HashMap[Symbol, String]
+  lazy val symbolCache = new mutable.HashMap[Symbol, String]
   implicit class XtensionSymbolSSymbol(sym: Symbol) {
     def toSemantic: String = {
       def uncached(sym: Symbol): String =
         if (sym.isSemanticdbGlobal) Symbols.Global(sym.owner, sym.descriptor) else freshSymbol()
-      val ssym = symbolCache.get(sym)
-      if (ssym != null) ssym
-      else {
-        val ssym = uncached(sym)
-        symbolCache.put(sym, ssym)
-        ssym
-      }
+      symbolCache.getOrElseUpdate(sym, uncached(sym))
     }
   }
 


### PR DESCRIPTION
Specifically, unlike java version, it provides getOrElseUpdate.