### PR TITLE
ReificationMacros: backquote Unquote tokens

### DIFF
--- a/scalameta/quasiquotes/shared/src/main/scala-3/scala/meta/internal/quasiquotes/ReificationMacros.scala
+++ b/scalameta/quasiquotes/shared/src/main/scala-3/scala/meta/internal/quasiquotes/ReificationMacros.scala
@@ -8,6 +8,7 @@ import org.scalameta.invariants._
 import scala.meta.dialects
 import scala.meta.internal.parsers.Absolutize._
 import scala.meta.internal.parsers.Messages
+import scala.meta.internal.prettyprinters.TokensToString
 import scala.meta.internal.trees._
 import scala.meta.internal.trees.{Liftables => AstLiftables, Reflection => AstReflection}
 import scala.meta.parsers._
@@ -312,7 +313,7 @@ class ReificationMacros(using val internalQuotes: Quotes) extends HasInternalQuo
     }
 
     val (psourceVal, psourceExpr) = getValRef("psource")('{
-      new Origin.ParsedSource(Input.String(${ Expr(input.text.replace("$$", "$")) }))
+      new Origin.ParsedSource(Input.String(${ Expr(TokensToString.quasi(meta.tokens, input)) }))
     })
     val valDefs = List(psourceVal)
 

--- a/scalameta/tokens/shared/src/main/scala/scala/meta/internal/prettyprinters/TokensToString.scala
+++ b/scalameta/tokens/shared/src/main/scala/scala/meta/internal/prettyprinters/TokensToString.scala
@@ -2,6 +2,7 @@ package scala.meta
 package internal
 package prettyprinters
 
+import scala.meta.inputs.Input
 import scala.meta.tokens._
 
 object TokensToString {
@@ -9,5 +10,38 @@ object TokensToString {
     val sb = new StringBuilder
     tokens.foreach(t => sb.append(t.text))
     sb.result()
+  }
+
+  /**
+   * Serialize tokens for quasiquotes, ensuring each token would subsequently be parsed as a single
+   * token, so that Origin.ParsedSpliced positions remain valid.
+   *
+   * This includes converting an Unquote into an Ident (to avoid `\${foo}` getting parsed as
+   * multiple tokens); also, what was an escaped `$$` in the original input should be output as a
+   * single `$` (but we get it here for free since that `$$` was parsed as `Ident($)`).
+   */
+  def quasi(tokens: Tokens, input: Input): String = {
+    val sb = new java.lang.StringBuilder
+    val chars = input.chars
+    tokens.foreach {
+      case t: Token.Unquote => // output any identifier; let's use original as a human hint
+        sb.append('`')
+        var idx = t.start
+        val maxend = idx + 50
+        while (idx < t.end && {
+            if (idx > maxend) {
+              sb.append("...")
+              false
+            } else {
+              val ch = chars(idx)
+              if (Character.isWhitespace(ch)) sb.append(' ') // no newlines
+              else if (ch != '`') sb.append(ch) // no backquotes
+              true
+            }
+          }) idx += 1
+        sb.append('`')
+      case t => sb.append(chars, t.start, t.len)
+    }
+    sb.toString
   }
 }

--- a/tests/shared/src/test/scala-3/scala/meta/tests/quasiquotes/Scala3SpecificSuccessSuite.scala
+++ b/tests/shared/src/test/scala-3/scala/meta/tests/quasiquotes/Scala3SpecificSuccessSuite.scala
@@ -15,12 +15,12 @@ class Scala3SpecificSuccessSuite extends TreeSuiteBase {
       """
     assertPositions(
       foo(Type.Name("AAA")),
-      """|<?>Defn.Class class AAA { val a: Int = 1 }</?> [0:...class $name:...:53)
-         |<tparamClause>Type.ParamClause         class $name@@:</tparamClause> [20::20)
-         |<ctor>Ctor.Primary         class $name@@:</ctor> [20::20)
-         |<templ>Template { val a: Int = 1 }</templ> [20<:...>46)
-         |<body>Template.Body { val a: Int = 1 }</body> [20<:...>46)
-         |<stats0>Defn.Val val a: Int = 1</stats0> [32:val a: Int = 1:46)
+      """|<?>Defn.Class class AAA { val a: Int = 1 }</?> [0:...class `$name`:...:55)
+         |<tparamClause>Type.ParamClause         class `$name`@@:</tparamClause> [22::22)
+         |<ctor>Ctor.Primary         class `$name`@@:</ctor> [22::22)
+         |<templ>Template { val a: Int = 1 }</templ> [22<:...>48)
+         |<body>Template.Body { val a: Int = 1 }</body> [22<:...>48)
+         |<stats0>Defn.Val val a: Int = 1</stats0> [34:val a: Int = 1:48)
          |""".stripMargin,
       showPosition = true,
       showFieldName = true,
@@ -36,12 +36,12 @@ class Scala3SpecificSuccessSuite extends TreeSuiteBase {
       """
     assertPositions(
       foo(Type.Name("AAA")),
-      """|<?>Defn.Class class AAA { val a: Int = 1 }</?> [0:...class $name:...:53)
-         |<tparamClause>Type.ParamClause         class $name@@:</tparamClause> [20::20)
-         |<ctor>Ctor.Primary         class $name@@:</ctor> [20::20)
-         |<templ>Template { val a: Int = 1 }</templ> [20<:...>46)
-         |<body>Template.Body { val a: Int = 1 }</body> [20<:...>46)
-         |<stats0>Defn.Val val a: Int = 1</stats0> [32:val a: Int = 1:46)
+      """|<?>Defn.Class class AAA { val a: Int = 1 }</?> [0:...class `$name`:...:55)
+         |<tparamClause>Type.ParamClause         class `$name`@@:</tparamClause> [22::22)
+         |<ctor>Ctor.Primary         class `$name`@@:</ctor> [22::22)
+         |<templ>Template { val a: Int = 1 }</templ> [22<:...>48)
+         |<body>Template.Body { val a: Int = 1 }</body> [22<:...>48)
+         |<stats0>Defn.Val val a: Int = 1</stats0> [34:val a: Int = 1:48)
          |""".stripMargin,
       showPosition = true,
       showFieldName = true,
@@ -80,19 +80,19 @@ class Scala3SpecificSuccessSuite extends TreeSuiteBase {
     assertTokensAsStructureLines(
       quoted.tokens,
       """|BOF [0..0)
-         |Ident($) [0..1)
-         |LeftBrace [1..2)
-         |Ident(fooTypes) [2..10)
-         |LeftParen [10..11)
-         |Constant.Int(0) [11..12)
+         |Ident(${fooTypes(0)}) [0..16)
+         |Semicolon [16..17)
+         |Space [17..18)
+         |Constant.String(any message) [18..31)
+         |EOF [31..31)
          |""".stripMargin
     )
     val pos = quoted.pos
-    assertNoDiff(pos.toString, """[0..12) in Input.String("${fooTypes(0)}; "any message"")""")
-    assertNoDiff(pos.text, """${fooTypes(0""")
+    assertNoDiff(pos.toString, """[0..31) in Input.String("`${fooTypes(0)}`; "any message"")""")
+    assertNoDiff(pos.text, """`${fooTypes(0)}`; "any message"""")
     assertPositions(
       quoted,
-      """|<stats1>Lit.String (</stats1> [10:(:11)
+      """|<stats1>Lit.String "any message"</stats1> [18:"any message":31)
          |""".stripMargin,
       showPosition = true,
       showFieldName = true
@@ -101,7 +101,7 @@ class Scala3SpecificSuccessSuite extends TreeSuiteBase {
     val syntax =
       """|{
          |  Foo
-         |  (
+         |  "any message"
          |}
          |""".stripMargin
     assertNoDiff(quoted.text, syntax)

--- a/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/DottySuccessSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/DottySuccessSuite.scala
@@ -193,19 +193,19 @@ class DottySuccessSuite extends TreeSuiteBase {
     assertTokensAsStructureLines(
       quoted.tokens,
       """|BOF [0..0)
-         |MacroSplice [0..1)
-         |LeftBrace [1..2)
-         |Ident(fooTypes) [2..10)
-         |LeftParen [10..11)
-         |Constant.Int(0) [11..12)
+         |Ident(${fooTypes(0)}) [0..16)
+         |Semicolon [16..17)
+         |Space [17..18)
+         |Constant.String(any message) [18..31)
+         |EOF [31..31)
          |""".stripMargin
     )
     val pos = quoted.pos
-    assertNoDiff(pos.toString, """[0..12) in Input.String("${fooTypes(0)}; "any message"")""")
-    assertNoDiff(pos.text, """${fooTypes(0""")
+    assertNoDiff(pos.toString, """[0..31) in Input.String("`${fooTypes(0)}`; "any message"")""")
+    assertNoDiff(pos.text, """`${fooTypes(0)}`; "any message"""")
     assertPositions(
       quoted,
-      """|<stats1>Lit.String (</stats1> [10:(:11)
+      """|<stats1>Lit.String "any message"</stats1> [18:"any message":31)
          |""".stripMargin,
       showPosition = true,
       showFieldName = true
@@ -214,7 +214,7 @@ class DottySuccessSuite extends TreeSuiteBase {
     val syntax =
       """|{
          |  Foo
-         |  (
+         |  "any message"
          |}
          |""".stripMargin
     assertNoDiff(quoted.text, syntax)

--- a/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -2361,19 +2361,19 @@ class SuccessSuite extends TreeSuiteBase {
     assertTokensAsStructureLines(
       quoted.tokens,
       """|BOF [0..0)
-         |Ident($) [0..1)
-         |LeftBrace [1..2)
-         |Ident(fooTypes) [2..10)
-         |LeftParen [10..11)
-         |Constant.Int(0) [11..12)
+         |Ident(${fooTypes(0)}) [0..16)
+         |Semicolon [16..17)
+         |Space [17..18)
+         |Constant.String(any message) [18..31)
+         |EOF [31..31)
          |""".stripMargin
     )
     val pos = quoted.pos
-    assertNoDiff(pos.toString, """[0..12) in Input.String("${fooTypes(0)}; "any message"")""")
-    assertNoDiff(pos.text, """${fooTypes(0""")
+    assertNoDiff(pos.toString, """[0..31) in Input.String("`${fooTypes(0)}`; "any message"")""")
+    assertNoDiff(pos.text, """`${fooTypes(0)}`; "any message"""")
     assertPositions(
       quoted,
-      """|<stats1>Lit.String (</stats1> [10:(:11)
+      """|<stats1>Lit.String "any message"</stats1> [18:"any message":31)
          |""".stripMargin,
       showPosition = true,
       showFieldName = true
@@ -2382,7 +2382,7 @@ class SuccessSuite extends TreeSuiteBase {
     val syntax =
       """|{
          |  Foo
-         |  (
+         |  "any message"
          |}
          |""".stripMargin
     assertNoDiff(quoted.text, syntax)


### PR DESCRIPTION
Since we are using `ParsedSpliced` origin for quasiquotes with splices, it preserves token positions but not text. The problem is that we must then preserve the number of tokens, for these positions to make sense.

When we splice `$foo`, this is parsed by LegacyScanner as a single token `Ident($foo)`, and the token counts are correct (and this is verified by our unit tests).

However, if we splice `${foo}`, this results in additional tokens, such as `Ident($)`, `LeftBrace({)`, `RightBrace(})` and whatever expression `foo` is tokenized as. Thus the token positions are no longer valid, as the unit tests added in the previous commit attest.

All we need to do is escape, or backquote, Unquote tokens to produce new input that would be used as the `ParsedSource` for quasiquotes.

This also correctly serializes previously escaped `$` characters, since `$$` would be parsed as a `Ident($)` token.

Fixes #4434.