### PR TITLE
Add ApplyContextTree for context parameter application

### DIFF
--- a/docs/semanticdb/specification.md
+++ b/docs/semanticdb/specification.md
@@ -1037,6 +1037,7 @@ message Tree {
     OriginalTree original_tree = 6;
     SelectTree select_tree = 7;
     TypeApplyTree type_apply_tree = 8;
+    ApplyContextTree apply_context_tree = 9;
   }
 }
 ```
@@ -1121,6 +1122,15 @@ message TypeApplyTree {
 
 A `TypeApplyTree` represents the type application of a method, providing that
 method with type arguments.
+
+An `ApplyContextTree` represents a contextual method application, using Scala 3 `using` syntax.
+
+```protobuf
+message ApplyContextTree {
+  Tree function = 1;
+  repeated Tree arguments = 2;
+}
+```
 
 ## Data Schemas
 

--- a/semanticdb/semanticdb/shared/src/main/proto/semanticdb.proto
+++ b/semanticdb/semanticdb/shared/src/main/proto/semanticdb.proto
@@ -396,10 +396,16 @@ message Tree {
     OriginalTree original_tree = 6;
     SelectTree select_tree = 7;
     TypeApplyTree type_apply_tree = 8;
+    ApplyContextTree apply_context_tree = 9;
   }
 }
 
 message ApplyTree {
+  Tree function = 1;
+  repeated Tree arguments = 2;
+}
+
+message ApplyContextTree {
   Tree function = 1;
   repeated Tree arguments = 2;
 }

--- a/semanticdb/semanticdb/shared/src/main/scala/scala/meta/internal/metap/SyntheticPrinter.scala
+++ b/semanticdb/semanticdb/shared/src/main/scala/scala/meta/internal/metap/SyntheticPrinter.scala
@@ -43,6 +43,11 @@ trait SyntheticPrinter extends BasePrinter with RangePrinter with SymbolInformat
         out.print("(")
         rep(tree.arguments, ", ")(pprint)
         out.print(")")
+      case tree: ApplyContextTree =>
+        pprint(tree.function)
+        out.print("(using ")
+        rep(tree.arguments, ", ")(pprint)
+        out.print(")")
       case tree: FunctionTree =>
         out.print("{")
         rep("(", tree.parameters, ", ", ") => ")(pprint)


### PR DESCRIPTION
As a continuation of #2464. Closes #2460. One step towards scala/scala3#22936.

## Changes

- [x] semanticdb: Add context apply tree
- [x] metap: Add support for printing ApplyContextTree
- [x] Specification
