### PR TITLE
Tokenizer: add {Int,Float}XL tokens and trees

### DIFF
--- a/scalameta/common/shared/src/main/scala/scala/meta/AnyDecimal.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/AnyDecimal.scala
@@ -1,0 +1,33 @@
+package scala.meta
+
+import java.math.{BigDecimal => JBigDec, MathContext}
+
+case class AnyDecimal(digits: String, exponent: String) {
+
+  override def toString: String = if (exponent.isEmpty) digits else digits + 'e' + exponent
+
+  def toBigDecimalOpt: Option[BigDecimal] = {
+    val expOpt =
+      if (exponent.isEmpty) Some(0)
+      else if (exponent.length > 11) None // Int.MaxValue contains 10 decimal digits, and sign
+      else {
+        val lexp = exponent.toLong
+        val iexp = lexp.toInt
+        if (iexp != lexp) None else Some(iexp)
+      }
+    expOpt.flatMap { exp =>
+      val mc = MathContext.UNLIMITED
+      val partial = new JBigDec(digits, mc)
+      def res(bd: JBigDec) = Some(new BigDecimal(bd, mc))
+      if (exp == 0) {
+        val normalized = if (partial.scale().abs <= 1) partial else partial.stripTrailingZeros()
+        res(normalized)
+      } else {
+        val totalScale = partial.scale() - exp.toLong
+        if (totalScale.toInt != totalScale) None // overflows
+        else res(partial.movePointRight(exp).stripTrailingZeros())
+      }
+    }
+  }
+
+}

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -1452,6 +1452,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
     currToken match {
       case tok: Constant.Int => withUnary(Lit.Int(unary(tok.value).intValue))
       case tok: Constant.Long => withUnary(Lit.Long(unary(tok.value).longValue))
+      case tok: Constant.IntXL => withUnary(Lit.IntXL(unary(tok.value)))
       case tok: Constant.Float => getBigDecimal(tok, Lit.Float.apply)
       case tok: Constant.Double => getBigDecimal(tok, Lit.Double.apply)
       case tok => unreachable(tok)
@@ -1460,6 +1461,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
 
   private def rawLiteral(unary: Unary): Lit = nextAfter {
     val res = currToken match {
+      case t: Constant.FloatXL => Left(Lit.FloatXL(t.value))
       case _: NumericConstant[_] => rawNumericLiteral(unary match {
           case unary: Unary.Numeric => unary
           case _ => Unary.Noop

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
@@ -760,20 +760,23 @@ class LegacyScanner(input: Input, dialect: Dialect) {
   private def setFractionOnDot(): Unit = {
     putChar('.')
     readDigits(10)
-    token = DOUBLELIT
+    token = DECIMALLIT
     setFractionExponentAndTypeSuffix()
   }
 
   private def setFractionExponentAndTypeSuffix(): Boolean = {
     // token is either DOUBLELIT if we have seen a dot, or INTLIT if only digits
+    decimalExponent = ""
     if (ch == 'e' || ch == 'E') {
-      val preExponentLen = cbuf.length()
-      putCharAndNext()
+      setStrVal()
+      nextChar()
       if (ch == '+' || ch == '-') putCharAndNext()
-      token = DOUBLELIT
-      if (isDigit()) readDigits(10)
-      else {
-        cbuf.setLength(preExponentLen) // to make it a parsable value
+      token = DECIMALLIT
+      if (isDigit()) {
+        readDigits(10)
+        decimalExponent = getAndResetCBuf()
+      } else {
+        resetCBuf()
         setInvalidToken(next) {
           val isLeadingSeparator = isNumberSeparator() && {
             nextChar()
@@ -795,7 +798,7 @@ class LegacyScanner(input: Input, dialect: Dialect) {
     }
     token != INTLIT && {
       checkNoLetter()
-      setStrVal()
+      if (cbuf.length() != 0) setStrVal()
       true
     }
   }

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyToken.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyToken.scala
@@ -29,7 +29,8 @@ object LegacyToken {
   final val INTERPOLATIONID = LITERAL_BEG + 8 // the lead identifier of an interpolated string
   final val XMLLIT = LITERAL_BEG + 9
   final val XMLLITEND = LITERAL_BEG + 10
-  final val LITERAL_END = LITERAL_BEG + 11
+  final val DECIMALLIT = LITERAL_BEG + 11
+  final val LITERAL_END = LITERAL_BEG + 12
 
   /** identifiers */
   final val IDENTIFIER = 10

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
@@ -173,7 +173,10 @@ class ScalametaTokenizer(input: Input, dialect: Dialect)(implicit options: Token
       case IDENTIFIER => Token.Ident(input, dialect, curr.offset, curr.endOffset, curr.strVal)
       case INTLIT => curr.intVal(lastEmittedToken).fold(
           getInvalid(curr, _),
-          Token.Constant.Int(input, dialect, curr.offset, curr.endOffset, _)
+          _.fold(
+            Token.Constant.IntXL(input, dialect, curr.offset, curr.endOffset, _),
+            Token.Constant.Int(input, dialect, curr.offset, curr.endOffset, _)
+          )
         )
       case LONGLIT => curr.longVal(lastEmittedToken).fold(
           getInvalid(curr, _),
@@ -185,6 +188,10 @@ class ScalametaTokenizer(input: Input, dialect: Dialect)(implicit options: Token
         )
       case DOUBLELIT => curr.doubleVal.fold(
           getInvalid(curr, _),
+          Token.Constant.Double(input, dialect, curr.offset, curr.endOffset, _)
+        )
+      case DECIMALLIT => curr.doubleOrDecimalVal.fold(
+          Token.Constant.FloatXL(input, dialect, curr.offset, curr.endOffset, _),
           Token.Constant.Double(input, dialect, curr.offset, curr.endOffset, _)
         )
       case CHARLIT => Token.Constant.Char(input, dialect, curr.offset, curr.endOffset, curr.charVal)

--- a/scalameta/tokens/shared/src/main/scala/scala/meta/tokens/Token.scala
+++ b/scalameta/tokens/shared/src/main/scala/scala/meta/tokens/Token.scala
@@ -227,10 +227,14 @@ object Token {
     class Int(value: BigInt) extends NumericConstant[BigInt]
     @freeform("long constant")
     class Long(value: BigInt) extends NumericConstant[BigInt]
+    @freeform("generic integer constant")
+    class IntXL(value: BigInt) extends NumericConstant[BigInt]
     @freeform("float constant")
     class Float(value: BigDecimal) extends NumericConstant[BigDecimal]
     @freeform("double constant")
     class Double(value: BigDecimal) extends NumericConstant[BigDecimal]
+    @freeform("generic floating-point constant")
+    class FloatXL(value: AnyDecimal) extends Constant[AnyDecimal]
     @freeform("character constant")
     class Char(value: scala.Char) extends Constant[scala.Char]
     @freeform("symbol constant")

--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -262,6 +262,25 @@ object Lit {
     private[meta] def apply(number: scala.BigDecimal): Float = apply(number.toString)
   }
   @ast
+  class IntXL(private val value36: JString) extends Lit {
+    val value = IntXL.fromBase36(value36)
+  }
+  object IntXL {
+    def apply(value: BigInt)(implicit dialect: Dialect): IntXL = apply(toBase36(value))
+    def toBase36(obj: BigInt): JString =
+      if (obj.signum == 0) "" else obj.toString(Character.MAX_RADIX)
+    def fromBase36(str: JString): BigInt =
+      if (str.isEmpty) BigInt(0) else BigInt(str, Character.MAX_RADIX)
+  }
+  @ast
+  class FloatXL(digits: JString, exponent: JString) extends Lit {
+    val value = AnyDecimal(digits, exponent)
+  }
+  object FloatXL {
+    def apply(value: AnyDecimal)(implicit dialect: Dialect): FloatXL =
+      apply(value.digits, value.exponent)
+  }
+  @ast
   class WithUnary(op: Term.Name, arg: Lit) extends Lit {
     def value = (op.value, arg.value)
   }

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeStructure.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeStructure.scala
@@ -37,6 +37,7 @@ object TreeStructure {
         case x: Lit.Double => asFloat(x.format, 'd') :: Nil
         case x: Lit.Float => asFloat(x.format, 'f') :: Nil
         case x: Lit.Long => x.value.toString + 'L' :: Nil
+        case x: Lit.FloatXL => s(x.digits) :: s(x.exponent) :: Nil
         case x: Lit.WithUnary => s(x.op.value) :: anyTree(x.arg) :: Nil
         case x: Lit => x.value.toString :: Nil
         case x: Term.ArgClause if x.mod.isEmpty => anyStructure(x.values) :: Nil

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -799,6 +799,8 @@ object TreeSyntax {
           else if (format.forall(Character.isDigit)) Some(".0")
           else None
         s(format, o(suffix))
+      case t: Lit.IntXL => s(t.value.toString)
+      case t: Lit.FloatXL => s(t.digits, w("e", s(t.exponent)))
       case t: Lit.WithUnary => s(t.op, t.arg)
       case t @ Lit.Char(value) =>
         val syntax = t.pos match {

--- a/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -65,6 +65,7 @@ class SurfaceSuite extends FunSuite {
     assertNoDiff(
       diagnostic,
       """|
+         |scala.meta.AnyDecimal
          |scala.meta.Dialect
          |scala.meta.Name.ImplicitName
          |scala.meta.Tree
@@ -346,7 +347,9 @@ class SurfaceSuite extends FunSuite {
          |scala.meta.Lit.Char
          |scala.meta.Lit.Double
          |scala.meta.Lit.Float
+         |scala.meta.Lit.FloatXL
          |scala.meta.Lit.Int
+         |scala.meta.Lit.IntXL
          |scala.meta.Lit.Long
          |scala.meta.Lit.Null
          |scala.meta.Lit.Short
@@ -594,7 +597,9 @@ class SurfaceSuite extends FunSuite {
          |scala.meta.tokens.Token.Constant.Char
          |scala.meta.tokens.Token.Constant.Double
          |scala.meta.tokens.Token.Constant.Float
+         |scala.meta.tokens.Token.Constant.FloatXL
          |scala.meta.tokens.Token.Constant.Int
+         |scala.meta.tokens.Token.Constant.IntXL
          |scala.meta.tokens.Token.Constant.Long
          |scala.meta.tokens.Token.Constant.String
          |scala.meta.tokens.Token.Constant.Symbol

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
@@ -24,7 +24,7 @@ class ReflectionSuite extends TreeSuiteBase {
     val sym = symbolOf[scala.meta.Tree]
     assert(sym.isRoot)
     val root = sym.asRoot
-    assertEquals((root.allBranches.length, root.allLeafs.length), (74, 486))
+    assertEquals((root.allBranches.length, root.allLeafs.length), (74, 490))
   }
 
   test("If") {

--- a/tests/jvm/src/test/scala-2/scala/meta/tests/tokens/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2/scala/meta/tests/tokens/ReflectionSuite.scala
@@ -29,7 +29,9 @@ class ReflectionSuite extends TreeSuiteBase {
          |Token.Constant.Char
          |Token.Constant.Double
          |Token.Constant.Float
+         |Token.Constant.FloatXL
          |Token.Constant.Int
+         |Token.Constant.IntXL
          |Token.Constant.Long
          |Token.Constant.String
          |Token.Constant.Symbol

--- a/tests/shared/src/test/scala-2/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala-2/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -328,7 +328,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     assertEquals(templStat("0.0f").reprint, "0.0f")
     assertEquals(templStat("0.0F").reprint, "0.0f")
     assertEquals(templStat("1.4f").reprint, "1.4f")
-    assertEquals(templStat("1.40f").reprint, "1.40f")
+    assertEquals(templStat("1.40f").reprint, "1.4f")
     assertEquals(templStat("0.0").reprint, "0.0")
     assertEquals(templStat("0d").reprint, "0d")
     assertEquals(templStat("0D").reprint, "0d")

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
@@ -243,6 +243,10 @@ trait CommonTrees extends CommonTrees.LowPriorityDefinitions {
   final def lit(v: Double) = Lit.Double(v)
   final def flt(v: String) = Lit.Float(v)
   final def lit(v: Float) = Lit.Float(v)
+  final def intXL(v: BigInt): Lit.IntXL = Lit.IntXL(v)
+  final def intXL(v: String): Lit.IntXL = intXL(BigInt(v))
+  final def fltXL(v: String, exp: String = ""): Lit = Lit.FloatXL(v, exp)
+  final def dec(v: String, exp: String = "") = AnyDecimal(v, exp)
   final def lit(op: String, v: Lit): Lit = Lit.WithUnary(op, v)
   final def str(v: String) = Lit.String(v)
   final def lit(v: String) = str(v)
@@ -251,6 +255,7 @@ trait CommonTrees extends CommonTrees.LowPriorityDefinitions {
   final def lit(v: Symbol) = Lit.Symbol(v)
   final def init(tpe: Type, args: Term.ArgClause*): Init = Init(tpe, anon, args.toList)
   final def blk(stats: Stat*): Term.Block = Term.Block(stats.toList)
+  final def unary(op: String, v: Term): Term.ApplyUnary = Term.ApplyUnary(op, v)
 
   final def stats(vals: Stat*): Stat.Block = Stat.Block(vals.toList)
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/LitSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/LitSuite.scala
@@ -25,7 +25,9 @@ class LitSuite extends ParseSuite {
 
   test("-9223372036854775808L")(assertTree(term("-9223372036854775808L"))(lit(-9223372036854775808L)))
 
-  test("42.42")(matchSubStructure[Stat]("42.42", { case Lit(42.42) => () }))
+  test("42.42")(
+    matchSubStructure[Stat]("42.42", { case t: Lit.Double => assertEquals(t.format, "42.42") })
+  )
 
   test("42.0f")(matchSubStructure[Stat]("42.42f", { case Lit(42.42f) => () }))
 
@@ -280,6 +282,37 @@ class LitSuite extends ParseSuite {
     ("-2.5e-324", dbl("-2.5E-324"), -Double.MinPositiveValue, "-2.5E-324"),
     ("4.8e-324", dbl("4.8E-324"), Double.MinPositiveValue, "4.8E-324"),
     ("-4.8E-324", dbl("-4.8E-324"), -Double.MinPositiveValue, "-4.8E-324"),
+    (
+      "1.7976931348623158e+308",
+      fltXL("1.7976931348623158", "+308"),
+      dec("1.7976931348623158", "+308"),
+      "1.7976931348623158e+308"
+    ),
+    (
+      "-1.7976931348623158e+308",
+      lit("-", fltXL("1.7976931348623158", "+308")),
+      ("-", dec("1.7976931348623158", "+308")),
+      "-1.7976931348623158e+308"
+    ),
+    ("1e10_0000_000_000", fltXL("1", "100000000000"), dec("1", "100000000000"), "1e100000000000"),
+    ("1_000_000_000_000", intXL(1000000000000L), BigInt(1000000000000L), "1000000000000"),
+    (
+      "1_000_000_000_000_000_000",
+      intXL("1000000000000000000"),
+      BigInt("1000000000000000000"),
+      "1000000000000000000"
+    ),
+    ("0b111111111111111111111111111111110", intXL(8589934590L), BigInt(8589934590L), "8589934590"),
+    (
+      "-0b111111111111111111111111111111110",
+      intXL(-8589934590L),
+      BigInt(-8589934590L),
+      "-8589934590"
+    ),
+    ("2147483648", intXL(2147483648L), BigInt(2147483648L), "2147483648"),
+    ("-2147483649", intXL(-2147483649L), BigInt(-2147483649L), "-2147483649"),
+    ("0xffffffff0", intXL(68719476720L), BigInt(68719476720L), "68719476720"),
+    ("-0xffffffff0", intXL(-68719476720L), BigInt(-68719476720L), "-68719476720"),
     ("0b00101010", lit(42), 42, "42"),
     ("0B_0010_1010", lit(42), 42, "42"),
     ("0b_0010_1010L", lit(42L), 42L, "42L")
@@ -302,18 +335,6 @@ class LitSuite extends ParseSuite {
 
   Seq(
     (
-      "2147483648",
-      """|<input>:1: error: integer number out of range for Int
-         |2147483648
-         |^""".stripMargin
-    ),
-    (
-      "-2147483649",
-      """|<input>:1: error: integer number out of range for Int
-         |-2147483649
-         | ^""".stripMargin
-    ),
-    (
       "9223372036854775808L",
       """|<input>:1: error: integer number out of range for Long
          |9223372036854775808L
@@ -323,30 +344,6 @@ class LitSuite extends ParseSuite {
       "-9223372036854775809L",
       """|<input>:1: error: integer number out of range for Long
          |-9223372036854775809L
-         | ^""".stripMargin
-    ),
-    (
-      "0xffffffff0",
-      """|<input>:1: error: integer number out of range for Int
-         |0xffffffff0
-         |^""".stripMargin
-    ),
-    (
-      "-0xffffffff0",
-      """|<input>:1: error: integer number out of range for Int
-         |-0xffffffff0
-         | ^""".stripMargin
-    ),
-    (
-      "0b111111111111111111111111111111110", // 33
-      """|<input>:1: error: integer number out of range for Int
-         |0b111111111111111111111111111111110
-         |^""".stripMargin
-    ),
-    (
-      "-0b111111111111111111111111111111110",
-      """|<input>:1: error: integer number out of range for Int
-         |-0b111111111111111111111111111111110
          | ^""".stripMargin
     ),
     (
@@ -360,30 +357,6 @@ class LitSuite extends ParseSuite {
       """|<input>:1: error: integer number out of range for Long
          |-0xffffffffffffffff0L
          | ^""".stripMargin
-    ),
-    (
-      "1.7976931348623158e+308",
-      """|<input>:1: error: floating-point value out of range for Double
-         |1.7976931348623158e+308
-         |^""".stripMargin
-    ),
-    (
-      "-1.7976931348623158e+308",
-      """|<input>:1: error: floating-point value out of range for Double
-         |-1.7976931348623158e+308
-         | ^""".stripMargin
-    ),
-    (
-      "1e10_0000_000_000",
-      """|<input>:1: error: malformed floating-point Double number
-         |1e10_0000_000_000
-         |^""".stripMargin
-    ),
-    (
-      "1_000_000_000_000",
-      """|<input>:1: error: integer number out of range for Int
-         |1_000_000_000_000
-         |^""".stripMargin
     ),
     (
       "1_000_000_000_000_000_000_000l",


### PR DESCRIPTION
In tokenizer, extract fractional-value tokens as Constant.FloatXL unless they have an explicit suffix identifying it as Float or Double, or if they are within Double range; at the same time, integer tokens that do not have a suffix will continue to be extracted as Constant.Int if they are within 32-bit, and as Constant.IntXL otherwise.

Add a new AnyDecimal "numeric" type which refers to arbitrary-precision decimal values.

Fixes #4204.