### PR TITLE
MoreHelpers: fix origin checking

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/MoreHelpers.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/MoreHelpers.scala
@@ -12,7 +12,8 @@ import munit._
 object MoreHelpers {
 
   def requireNonEmptyOrigin(tree: Tree): tree.type = {
-    val missingOrigin = TestHelpers.collect(tree) { case t if t.origin == Origin.None => t }
+    val missingOrigin = TestHelpers
+      .collect(tree) { case t if !t.origin.isInstanceOf[Origin.Parsed] => t }
     Assertions.assertEquals(
       missingOrigin.map(_.structure),
       Nil,


### PR DESCRIPTION
Now all trees by default use at least DialectOnly origin, so we need to upgrade our check.