### PR TITLE
ScannerTokens: outdent unindented case correctly

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -1999,31 +1999,34 @@ class ControlSyntaxSuite extends BaseDottySuite {
 
   test("match-chained indented") {
     val layout =
-      """|(xs match {
-         |  case Nil => "empty"
-         |  case x :: xs1 => "nonempty"
-         |}) match {
-         |  case "empty" => 0
-         |  case "nonempty" => 1
+      """|xs match {
+         |  case Nil =>
+         |    "empty"
+         |  case x :: xs1 =>
+         |    "nonempty" match {
+         |      case "empty" => 0
+         |      case "nonempty" => 1
+         |    }
          |}
          |""".stripMargin
 
     val tree = tmatch(
-      tmatch(
-        tname("xs"),
-        Case(tname("Nil"), None, str("empty")),
-        Case(patinfix(patvar("x"), "::", patvar("xs1")), None, str("nonempty"))
-      ),
-      Case(str("empty"), None, int(0)),
-      Case(str("nonempty"), None, int(1))
+      tname("xs"),
+      Case(tname("Nil"), None, str("empty")),
+      Case(
+        patinfix(patvar("x"), "::", patvar("xs1")),
+        None,
+        tmatch(str("nonempty"), Case(str("empty"), None, int(0)), Case(str("nonempty"), None, int(1)))
+      )
     )
 
     runTestAssert[Stat](
       """|xs match {
          |  case Nil => "empty"
-         |  case x :: xs1 => "nonempty" } match {
+         |  case x :: xs1 => "nonempty" match {
          |    case "empty" => 0
          |    case "nonempty" => 1
+         |  }
          |}
          |""".stripMargin,
       layout

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
@@ -2295,19 +2295,17 @@ class FewerBracesSuite extends BaseDottySuite {
          |""".stripMargin
     val layout =
       """|val a = List("").map {
-         |  case x => x
-         |}.trim
+         |  case x =>
+         |    x.trim
+         |}
          |""".stripMargin
     val tree = Defn.Val(
       Nil,
       List(patvar("a")),
       None,
-      tselect(
-        tapply(
-          tselect(tapply("List", str("")), "map"),
-          Term.PartialFunction(List(Case(patvar("x"), None, "x")))
-        ),
-        "trim"
+      tapply(
+        tselect(tapply("List", str("")), "map"),
+        Term.PartialFunction(List(Case(patvar("x"), None, tselect("x", "trim"))))
       )
     )
     runTestAssert[Stat](code, layout)(tree)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -949,12 +949,14 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |
          |""".stripMargin,
       Some(
-        """|val hello = (xs match {
-           |  case Nil => "empty"
-           |  case x :: xs1 => "nonempty"
-           |}) match {
-           |  case true => 0
-           |  case false => 1
+        """|val hello = xs match {
+           |  case Nil =>
+           |    "empty"
+           |  case x :: xs1 =>
+           |    "nonempty" match {
+           |      case true => 0
+           |      case false => 1
+           |    }
            |}
            |""".stripMargin
       )
@@ -963,13 +965,13 @@ class SignificantIndentationSuite extends BaseDottySuite {
       List(patvar("hello")),
       None,
       tmatch(
-        tmatch(
-          tname("xs"),
-          Case(tname("Nil"), None, str("empty")),
-          Case(patinfix(patvar("x"), "::", patvar("xs1")), None, str("nonempty"))
-        ),
-        Case(bool(true), None, int(0)),
-        Case(bool(false), None, int(1))
+        tname("xs"),
+        Case(tname("Nil"), None, str("empty")),
+        Case(
+          patinfix(patvar("x"), "::", patvar("xs1")),
+          None,
+          tmatch(str("nonempty"), Case(bool(true), None, int(0)), Case(bool(false), None, int(1)))
+        )
       )
     ))
 


### PR DESCRIPTION
Case body is only terminated on non-case if it was not indented relative to the `catch`/`match` expression. Fixes scalameta/scalafmt#5046.