### PR TITLE
Bold the quasiquotes comments not preserved docs

### DIFF
--- a/docs/trees/guide.md
+++ b/docs/trees/guide.md
@@ -268,7 +268,7 @@ println(q"$left + $right")
 > It's important to keep in mind that quasiquotes expand at compile-time into
 > the same program as if you had written normal constructors by hand.
 > This means, for example, that formatting details or comments are not preserved
-> if interpolated values are used, because the complete source is not available
+> **if interpolated values are used**, because the complete source is not available
 > at compile-time.
 
 ```scala mdoc


### PR DESCRIPTION
I was fiddling with this, couldnt figure out why in my playground examples the comments are there, but in "real project" (https://github.com/sake92/regenesca/blob/main/example/src/example/Example.scala#L20-L30)

TLDR:
If you do `source""" /**/ val x = 5 """.syntax` that works 
But `source""" /**/ val ${myVarName} = 5 """.syntax` does not