### PR TITLE
Semanticdb: fix direct reliance on URLClassLoader

### DIFF
--- a/semanticdb/metac/src/main/scala/scala/meta/internal/metac/Main.scala
+++ b/semanticdb/metac/src/main/scala/scala/meta/internal/metac/Main.scala
@@ -1,11 +1,11 @@
 package scala.meta.internal.metac
 
 import scala.meta.cli._
+import scala.meta.internal.classpath.ClasspathUtils
 import scala.meta.internal.semanticdb.scalac._
 import scala.meta.metac._
 
 import java.io._
-import java.net._
 import java.nio.channels._
 import java.nio.file._
 
@@ -21,8 +21,7 @@ class Main(settings: Settings, reporter: Reporter) {
     manifestStream.close()
     val pluginClasspath = classOf[SemanticdbPlugin].getClassLoader match {
       case null => manifestDir.toString
-      case cl: URLClassLoader => cl.getURLs.map(_.getFile).mkString(File.pathSeparator)
-      case cl => sys.error(s"unsupported classloader: $cl")
+      case cl => ClasspathUtils.getClassPathEntries(cl).mkString(File.pathSeparator)
     }
     val enablePluginArgs = List("-Xplugin:" + pluginClasspath, "-Xplugin-require:semanticdb")
     val enableRangeposArgs = List("-Yrangepos")

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/interactive/InteractiveSemanticdb.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/interactive/InteractiveSemanticdb.scala
@@ -1,12 +1,10 @@
 package scala.meta.interactive
 
+import scala.meta.internal.classpath.ClasspathUtils
 import scala.meta.internal.semanticdb.scalac._
 import scala.meta.internal.{semanticdb => s}
-import scala.meta.io.AbsolutePath
 
 import java.io.File
-import java.net.URLClassLoader
-import java.nio.file.Files
 
 import scala.reflect.io.VirtualDirectory
 import scala.tools.nsc.Settings
@@ -110,10 +108,8 @@ object InteractiveSemanticdb extends VersionCompilerOps {
     richUnit
   }
 
-  private def thisClasspath: String = this.getClass.getClassLoader match {
-    case url: URLClassLoader => url.getURLs.map(_.toURI.getPath).mkString(File.pathSeparator)
-    case els => throw new IllegalStateException(s"Expected URLClassloader, got $els")
-  }
+  private def thisClasspath: String = ClasspathUtils
+    .getClassPathEntries(this.getClass.getClassLoader).mkString(File.pathSeparator)
 
   private def ask[A](f: Response[A] => Unit): Response[A] = {
     val r = new Response[A]

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/classpath/ClasspathUtils.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/classpath/ClasspathUtils.scala
@@ -1,0 +1,21 @@
+package scala.meta.internal.classpath
+
+import java.io.File
+import java.net.URLClassLoader
+import java.nio.file.Path
+import java.nio.file.Paths
+
+object ClasspathUtils {
+
+  def getDefaultClassPathEntries: Seq[Path] = System.getProperty("java.class.path")
+    .split(File.pathSeparator).map(x => Paths.get(x))
+
+  def getClassPathEntriesOpt(cl: ClassLoader): Option[Seq[Path]] = cl match {
+    case cl: URLClassLoader => Some(cl.getURLs.map(x => Paths.get(x.toURI)))
+    case _ => None
+  }
+
+  def getClassPathEntries(cl: ClassLoader): Seq[Path] = getClassPathEntriesOpt(cl)
+    .getOrElse(getDefaultClassPathEntries)
+
+}

--- a/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/MetacScalaLibrary.scala
+++ b/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/MetacScalaLibrary.scala
@@ -1,13 +1,13 @@
 package scala.meta.tests.semanticdb
 
 import scala.meta.cli._
+import scala.meta.internal.classpath.ClasspathUtils
 import scala.meta.internal.io.FileIO
 import scala.meta.io.AbsolutePath
 import scala.meta.metac._
 import scala.meta.tests.BuildInfo
 
 import java.io.File
-import java.net.URLClassLoader
 import java.nio.file.Files
 import java.nio.file.Paths
 
@@ -41,7 +41,7 @@ object MetacScalaLibrary {
       Files.isDirectory(library),
       s"$library is not a directory! Run `sbt download-scala-library`"
     )
-    val classpath = this.getClass.getClassLoader.asInstanceOf[URLClassLoader].getURLs.map(_.getPath)
+    val classpath = ClasspathUtils.getClassPathEntries(this.getClass.getClassLoader).map(_.toString)
       .filter(_.contains("scala-library")).mkString(File.pathSeparator)
     val files = FileIO.listAllFilesRecursively(AbsolutePath(library)).map(_.toString)
       .filter(_.endsWith("scala"))

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/testkit/ScalacParser.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/testkit/ScalacParser.scala
@@ -1,6 +1,7 @@
 package scala.meta.tests.testkit
 
 import java.io.File
+import java.net.URLClassLoader
 
 import scala.collection.mutable
 import scala.reflect.internal.util.CodeAction
@@ -15,11 +16,13 @@ object ScalacParser {
   var current: ClassLoader = Thread.currentThread().getContextClassLoader
   val files: mutable.Buffer[File] = collection.mutable.Buffer.empty[java.io.File]
   val settings = new Settings()
-  files.appendAll(System.getProperty("sun.boot.class.path").split(":").map(new java.io.File(_)))
+  Seq("sun.boot.class.path", "java.class.path").foreach { prop =>
+    System.getProperty(prop).split(File.pathSeparator)
+      .foreach(entry => files.append(new File(entry)))
+  }
   while (current != null) {
     current match {
-      case t: java.net.URLClassLoader => files
-          .appendAll(t.getURLs.map(u => new java.io.File(u.toURI)))
+      case t: URLClassLoader => t.getURLs.foreach(u => files.append(new File(u.toURI)))
       case _ =>
     }
     current = current.getParent


### PR DESCRIPTION
In Java 11, URLClassLoader is no longer used, and the only documented simple solution is to use `java.class.path` system property. Possibly fixes #1985.