### PR TITLE
Trees: add Lit.WithUnary

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/Trees.scala
@@ -262,6 +262,10 @@ object Lit {
     private[meta] def apply(number: scala.BigDecimal): Float = apply(number.toString)
   }
   @ast
+  class WithUnary(op: Term.Name, arg: Lit) extends Lit {
+    def value = (op.value, arg.value)
+  }
+  @ast
   class Byte(value: scala.Byte) extends Lit
   @ast
   class Short(value: scala.Short) extends Lit

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeStructure.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeStructure.scala
@@ -25,7 +25,7 @@ object TreeStructure {
   private def iterableStructure(xs: Seq[_], cls: String): Show.Result =
     if (xs.isEmpty) s("Nil") else s(s"$cls(", r(xs.map(x => i(anyStructure(x))), ","), n(")"))
 
-  private def anyTree(tree: Tree) = TreeSyntax.withComments(tree) {
+  private def anyTree(tree: Tree): Show.Result = TreeSyntax.withComments(tree) {
     def getArgs: List[Show.Result] = {
       def default = tree.productIterator.map(anyStructure).toList
       tree match {
@@ -37,6 +37,7 @@ object TreeStructure {
         case x: Lit.Double => asFloat(x.format, 'd') :: Nil
         case x: Lit.Float => asFloat(x.format, 'f') :: Nil
         case x: Lit.Long => x.value.toString + 'L' :: Nil
+        case x: Lit.WithUnary => s(x.op.value) :: anyTree(x.arg) :: Nil
         case x: Lit => x.value.toString :: Nil
         case x: Term.ArgClause if x.mod.isEmpty => anyStructure(x.values) :: Nil
         case x: Term.ParamClause if x.mod.isEmpty => anyStructure(x.values) :: Nil

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -794,6 +794,7 @@ object TreeSyntax {
       case t: Lit.Double =>
         val format = t.format
         w(s(format), "d", Character.toLowerCase(format.last) != 'd')
+      case t: Lit.WithUnary => s(t.op, t.arg)
       case t @ Lit.Char(value) =>
         val syntax = t.pos match {
           case Position.None => SingleQuotes(value)

--- a/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -353,6 +353,7 @@ class SurfaceSuite extends FunSuite {
          |scala.meta.Lit.String
          |scala.meta.Lit.Symbol
          |scala.meta.Lit.Unit
+         |scala.meta.Lit.WithUnary
          |scala.meta.Member
          |scala.meta.Member.Apply
          |scala.meta.Member.ArgClause

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
@@ -24,7 +24,7 @@ class ReflectionSuite extends TreeSuiteBase {
     val sym = symbolOf[scala.meta.Tree]
     assert(sym.isRoot)
     val root = sym.asRoot
-    assertEquals((root.allBranches.length, root.allLeafs.length), (74, 484))
+    assertEquals((root.allBranches.length, root.allLeafs.length), (74, 486))
   }
 
   test("If") {
@@ -131,6 +131,7 @@ class ReflectionSuite extends TreeSuiteBase {
          |scala.meta.Ctor.Block
          |scala.meta.Ctor.Primary
          |scala.meta.Init
+         |scala.meta.Lit
          |scala.meta.Name
          |scala.meta.Name.Anonymous
          |scala.meta.Pat

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
@@ -243,6 +243,7 @@ trait CommonTrees extends CommonTrees.LowPriorityDefinitions {
   final def lit(v: Double) = Lit.Double(v)
   final def flt(v: String) = Lit.Float(v)
   final def lit(v: Float) = Lit.Float(v)
+  final def lit(op: String, v: Lit): Lit = Lit.WithUnary(op, v)
   final def str(v: String) = Lit.String(v)
   final def lit(v: String) = str(v)
   final def lit(v: Char) = Lit.Char(v)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/LitSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/LitSuite.scala
@@ -173,9 +173,9 @@ class LitSuite extends ParseSuite {
   }
 
   test("unary: ~1.0") {
-    val tree = Term.ApplyUnary(tname("~"), lit(1d))
+    val tree = lit("~", lit(1d))
     runTestAssert[Stat]("~1.0", "~1.0d")(tree)
-    runTestAssert[Stat]("~1.0(0)", "(~1.0d)(0)")(tapply(tree, lit(0)))
+    runTestAssert[Stat]("~1.0(0)", "~1.0d(0)")(tapply(tree, lit(0)))
   }
 
   test("unary: !1.0") {


### PR DESCRIPTION
Unlike Term.ApplyUnary, this tree is accepted even in patterns, or anywhere a literal is expected.