### PR TITLE
Fix quasiquote parsing in inlined code

### DIFF
--- a/tests/shared/src/test/scala-3/scala/meta/tests/quasiquotes/Scala3SpecificSuccessSuite.scala
+++ b/tests/shared/src/test/scala-3/scala/meta/tests/quasiquotes/Scala3SpecificSuccessSuite.scala
@@ -34,11 +34,18 @@ class Scala3SpecificSuccessSuite extends TreeSuiteBase {
         class $name:
           val a: Int = 1
       """
-    assertEquals(
-      compileErrors("""foo(Type.Name("AAA"))"""),
-      s"""|error: double quotes are not allowed in single-line quasiquotes
-          |package scala.meta.tests
-          |             ^""".stripMargin
+    assertPositions(
+      foo(Type.Name("AAA")),
+      """|<?>Defn.Class class AAA { val a: Int = 1 }</?> <none>
+         |<tparamClause>Type.ParamClause @?@</tparamClause> <none>
+         |<ctor>Ctor.Primary @?@</ctor> <none>
+         |<templ>Template { val a: Int = 1 }</templ> <none>
+         |<body>Template.Body { val a: Int = 1 }</body> <none>
+         |<stats0>Defn.Val val a: Int = 1</stats0> <none>
+         |""".stripMargin,
+      showPosition = true,
+      showFieldName = true,
+      skipFullTree = false
     )
   }
 
@@ -56,11 +63,13 @@ class Scala3SpecificSuccessSuite extends TreeSuiteBase {
 
   test("single-line - parse when inlined") {
     inline def foo() = q"val aaa: Int = 1"
-    assertEquals(
-      compileErrors("""foo()"""),
-      s"""|error: `;` expected but `string constant` found
-          |package scala.meta.tests
-          |    ^""".stripMargin
+    assertPositions(
+      foo(),
+      """|<?>Defn.Val val aaa: Int = 1</?> [0:val aaa: Int = 1:16)
+         |""".stripMargin,
+      showPosition = true,
+      showFieldName = true,
+      skipFullTree = false
     )
   }
 


### PR DESCRIPTION
After inlining, the position shown by `Position.ofMacroExpansion` would change, breaking the scalameta quasiquote parser and having it result with errors. Now we use the StringContext position, as that does not seem to be affected by inlining.