### PR TITLE
Dialect: disallow symbol literals in scala3

### DIFF
--- a/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -93,7 +93,7 @@ package object dialects {
     .withAllowAsForImportRename(true).withAllowStarWildcardImport(true)
     .withAllowProcedureSyntax(false).withAllowDoWhile(false).withAllowStarAsTypePlaceholder(true)
     .withUseInfixTypePrecedence(true).withAllowInfixOperatorAfterNL(true)
-    .withAllowBinaryLiterals(false).withAllowQuietSyntax(true)
+    .withAllowBinaryLiterals(false).withAllowQuietSyntax(true).withAllowSymbolLiterals(false)
 
   implicit val Scala31: Dialect = Scala30.withAllowErasedDefs(true)
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/UnclosedTokenSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/UnclosedTokenSuite.scala
@@ -44,7 +44,7 @@ class UnclosedTokenSuite extends ParseSuite {
     interceptMessage[ParseException](
       """|<input>:1: error: unclosed character literal
          | '.,
-         |   ^""".stripMargin.lf2nl
+         |  ^""".stripMargin.lf2nl
     )(stat(
       """| '.,
          |""".stripMargin

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
@@ -383,7 +383,7 @@ class MacroSuite extends BaseDottySuite {
       val error =
         """|<input>:1: error: Symbol literals are no longer allowed
            |'foo
-           |^""".stripMargin
+           | ^""".stripMargin
       runTestError[Stat](code, error)
     }
     locally {
@@ -399,7 +399,7 @@ class MacroSuite extends BaseDottySuite {
     locally {
       implicit val dialect: Dialect = dialects.Scala3.withAllowSymbolLiterals(true)
         .withAllowSpliceAndQuote(true)
-      runTestAssert[Stat](code)(treeWithQuote)
+      runTestAssert[Stat](code)(treeWithSymbol)
     }
 
     // default scala3


### PR DESCRIPTION
Adjust LegacyScanner to abide by this flag when reading tokens.
Helps with scalameta/scalafmt#5202.