### PR TITLE
TreeSyntacticGroup: align with ScalametaParser

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntacticGroup.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntacticGroup.scala
@@ -137,26 +137,25 @@ object TreeSyntacticGroup {
   @leaf
   object Path extends AllSimpleGroup
 
-  def opNeedsParensSameAssoc(
+  def opNeedsParens(
       outerPrecedence: Int,
       innerPrecedence: Int,
-      isLeftAssoc: => Boolean,
-      isLhs: => Boolean
+      ifSamePrecedence: => Boolean
   ): Boolean = {
     val diffPrecedence = outerPrecedence - innerPrecedence
-    if (diffPrecedence < 0) !isLeftAssoc
-    else if (diffPrecedence > 0) isLeftAssoc
-    else isLeftAssoc != isLhs
+    diffPrecedence > 0 || diffPrecedence == 0 && ifSamePrecedence
   }
 
   def opNeedsParens(outerOp: Name, innerOp: Name, isLhs: => Boolean)(implicit
       dialect: Dialect
   ): Boolean = {
     val outerIsLeftAssoc = outerOp.isLeftAssoc
-    if (outerIsLeftAssoc != innerOp.isLeftAssoc) true
+    @inline
+    def ifSamePrecedence = outerIsLeftAssoc != isLhs
+    if (outerIsLeftAssoc != innerOp.isLeftAssoc) true // not really true but visually clearer
     else if (!outerOp.is[Type] || dialect.useInfixTypePrecedence)
-      opNeedsParensSameAssoc(outerOp.precedence, innerOp.precedence, outerIsLeftAssoc, isLhs)
-    else outerIsLeftAssoc != isLhs
+      opNeedsParens(outerOp.precedence, innerOp.precedence, ifSamePrecedence)
+    else ifSamePrecedence
   }
 
   def opNeedsParens(outer: Member.Infix, inner: Member.Infix)(implicit dialect: Dialect): Boolean =

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -1399,18 +1399,18 @@ class TermSuite extends ParseSuite {
 
   test("infix assoc and precedence: mix 1") {
     val code = "foo :: (bar == baz) :: qux == xuq *: (zab +: rab) * oof"
-    val layout = "(foo :: (bar == baz) :: qux) == (xuq *: zab +: rab) * oof"
+    val layout = "(foo :: (bar == baz) :: qux) == (xuq *: (zab +: rab)) * oof"
     val tree = tinfix(
       tinfix("foo", "::", tinfix(tinfix("bar", "==", "baz"), "::", "qux")),
       "==",
       tinfix(tinfix("xuq", "*:", tinfix("zab", "+:", "rab")), "*", "oof")
     )
-    parseAndCheckTree[Stat](code, layout)(tree)
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("infix assoc and precedence: mix 2") {
     val code = "foo :: (bar == baz) :: (qux == xuq) *: (zab +: rab) * oof"
-    val layout = "foo :: (bar == baz) :: (((qux == xuq) *: zab +: rab) * oof)"
+    val layout = "foo :: (bar == baz) :: (((qux == xuq) *: (zab +: rab)) * oof)"
     val tree = tinfix(
       "foo",
       "::",
@@ -1420,12 +1420,12 @@ class TermSuite extends ParseSuite {
         tinfix(tinfix(tinfix("qux", "==", "xuq"), "*:", tinfix("zab", "+:", "rab")), "*", "oof")
       )
     )
-    parseAndCheckTree[Stat](code, layout)(tree)
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("infix assoc and precedence: mix 3") {
     val code = "(foo :: bar) == (baz :: qux) == (xuq *: zab) +: (rab * oof)"
-    val layout = "(foo :: bar) == (baz :: qux) == ((xuq *: zab) +: (rab * oof))"
+    val layout = "(foo :: bar) == (baz :: qux) == (xuq *: zab +: (rab * oof))"
     val tree = tinfix(
       tinfix(tinfix("foo", "::", "bar"), "==", tinfix("baz", "::", "qux")),
       "==",


### PR DESCRIPTION
During parsing, we correctly put precedence over associativity, so let's do the same when handling tree syntax and parentheses.