### PR TITLE
Revert "SBT: add sbt-sonatype plugin for updated config"

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -27,6 +27,5 @@ addSbtPlugin("org.scala-js"       % "sbt-scalajs"      % "1.18.2")
 addSbtPlugin("org.scala-native"   % "sbt-scala-native" % "0.5.6")
 addSbtPlugin("org.scalameta"      % "sbt-mdoc"         % "2.6.4")
 addSbtPlugin("org.scalameta"      % "sbt-munit"        % "1.1.0")
-addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"     % "3.12.2")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")


### PR DESCRIPTION
Reverts scalameta/scalameta#4193. It's not needed, sbt-ci-release includes it.