### PR TITLE
ScalametaParser: support named tuples in extractor patterns

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2820,6 +2820,11 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
   }
 
   /* In addition to above named tuple patterns are allowed*/
+  object seqOKWithNamed extends SeqContextSensitive {
+    val isSequenceOK = true
+    override val isNamedTupleOk: Boolean = true
+  }
+
   object noSeqWithNamed extends SeqContextSensitive {
     val isSequenceOK = false
     override def isNamedTupleOk: Boolean = true
@@ -2846,7 +2851,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
   def entrypointPattern(): Pat = seqOK.entrypointPattern()
   def unquotePattern(): Pat = noSeq.unquotePattern()
   def unquoteSeqPattern(): Pat = seqOK.unquotePattern()
-  def seqPatterns(): List[Pat] = seqOK.patterns()
+  def seqPatterns(): List[Pat] = seqOKWithNamed.patterns()
   def argumentPattern(): Pat = seqOK.pattern()
   def argumentPatterns(): List[Pat] = inParens(if (at[RightParen]) Nil else seqPatterns())
   def xmlLiteralPattern(): Pat = syntaxError("XML literals are not supported", at = currToken)

--- a/tests/shared/src/test/scala-2/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/tests/shared/src/test/scala-2/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -2358,4 +2358,11 @@ class SuccessSuite extends TreeSuiteBase {
     assertOriginType(fOfX, classOf[Origin.DialectOnly])
   }
 
+  test("extract pattern with named fields") {
+    val q"Foo(name = $name, id = $id)" = q"""Foo(name = "123", id = 456)"""
+    assertTrees(name, id)(lit("123"), lit(456))
+    assertWithOriginalSyntax(name, "\"123\"", "\"123\"")
+    assertWithOriginalSyntax(id, "456", "456")
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
@@ -185,6 +185,7 @@ trait CommonTrees extends CommonTrees.LowPriorityDefinitions {
 
   final def patinfix(lt: Pat, op: String, rt: Pat*): Pat.ExtractInfix = Pat
     .ExtractInfix(lt, tname(op), rt.toList)
+  final def patextract(fun: Term, args: Pat*) = Pat.Extract(fun, args.toList)
   final val patwildcard = Pat.Wildcard()
 
   final val noBounds = Type.Bounds.empty

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NamedTuplesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NamedTuplesSuite.scala
@@ -116,4 +116,48 @@ class NamedTuplesSuite extends BaseDottySuite {
       )
     ))
   }
+
+  test("extractor with named fields: all") {
+    val code = """|a match {
+                  |  case Foo(name = nme, id = 123) =>
+                  |}
+                  |""".stripMargin
+    val error = """|<input>:2: error: `)` expected but `=` found
+                   |  case Foo(name = nme, id = 123) =>
+                   |                ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("extractor with named fields: some, with varargs") {
+    val code = """|a match {
+                  |  case Foo(x = y, z, rest*) =>
+                  |}
+                  |""".stripMargin
+    val error = """|<input>:2: error: `)` expected but `=` found
+                   |  case Foo(x = y, z, rest*) =>
+                   |             ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("extractor with named fields: assignment") {
+    val code = """val Foo(name = name, id = id) = Foo(name = "123", id = 456)"""
+    val error = """|<input>:1: error: `)` expected but `=` found
+                   |val Foo(name = name, id = id) = Foo(name = "123", id = 456)
+                   |             ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("extractor with named fields: case clause only") {
+    val code = """case (a = 123, b = (c = "123", d = 123)) =>"""
+    val tree = Case(
+      Pat.Tuple(List(
+        Pat.Assign("a", lit(123)),
+        Pat.Assign("b", Pat.Tuple(List(Pat.Assign("c", lit("123")), Pat.Assign("d", lit(123)))))
+      )),
+      None,
+      blk()
+    )
+    runTestAssert[Case](code)(tree)
+  }
+
 }


### PR DESCRIPTION
This PR adds support for named patterns in extractor patterns (e.g. when matching case classes).