### PR TITLE
improvement: Add an ability to release specific semanticdb version

### DIFF
--- a/.github/workflows/release-semanticdb.yml
+++ b/.github/workflows/release-semanticdb.yml
@@ -1,0 +1,48 @@
+name: Release semanticdb
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Scalameta version (e.g., 1.2.3)"
+        required: true
+      branch:
+        description: "Branch or tag to release from (e.g., v4.10.13)"
+        required: true
+      scala:
+        description: "Scala version (e.g., 2.13.16)"
+        required: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out tag v${{ github.event.inputs.version }}
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.branch }}
+      - uses: olafurpg/setup-scala@v14
+      - name: Set up JVM
+        uses: actions/setup-java@v5
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
+      - name: Publish ${{ github.event.inputs.project }} to Sonatype
+        run: sbt -Dscalameta.version=${{ github.event.inputs.version }} "set ThisBuild/isSnapshot := false; ci-release"
+        env:
+          CI_COMMIT_TAG: v${{ github.event.inputs.version }}
+          CI_RELEASE: ${{ github.event.inputs.scala != '' && format('++{0} ', github.event.inputs.scala) || '+' }}; semanticdbScalacCore/publishSigned; semanticdbScalacPlugin/publishSigned; semanticdbMetac/publishSigned; semanticdbMetap/publishSigned
+          SCALAMETA_PLATFORM: ${{ github.event.inputs.platform }}
+          GIT_USER: scalameta@scalameta.org
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          GITHUB_DEPLOY_KEY: ${{ secrets.GITHUB_DEPLOY_KEY }}
+          GOOGLE_APPLICATION_CREDENTIALS:
+            ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+          GOOGLE_APPLICATION_CREDENTIALS_JSON:
+            ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON }}


### PR DESCRIPTION
This enables us:
- release for a specific Scala version from a branch with needed fixes. Sometimes those are needed, in the most recent case to fix semanticdb plugin and update sbt for releasing
- not have to remember what exactly needs to be release for semanticdb
- set isSnapshot to false, which was breaking the release previously (might be sbt-ci-release bug)

This is only needed for releasing semanticdb, so I removed the project input parameter.

I am already testing it in https://github.com/scalameta/scalameta/actions/runs/18155195434/job/51673342558