### PR TITLE
Transformer: transform all fields, not a subset

### DIFF
--- a/scalameta/common/shared/src/main/scala/scala/meta/internal/transversers/transformer.scala
+++ b/scalameta/common/shared/src/main/scala/scala/meta/internal/transversers/transformer.scala
@@ -77,9 +77,10 @@ class TransformerMacros(val c: Context) extends TransverserMacros {
 
   def leafHandler(l: Leaf, treeName: TermName): Tree = {
     val constructor = hygienicRef(l.sym.companion)
-    val relevantFields = l.fields.filter(f => !(f.tpe =:= typeOf[Any]) && !(f.tpe =:= typeOf[String]))
-    if (relevantFields.isEmpty) return q"$treeName"
-    val transformedFields: List[ValDef] = relevantFields.map(transformField(treeName))
+    val hasOnlyPrimitiveFields = l.fields
+      .forall(f => f.tpe =:= typeOf[Any] || PrimitiveTpe.unapply(f.tpe))
+    if (hasOnlyPrimitiveFields) return q"$treeName"
+    val transformedFields: List[ValDef] = l.fields.map(transformField(treeName))
 
     q"""
       var same = true


### PR DESCRIPTION
The logic was likely intended to make sure there are non-trivial fields to transform, but instead it ended up transforming only a subset.

It hasn't been triggered so far since trees containing a string field contained no other fields, but we are about to change that.