### PR TITLE
ScalametaParser: allow NL before infix type args

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2010,7 +2010,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect) {
         // Infix chain continues.
         // In the running example, we're at `a [+] b`.
         val hasTypeArgs = at[LeftBracket] ||
-          isIndentingOrEOL(nonOptBracesOK = false) && tryAhead[LeftBracket]
+          isIndentingOrEOL(nonOptBracesOK = true) && tryAhead[LeftBracket]
         val targs = if (hasTypeArgs) exprTypeArgs() else emptyTypeArgs
 
         // Check whether we're still infix or already postfix by testing the current token.

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -1218,4 +1218,50 @@ class TermSuite extends ParseSuite {
     runTestAssert[Stat](code, layout)(tree)
   }
 
+  test("infix with inline type args") {
+    val code =
+      """|a op [T]
+         |  b
+         |""".stripMargin
+    val layout = "a op[T] b"
+    val tree = tinfix("a", "op", List("T"), "b")
+    runTestAssert[Stat](code, layout)(tree)
+  }
+
+  test("infix with indented type args") {
+    val code =
+      """|a op
+         |  [T]
+         |  b
+         |""".stripMargin
+    val error =
+      """|<input>:1: error: `end of file` expected but `\n` found
+         |a op
+         |    ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("postfix with illegal inline type args") {
+    val code =
+      """|a op [T]
+         |""".stripMargin
+    val error =
+      """|<input>:1: error: type application is not allowed for postfix operators
+         |a op [T]
+         |     ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("postfix with illegal indented type args") {
+    val code =
+      """|a op
+         |  [T]
+         |""".stripMargin
+    val error =
+      """|<input>:1: error: `end of file` expected but `\n` found
+         |a op
+         |    ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -1234,11 +1234,9 @@ class TermSuite extends ParseSuite {
          |  [T]
          |  b
          |""".stripMargin
-    val error =
-      """|<input>:1: error: `end of file` expected but `\n` found
-         |a op
-         |    ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "a op[T] b"
+    val tree = tinfix("a", "op", List("T"), "b")
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("postfix with illegal inline type args") {
@@ -1258,9 +1256,9 @@ class TermSuite extends ParseSuite {
          |  [T]
          |""".stripMargin
     val error =
-      """|<input>:1: error: `end of file` expected but `\n` found
-         |a op
-         |    ^""".stripMargin
+      """|<input>:2: error: type application is not allowed for postfix operators
+         |  [T]
+         |  ^""".stripMargin
     runTestError[Stat](code, error)
   }
 


### PR DESCRIPTION
Fix for #4233, follow-up to #4227.