### PR TITLE
ast: fix mima problems by restoring old apply

### DIFF
--- a/scala3-tree-lifts/macro/src/main/scala/org/scalameta/adt/TreeLiftsGenerate.scala
+++ b/scala3-tree-lifts/macro/src/main/scala/org/scalameta/adt/TreeLiftsGenerate.scala
@@ -35,7 +35,7 @@ class TreeLiftsGenerateMacros(val c: Context) extends AdtReflection with CommonN
     .asClass
 
   private lazy val privateFields = getPrivateFields(TypeName(c.freshName())).asList
-    .collect { case PrivateField(field, true) => field.name }
+    .collect { case PrivateField(field, version) if version ne null => field.name }
 
   def customAdts(root: Root): Option[List[Adt]] = {
     val nonQuasis = root.allLeafs.filter(leaf => !(leaf.tpe <:< QuasiSymbol.toType))

--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/NamerMacros.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/trees/NamerMacros.scala
@@ -111,7 +111,7 @@ trait CommonNamerMacros extends MacroHelpers {
     """
   }
 
-  protected case class PrivateField(field: ValOrDefDef, persist: Boolean = false)
+  protected case class PrivateField(field: ValOrDefDef, version: Version)
   protected case class PrivateFields(
       prototype: PrivateField,
       parent: PrivateField,
@@ -124,17 +124,19 @@ trait CommonNamerMacros extends MacroHelpers {
 
   protected def getPrivateFields(iname: TypeName): PrivateFields = PrivateFields(
     prototype = PrivateField(
-      q"@$TransientAnnotation private[meta] override val privatePrototype: $iname = null"
+      q"@$TransientAnnotation private[meta] override val privatePrototype: $iname = null",
+      version = null
     ),
-    parent = PrivateField(q"private[meta] override val privateParent: $TreeClass = null"),
-    origin = PrivateField(q"override val origin: $OriginClass = $OriginModule.None", persist = true),
+    parent =
+      PrivateField(q"private[meta] override val privateParent: $TreeClass = null", version = null),
+    origin = PrivateField(q"override val origin: $OriginClass = $OriginModule.None", Version.zero),
     begComment = PrivateField(
       q"override val begComment: $OptionClass[$CommentsClass] = $NoneModule",
-      persist = true
+      Version(4, 14, 2)
     ),
     endComment = PrivateField(
       q"override val endComment: $OptionClass[$CommentsClass] = $NoneModule",
-      persist = true
+      Version(4, 14, 2)
     )
   )
 


### PR DESCRIPTION
Since we have added new private fields, the "private field" portion of the apply methods has changed. Instead, we should preserve the old apply signatures and add the new ones.

For that, let's mark each private field with the version after which it was added (and the original ones will refer to v0.0.0). And for each of these versions, we'll generate a variant of apply, with an appropriate signature.
