### PR TITLE
LegacyScanner: cleanup MacroSplice and MacroQuote

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -105,11 +105,11 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
   def isIdentOrExprIntro(token: Token): Boolean = isExprIntroImpl(token)(true)
 
   private def isExprIntroImpl(token: Token)(isIdentOK: => Boolean): Boolean = token match {
-    case _: Ident => isIdentOK
+    case t: Ident => isIdentOK ||
+      dialect.allowSpliceAndQuote && t.value.nonEmpty && t.value.charAt(0) == '$'
     case _: Literal | _: Interpolation.Id | _: Xml.Start | _: KwDo | _: KwFor | _: KwIf | _: KwNew |
         _: KwReturn | _: KwSuper | _: KwThis | _: KwThrow | _: KwTry | _: KwWhile | _: LeftParen |
-        _: LeftBrace | _: Underscore | _: Unquote | _: MacroSplice | _: MacroQuote |
-        _: Indentation.Indent => true
+        _: LeftBrace | _: Underscore | _: Unquote | _: MacroQuote | _: Indentation.Indent => true
     case _: LeftBracket => dialect.allowPolymorphicFunctions
     case _ => false
   }
@@ -146,7 +146,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
 
   private def matchesAfterInlineMatchMod(token: Token): Boolean = token match {
     case _: LeftParen | _: LeftBrace | _: KwNew | _: Ident | _: Literal | _: Interpolation.Id |
-        _: Xml.Start | _: KwSuper | _: KwThis | _: MacroSplice | _: MacroQuote => true
+        _: Xml.Start | _: KwSuper | _: KwThis | _: MacroQuote => true
     case _ => false
   }
 

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyToken.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyToken.scala
@@ -134,7 +134,6 @@ object LegacyToken {
   final val UNQUOTE = 400
   final val ELLIPSIS = 401
   final val MACROQUOTE = 402
-  final val MACROSPLICE = 403
 
   val kw2legacytoken = Map[String, LegacyToken](
     "abstract" -> ABSTRACT,

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
@@ -276,7 +276,6 @@ class ScalametaTokenizer(input: Input, dialect: Dialect)(implicit options: Token
       case CTXARROW => Token.ContextArrow(input, dialect, curr.offset)
 
       case MACROQUOTE => Token.MacroQuote(input, dialect, curr.offset)
-      case MACROSPLICE => Token.MacroSplice(input, dialect, curr.offset)
 
       case WHITESPACE_SPC => Token.Space(input, dialect, curr.offset)
       case WHITESPACE_TAB => Token.Tab(input, dialect, curr.offset)

--- a/scalameta/tokens/shared/src/main/scala/scala/meta/tokens/Token.scala
+++ b/scalameta/tokens/shared/src/main/scala/scala/meta/tokens/Token.scala
@@ -199,8 +199,8 @@ object Token {
   class ContextArrow extends FunctionArrow
   @fixed("'")
   class MacroQuote extends SymbolicKeyword
-  @fixed("$")
-  class MacroSplice extends SymbolicKeyword
+  @fixed("$") @deprecated("use Ident($) instead", "v4.14.5")
+  private[meta] class MacroSplice extends SymbolicKeyword
 
   // Delimiters
   @fixed("(")

--- a/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -668,7 +668,6 @@ class SurfaceSuite extends FunSuite {
          |scala.meta.tokens.Token.LeftBracket
          |scala.meta.tokens.Token.LeftParen
          |scala.meta.tokens.Token.MacroQuote
-         |scala.meta.tokens.Token.MacroSplice
          |scala.meta.tokens.Token.MultiHS
          |scala.meta.tokens.Token.MultiNL
          |scala.meta.tokens.Token.RightArrow

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
@@ -144,24 +144,9 @@ class MacroSuite extends BaseDottySuite {
     val code = " 'x "
     val tree = Term.QuotedMacroExpr(tname("x"))
     runTestAssert[Stat](code)(tree)
-    runTestError[Stat](
-      "' x",
-      """|<input>:1: error: unclosed character literal
-         |' x
-         |  ^""".stripMargin
-    )
-    runTestError[Stat](
-      "'`x`",
-      """|<input>:1: error: unclosed character literal
-         |'`x`
-         |  ^""".stripMargin
-    )
-    runTestError[Stat](
-      "' `x`",
-      """|<input>:1: error: unclosed character literal
-         |' `x`
-         |  ^""".stripMargin
-    )
+    runTestAssert[Stat]("' x", code)(tree)
+    runTestAssert[Stat]("'`x`", code)(tree)
+    runTestAssert[Stat]("' `x`", code)(tree)
     runTestAssert[Stat]("`'x`")(tname("'x"))
   }
 
@@ -170,24 +155,9 @@ class MacroSuite extends BaseDottySuite {
     val tree = Term.QuotedMacroExpr(blk(Term.QuotedMacroExpr(tname("x"))))
     runTestAssert[Stat](code)(tree)
     runTestAssert[Stat]("' { 'x }", code)(tree)
-    runTestError[Stat](
-      "' { ' x }",
-      """|<input>:1: error: unclosed character literal
-         |' { ' x }
-         |      ^""".stripMargin
-    )
-    runTestError[Stat](
-      "'{ '`x` }",
-      """|<input>:1: error: unclosed character literal
-         |'{ '`x` }
-         |     ^""".stripMargin
-    )
-    runTestError[Stat](
-      "'{ ' `x` }",
-      """|<input>:1: error: unclosed character literal
-         |'{ ' `x` }
-         |     ^""".stripMargin
-    )
+    runTestAssert[Stat]("' { ' x }", code)(tree)
+    runTestAssert[Stat]("'{ '`x` }", code)(tree)
+    runTestAssert[Stat]("'{ ' `x` }", code)(tree)
     val backquoted = Term.QuotedMacroExpr(blk(tname("'x")))
     runTestAssert[Stat]("'{ `'x` }")(backquoted)
   }
@@ -197,24 +167,9 @@ class MacroSuite extends BaseDottySuite {
     val tree = Term.SplicedMacroExpr(blk(Term.QuotedMacroExpr(tname("x"))))
     runTestAssert[Stat](code)(tree)
     runTestAssert[Stat]("$ { 'x }", code)(tree)
-    runTestError[Stat](
-      "$ { ' x }",
-      """|<input>:1: error: unclosed character literal
-         |$ { ' x }
-         |      ^""".stripMargin
-    )
-    runTestError[Stat](
-      "${ '`x` }",
-      """|<input>:1: error: unclosed character literal
-         |${ '`x` }
-         |     ^""".stripMargin
-    )
-    runTestError[Stat](
-      "${ ' `x` }",
-      """|<input>:1: error: unclosed character literal
-         |${ ' `x` }
-         |     ^""".stripMargin
-    )
+    runTestAssert[Stat]("$ { ' x }", code)(tree)
+    runTestAssert[Stat]("${ '`x` }", code)(tree)
+    runTestAssert[Stat]("${ ' `x` }", code)(tree)
     val backquoted = Term.SplicedMacroExpr(blk(tname("'x")))
     runTestAssert[Stat]("${ `'x` }")(backquoted)
   }
@@ -224,10 +179,9 @@ class MacroSuite extends BaseDottySuite {
     val tree = Term.QuotedMacroExpr(blk(Term.SplicedMacroExpr(tname("x"))))
     runTestAssert[Stat](code)(tree)
     runTestAssert[Stat]("' { $x }", code)(tree)
-    val spaceTree = Term.QuotedMacroExpr(blk(tpostfix("$", "x")))
-    runTestAssert[Stat]("' { $ x }", "'{ $ x }")(spaceTree)
-    runTestAssert[Stat]("'{ $`x` }", "'{ $ x }")(spaceTree)
-    runTestAssert[Stat]("'{ $ `x` }", "'{ $ x }")(spaceTree)
+    runTestAssert[Stat]("' { $ x }", code)(tree)
+    runTestAssert[Stat]("'{ $`x` }", code)(tree)
+    runTestAssert[Stat]("'{ $ `x` }", code)(tree)
     val backquoted = Term.QuotedMacroExpr(blk(tname("$x")))
     parseAndCheckTree[Stat]("'{ `$x` }", code)(backquoted)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/GranularWhitespaceTokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/GranularWhitespaceTokenizerSuite.scala
@@ -1273,7 +1273,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
     assertTokens("$ { a }", dialects.Scala3) {
       case Tokens(
             BOF(),
-            MacroSplice(),
+            Ident("$"),
             Space(),
             LeftBrace(),
             Space(),

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
@@ -1226,7 +1226,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
     assertTokens("$ { a }", dialects.Scala3) {
       case Tokens(
             BOF(),
-            MacroSplice(),
+            Ident("$"),
             Space(),
             LeftBrace(),
             Space(),


### PR DESCRIPTION
- deprecate MacroSplice, instead use Ident($)
  - whether `$x` is a splice is only known in the parser, thus the scanner simply parsed it as an Ident
  - however, `$ x` would then also be a valid slice, with the scanner producing an Ident($), but the parser didn't handle it
  - the only remaining case was `${ ... }` which should be a splice but it's simpler also to produce an Ident($) here as well
- always use MacroQuote since quoted Symbol has been removed from scala3
  - `'x` is always a macro quote if it's not followed by a single quote
  - the same applies to '`[` and `'{` but it was not parsed as Symbol
  - so is `' x`  but can't be parsed as a Symbol so we didn't handle it
  - let's consolidate all three cases and parse all as MacroQuote