### PR TITLE
ScalametaParser: always parse literals fully

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/Unary.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/Unary.scala
@@ -13,10 +13,7 @@ private[meta] object Unary {
 
   private def unaryWithKey[T <: Unary](unary: T) = unary.op -> unary
 
-  def unapply(token: Token.Ident): Option[(String, Unary)] = {
-    val op = token.text
-    opMap.get(op).map(op -> _)
-  }
+  def unapply(token: Token.Ident): Option[Unary] = opMap.get(token.text)
 
   sealed trait Numeric extends Unary {
     def apply(value: BigInt): BigInt

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/LitSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/LitSuite.scala
@@ -152,10 +152,9 @@ class LitSuite extends ParseSuite {
   }
 
   test("unary: !1") {
-    val number = lit(1)
-    runTestAssert[Stat]("!1")(Term.ApplyUnary(tname("!"), number))
-    val tree = Term.ApplyUnary(tname("!"), tapply(number, lit(0)))
-    runTestAssert[Stat]("!1(0)")(tree)
+    val number = lit("!", lit(1))
+    runTestAssert[Stat]("!1")(number)
+    runTestAssert[Stat]("!1(0)")(tapply(number, lit(0)))
   }
 
   test("unary: +1.0") {
@@ -179,10 +178,9 @@ class LitSuite extends ParseSuite {
   }
 
   test("unary: !1.0") {
-    val number = lit(1d)
-    runTestAssert[Stat]("!1.0", "!1.0")(Term.ApplyUnary(tname("!"), number))
-    val tree = Term.ApplyUnary(tname("!"), tapply(number, lit(0)))
-    runTestAssert[Stat]("!1.0(0)", "!1.0(0)")(tree)
+    val number = lit("!", lit(1d))
+    runTestAssert[Stat]("!1.0", "!1.0")(number)
+    runTestAssert[Stat]("!1.0(0)", "!1.0(0)")(tapply(number, lit(0)))
   }
 
   test("unary: !true") {


### PR DESCRIPTION
Instead of a special case for numeric literals, recognize any.