### PR TITLE
ScannerTokens: handle `given` pattern after `case`

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -477,7 +477,8 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
           }
         } else currRef(sepRegions)
       case _: KwEnum => currRef(RegionTemplateMark :: sepRegions)
-      case _: KwGiven if !prevToken.is[Dot] => currRef(new RegionGivenDecl(curr) :: sepRegions)
+      case _: KwGiven if !prevToken.isAny[Dot, KwCase] =>
+        currRef(new RegionGivenDecl(curr) :: sepRegions)
       case _: KwWith => currRef(dropRegionLine(sepRegions) match {
           case (_: RegionGivenDecl) :: rs => rs
           case _ => sepRegions

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
@@ -696,20 +696,23 @@ class GivenUsingSuite extends BaseDottySuite {
       """|object a {
          |  def foo = bar {
          |    case given String =>
-         |      end foo
          |  }
+         |  end foo
          |}
          |""".stripMargin
     val tree = Defn.Object(
       Nil,
       "a",
-      tpl(Defn.Def(
-        Nil,
-        "foo",
-        Nil,
-        None,
-        tapply("bar", Term.PartialFunction(List(Case(Pat.Given("String"), None, Term.EndMarker("foo")))))
-      ))
+      tpl(
+        Defn.Def(
+          Nil,
+          "foo",
+          Nil,
+          None,
+          tapply("bar", Term.PartialFunction(List(Case(Pat.Given("String"), None, blk()))))
+        ),
+        Term.EndMarker("foo")
+      )
     )
     runTestAssert[Stat](code, layout)(tree)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
@@ -684,4 +684,34 @@ class GivenUsingSuite extends BaseDottySuite {
     runTestAssert[Stat](code)(tree)
   }
 
+  test("scalafmt #4764") {
+    val code =
+      """|object a:
+         |  def foo =
+         |    bar:
+         |      case given String =>
+         |  end foo
+         |""".stripMargin
+    val layout =
+      """|object a {
+         |  def foo = bar {
+         |    case given String =>
+         |      end foo
+         |  }
+         |}
+         |""".stripMargin
+    val tree = Defn.Object(
+      Nil,
+      "a",
+      tpl(Defn.Def(
+        Nil,
+        "foo",
+        Nil,
+        None,
+        tapply("bar", Term.PartialFunction(List(Case(Pat.Given("String"), None, Term.EndMarker("foo")))))
+      ))
+    )
+    runTestAssert[Stat](code, layout)(tree)
+  }
+
 }


### PR DESCRIPTION
Helps with scalameta/scalafmt#4764.