### PR TITLE
ScalametaParser: keep type tuple with named types

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
@@ -2262,7 +2262,7 @@ class FewerBracesSuite extends BaseDottySuite {
          |        Int) = b
          |""".stripMargin
     val layout = "given (b: Int) = b"
-    val tree = Defn.GivenAlias(Nil, "", Nil, Type.TypedParam("b", "Int", Nil), "b")
+    val tree = Defn.GivenAlias(Nil, "", Nil, Type.Tuple(List(Type.TypedParam("b", "Int", Nil))), "b")
     runTestAssert[Stat](code, layout)(tree)
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NamedTuplesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NamedTuplesSuite.scala
@@ -252,9 +252,10 @@ class NamedTuplesSuite extends BaseDottySuite {
   test("sfmt#4948 single-value named tuple type: scala37") {
     implicit val dialect: Dialect = dialects.Scala37
     val code = """type A = (a: Int)"""
-    val layout = """type A = a: Int"""
-    val tree = Defn.Type(Nil, pname("A"), Nil, Type.TypedParam("a", "Int", Nil), noBounds)
-    parseAndCheckTree[Stat](code, layout)(tree)
+    val layout = """type A = (a: Int)"""
+    val tree = Defn
+      .Type(Nil, pname("A"), Nil, Type.Tuple(List(Type.TypedParam("a", "Int", Nil))), noBounds)
+    runTestAssert[Stat](code, layout)(tree)
   }
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NamedTuplesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NamedTuplesSuite.scala
@@ -241,4 +241,20 @@ class NamedTuplesSuite extends BaseDottySuite {
     runTestAssert[Case](code, layout)(tree)
   }
 
+  test("sfmt#4948 single-value named tuple type: scala36") {
+    implicit val dialect: Dialect = dialects.Scala36
+    val code = """type A = (a: Int)"""
+    val layout = """type A = a: Int"""
+    val tree = Defn.Type(Nil, pname("A"), Nil, Type.TypedParam("a", "Int", Nil), noBounds)
+    parseAndCheckTree[Stat](code, layout)(tree)
+  }
+
+  test("sfmt#4948 single-value named tuple type: scala37") {
+    implicit val dialect: Dialect = dialects.Scala37
+    val code = """type A = (a: Int)"""
+    val layout = """type A = a: Int"""
+    val tree = Defn.Type(Nil, pname("A"), Nil, Type.TypedParam("a", "Int", Nil), noBounds)
+    parseAndCheckTree[Stat](code, layout)(tree)
+  }
+
 }


### PR DESCRIPTION
Follow-on to #4284.