### PR TITLE
ast: use DialectOnly origin in `copy`, for `apply`

### DIFF
--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/ast.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/ast.scala
@@ -140,6 +140,10 @@ class AstNamerMacros(val c: Context) extends Reflection with CommonNamerMacros {
           istats1 += declareGetter(p.name, p.tpt, mods)
           p
         }
+        val privateArgsForCopy = privateApplyParams.map(p =>
+          if (p.name.toString == "origin") q"$OriginModule.DialectOnly.fromOrigin(${p.name})"
+          else p.rhs
+        )
 
         // step 5: turn all parameters into vars, create getters and setters
         params.foreach { p =>
@@ -205,7 +209,7 @@ class AstNamerMacros(val c: Context) extends Reflection with CommonNamerMacros {
             q"""
             $mods def copy(..$params): $iname
           """
-          val args = params.map(getParamArg)
+          val args = privateArgsForCopy ++ params.map(getParamArg)
           stats1 +=
             q"""
             final override def copy(..$params): $iname = {

--- a/scalameta/trees/shared/src/main/scala/scala/meta/trees/Origin.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/trees/Origin.scala
@@ -71,6 +71,9 @@ object Origin {
   object DialectOnly {
     implicit def fromDialect(implicit dialect: Dialect): DialectOnly = new DialectOnly(dialect)
 
+    private[meta] def fromOrigin(origin: Origin): Origin = origin.dialectOpt
+      .fold[Origin](Origin.None)(x => fromDialect(x))
+
     private[meta] def getFromArgs(args: Any*): DialectOnly = {
       val queue = scala.collection.mutable.Queue.empty[Iterator[Any]]
       @scala.annotation.tailrec

--- a/tests/shared/src/test/scala/scala/meta/tests/trees/TreeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/trees/TreeSuite.scala
@@ -31,7 +31,7 @@ class TreeSuite extends TreeSuiteBase {
       tree.copy(body = tree.body)
     }
     assertEquals(tree.origin.dialectOpt, Some(dialects.Scala3))
-    assertEquals(copy.origin.dialectOpt, Some(dialects.Scala213))
+    assertEquals(copy.origin.dialectOpt, Some(dialects.Scala3))
     assertEquals(tree.structure, copy.structure)
 
     val expectedSyntax =
@@ -43,10 +43,7 @@ class TreeSuite extends TreeSuiteBase {
     assertEquals(copy.syntax, expectedSyntax)
     // however, `.toString` attempts to take the dialect from the tree
     assertEquals(tree.toString, expectedSyntax)
-    interceptMessage[UnsupportedOperationException]("Scala213 doesn't support inline modifiers")(
-      copy.toString
-    )
-
+    assertEquals(copy.toString, expectedSyntax)
   }
 
 }


### PR DESCRIPTION
Fixes #4351.