### PR TITLE
ScalametaParser: no `unapply` to copy Type trees

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1144,10 +1144,9 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
       def loop(outerTpe: Type, convertTypevars: Boolean): Type = setPos(outerTpe) {
         outerTpe match {
           case q: Quasi => q
-          case tpe @ Type.Name(value) if convertTypevars && value(0).isLower => Type.Var(tpe)
-          case tpe: Type.Name => tpe
+          case t: Type.Name => if (convertTypevars && t.value(0).isLower) Type.Var(t) else t
           case tpe: Type.Select => tpe
-          case Type.Project(qual, name) => Type.Project(copyType(qual), name)
+          case t: Type.Project => Type.Project(copyType(t.qual), t.name)
           case tpe: Type.Singleton => tpe
           case t: Type.Apply =>
             val args1 = t.argClause match {
@@ -1155,7 +1154,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
               case x: Type.ArgClause => copyPos(x)(Type.ArgClause(x.values.map(convertType)))
             }
             Type.Apply(copyType(t.tpe), args1)
-          case Type.ApplyInfix(lhs, op, rhs) => Type.ApplyInfix(copyType(lhs), op, copyType(rhs))
+          case t: Type.ApplyInfix => Type.ApplyInfix(copyType(t.lhs), t.op, copyType(t.rhs))
           case t: Type.ByName => convertByName(t)(Type.ByName(_))
           case t: Type.PureByName => convertByName(t)(Type.PureByName(_))
           case t: Type.Function => convertFunc(t)(Type.Function(_, _))
@@ -1163,11 +1162,11 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
           case t: Type.ContextFunction => convertFunc(t)(Type.ContextFunction(_, _))
           case t: Type.PureContextFunction => convertFunc(t)(Type.PureContextFunction(_, _))
           case t: Type.PolyFunction => Type.PolyFunction(t.tparamClause, copyType(t.tpe))
-          case Type.Tuple(elements) => Type.Tuple(elements.map(convertType))
-          case Type.With(lhs, rhs) => Type.With(copyType(lhs), copyType(rhs))
-          case Type.Refine(tpe, stats) => Type.Refine(tpe.map(copyType), stats)
-          case Type.Existential(underlying, stats) => Type.Existential(copyType(underlying), stats)
-          case Type.Annotate(underlying, annots) => Type.Annotate(copyType(underlying), annots)
+          case t: Type.Tuple => Type.Tuple(t.args.map(convertType))
+          case t: Type.With => Type.With(copyType(t.lhs), copyType(t.rhs))
+          case t: Type.Refine => Type.Refine(t.tpe.map(copyType), t.body)
+          case t: Type.Existential => Type.Existential(copyType(t.tpe), t.body)
+          case t: Type.Annotate => Type.Annotate(copyType(t.tpe), t.annots)
           case t: Type.Wildcard => Type.Wildcard(t.bounds)
           case t: Type.AnonymousLambda => Type.AnonymousLambda(copyType(t.tpe))
           case t: Type.AnonymousParam => Type.AnonymousParam(t.variant)

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
@@ -1107,4 +1107,31 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
        |""".stripMargin
   )
 
+  // #4208
+  checkPositions[Term](
+    """|"" match {
+       |  case _: Foo[{ type A = Bar }] =>
+       |}
+       |""".stripMargin,
+    """|<expr>Lit.String ""</expr> [0:"":2)
+       |<casesBlock>Term.CasesBlock {
+       |  case _: Foo[{ type A = Bar }] =>
+       |}</casesBlock> [9:{...:47)
+       |<cases0>Case case _: Foo[{ type A = Bar }] =></cases0> [13:case _: Foo[{ type A = Bar }] =>:45)
+       |<pat>Pat.Typed _: Foo[{ type A = Bar }]</pat> [18:_: Foo[{ type A = Bar }]:42)
+       |<rhs>Type.Apply Foo[{ type A = Bar }]</rhs> [21:Foo[{ type A = Bar }]:42)
+       |<argClause>Type.ArgClause [{ type A = Bar }]</argClause> [24:[{ type A = Bar }]:42)
+       |<values0>Type.Refine { type A = Bar }</values0> [25:{ type A = Bar }:41)
+       |<body>Stat.Block {
+       |  type A = Bar
+       |}</body> <none>
+       |<stats0>Defn.Type type A = Bar</stats0> [27:type A = Bar:39)
+       |<tparamClause>Type.ParamClause   case _: Foo[{ type A @@= Bar }] =></tparamClause> [34::34)
+       |<bounds>Type.Bounds   case _: Foo[{ type A @@= Bar }] =></bounds> [34::34)
+       |<body>Term.Block @@}</body> [46::46)
+       |""".stripMargin,
+    showPosition = true,
+    showFieldName = true
+  )
+
 }

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
@@ -1122,9 +1122,7 @@ class TokensPositionSuite extends BasePositionSuite(dialects.Scala213) {
        |<rhs>Type.Apply Foo[{ type A = Bar }]</rhs> [21:Foo[{ type A = Bar }]:42)
        |<argClause>Type.ArgClause [{ type A = Bar }]</argClause> [24:[{ type A = Bar }]:42)
        |<values0>Type.Refine { type A = Bar }</values0> [25:{ type A = Bar }:41)
-       |<body>Stat.Block {
-       |  type A = Bar
-       |}</body> <none>
+       |<body>Stat.Block { type A = Bar }</body> [25:{ type A = Bar }:41)
        |<stats0>Defn.Type type A = Bar</stats0> [27:type A = Bar:39)
        |<tparamClause>Type.ParamClause   case _: Foo[{ type A @@= Bar }] =></tparamClause> [34::34)
        |<bounds>Type.Bounds   case _: Foo[{ type A @@= Bar }] =></bounds> [34::34)


### PR DESCRIPTION
Since tree fields are changing, and `unapply` always supports only the initial field composition, let's not use `unapply` when constructing a new tree from these fields, as they might lose their parsed positions. Fixes #4208.