### PR TITLE
ScaladocParser: fix stripping space around EOL

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
@@ -306,14 +306,16 @@ object ScaladocParser {
   private val ws = "[ \r\t]"
   private val scaladocDelim = Pattern.compile(s"$ws*(?:$$|\n$ws*\\**)")
 
+  /** removes all trailing space, ensures newline at EOF */
+  private[meta] def stripTrailingSpaces(content: CharSequence): String = scaladocDelim
+    .matcher(content).replaceAll("\n")
+
   /** Parses a scaladoc comment */
   def parse(comment: String): Option[Scaladoc] = {
     val isScaladoc = comment.length >= 5 && comment.startsWith("/**") && comment.endsWith("*/")
     if (!isScaladoc) None
     else {
-      val content = CharBuffer.wrap(comment, 3, comment.length - 2)
-      // removes all trailing space, ensures newline at EOF
-      val text = scaladocDelim.matcher(content).replaceAll("\n")
+      val text = stripTrailingSpaces(CharBuffer.wrap(comment, 3, comment.length - 2))
       fastparse.parse(text, parser(_)) match {
         case p: Parsed.Success[Scaladoc] => Some(p.value)
         case _ => None

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
@@ -303,8 +303,7 @@ object ScaladocParser {
     paraSep.? ~ docParser ~ spacesMin(0) ~ End
   }
 
-  private val ws = "[ \r\t]"
-  private val scaladocDelim = Pattern.compile(s"$ws*(?:$$|\n$ws*\\**)")
+  private val scaladocDelim = Pattern.compile("[ \r\t]*(?:\n(?:[ \r\t]*\\*+)?|$)")
 
   /** removes all trailing space, ensures newline at EOF */
   private[meta] def stripTrailingSpaces(content: CharSequence): String = scaladocDelim

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
@@ -1770,6 +1770,22 @@ class ScaladocParserSuite extends FunSuite {
     assertEquals(Table.Center.leftPad(7), 3)
   }
 
+  test("strip trailing space") {
+    // XXX: \u0020 is a space, to make sure it's not removed by the editor
+    val input =
+      s"""|foo  \u0020
+          | \t**bar \r
+          |  baz   \r\t
+          |  *qux""".stripMargin
+    val output =
+      """|foo
+         |bar
+         |baz
+         |qux
+         |""".stripMargin
+    assertEquals(ScaladocParser.stripTrailingSpaces(input), output)
+  }
+
 }
 
 object ScaladocParserSuite {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
@@ -1780,7 +1780,7 @@ class ScaladocParserSuite extends FunSuite {
     val output =
       """|foo
          |bar
-         |baz
+         |  baz
          |qux
          |""".stripMargin
     assertEquals(ScaladocParser.stripTrailingSpaces(input), output)


### PR DESCRIPTION
Currently, we are always stripping leading space, whether or not it precedes the `*` margin character.