### PR TITLE
ScannerTokens: further limit start of Given region

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -491,9 +491,9 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
       case _: KwEnum => currRef(RegionTemplateMark :: sepRegions)
       case _: KwGiven if !prevToken.isAny[Dot, KwCase] =>
         currRef(dropRegionLine(sepRegions) match {
-          case (_: RegionFor) :: _ => sepRegions
-          case (_: RegionDelim) :: (_: RegionFor) :: _ => sepRegions
-          case rs => new RegionGivenDecl(curr) :: rs
+          case rs @ (Nil | (_: RegionBrace | _: RegionIndent) :: _) => new RegionGivenDecl(curr) ::
+              rs
+          case _ => sepRegions
         })
       case _: KwWith => currRef(dropRegionLine(sepRegions) match {
           case (_: RegionGivenDecl) :: rs => rs

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/PatSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/PatSuite.scala
@@ -188,12 +188,7 @@ class PatSuite extends ParseSuite {
         blk(Import(List(Importer("foo", List(Importee.Wildcard())))), tapply("x"))
       )))
     )
-
-    val error =
-      """|<input>:3: error: `}` expected but `identifier` found
-         |  x()
-         |  ^""".stripMargin
-    runTestError[Stat](code, error)
+    runTestAssert[Stat](code, layout)(tree)
 
     val codeInParens =
       """|withFoo { case foo @ (given Foo) => 
@@ -201,7 +196,7 @@ class PatSuite extends ParseSuite {
          |  x()
          |}
          |""".stripMargin
-    parseAndCheckTree[Stat](codeInParens, layout)(tree)
+    runTestAssert[Stat](codeInParens, layout)(tree)
   }
 
 }


### PR DESCRIPTION
Specify when it could happen, instead of excluding when it couldn't. Fixes #4428.