### PR TITLE
Trees: move viewbounds into Type.Bounds as well

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -698,7 +698,9 @@ object Type {
       lo: Option[Type],
       hi: Option[Type],
       @newField("4.12.3")
-      context: List[sm.Type] = Nil
+      context: List[sm.Type] = Nil,
+      @newField("4.12.3")
+      view: List[Type] = Nil
   ) extends Tree
   object Bounds {
     val empty: Bounds = Bounds(None, None)
@@ -760,8 +762,8 @@ object Type {
   }
 
   object ParamBoundsCtor {
-    def apply(tbounds: Bounds, cbounds: List[Type]): Bounds = tbounds
-      .copy(context = tbounds.context ++ cbounds)
+    def apply(tbounds: Bounds, vbounds: List[Type], cbounds: List[Type]): Bounds = tbounds
+      .copy(context = tbounds.context ++ cbounds, view = tbounds.view ++ vbounds)
   }
 
   @ast
@@ -770,14 +772,15 @@ object Type {
       name: meta.Name,
       tparamClause: ParamClause,
       @replacesFields("4.12.3", ParamBoundsCtor)
-      bounds: Bounds,
-      vbounds: List[Type]
+      bounds: Bounds
   ) extends Member.Param with Tree.WithTParamClause {
     @replacedField("4.6.0")
     final def tparams: List[Param] = tparamClause.values
 
     @replacedField("4.12.3", pos = 3)
     final def tbounds: Type.Bounds = bounds
+    @replacedField("4.12.3", pos = 4)
+    final def vbounds: List[Type] = bounds.view
     @replacedField("4.12.3", pos = 5)
     final def cbounds: List[Type] = bounds.context
   }

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
@@ -148,7 +148,7 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
        |Type.ParamClause [A <% B[A]]
        |Type.Param A <% B[A]
        |Type.ParamClause def f[A @@<% B[A]]: C
-       |Type.Bounds def f[A @@<% B[A]]: C
+       |Type.Bounds <% B[A]
        |Type.Apply B[A]
        |Type.ArgClause [A]
        |""".stripMargin

--- a/tests/shared/src/test/scala-2/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/tests/shared/src/test/scala-2/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -1723,8 +1723,12 @@ class SuccessSuite extends TreeSuiteBase {
       List(Mod.Covariant()),
       "Z",
       List(pparam("Q"), pparam("W")),
-      bounds("E", "R", List(Type.With(pname("U"), pname("I")))),
-      List(Type.With(pname("T"), pname("Y")))
+      bounds(
+        "E",
+        "R",
+        cb = List(Type.With(pname("U"), pname("I"))),
+        vb = List(Type.With(pname("T"), pname("Y")))
+      )
     ))
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
@@ -140,15 +140,14 @@ trait CommonTrees extends CommonTrees.LowPriorityDefinitions {
       mods: List[Mod],
       s: String,
       params: List[Type.Param] = Nil,
-      bounds: Type.Bounds = noBounds,
-      vb: List[Type] = Nil
+      bounds: Type.Bounds = noBounds
   ): Type.Param = {
     val nameTree = s match {
       case "" => anon
       case "_" => phName
       case _ => pname(s)
     }
-    Type.Param(mods, nameTree, params, bounds, vb)
+    Type.Param(mods, nameTree, params, bounds)
   }
 
   final def pinfix(lt: Type, op: String, rt: Type): Type.ApplyInfix = Type.ApplyInfix(lt, op, rt)
@@ -191,8 +190,12 @@ trait CommonTrees extends CommonTrees.LowPriorityDefinitions {
   final val noBounds = Type.Bounds.empty
   final def loBound(bound: Type): Type.Bounds = Type.Bounds(Some(bound), None)
   final def hiBound(bound: Type): Type.Bounds = Type.Bounds(None, Some(bound))
-  final def bounds(lo: Type = null, hi: Type = null, cb: List[Type] = Nil): Type.Bounds = Type
-    .Bounds(Option(lo), Option(hi), cb)
+  final def bounds(
+      lo: Type = null,
+      hi: Type = null,
+      cb: List[Type] = Nil,
+      vb: List[Type] = Nil
+  ): Type.Bounds = Type.Bounds(Option(lo), Option(hi), cb, vb)
 
   final def pwildcard(bounds: Type.Bounds): Type.Wildcard = Type.Wildcard(bounds)
   final val pwildcard: Type.Wildcard = pwildcard(noBounds)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
@@ -91,7 +91,7 @@ class DefnSuite extends ParseSuite {
 
   test("def x[A <% B] = 2") {
     assertTree(templStat("def x[A <% B] = 2")) {
-      Defn.Def(Nil, tname("x"), pparam(Nil, "A", vb = pname("B") :: Nil) :: Nil, Nil, None, int(2))
+      Defn.Def(Nil, tname("x"), List(pparam("A", bounds(vb = pname("B") :: Nil))), Nil, None, int(2))
     }
   }
 


### PR DESCRIPTION
Pretending to have them outside, within Type.Param, was leading to an inconsistency in positions, where Type.Bounds would have viewbounds within its limits but in a parent tree.