### PR TITLE
ReificationMacros: fall back to partial origin

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/Pos.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/Pos.scala
@@ -23,7 +23,7 @@ class IndexPos(index: => Int) extends Pos {
 
 class TreePos(tree: Tree) extends Pos {
   val (begIndex, endIndex) = tree.origin match {
-    case x: Origin.Parsed => (x.begTokenIdx, x.endTokenIdx - 1)
+    case x: Origin.Partial => (x.begTokenIdx, x.endTokenIdx - 1)
     case _ => sys.error(s"internal error: unpositioned prototype ${tree.syntax}: ${tree.structure}")
   }
 }

--- a/scalameta/scalameta/shared/src/main/scala/scala/meta/package.scala
+++ b/scalameta/scalameta/shared/src/main/scala/scala/meta/package.scala
@@ -86,7 +86,8 @@ package object meta
   implicit class XtensionTreeT[A <: Tree](private val tree: A) extends AnyVal {
     def maybeParse(implicit dialect: Dialect, parse: parsers.Parse[A]): Parsed[A] =
       tree.origin match {
-        case o: trees.Origin.Parsed if o.dialect.isEquivalentTo(dialect) => Parsed.Success(tree)
+        case o: trees.Origin.ParsedPartial if o.dialect.isEquivalentTo(dialect) =>
+          Parsed.Success(tree)
         case _ => tree.reparseAs[A]
       }
   }

--- a/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -190,7 +190,10 @@ class SurfaceSuite extends FunSuite {
          |scala.meta.trees.Origin.DialectOnly *
          |scala.meta.trees.Origin.None *
          |scala.meta.trees.Origin.Parsed *
+         |scala.meta.trees.Origin.ParsedPartial *
          |scala.meta.trees.Origin.ParsedSource *
+         |scala.meta.trees.Origin.ParsedSpliced *
+         |scala.meta.trees.Origin.Partial *
          |""".stripMargin.lf2nl
     )
   }

--- a/tests/shared/src/test/scala-3/scala/meta/tests/quasiquotes/Scala3SpecificSuccessSuite.scala
+++ b/tests/shared/src/test/scala-3/scala/meta/tests/quasiquotes/Scala3SpecificSuccessSuite.scala
@@ -15,12 +15,12 @@ class Scala3SpecificSuccessSuite extends TreeSuiteBase {
       """
     assertPositions(
       foo(Type.Name("AAA")),
-      """|<?>Defn.Class class AAA { val a: Int = 1 }</?> <none>
-         |<tparamClause>Type.ParamClause @?@</tparamClause> <none>
-         |<ctor>Ctor.Primary @?@</ctor> <none>
-         |<templ>Template { val a: Int = 1 }</templ> <none>
-         |<body>Template.Body { val a: Int = 1 }</body> <none>
-         |<stats0>Defn.Val val a: Int = 1</stats0> <none>
+      """|<?>Defn.Class class AAA { val a: Int = 1 }</?> [0:...class $name:...:53)
+         |<tparamClause>Type.ParamClause         class $name@@:</tparamClause> [20::20)
+         |<ctor>Ctor.Primary         class $name@@:</ctor> [20::20)
+         |<templ>Template { val a: Int = 1 }</templ> [20<:...>46)
+         |<body>Template.Body { val a: Int = 1 }</body> [20<:...>46)
+         |<stats0>Defn.Val val a: Int = 1</stats0> [32:val a: Int = 1:46)
          |""".stripMargin,
       showPosition = true,
       showFieldName = true,
@@ -36,12 +36,12 @@ class Scala3SpecificSuccessSuite extends TreeSuiteBase {
       """
     assertPositions(
       foo(Type.Name("AAA")),
-      """|<?>Defn.Class class AAA { val a: Int = 1 }</?> <none>
-         |<tparamClause>Type.ParamClause @?@</tparamClause> <none>
-         |<ctor>Ctor.Primary @?@</ctor> <none>
-         |<templ>Template { val a: Int = 1 }</templ> <none>
-         |<body>Template.Body { val a: Int = 1 }</body> <none>
-         |<stats0>Defn.Val val a: Int = 1</stats0> <none>
+      """|<?>Defn.Class class AAA { val a: Int = 1 }</?> [0:...class $name:...:53)
+         |<tparamClause>Type.ParamClause         class $name@@:</tparamClause> [20::20)
+         |<ctor>Ctor.Primary         class $name@@:</ctor> [20::20)
+         |<templ>Template { val a: Int = 1 }</templ> [20<:...>46)
+         |<body>Template.Body { val a: Int = 1 }</body> [20<:...>46)
+         |<stats0>Defn.Val val a: Int = 1</stats0> [32:val a: Int = 1:46)
          |""".stripMargin,
       showPosition = true,
       showFieldName = true,

--- a/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -2306,7 +2306,7 @@ class SuccessSuite extends TreeSuiteBase {
     )
 
     assertOriginType(valX, classOf[Origin.Parsed])
-    assertOriginType(fOfX, classOf[Origin.DialectOnly])
+    assertOriginType(fOfX, classOf[Origin.ParsedSpliced])
   }
 
   test("extract pattern with named fields") {


### PR DESCRIPTION
Currently, we use Origin.Parsed if quasiquote source has no holes (or no interpolations), and DialectOnly otherwise.

Instead of DialectOnly, let's expose some partial information about the origin (that is, everything but text associated with the position since that would refer to unexpanded tokens) which would allow us to compare token positions if not their content.

Helps with #3372.