### PR TITLE
ScannerTokens: no fewer braces within ParamClause

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -819,7 +819,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
                  *   - after fewer-braces method call: will apply if not handled otherwise
                  */
                 def couldBeFewerBraces(): Boolean = dialect.allowFewerBraces &&
-                  !sepRegions.contains(RegionDefMark) && getPrevToken(prevPos)
+                  !sepRegions.exists(_.isInstanceOf[RegionHasParamMark]) && getPrevToken(prevPos)
                     .isAny[Ident, CloseDelim]
                 sepRegions match {
                   case (_: RegionTemplateDecl) :: rs =>

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SepRegion.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SepRegion.scala
@@ -37,9 +37,11 @@ final class RegionCaseExpr(override val indent: Int) extends SepRegionNonIndente
 final class RegionCaseBody(override val indent: Int, val arrow: Token)
     extends SepRegionNonIndented with CanProduceLF
 
+sealed trait RegionHasParamMark extends RegionNonDelimNonIndented
+
 sealed trait RegionDefDecl extends RegionNonDelimNonIndented
 // initial mark of a definition (before colon)
-case object RegionDefMark extends RegionDefDecl
+case object RegionDefMark extends RegionDefDecl with RegionHasParamMark
 // the type part of a definition (between colon and optional equals)
 case object RegionDefType extends RegionDefDecl
 
@@ -47,13 +49,13 @@ case object RegionDefType extends RegionDefDecl
 sealed trait RegionTemplateDecl extends RegionNonDelimNonIndented
 
 /** the initial part of declaration, before the template */
-case object RegionTemplateMark extends RegionTemplateDecl with CanProduceLF
+case object RegionTemplateMark extends RegionTemplateDecl with RegionHasParamMark with CanProduceLF
 
 /** the initial part of the template, containing any inherit clauses */
 case object RegionTemplateInherit extends RegionTemplateDecl
 
 // the initial part of a given declaration or definition, before `=` or template
-final class RegionGivenDecl(val kw: Token) extends RegionNonDelimNonIndented with CanProduceLF
+final class RegionGivenDecl(val kw: Token) extends RegionHasParamMark with CanProduceLF
 
 /**
  * this marks the template body (or constructs which look like a template body, such as extensions).
@@ -63,7 +65,7 @@ final class RegionGivenDecl(val kw: Token) extends RegionNonDelimNonIndented wit
 case object RegionTemplateBody extends RegionNonDelimNonIndented
 
 /** this marks the initial part of extension */
-case object RegionExtensionMark extends RegionNonDelimNonIndented
+case object RegionExtensionMark extends RegionHasParamMark
 
 /**
  * All control statements

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -812,7 +812,7 @@ object TreeSyntax {
         s(w(t.mods, " "), kw("def "), t.name, t.paramClauseGroups, kw(": "), t.decltpe)
       case t: Decl.Given =>
         val sig = givenSig(t.name, t.paramClauseGroups)
-        r(" ")(t.mods, sig, p(AnnotTyp, t.decltpe))
+        r(" ")(t.mods, sig, givenDeclTpe(t.decltpe))
       case t: Defn.Val =>
         s(w(t.mods, " "), kw("val"), " ", r(t.pats, ", "), t.decltpe, " ", kw("="), " ", t.rhs)
       case t: Defn.Var =>
@@ -846,7 +846,7 @@ object TreeSyntax {
 
       case t: Defn.GivenAlias =>
         val sig = givenSig(t.name, t.paramClauseGroups)
-        r(" ")(t.mods, sig, p(AnnotTyp, t.decltpe), kw("="), t.body)
+        r(" ")(t.mods, sig, givenDeclTpe(t.decltpe), kw("="), t.body)
       case t: Defn.Given =>
         val sig = givenSig(t.name, t.paramClauseGroups)
         r(" ")(t.mods, sig, t.templ)
@@ -1029,6 +1029,11 @@ object TreeSyntax {
       def oldSyntax = s(kwGiven, w(" ", s(name, o(pcgs.headOption)), ":"))
       def newSyntax = r(" ")(kwGiven, w(name, ":"), r(pcgs.map(givenCond)))
       s(if (useNewSyntax) newSyntax else oldSyntax)
+    }
+
+    private def givenDeclTpe(decltpe: Type): Show.Result = decltpe match {
+      case _: Type.TypedParam => w("(", decltpe, ")")
+      case _ => p(AnnotTyp, decltpe)
     }
 
     // Multiples and optionals

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
@@ -2079,4 +2079,65 @@ class FewerBracesSuite extends BaseDottySuite {
     runTestAssert[Stat](code, layout)(tree)
   }
 
+  test("#4152 not fewer braces: class") {
+    val code = """|class A(b:
+                  |        Int)
+                  |""".stripMargin
+    val error = """|<input>:1: error: `identifier` expected but `indent` found
+                   |class A(b:
+                   |          ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("#4152 not fewer braces: extension 1") {
+    val code = """|extension (b:
+                  |        Int)
+                  |  def foo = b
+                  |""".stripMargin
+    val error = """|<input>:1: error: `identifier` expected but `indent` found
+                   |extension (b:
+                   |             ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("#4152 not fewer braces: extension with type params") {
+    val code = """|extension [B:
+                  |        Seq](b:
+                  |        Int)
+                  |  def foo = b
+                  |""".stripMargin
+    val error = """|<input>:1: error: `identifier` expected but `indent` found
+                   |extension [B:
+                   |             ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("#4152 not fewer braces: given") {
+    val code = """|given (b:
+                  |        Int) = b
+                  |""".stripMargin
+    val error = """|<input>:1: error: `identifier` expected but `indent` found
+                   |given (b:
+                   |         ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("#4152 not fewer braces: def") {
+    val code = """|def A(b:
+                  |        Int) = ???
+                  |""".stripMargin
+    val layout = "def A(b: Int) = ???"
+    val tree = Defn.Def(Nil, "A", Nil, List(List(tparam("b", "Int"))), None, "???")
+    runTestAssert[Stat](code, layout)(tree)
+  }
+
+  test("#4152 not fewer braces: type") {
+    val code = """|def A[B:
+                  |        Seq] = ???
+                  |""".stripMargin
+    val layout = "def A[B: Seq] = ???"
+    val tree = Defn.Def(Nil, "A", List(pparam("B", bounds(cb = List("Seq")))), Nil, None, "???")
+    runTestAssert[Stat](code, layout)(tree)
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
@@ -2083,10 +2083,9 @@ class FewerBracesSuite extends BaseDottySuite {
     val code = """|class A(b:
                   |        Int)
                   |""".stripMargin
-    val error = """|<input>:1: error: `identifier` expected but `indent` found
-                   |class A(b:
-                   |          ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "class A(b: Int)"
+    val tree = Defn.Class(Nil, pname("A"), Nil, ctorp(tparam("b", "Int")), tplNoBody())
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("#4152 not fewer braces: extension 1") {
@@ -2094,10 +2093,10 @@ class FewerBracesSuite extends BaseDottySuite {
                   |        Int)
                   |  def foo = b
                   |""".stripMargin
-    val error = """|<input>:1: error: `identifier` expected but `indent` found
-                   |extension (b:
-                   |             ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "extension (b: Int) def foo = b"
+    val tree = Defn
+      .ExtensionGroup(Nil, List(List(tparam("b", "Int"))), Defn.Def(Nil, "foo", Nil, None, "b"))
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("#4152 not fewer braces: extension with type params") {
@@ -2106,20 +2105,22 @@ class FewerBracesSuite extends BaseDottySuite {
                   |        Int)
                   |  def foo = b
                   |""".stripMargin
-    val error = """|<input>:1: error: `identifier` expected but `indent` found
-                   |extension [B:
-                   |             ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "extension [B: Seq](b: Int) def foo = b"
+    val tree = Defn.ExtensionGroup(
+      List(pparam("B", bounds(cb = List("Seq")))),
+      List(List(tparam("b", "Int"))),
+      Defn.Def(Nil, "foo", Nil, None, "b")
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("#4152 not fewer braces: given") {
     val code = """|given (b:
                   |        Int) = b
                   |""".stripMargin
-    val error = """|<input>:1: error: `identifier` expected but `indent` found
-                   |given (b:
-                   |         ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "given (b: Int) = b"
+    val tree = Defn.GivenAlias(Nil, "", Nil, Type.TypedParam("b", "Int", Nil), "b")
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("#4152 not fewer braces: def") {


### PR DESCRIPTION
Whether within Def, Extension, Given or Class. Fixes #4152.