### PR TITLE
Refactor: simplify Metadata.registry annotation

### DIFF
--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/Reflection.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/Reflection.scala
@@ -35,7 +35,7 @@ trait Reflection extends AdtReflection {
   private lazy val scalaMetaRegistry: Map[Symbol, List[Symbol]] =
     AllModule.initialize.annotations match {
       case List(ann) if ann.tree.tpe =:= RegistryAnnotation.toType =>
-        val q"new $_($_.$_[..$_](..${astPaths: List[String]}))" = ann.tree
+        val q"new $_(..${astPaths: List[String]})" = ann.tree
         val astClasses = astPaths.map { astPath =>
           @tailrec
           def locateModule(root: ModuleSymbol, parts: List[String]): ModuleSymbol = parts match {

--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/metadata.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/metadata.scala
@@ -20,5 +20,5 @@ object Metadata {
   class astField extends StaticAnnotation
   @getter
   class auxiliary extends StaticAnnotation
-  class registry(paths: List[String]) extends StaticAnnotation
+  class registry(paths: String*) extends StaticAnnotation
 }

--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/registry.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/registry.scala
@@ -29,7 +29,7 @@ class RegistryMacros(val c: Context) extends AstReflection with MacroHelpers {
       ) = mdef
       val enclosingUnit = c.asInstanceOf[{ def enclosingUnit: { def body: Tree } }].enclosingUnit
         .body
-      val anns1 = anns :+ q"new $AstMetadataModule.registry(${enclosingUnit.detectAst})"
+      val anns1 = anns :+ q"new $AstMetadataModule.registry(..${enclosingUnit.detectAst})"
       ModuleDef(Modifiers(flags, privateWithin, anns1), name, Template(parents, self, stats))
     }
   })


### PR DESCRIPTION
We replace the List with varargs, so that we do not have to "unapply" the List apply signature in the quasiquote when reading the registry in a macro. 