### PR TITLE
TextDocumentOps: get pattern occurrences in ValDef

### DIFF
--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SyntheticOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SyntheticOps.scala
@@ -43,6 +43,11 @@ trait SyntheticOps {
     def toRange: s.Range = toMeta.toRange
     def toSemanticOriginal: s.OriginalTree = toRange.toSemanticOriginal
 
+    def hasSyntheticSymbol: Boolean = gTree.symbol match {
+      case s: g.Symbol => s.isSynthetic
+      case _ => false
+    }
+
   }
 
 }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
@@ -444,10 +444,8 @@ trait TextDocumentOps {
                 traverse(t.body)
                 tryFindMtree(t)
               case t: g.ValDef =>
-                t.symbol match {
-                  case x: g.Symbol if x.isSynthetic => traverse(t.tpt); traverse(t.rhs)
-                  case _ =>
-                }
+                if (t.hasSyntheticSymbol) traverse(t.tpt)
+                traverse(t.rhs)
                 processMemberDef(t)
               case t: g.MemberDef => processMemberDef(t)
               case t: g.Ident => t.pos match {

--- a/tests-semanticdb/src/test/resources/example/ValPattern.scala
+++ b/tests-semanticdb/src/test/resources/example/ValPattern.scala
@@ -23,18 +23,18 @@ class ValPattern/*<=example.ValPattern#*/ {
     )
     locally/*=>scala.Predef.locally().*/ {
       val (left/*<=local6*/, right/*<=local7*/) = (1, 2)
-      val Some/*=>scala.Some.*/(number1/*<=local10*/) =
+      val Some/*=>scala.Some.*/(number1/*<=local9*/) =
         Some/*=>scala.Some.*/(1)
 
       var (leftVar/*<=local11*/, rightVar/*<=local12*/) = (1, 2)
-      var Some/*=>scala.Some.*/(number1Var/*<=local15*/) =
+      var Some/*=>scala.Some.*/(number1Var/*<=local14*/) =
         Some/*=>scala.Some.*/(1)
       println/*=>scala.Predef.println(+1).*/(
         (
-          number1/*=>local9*/,
+          number1/*=>local10*/,
           left/*=>local6*/,
           right/*=>local7*/,
-          number1Var/*=>local14*/,
+          number1Var/*=>local15*/,
           leftVar/*=>local11*/,
           rightVar/*=>local12*/
         )

--- a/tests-semanticdb/src/test/resources/example/ValPattern.scala
+++ b/tests-semanticdb/src/test/resources/example/ValPattern.scala
@@ -23,11 +23,11 @@ class ValPattern/*<=example.ValPattern#*/ {
     )
     locally/*=>scala.Predef.locally().*/ {
       val (left/*<=local6*/, right/*<=local7*/) = (1, 2)
-      val Some/*=>scala.Some.*/(number1/*<=local9*/) =
+      val Some/*=>scala.Some.*/(number1/*<=local10*/) =
         Some/*=>scala.Some.*/(1)
 
       var (leftVar/*<=local11*/, rightVar/*<=local12*/) = (1, 2)
-      var Some/*=>scala.Some.*/(number1Var/*<=local14*/) =
+      var Some/*=>scala.Some.*/(number1Var/*<=local15*/) =
         Some/*=>scala.Some.*/(1)
       println/*=>scala.Predef.println(+1).*/(
         (

--- a/tests-semanticdb/src/test/resources/metac.expect_2.12
+++ b/tests-semanticdb/src/test/resources/metac.expect_2.12
@@ -5296,12 +5296,12 @@ Occurrences:
 [24:11..24:15): left <= local6
 [24:17..24:22): right <= local7
 [25:10..25:14): Some => scala/Some.
-[25:15..25:22): number1 <= local9
+[25:15..25:22): number1 <= local10
 [26:8..26:12): Some => scala/Some.
 [28:11..28:18): leftVar <= local11
 [28:20..28:28): rightVar <= local12
 [29:10..29:14): Some => scala/Some.
-[29:15..29:25): number1Var <= local14
+[29:15..29:25): number1Var <= local15
 [30:8..30:12): Some => scala/Some.
 [31:6..31:13): println => scala/Predef.println(+1).
 [33:10..33:17): number1 => local10

--- a/tests-semanticdb/src/test/resources/metac.expect_2.12
+++ b/tests-semanticdb/src/test/resources/metac.expect_2.12
@@ -5264,9 +5264,9 @@ local12 => var local rightVar: Int
 local13 => val local x$4: : Tuple2[Int, Int]
   Tuple2 => scala/Tuple2#
   Int => scala/Int#
-local14 => var local number1Var: Int
+local14 => val local number1Var: Int
   Int => scala/Int#
-local15 => val local number1Var: Int
+local15 => var local number1Var: Int
   Int => scala/Int#
 
 Occurrences:
@@ -5296,18 +5296,18 @@ Occurrences:
 [24:11..24:15): left <= local6
 [24:17..24:22): right <= local7
 [25:10..25:14): Some => scala/Some.
-[25:15..25:22): number1 <= local10
+[25:15..25:22): number1 <= local9
 [26:8..26:12): Some => scala/Some.
 [28:11..28:18): leftVar <= local11
 [28:20..28:28): rightVar <= local12
 [29:10..29:14): Some => scala/Some.
-[29:15..29:25): number1Var <= local15
+[29:15..29:25): number1Var <= local14
 [30:8..30:12): Some => scala/Some.
 [31:6..31:13): println => scala/Predef.println(+1).
-[33:10..33:17): number1 => local9
+[33:10..33:17): number1 => local10
 [34:10..34:14): left => local6
 [35:10..35:15): right => local7
-[36:10..36:20): number1Var => local14
+[36:10..36:20): number1Var => local15
 [37:10..37:17): leftVar => local11
 [38:10..38:18): rightVar => local12
 

--- a/tests-semanticdb/src/test/resources/metac.expect_2.13
+++ b/tests-semanticdb/src/test/resources/metac.expect_2.13
@@ -5536,9 +5536,9 @@ local12 => var local rightVar: Int
 local13 => val local x$4: : Tuple2[Int, Int]
   Tuple2 => scala/Tuple2#
   Int => scala/Int#
-local14 => var local number1Var: Int
+local14 => val local number1Var: Int
   Int => scala/Int#
-local15 => val local number1Var: Int
+local15 => var local number1Var: Int
   Int => scala/Int#
 
 Occurrences:
@@ -5568,18 +5568,18 @@ Occurrences:
 [24:11..24:15): left <= local6
 [24:17..24:22): right <= local7
 [25:10..25:14): Some => scala/Some.
-[25:15..25:22): number1 <= local10
+[25:15..25:22): number1 <= local9
 [26:8..26:12): Some => scala/Some.
 [28:11..28:18): leftVar <= local11
 [28:20..28:28): rightVar <= local12
 [29:10..29:14): Some => scala/Some.
-[29:15..29:25): number1Var <= local15
+[29:15..29:25): number1Var <= local14
 [30:8..30:12): Some => scala/Some.
 [31:6..31:13): println => scala/Predef.println(+1).
-[33:10..33:17): number1 => local9
+[33:10..33:17): number1 => local10
 [34:10..34:14): left => local6
 [35:10..35:15): right => local7
-[36:10..36:20): number1Var => local14
+[36:10..36:20): number1Var => local15
 [37:10..37:17): leftVar => local11
 [38:10..38:18): rightVar => local12
 

--- a/tests-semanticdb/src/test/resources/metac.expect_2.13
+++ b/tests-semanticdb/src/test/resources/metac.expect_2.13
@@ -5568,12 +5568,12 @@ Occurrences:
 [24:11..24:15): left <= local6
 [24:17..24:22): right <= local7
 [25:10..25:14): Some => scala/Some.
-[25:15..25:22): number1 <= local9
+[25:15..25:22): number1 <= local10
 [26:8..26:12): Some => scala/Some.
 [28:11..28:18): leftVar <= local11
 [28:20..28:28): rightVar <= local12
 [29:10..29:14): Some => scala/Some.
-[29:15..29:25): number1Var <= local14
+[29:15..29:25): number1Var <= local15
 [30:8..30:12): Some => scala/Some.
 [31:6..31:13): println => scala/Predef.println(+1).
 [33:10..33:17): number1 => local10


### PR DESCRIPTION
Also, always traverse ValDef rhs first, as it helps with capturing pattern occurrences from LHS since for pattern occurrence conflicts the last one wins. Fixes #4169.