### PR TITLE
Comment out ellipsis tokens for quasiquotes

### DIFF
--- a/scalameta/tokens/shared/src/main/scala/scala/meta/internal/prettyprinters/TokensToString.scala
+++ b/scalameta/tokens/shared/src/main/scala/scala/meta/internal/prettyprinters/TokensToString.scala
@@ -40,6 +40,7 @@ object TokensToString {
             }
           }) idx += 1
         sb.append('`')
+      case t: Token.Ellipsis => sb.append("/* ").append(chars, t.start, t.len).append(" */")
       case t => sb.append(chars, t.start, t.len)
     }
     sb.toString

--- a/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/DottySuccessSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/DottySuccessSuite.scala
@@ -231,20 +231,20 @@ class DottySuccessSuite extends TreeSuiteBase {
     assertTokensAsStructureLines(
       quoted.tokens,
       """|BOF [0..0)
-         |Dot [0..1)
-         |Dot [1..2)
-         |Ident($terms) [2..10)
-         |Semicolon [10..11)
-         |Space [11..12)
-         |Constant.String(any message) [12..25)
+         |Comment( .. ) [0..8)
+         |Ident($terms) [8..16)
+         |Semicolon [16..17)
+         |Space [17..18)
+         |Constant.String(any message) [18..31)
+         |EOF [31..31)
          |""".stripMargin
     )
     val pos = quoted.pos
-    assertNoDiff(pos.toString, """[0,25) in str(..`$terms`; "any message")""")
-    assertNoDiff(pos.text, """..`$terms`; "any message"""")
+    assertNoDiff(pos.toString, """[0,31) in str(/* .. */`$terms`; "any message")""")
+    assertNoDiff(pos.text, """/* .. */`$terms`; "any message"""")
     assertPositions(
       quoted,
-      """|<stats1>Lit.String  </stats1> [11::12)
+      """|<stats1>Lit.String "any message"</stats1> [18:"any message":31)
          |""".stripMargin,
       showPosition = true,
       showFieldName = true
@@ -253,7 +253,7 @@ class DottySuccessSuite extends TreeSuiteBase {
     val syntax =
       """|{
          |  Foo
-         |   
+         |  "any message"
          |}
          |""".stripMargin
     assertNoDiff(quoted.text, syntax)

--- a/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -2398,20 +2398,20 @@ class SuccessSuite extends TreeSuiteBase {
     assertTokensAsStructureLines(
       quoted.tokens,
       """|BOF [0..0)
-         |Dot [0..1)
-         |Dot [1..2)
-         |Ident($terms) [2..10)
-         |Semicolon [10..11)
-         |Space [11..12)
-         |Constant.String(any message) [12..25)
+         |Comment( .. ) [0..8)
+         |Ident($terms) [8..16)
+         |Semicolon [16..17)
+         |Space [17..18)
+         |Constant.String(any message) [18..31)
+         |EOF [31..31)
          |""".stripMargin
     )
     val pos = quoted.pos
-    assertNoDiff(pos.toString, """[0,25) in str(..`$terms`; "any message")""")
-    assertNoDiff(pos.text, """..`$terms`; "any message"""")
+    assertNoDiff(pos.toString, """[0,31) in str(/* .. */`$terms`; "any message")""")
+    assertNoDiff(pos.text, """/* .. */`$terms`; "any message"""")
     assertPositions(
       quoted,
-      """|<stats1>Lit.String  </stats1> [11::12)
+      """|<stats1>Lit.String "any message"</stats1> [18:"any message":31)
          |""".stripMargin,
       showPosition = true,
       showFieldName = true
@@ -2420,7 +2420,7 @@ class SuccessSuite extends TreeSuiteBase {
     val syntax =
       """|{
          |  Foo
-         |   
+         |  "any message"
          |}
          |""".stripMargin
     assertNoDiff(quoted.text, syntax)


### PR DESCRIPTION
We are already backquoting the unquote token, thus replacing it with an Ident; we could also backquote the ellipsis as well but if the output were to be used not just for tokenization but also for parsing, it might result in two consecutive idents where in reality only one entity would be expected.

This is an attempt to reproduce and resolve #4481 by using the same logic as #4435 .
