### PR TITLE
TreeSyntax: look for brace, not just Term.Block

### DIFF
--- a/scalameta/common/shared/src/main/scala/scala/meta/prettyprinters/Show.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/prettyprinters/Show.scala
@@ -50,34 +50,44 @@ private[meta] object Show {
       sb.toString
     }
     final def isEmpty: Boolean = this eq None
+    def headChar: Option[Char]
   }
 
   final case object None extends Result {
     override def desc: String = "None"
+    def headChar: Option[Char] = Option.empty
   }
   final case class Str(value: String) extends Result {
     override def desc: String = s"Str($value)"
+    def headChar: Option[Char] = value.headOption
   }
   final case class Sequence(xs: Result*) extends Result {
     override def desc: String = s"Sequence(#${xs.length})"
+    def headChar: Option[Char] = xs.view.flatMap(_.headChar).headOption
   }
   final case class Repeat(xs: Seq[Result], sep: String) extends Result {
     override def desc: String = s"Repeat(#${xs.length}, s=$sep)"
+    def headChar: Option[Char] = xs.view.flatMap(_.headChar).headOption
   }
   final case class Indent(res: Result) extends Result {
     override def desc: String = s"Indent(r=${res.desc})"
+    def headChar: Option[Char] = res.headChar
   }
   final case class Newline(res: Result) extends Result {
     override def desc: String = s"Newline(r=${res.desc})"
+    def headChar: Option[Char] = Option.empty
   }
   final case class Meta(data: Any, res: Result) extends Result {
     override def desc: String = s"Meta(d=$data, r=${res.desc})"
+    def headChar: Option[Char] = res.headChar
   }
   final case class Wrap(prefix: String, res: Result, suffix: String) extends Result {
     override def desc: String = s"Wrap(p=$prefix, r=${res.desc}, s=$suffix)"
+    def headChar: Option[Char] = prefix.headOption.orElse(res.headChar)
   }
   final case class Function(fn: StringBuilder => Result) extends Result {
     override def desc: String = s"Function(...)"
+    def headChar: Option[Char] = Option.empty
   }
 
   def apply[T](f: T => Result): Show[T] = new Show[T] {

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -1078,15 +1078,14 @@ object TreeSyntax {
     implicit def syntaxCases: Syntax[Seq[CaseTree]] = Syntax(cases => r(cases.map(i(_))))
 
     private def printStats(stats: Seq[Stat]) = r {
-      val builder = List.newBuilder[Show.Result]
       var prevStat: Stat = null
-      stats.foreach { stat =>
-        if (stat.is[Term.Block] && null != prevStat && guessNeedsLineSep(prevStat)) builder +=
-          System.lineSeparator
-        builder += i(stat)
+      stats.map { stat =>
+        val showStat = i(stat)
+        val needNL = null != prevStat && showStat.headChar.contains('{') &&
+          guessNeedsLineSep(prevStat)
         prevStat = stat
+        if (needNL) n(showStat) else showStat
       }
-      builder.result()
     }
 
     private def printCaps(captures: List[Term.Ref], prefix: String = ""): Show.Result =


### PR DESCRIPTION
In the logic deciding whether to insert a newline between two stats, checking if the next stat is a block is insufficient, as it could be an expression (select or infix chain) which *starts* with a block.

Instead, let's turn it into a Show.Result and check if it starts with a brace.

Fixes #4202.