### PR TITLE
bugfix: Adjust `into` according to SIP-71

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -973,18 +973,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
           next()
           autoEndPos(startPos)(Type.Repeated(t))
         } else t
-      def atInto() = {
-        val intoPos = currIndex
-        val mod = atPos(intoPos)(Mod.Into())
-        next()
-        autoEndPos(intoPos)(Type.FunctionArg(mod :: Nil, typ(inParam = true)))
-      }
-      currToken match {
-        case soft.KwInto() => atInto()
-        case _: LeftParen if nextIf(soft.KwInto.matches(peekToken)) =>
-          withRepeated(inParensAfterOpen(atInto()))
-        case _ => withRepeated(typ(inParam = true))
-      }
+      withRepeated(typ(inParam = true))
     }
 
     def paramType(): Type = {
@@ -3037,6 +3026,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
   private def modifier(tok: Ident, isLocal: Boolean): Mod = tok.text match {
     case soft.KwInline() => atCurPosNext(Mod.Inline())
     case soft.KwInfix() => atCurPosNext(Mod.Infix())
+    case soft.KwInto() => atCurPosNext(Mod.Into())
     case soft.KwOpen() if !isLocal => atCurPosNext(Mod.Open())
     case soft.KwOpaque() => atCurPosNext(Mod.Opaque())
     case soft.KwTransparent() => atCurPosNext(Mod.Transparent())

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -120,10 +120,19 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
       val next = getNextIndex(index)
       isDclIntro(next) || isModifier(next) || f(tokens(next))
     }
+    @inline
+    def nextIsClassOrObjectorOpaqueType: Boolean = {
+      val next = getNextIndex(index)
+      tokens(next) match {
+        case _: KwClass | _: KwType | _: KwTrait => true
+        case otherwise => isModifier(next)
+      }
+    }
 
     tokens(index).text match {
       case soft.KwTransparent() => nextIsDclIntroOrModifierOr(_.isAny[KwTrait, KwClass])
       case soft.KwOpaque() => nextIsDclIntroOrModifierOr(_ => false)
+      case soft.KwInto() => nextIsClassOrObjectorOpaqueType
       case soft.KwInline() => nextIsDclIntroOrModifierOr(matchesAfterInlineMatchMod)
       case soft.KwOpen() | soft.KwInfix() | soft.KwErased() | soft.KwTracked() =>
         isDefIntro(getNextIndex(index))


### PR DESCRIPTION
https://docs.scala-lang.org/sips/71.html#syntax-changes

I skipped checking if type is opaque, I don't think we need to be that exact in the parser.