### PR TITLE
Show: replace `\r` and/or `\n` with EOL

### DIFF
--- a/scalameta/tokens/shared/src/main/scala/scala/meta/internal/prettyprinters/TokenSyntax.scala
+++ b/scalameta/tokens/shared/src/main/scala/scala/meta/internal/prettyprinters/TokenSyntax.scala
@@ -6,7 +6,5 @@ import scala.meta.prettyprinters._
 import scala.meta.tokens._
 
 object TokenSyntax {
-  import Show.{sequence => s}
-
-  def apply[T <: Token](dialect: Dialect): Syntax[T] = Syntax(x => s(x.text))
+  def apply[T <: Token](dialect: Dialect): Syntax[T] = Syntax(x => Show.asis(x.text))
 }

--- a/tests/shared/src/test/scala-2/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala-2/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -652,7 +652,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
         )
       )))
     )))
-    assertEquals(tree.syntax, code)
+    assertEquals(tree.syntax, code.lf2nl)
     assertEquals(
       tree.reprint,
       s"""package foo1

--- a/tests/shared/src/test/scala-2/scala/meta/tests/transversers/SimpleTraverserSuite.scala
+++ b/tests/shared/src/test/scala-2/scala/meta/tests/transversers/SimpleTraverserSuite.scala
@@ -17,7 +17,7 @@ class SimpleTraverserSuite extends TreeSuiteBase {
     val log = scala.collection.mutable.ListBuffer[String]()
     object traverser extends SimpleTraverser {
       override def apply(tree: Tree): Unit = {
-        log += tree.toString.trim.replace("\n", " ")
+        log += tree.toString.trim.replace(EOL, " ")
         super.apply(tree)
       }
     }

--- a/tests/shared/src/test/scala-2/scala/meta/tests/transversers/TraverserSuite.scala
+++ b/tests/shared/src/test/scala-2/scala/meta/tests/transversers/TraverserSuite.scala
@@ -16,7 +16,7 @@ class TraverserSuite extends TreeSuiteBase {
     val log = scala.collection.mutable.ListBuffer[String]()
     object traverser extends Traverser {
       override def apply(tree: Tree): Unit = {
-        log += tree.toString.trim.replace("\n", " ")
+        log += tree.toString.trim.replace(EOL, " ")
         super.apply(tree)
       }
     }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ToplevelTermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ToplevelTermSuite.scala
@@ -14,7 +14,7 @@ class ToplevelTermSuite extends TreeSuiteBase {
 
     val tree = sourceString.parse[Source].get
 
-    assertEquals(tree.syntax, sourceString)
+    assertEquals(tree.syntax, sourceString.lf2nl)
     val expected = Source(List(
       Defn.Def(Nil, tname("foo"), Nil, List(List(tparam("x", "Int"))), Some(pname("Int")), tname("x")),
       tapply(tname("foo"), tname("x"))
@@ -32,7 +32,7 @@ class ToplevelTermSuite extends TreeSuiteBase {
 
     val tree = sourceString.parse[Source].get
 
-    assertEquals(tree.syntax, sourceString)
+    assertEquals(tree.syntax, sourceString.lf2nl)
     val expected = Source(List(Pkg(
       tname("bar"),
       List(
@@ -52,7 +52,7 @@ class ToplevelTermSuite extends TreeSuiteBase {
 
     val tree = sourceString.parse[Source].get
 
-    assertEquals(tree.syntax, sourceString)
+    assertEquals(tree.syntax, sourceString.lf2nl)
     val expected = Source(List(
       Defn.Def(Nil, tname("foo"), Nil, List(List(tparam("x", "Int"))), Some(pname("Int")), tname("x")),
       tapply(tname("foo"), tname("x"))

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/Scala3SyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/Scala3SyntaxSuite.scala
@@ -7,13 +7,13 @@ class Scala3SyntaxSuite extends BaseDottySuite {
   test("given intOrd: Ord[Int] with \n{ def f(): Int = 1 }") {
     assertEquals(
       templStat("given intOrd: Ord[Int] with \n{ def f(): Int = 1 }").syntax,
-      "given intOrd: Ord[Int] with \n{ def f(): Int = 1 }"
+      "given intOrd: Ord[Int] with \n{ def f(): Int = 1 }".lf2nl
     )
 
     matchSubStructure[Stat](
       "given intOrd: Ord[Int] with \n{ def f(): Int = 1 }",
       { case givenDefn: Defn.Given =>
-        assertEquals(givenDefn.templ.syntax, "Ord[Int] with \n{ def f(): Int = 1 }")
+        assertEquals(givenDefn.templ.syntax, "Ord[Int] with \n{ def f(): Int = 1 }".lf2nl)
       }
     )
   }
@@ -21,13 +21,13 @@ class Scala3SyntaxSuite extends BaseDottySuite {
   test("private final given intOrd: Ord[Int] with \n{ def f(): Int = 1 }") {
     assertEquals(
       templStat("private final given intOrd: Ord[Int] with \n{ def f(): Int = 1 }").syntax,
-      "private final given intOrd: Ord[Int] with \n{ def f(): Int = 1 }"
+      "private final given intOrd: Ord[Int] with \n{ def f(): Int = 1 }".lf2nl
     )
 
     matchSubStructure[Stat](
       "private final given intOrd: Ord[Int] with \n{ def f(): Int = 1 }",
       { case givenDefn: Defn.Given =>
-        assertEquals(givenDefn.templ.syntax, "Ord[Int] with \n{ def f(): Int = 1 }")
+        assertEquals(givenDefn.templ.syntax, "Ord[Int] with \n{ def f(): Int = 1 }".lf2nl)
       }
     )
   }


### PR DESCRIPTION
We output `EOL` for every Newline element but we don't do the same for string elements leading to inconsistent and possibly incorrect output. Helps with #3372.