### PR TITLE
ScalametaParser: PolyFunction is not a simple expr

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
@@ -398,4 +398,31 @@ class DefnSuite extends ParseSuite {
     runTestAssert[Stat](code, layout)(tree)
   }
 
+  test("#4147 func") {
+    val code = """|def a: Int = c { D => e =>
+                  |  def f = e
+                  |
+                  |  f
+                  |}
+                  |""".stripMargin
+    val layout = """|def a: Int = c {
+                    |  D => e => {
+                    |    def f = e
+                    |    f
+                    |  }
+                    |}
+                    |""".stripMargin
+    val tree = Defn.Def(
+      Nil,
+      "a",
+      Nil,
+      Some("Int"),
+      tapply(
+        "c",
+        blk(tfunc(tparam("D"))(tfunc(tparam("e"))(blk(Defn.Def(Nil, "f", Nil, None, "e"), "f"))))
+      )
+    )
+    runTestAssert[Stat](code, layout)(tree)
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -2921,10 +2921,24 @@ class SignificantIndentationSuite extends BaseDottySuite {
                   |  f
                   |}
                   |""".stripMargin
-    val error = """|<input>:2: error: illegal start of simple expression
-                   |  def f = e
-                   |  ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = """|def a: Int = c {
+                    |  [D] => e => {
+                    |    def f = e
+                    |    f
+                    |  }
+                    |}
+                    |""".stripMargin
+    val tree = Defn.Def(
+      Nil,
+      "a",
+      Nil,
+      Some("Int"),
+      tapply(
+        "c",
+        blk(tpolyfunc(pparam("D"))(tfunc(tparam("e"))(blk(Defn.Def(Nil, "f", Nil, None, "e"), "f"))))
+      )
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
 }


### PR DESCRIPTION
See https://dotty.epfl.ch/docs/reference/syntax.html#expressions-2. Fixes #4147.