### PR TITLE
Trees: Type.Capturing now takes a Type.Captures

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -812,10 +812,19 @@ object Type {
     final def stats: List[Tree] = typeDefs
   }
 
+  @branch
+  trait Captures extends Tree
+
+  @ast
+  class CapturesAny() extends Captures
+
+  @ast
+  class CapturesSet(values: List[Term.Ref]) extends Captures
+
   @ast
   class Capturing(
       tpe: Type,
-      caps: List[Term.Ref] // [cap]tures or [cap]abilities
+      caps: Captures // [cap]tures or [cap]abilities
   ) extends Type
 
   def fresh(): Type.Name = fresh("fresh")

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -713,9 +713,11 @@ object TreeSyntax {
         val bounds = printBounds(t.bounds, t.vbounds)
         s(w(mods, " "), variance, t.name, t.tparamClause, bounds)
       case t: Type.Block => s(w(r(t.typeDefs, "; "), "; "), t.tpe)
+      case _: Type.CapturesAny => s()
+      case t: Type.CapturesSet => s("{", r(t.values, ", "), "}")
       case t: Type.Capturing => t.tpe match {
           case tpe: Type.FunctionLikeType => s(tpe)
-          case tpe => s(tpe, printCaps(t.caps, "^"))
+          case tpe => s(tpe, "^", t.caps)
         }
 
       // Pat
@@ -1101,16 +1103,13 @@ object TreeSyntax {
       }
     }
 
-    private def printCaps(captures: List[Term.Ref], prefix: String = ""): Show.Result =
-      s(prefix, w("{", r(captures, ", "), "}"))
-
     private def printFunctionLikeType(
         t: Type.FunctionLikeType,
         params: Show.Result,
         arrow: String
     ): Show.Result = {
       val caps = t.parent match {
-        case Some(p: Type.Capturing) => printCaps(p.caps)
+        case Some(p: Type.Capturing) if p.tpe eq t => s(p.caps)
         case _ => Show.None
       }
       m(Typ, s(w(params, " "), kw(arrow), caps, " ", p(Typ, t.res)))

--- a/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -528,6 +528,9 @@ class SurfaceSuite extends FunSuite {
          |scala.meta.Type.ByName
          |scala.meta.Type.ByNameType
          |scala.meta.Type.CapSetName
+         |scala.meta.Type.Captures
+         |scala.meta.Type.CapturesAny
+         |scala.meta.Type.CapturesSet
          |scala.meta.Type.Capturing
          |scala.meta.Type.CasesBlock
          |scala.meta.Type.ContextFunction

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
@@ -24,7 +24,7 @@ class ReflectionSuite extends TreeSuiteBase {
     val sym = symbolOf[scala.meta.Tree]
     assert(sym.isRoot)
     val root = sym.asRoot
-    assertEquals((root.allBranches.length, root.allLeafs.length), (73, 479))
+    assertEquals((root.allBranches.length, root.allLeafs.length), (74, 484))
   }
 
   test("If") {
@@ -151,6 +151,7 @@ class ReflectionSuite extends TreeSuiteBase {
          |scala.meta.Type
          |scala.meta.Type.ArgClause
          |scala.meta.Type.Bounds
+         |scala.meta.Type.Captures
          |scala.meta.Type.CasesBlock
          |scala.meta.Type.FuncParamClause
          |scala.meta.Type.Name

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
@@ -193,8 +193,12 @@ trait CommonTrees extends CommonTrees.LowPriorityDefinitions {
     .PureContextFunction(param.toList, res)
   final def ppolyfunc(params: Type.Param*)(body: Type) = Type.PolyFunction(params.toList, body)
 
-  final def pcap(tpe: Type, caps: Term.Ref*): Type.Capturing = Type.Capturing(tpe, caps.toList)
-  final def pcap(tpe: String, caps: String*): Type.Capturing = pcap(tpe, caps.map(tnameOrCapset): _*)
+  final def pcap(tpe: Type): Type.Capturing = Type.Capturing(tpe, Type.CapturesAny())
+  final def pcap(tpe: Type, caps: Term.Ref*): Type.Capturing = Type
+    .Capturing(tpe, Type.CapturesSet(caps.toList))
+  final def pcap(tpe: String): Type.Capturing = pcap(pname(tpe))
+  final def pcap(tpe: String, caps: String*): Type.Capturing =
+    pcap(pname(tpe), caps.map(tnameOrCapset): _*)
 
   final def tpc(tp: Term.Param*): Term.ParamClause = tpc(null, tp: _*)
   final def tpc(mod: Mod.ParamsType, tp: Term.Param*): Term.ParamClause = Term

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
@@ -696,11 +696,9 @@ class TypeSuite extends BaseDottySuite {
   test("#4385 capture checking: empty") {
     implicit val dialect: Dialect = dialects.Scala3Future
     val code = "def foo(a: A^{}): Unit"
-    val error =
-      """|<input>:1: error: `identifier` expected but `}` found
-         |def foo(a: A^{}): Unit
-         |              ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "def foo(a: A^{}): Unit"
+    val tree = Decl.Def(Nil, "foo", Nil, List(List(tparam("a", Some(pcap("A", Nil: _*))))), "Unit")
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("scala36 type member context bounds 1") {


### PR DESCRIPTION
Capture checking is still an experimental, fluid feature, and in our earlier implementation we failed to anticipate empty capabilities sets so let's fix that now. Fixes #4385.