### PR TITLE
ScalametaMimaUtils: fix detection of public outer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -217,7 +217,6 @@ lazy val io = crossProject(allPlatforms: _*).in(file("scalameta/io"))
     moduleName := "io",
     sharedSettings,
     description := "Scalameta IO abstractions",
-    mimaPreviousArtifacts := Set.empty, // XXX: io split off from trees, to remove after release
     crossScalaVersions := EarliestScala2Versions
   ).jsSettings(commonJsSettings).nativeSettings(nativeSettings)
 

--- a/project/ScalametaMimaUtils.scala
+++ b/project/ScalametaMimaUtils.scala
@@ -5,7 +5,9 @@ object ScalametaMimaUtils {
   def isPublic(obj: MemberInfo): Boolean = null != obj && !obj.nonAccessible &&
     isPublic(obj.owner, null)
 
-  def isPublic(obj: ClassInfo, ref: AnyRef): Boolean = obj == ref ||
-    null != obj && obj.isPublic && isPublic(obj.module, obj) && isPublic(obj.outer, obj)
+  def isPublic(obj: ClassInfo, ref: AnyRef): Boolean = obj == ref || NoClass == obj ||
+    null != obj && {
+      obj.isPublic && !obj.isScopedPrivate && !obj.isPrivate && !obj.isProtected
+    } && isPublic(obj.moduleClass, obj) && isPublic(obj.outer, obj)
 
 }


### PR DESCRIPTION
- detect that outermost is now NoClass instead of null
- use `moduleClass` instead of `module` to refer to containing object
- make sure that not only is the class public, but it is also neither
      private nor protected (since these are different flags, that's how
      it works)
    
Also, add filters for `Type.Capturing` which are now triggered.
