### PR TITLE
TextDocumentOps: traverse function properly

### DIFF
--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
@@ -522,9 +522,12 @@ trait TextDocumentOps {
               case AnnotatedOf(original) => traverse(original)
               case SelfTypeOf(original) => traverse(original)
               case SelectOf(original) => traverse(original)
-              case g.Function(params, body) if params.forall { param =>
-                    param.symbol.isSynthetic || param.name.decoded.startsWith("x$")
-                  } => traverse(body)
+              case gtree: g.Function =>
+                gtree.vparams.foreach { p =>
+                  val skip = p.symbol.isSynthetic || p.name.decoded.startsWith("x$")
+                  if (!skip) traverse(p)
+                }
+                traverse(gtree.body)
               case gtree: g.TypeTree if gtree.original != null => traverse(gtree.original)
               case gtree: g.TypeTreeWithDeferredRefCheck => traverse(gtree.check())
 

--- a/tests-semanticdb/src/test/resources/example/Synthetic_2.13.scala
+++ b/tests-semanticdb/src/test/resources/example/Synthetic_2.13.scala
@@ -42,6 +42,6 @@ class Synthetic/*<=example.Synthetic#*/ {
     a/*<=local11*/ <- scala.concurrent.Future/*=>scala.concurrent.Future.*/.successful/*=>scala.concurrent.Future.successful().*/(1)
     b/*<=local12*/ <- scala.concurrent.Future/*=>scala.concurrent.Future.*/.successful/*=>scala.concurrent.Future.successful().*/(2)
     if a/*=>local11*/ </*=>scala.Int#`<`(+3).*/ b/*=>local12*/
-  } yield a/*=>local13*/
+  } yield a/*=>local11*/
 
 }

--- a/tests-semanticdb/src/test/resources/metac.expect_2.13
+++ b/tests-semanticdb/src/test/resources/metac.expect_2.13
@@ -4207,7 +4207,7 @@ Occurrences:
 [43:7..43:8): a => local11
 [43:9..43:10): < => scala/Int#`<`(+3).
 [43:11..43:12): b => local12
-[44:10..44:11): a => local13
+[44:10..44:11): a => local11
 
 Synthetics:
 [3:2..3:6): List => *.apply[Int]

--- a/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/OccurrenceSuite.scala
+++ b/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/OccurrenceSuite.scala
@@ -20,12 +20,8 @@ import munit.FunSuite
 
 class OccurrenceSuite extends FunSuite {
 
-  private def testBody(body: OccurrenceSuite.TestBody): Unit = {
-    val expectedCompat =
-      if (ScalaVersion.atLeast213_15) body.expected
-      else body.expected.replace("  } yield a/*=>local13*/", "  } yield a/*=>local11*/")
-    assertNoDiff(body.obtained, expectedCompat)
-  }
+  private def testBody(body: OccurrenceSuite.TestBody): Unit =
+    assertNoDiff(body.obtained, body.expected)
 
   ScalaVersion.doIf("OccurrenceSuite", ScalaVersion.is212 || ScalaVersion.is213) {
     OccurrenceSuite.testCases.foreach(t => test(t.name)(t.body.fold(fail(_), testBody)))


### PR DESCRIPTION
In a recent version of compiler, it uses incorrect position values for anonymous functions which leads to incorrect symbol matching for that function instead of its body.

Hence, make sure we don't allow the function to get to the fallback case in the match and explicitly traverse parameters and body separately.

Fixes #3975.