### PR TITLE
ScalametaParser: allow indented infix type args

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1998,7 +1998,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
         // Infix chain has ended with a postfix expression.
         // This never happens in the running example.
         if (targs.nonEmpty)
-          syntaxError("type application is not allowed for postfix operators", at = currToken)
+          syntaxError("type application is not allowed for postfix operators", at = targs)
         val finQual = getPrevLhs(op)
         val term: Term = atPos(getLhsStartPos(finQual), op)(Term.SelectPostfix(finQual, op))
         Left(term)

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2009,7 +2009,9 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
       def getPostfixOrNextRhs(op: Term.Name): Either[Term, Term] = {
         // Infix chain continues.
         // In the running example, we're at `a [+] b`.
-        val targs = if (at[LeftBracket]) exprTypeArgs() else emptyTypeArgs
+        val hasTypeArgs = at[LeftBracket] ||
+          isIndentingOrEOL(nonOptBracesOK = false) && tryAhead[LeftBracket]
+        val targs = if (hasTypeArgs) exprTypeArgs() else emptyTypeArgs
 
         // Check whether we're still infix or already postfix by testing the current token.
         // In the running example, we're at `a + [b]` (infix).

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
@@ -854,9 +854,9 @@ class InfixSuite extends BaseDottySuite {
       """|a op [T]
          |""".stripMargin
     val error =
-      """|<input>:2: error: type application is not allowed for postfix operators
-         |
-         |^""".stripMargin
+      """|<input>:1: error: type application is not allowed for postfix operators
+         |a op [T]
+         |     ^""".stripMargin
     runTestError[Stat](code, error)
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
@@ -826,4 +826,50 @@ class InfixSuite extends BaseDottySuite {
     runTestAssert[Stat](code, layout)(tree)
   }
 
+  test("infix with inline type args") {
+    val code =
+      """|a op [T]
+         |  b
+         |""".stripMargin
+    val layout = "a op[T] b"
+    val tree = tinfix("a", "op", List("T"), "b")
+    runTestAssert[Stat](code, layout)(tree)
+  }
+
+  test("infix with indented type args") {
+    val code =
+      """|a op
+         |  [T]
+         |  b
+         |""".stripMargin
+    val error =
+      """|<input>:2: error: illegal start of simple expression
+         |  [T]
+         |  ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("postfix with illegal inline type args") {
+    val code =
+      """|a op [T]
+         |""".stripMargin
+    val error =
+      """|<input>:2: error: type application is not allowed for postfix operators
+         |
+         |^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("postfix with illegal indented type args") {
+    val code =
+      """|a op
+         |  [T]
+         |""".stripMargin
+    val error =
+      """|<input>:2: error: illegal start of simple expression
+         |  [T]
+         |  ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
@@ -842,11 +842,9 @@ class InfixSuite extends BaseDottySuite {
          |  [T]
          |  b
          |""".stripMargin
-    val error =
-      """|<input>:2: error: illegal start of simple expression
-         |  [T]
-         |  ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "a op[T] b"
+    val tree = tinfix("a", "op", List("T"), "b")
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("postfix with illegal inline type args") {
@@ -866,7 +864,7 @@ class InfixSuite extends BaseDottySuite {
          |  [T]
          |""".stripMargin
     val error =
-      """|<input>:2: error: illegal start of simple expression
+      """|<input>:2: error: type application is not allowed for postfix operators
          |  [T]
          |  ^""".stripMargin
     runTestError[Stat](code, error)


### PR DESCRIPTION
Follow-on to #4227.