### PR TITLE
Deterministic .semanticdb files

### DIFF
--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
@@ -43,19 +43,6 @@ trait TextDocumentOps {
   implicit class XtensionCompilationUnitDocument(unit: g.CompilationUnit) {
     def toTextDocument: s.TextDocument = toTextDocument(None)
 
-    private def orderOrElse[T](one: Ordering[T], another: Ordering[T]): Ordering[T] =
-      (x: T, y: T) => {
-        val res1 = one.compare(x, y)
-        if (res1 != 0) res1 else another.compare(x, y)
-      }
-
-    implicit val rangeOrder: Ordering[Option[s.Range]] = {
-      val byLine = Ordering.by[s.Range, Int](_.startLine)
-      val byChar = Ordering.by[s.Range, Int](_.startCharacter)
-      val byLineOrChar = orderOrElse(byLine, byChar)
-      Ordering.Option(byLineOrChar)
-    }
-
     def toTextDocument(explicitDialect: Option[m.Dialect]): s.TextDocument = {
       clearSymbolPointsCache()
       val occurrences = emptyOccurrenceMap()

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
@@ -43,10 +43,11 @@ trait TextDocumentOps {
   implicit class XtensionCompilationUnitDocument(unit: g.CompilationUnit) {
     def toTextDocument: s.TextDocument = toTextDocument(None)
 
-    private def orderOrElse[T](one: Ordering[T], another: Ordering[T]): Ordering[T] = (x, y) => {
-      val res1 = one.compare(x, y)
-      if (res1 != 0) res1 else another.compare(x, y)
-    }
+    private def orderOrElse[T](one: Ordering[T], another: Ordering[T]): Ordering[T] =
+      (x: T, y: T) => {
+        val res1 = one.compare(x, y)
+        if (res1 != 0) res1 else another.compare(x, y)
+      }
 
     implicit val rangeOrder: Ordering[Option[s.Range]] = {
       val byLine = Ordering.by[s.Range, Int](_.startLine)

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
@@ -6,8 +6,6 @@ import scala.meta.internal.scalacp._
 import scala.meta.internal.semanticdb.Implicits._
 import scala.meta.internal.semanticdb.Scala._
 import scala.meta.internal.{semanticdb => s}
-
-import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.reflect.internal._
 import scala.reflect.internal.{Flags => gf}
@@ -42,6 +40,10 @@ trait TextDocumentOps {
 
   implicit class XtensionCompilationUnitDocument(unit: g.CompilationUnit) {
     def toTextDocument: s.TextDocument = toTextDocument(None)
+
+    implicit val rangeOrder: Ordering[Option[s.Range]] =
+      Ordering.Option(Ordering.by[s.Range, Int](_.startLine)
+        .orElse(Ordering.by[s.Range, Int](_.startCharacter)))
 
     def toTextDocument(explicitDialect: Option[m.Dialect]): s.TextDocument = {
       clearSymbolPointsCache()
@@ -637,10 +639,10 @@ trait TextDocumentOps {
         text = unit.source.toText,
         md5 = unit.source.toMD5,
         language = s.Language.SCALA,
-        symbols = finalSymbols,
-        occurrences = finalOccurrences,
-        diagnostics = diagnostics,
-        synthetics = synthetics.toScalaSeq
+        symbols = finalSymbols.sortBy(_.symbol),
+        occurrences = finalOccurrences.sortBy(_.range),
+        diagnostics = diagnostics.sortBy(_.range),
+        synthetics = synthetics.toScalaSeq.sortBy(_.range)
       )
     }
   }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
@@ -6,6 +6,7 @@ import scala.meta.internal.scalacp._
 import scala.meta.internal.semanticdb.Implicits._
 import scala.meta.internal.semanticdb.Scala._
 import scala.meta.internal.{semanticdb => s}
+
 import scala.collection.mutable
 import scala.reflect.internal._
 import scala.reflect.internal.{Flags => gf}
@@ -41,9 +42,9 @@ trait TextDocumentOps {
   implicit class XtensionCompilationUnitDocument(unit: g.CompilationUnit) {
     def toTextDocument: s.TextDocument = toTextDocument(None)
 
-    implicit val rangeOrder: Ordering[Option[s.Range]] =
-      Ordering.Option(Ordering.by[s.Range, Int](_.startLine)
-        .orElse(Ordering.by[s.Range, Int](_.startCharacter)))
+    implicit val rangeOrder: Ordering[Option[s.Range]] = Ordering.Option(
+      Ordering.by[s.Range, Int](_.startLine).orElse(Ordering.by[s.Range, Int](_.startCharacter))
+    )
 
     def toTextDocument(explicitDialect: Option[m.Dialect]): s.TextDocument = {
       clearSymbolPointsCache()

--- a/semanticdb/semanticdb/shared/src/main/scala/scala/meta/internal/semanticdb/Implicits.scala
+++ b/semanticdb/semanticdb/shared/src/main/scala/scala/meta/internal/semanticdb/Implicits.scala
@@ -25,4 +25,16 @@ object Implicits {
     def toSemanticOriginal: OriginalTree = OriginalTree(range = Some(range))
   }
 
+  implicit val rangeOrdering: Ordering[Range] = new Ordering[Range] {
+    override def compare(a: Range, b: Range): Int = {
+      val byLine = Integer.compare(a.startLine, b.startLine)
+      if (byLine != 0) byLine
+      else {
+        val byCharacter = Integer.compare(a.startCharacter, b.startCharacter)
+        byCharacter
+      }
+    }
+  }
+
+  implicit val rangeOptionOrdering: Ordering[Option[Range]] = Ordering.Option[Range]
 }

--- a/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/OccurrenceSuite.scala
+++ b/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/OccurrenceSuite.scala
@@ -70,10 +70,9 @@ object OccurrenceSuite {
   def printTextDocument(doc: TextDocument): String = {
     val symtab = doc.symbols.iterator.map(info => info.symbol -> info).toMap
     val sb = new StringBuilder
-    val occurrences = doc.occurrences.sorted
     val input = Input.VirtualFile(doc.uri, doc.text)
     var offset = 0
-    occurrences.foreach { occ =>
+    doc.occurrences.foreach { occ =>
       val range = occ.range.get
       val pos = Position
         .Range(input, range.startLine, range.startCharacter, range.endLine, range.endCharacter)
@@ -93,21 +92,5 @@ object OccurrenceSuite {
     sb.append("/*").append(arrow)
       // replace package / with dot . to not upset GitHub syntax highlighting.
       .append(symbol.replace('/', '.')).append("*/")
-  }
-
-  implicit val occurrenceOrdering: Ordering[SymbolOccurrence] = new Ordering[SymbolOccurrence] {
-    override def compare(x: SymbolOccurrence, y: SymbolOccurrence): Int =
-      if (x.range.isEmpty) 0
-      else if (y.range.isEmpty) 0
-      else {
-        val a = x.range.get
-        val b = y.range.get
-        val byLine = Integer.compare(a.startLine, b.startLine)
-        if (byLine != 0) byLine
-        else {
-          val byCharacter = Integer.compare(a.startCharacter, b.startCharacter)
-          byCharacter
-        }
-      }
   }
 }


### PR DESCRIPTION
We are using bazel as a build tool, which relies on compilation being idempotent. Unordered sequences in .semanticdb files result in unnecessary jar files changes and build cache misses. 

Here I've added some order to TextDocument serialization to speed up bazel builds with semanticdb.
