### PR TITLE
TextDocumentOps: handle only for-apply w/ implicit

### DIFF
--- a/tests-semanticdb/src/test/scala-2.12/scala/meta/tests/semanticdb/PrintSuite.scala
+++ b/tests-semanticdb/src/test/scala-2.12/scala/meta/tests/semanticdb/PrintSuite.scala
@@ -48,6 +48,7 @@ class PrintSuite extends PrintSuiteBase {
        |}
        |""".stripMargin,
     """|[4:4..4:9): xs.to => *(List.canBuildFrom[Int])
+       |[4:4..4:9): xs.to => *[List]
        |""".stripMargin
   )
 

--- a/tests-semanticdb/src/test/scala-2.12/scala/meta/tests/semanticdb/PrintSuite.scala
+++ b/tests-semanticdb/src/test/scala-2.12/scala/meta/tests/semanticdb/PrintSuite.scala
@@ -40,4 +40,15 @@ class PrintSuite extends PrintSuiteBase {
        |orig(List).apply[Int]
        |""".stripMargin
   )
+
+  checkSynthetics(
+    """|object LegacySyntheticsTest {
+       |  def m1(xs: Set[Int]): List[Int] =
+       |    xs.to
+       |}
+       |""".stripMargin,
+    """|[4:4..4:9): xs.to => *(List.canBuildFrom[Int])
+       |""".stripMargin
+  )
+
 }


### PR DESCRIPTION
Previously, we'd cache that TypeApply, which is not handled for `for` comprehensions, would not have a synthetic, vs not used with for-comp.

Helps with scalacenter/scalafix#2175.