### PR TITLE
ScannerTokens: handle `package object` correctly

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -484,7 +484,11 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
           case _ => sepRegions
         })
       case _: KwObject | _: KwClass | _: KwTrait | _: KwPackage | _: KwNew
-          if dialect.allowSignificantIndentation => currRef(RegionTemplateMark :: sepRegions)
+          if dialect.allowSignificantIndentation =>
+        currRef(sepRegions match {
+          case RegionTemplateMark :: _ => sepRegions
+          case _ => RegionTemplateMark :: sepRegions
+        })
       case _: KwTry if !isPrevEndMarker() => currRef(RegionTry :: dropRegionLine(sepRegions))
       case _: KwMatch if !isPrevEndMarker() => getCaseIntro(sepRegions)
       case _: KwCatch => getCaseIntro(dropWhile(sepRegions)(_ ne RegionTry))

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -4184,4 +4184,19 @@ class ControlSyntaxSuite extends BaseDottySuite {
     runTestAssert[Stat](code, layout)(tree)
   }
 
+  test("#4214") {
+    val code =
+      """|package object scope:
+         |  val result = for
+         |    x <- twice:
+         |         "4".toInt
+         |  yield x
+         |""".stripMargin
+    val error =
+      """|<input>:4: error: `outdent` expected but `.` found
+         |         "4".toInt
+         |            ^""".stripMargin
+    runTestError[Source](code, error)
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -4192,11 +4192,29 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |         "4".toInt
          |  yield x
          |""".stripMargin
-    val error =
-      """|<input>:4: error: `outdent` expected but `.` found
-         |         "4".toInt
-         |            ^""".stripMargin
-    runTestError[Source](code, error)
+    val output =
+      """|package object scope {
+         |  val result = for (x <- twice {
+         |    "4".toInt
+         |  }) yield x
+         |}
+         |""".stripMargin
+    val tree = Source(List(Pkg.Object(
+      Nil,
+      "scope",
+      tpl(Defn.Val(
+        Nil,
+        List(patvar("result")),
+        None,
+        Term.ForYield(
+          Term.EnumeratorsBlock(List(
+            Enumerator.Generator(patvar("x"), tapply("twice", blk(tselect(lit("4"), "toInt"))))
+          )),
+          tname("x")
+        )
+      ))
+    )))
+    runTestAssert[Source](code, output)(tree)
   }
 
 }


### PR DESCRIPTION
Don't insert two template marks, for both `package` and `object`. Fixes #4214.