### PR TITLE
munit: finish upgrade to v1.1.0, use DiffOptions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -417,15 +417,11 @@ lazy val testsSemanticdb = project.in(file("tests-semanticdb")).settings(
 
 lazy val munitSettings = Def.settings(
   testFrameworks := List(new TestFramework("munit.Framework")),
+  dependencyOverrides ++= {
+    if (isScala3.value) Nil else Seq("org.scala-lang" % "scala-library" % scalaVersion.value)
+  },
   libraryDependencies += {
-    // TODO: this is getting ridiculous; any way to fix dependency on munit's
-    // scala version upgrades, specifically for 2.13 (and not 2.12 or earlier)?
-    val munitV =
-      if (isScala211.value) "0.7.29"
-      else if (scalaVersion.value == "2.13.13") "1.0.0"
-      else if (scalaVersion.value == "2.13.14") "1.0.2"
-      else if (scalaVersion.value == "2.13.15") "1.0.4"
-      else munit.sbtmunit.BuildInfo.munitVersion
+    val munitV = if (isScala211.value) "1.0.0-M10" else munit.sbtmunit.BuildInfo.munitVersion
     "org.scalameta" %%% "munit" % munitV
   }
 )

--- a/tests-semanticdb/src/test/scala-2.12/scala/meta/tests/package.scala
+++ b/tests-semanticdb/src/test/scala-2.12/scala/meta/tests/package.scala
@@ -1,0 +1,8 @@
+package scala.meta
+
+import munit.diff.DiffOptions
+
+package object tests {
+  implicit val diffOptions: DiffOptions = DiffOptions.withShowLines(true).withContextSize(10)
+    .withObtainedAsStripMargin(false)
+}

--- a/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/package.scala
+++ b/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/package.scala
@@ -1,0 +1,8 @@
+package scala.meta
+
+import munit.diff.DiffOptions
+
+package object tests {
+  implicit val diffOptions: DiffOptions = DiffOptions.withShowLines(true).withContextSize(10)
+    .withObtainedAsStripMargin(false)
+}

--- a/tests/shared/src/test/scala-2.12/scala/meta/tests/package.scala
+++ b/tests/shared/src/test/scala-2.12/scala/meta/tests/package.scala
@@ -1,0 +1,8 @@
+package scala.meta
+
+import munit.diff.DiffOptions
+
+package object tests {
+  implicit val diffOptions: DiffOptions = DiffOptions.withShowLines(true).withContextSize(10)
+    .withObtainedAsStripMargin(false)
+}

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/package.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/package.scala
@@ -1,0 +1,8 @@
+package scala.meta
+
+import munit.diff.DiffOptions
+
+package object tests {
+  implicit val diffOptions: DiffOptions = DiffOptions.withShowLines(true).withContextSize(10)
+    .withObtainedAsStripMargin(false)
+}


### PR DESCRIPTION
Use dependencyOverrides to avoid pulling in a conflicting version of scala-library from the munit package.