### PR TITLE
TreeSuiteBase: move asserting positions

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/TestHelpers.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/TestHelpers.scala
@@ -19,4 +19,14 @@ object TestHelpers {
 
   def tokensAsSyntax(tokens: Iterator[Token]) = tokens.map(_.syntax).mkString
 
+  def collect[B](tree: Tree)(pf: PartialFunction[Tree, B]): List[B] = {
+    val builder = List.newBuilder[B]
+    def loop(t: Tree): Unit = {
+      builder ++= pf.lift(t)
+      t.children.foreach(loop)
+    }
+    loop(tree)
+    builder.result()
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/TreeSuiteBase.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/TreeSuiteBase.scala
@@ -2,6 +2,7 @@ package scala.meta.tests
 
 import org.scalameta.internal.ScalaCompat
 import scala.meta._
+import scala.meta.internal.inputs._
 import scala.meta.tests.parsers.CommonTrees
 import scala.meta.tokenizers.Tokenize
 import scala.meta.tokenizers.TokenizerOptions
@@ -176,5 +177,97 @@ abstract class TreeSuiteBase extends FunSuite with CommonTrees {
 
   protected def tokenize(code: String)(implicit dialect: Dialect): Tokens = Tokenize
     .scalametaTokenize.apply(Input.String(code).withTokenizerOptions, dialect).get
+
+  /**
+   * Position tests assert that the position of tree nodes enclose the expected source range.
+   *
+   * Position tests are declared like this
+   * {{{
+   *   checkPositions[Type](
+   *     "[X] =>> (X, X)",
+   *     """|Type.Bounds [X@@] =>> (X, X)
+   *        |Type.Tuple (X, X)
+   *        |""".stripMargin
+   *   )
+   * }}}
+   *
+   * Every line in the output format shows the AST tree node type and the tokens for that tree node.
+   * Offset positions are rendered as "@@".
+   *
+   * Below is an example bug that is easy to catch with position tests.
+   *
+   * {{{
+   *   checkPositions[Stat](
+   *     "trait A { self: B => }",
+   *     """|Ctor.Primary trait A @@{ self: B => }
+   *        |Name.Anonymous {
+   *        |Template { self: B => }
+   *        |Self self: B
+   *        |""".stripMargin
+   *   )
+   * }}}
+   *
+   * Observe that the line {{{Name.Anonymous {}}} indicates that the position of the anonymous name
+   * encloses the `{` token. The correct output should be
+   * {{{Name.Anonymous trait A @@{ self: B =>}}}.
+   */
+  def assertPositions(
+      tree: Tree,
+      expected: String,
+      showPosition: Boolean = false,
+      showFieldName: Boolean = false
+  )(implicit loc: Location): Unit = {
+    val sb = new StringBuilder
+    TestHelpers.collect(tree) {
+      // Reduce the expected output by ignoring lines that can be trivially
+      // verified. A line can be trivially verified when you can re-print the
+      // `.syntax` without using tokens. For example, if a Mod.Lazy tree has
+      // the syntax "lazy" then it's trivially verified and excluded from the
+      // output.
+      case `tree` =>
+      case t: Lit.Null if t.text == "null" =>
+      case t: Lit.Unit if t.text == "()" => // This case is needed for Scala.js.
+      case t: Lit if t.value != null && t.text == t.value.toString =>
+      case t: Name if t.text == t.value =>
+      case t @ Importee.Name(Name(value)) if t.text == value =>
+      case t @ Pat.Var(Name(value)) if t.text == value =>
+      case t: Mod if s"Mod.${t.text.capitalize}" == t.productPrefix =>
+      case t: Type.Param if t.text == t.name.value =>
+      case t @ Term.Param(Nil, name, Some(tpe), _) if t.text == s"$name: $tpe" =>
+      case t @ Init(Type.Name(value), anon, Nil) if t.text == value =>
+      case t: Importee.Wildcard if t.text == "_" =>
+      case t: Pat.Wildcard if t.text == "_" =>
+      case t @ Term.ArgClause(arg :: Nil, None) if t.text == arg.text =>
+      case t @ Pat.ArgClause(arg :: Nil) if t.text == arg.text =>
+      case t =>
+        object IterableIndex {
+          def unapply(obj: Any): Option[Int] = obj match {
+            case x: Iterable[_] => x.zipWithIndex.collectFirst { case (`t`, idx) => idx }
+            case _ => None
+          }
+        }
+        val nameOpt =
+          if (showFieldName) t.parent.flatMap(p =>
+            p.productFields.iterator.zip(p.productIterator).collectFirst {
+              case (name, `t`) => name
+              case (name, Some(`t`)) => name
+              case (name, IterableIndex(idx)) => s"$name$idx"
+            }
+          ).orElse(Some("?"))
+          else None
+        nameOpt.foreach(x => sb.append('<').append(x).append('>'))
+        sb.append(t.productPrefix).append(' ')
+        val syntax = t.text
+        if (syntax.isEmpty) {
+          val (leading, trailing) = t.pos.lineContent.splitAt(t.pos.startColumn)
+          sb.append(leading).append("@@").append(trailing)
+        } else sb.append(syntax)
+        nameOpt.foreach(x => sb.append("</").append(x).append('>'))
+        if (showPosition) sb.append(' ').append(t.pos.desc)
+        sb.append('\n')
+    }
+    val obtained = sb.result()
+    assertNoDiff(obtained, expected)
+  }
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/MoreHelpers.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/MoreHelpers.scala
@@ -2,6 +2,7 @@ package scala.meta.tests.parsers
 
 import scala.meta._
 import scala.meta.internal.parsers._
+import scala.meta.tests.TestHelpers
 import scala.meta.tokenizers.TokenizerOptions
 import scala.meta.trees.Origin
 
@@ -9,18 +10,8 @@ import munit._
 
 object MoreHelpers {
 
-  def collect[B](tree: Tree)(pf: PartialFunction[Tree, B]): List[B] = {
-    val builder = List.newBuilder[B]
-    def loop(t: Tree): Unit = {
-      builder ++= pf.lift(t)
-      t.children.foreach(loop)
-    }
-    loop(tree)
-    builder.result()
-  }
-
   def requireNonEmptyOrigin(tree: Tree): tree.type = {
-    val missingOrigin = collect(tree) { case t if t.origin == Origin.None => t }
+    val missingOrigin = TestHelpers.collect(tree) { case t if t.origin == Origin.None => t }
     Assertions.assertEquals(
       missingOrigin.map(_.structure),
       Nil,


### PR DESCRIPTION
Previously, it was in BasePositionSuite, which also includes parsing.