### PR TITLE
Semanticdb: add arguments to Annotation message

### DIFF
--- a/docs/semanticdb/specification.md
+++ b/docs/semanticdb/specification.md
@@ -866,16 +866,19 @@ message Documentation {
 `Documentation` represents the documentation associated with a [Symbol](#symbol). The `format` fields
 specifies the format of the text stored in `message`.
 
-### Annotation
+### Annotation (protobuf)
 
 ```protobuf
 message Annotation {
   Type tpe = 1;
+  repeated Tree arguments = 2;
 }
 ```
 
-`Annotation` represents annotations. See [Languages](#languages) for information
-on how annotations in supported languages map onto this data structure.
+An `Annotation` represents an annotation with arguments, if any. The
+`arguments` would normally be `AssignTree` in Java where the parameters
+generally are required to be assignment expressions, or else any other
+`Tree`.
 
 ### AssignTree
 
@@ -2404,15 +2407,16 @@ package object symbols and object symbols are:
 
 <a name="scala-annotation"></a>
 
-### Annotation
+### Annotation (Scala)
 
 ```protobuf
 message Annotation {
   Type tpe = 1;
+  repeated Tree arguments = 2;
 }
 ```
 
-In Scala, [Annotation](#annotation) represents annotations [\[23\]][23].
+In Scala, [Annotation](#annotation-protobuf) represents annotations [\[23\]][23].
 
 <table>
   <tr>
@@ -2420,12 +2424,38 @@ In Scala, [Annotation](#annotation) represents annotations [\[23\]][23].
     <td><b>Explanation</b></td>
   </tr>
   <tr>
-    <td><code>Annotation(&lt;ann&gt;)</code></td>
-    <td>Definition annotation, e.g. <code>@ann def m: T</code>.</td>
+    <td><code>Annotation(TypeRef(None, &lt;NoArgs#&gt;, List()), None)</code></td>
+    <td><code>@NoArgs</code></td>
   </tr>
   <tr>
-    <td><code>Annotation(&lt;ann&gt;)</code></td>
-    <td>Type annotation, e.g. <code>T @ann</code>.</td>
+    <td>
+      <code>
+        Annotation(TypeRef(None, &lt;StringArg#&gt;, List()),
+        List(AssignTree(IdTree(&lt;StringArg#value().&gt;),
+          LiteralTree(StringConstant("arg")))))
+      </code>
+    </td>
+    <td><code>@StringArgs("arg")</code></td>
+  </tr>
+  <tr>
+    <td>
+      <code>
+        Annotation(TypeRef(None, &lt;ArrayArg#&gt;, List()),
+        List(AssignTree(IdTree(&lt;ArrayArg#value().&gt;),
+          ApplyTree(IdTree(&lt;scala/Array#&gt;), List())))
+      </code>
+    </td>
+    <td><code>@ArrayArg(Array())</code></td>
+  </tr>
+  <tr>
+    <td>
+      <code>
+        Annotation(TypeRef(None, &lt;EnumConstArg#&gt;, List()),
+        List(AssignTree(IdTree(&lt;EnumConstArg#value().&gt;),
+          SelectTree(IdTree(&lt;X#&gt;), IdTree(&lt;X#CONST.&gt;))))
+      </code>
+    </td>
+    <td><code>@EnumConstArg(X.CONST)</code></td>
   </tr>
   <tr>
     <td>Not supported</td>
@@ -2433,9 +2463,6 @@ In Scala, [Annotation](#annotation) represents annotations [\[23\]][23].
   </tr>
 </table>
 
-- At the moment, `Annotation` can't represent annotation arguments, which means
-  that the annotation in `@ann(x, y, z) def m: T` is represented as
-  `Annotation(<ann>)`. We may improve on this in the future.
 - At the moment, SemanticDB cannot represent expressions, which means that it
   cannot represent expression annotations as well. We do not plan to add support
   for expressions in SemanticDB, so it is highly unlikely that expression
@@ -3614,17 +3641,17 @@ modelled in [Scala symbols](#scala-symbol).
 
 <a name="java-annotation"></a>
 
-### Annotation
+### Annotation (Java)
 
 ```protobuf
 message Annotation {
   Type tpe = 1;
+  repeated Tree arguments = 2;
 }
 ```
 
-In Java, [Annotation](#annotation) represents `access_flags` in the JVMS `class`
-file format [\[92\]][92] but not the actual annotations [\[93\]][93]. We may
-improve on this in the future.
+In Java, [`Annotation`](#annotation-protobuf) represents a typed syntax tree of the JLS annotation
+construct [\[93\]][93].
 
 <table>
   <tr>
@@ -3632,15 +3659,60 @@ improve on this in the future.
     <td><b>Explanation</b></td>
   </tr>
   <tr>
-    <td><code>Annotation(TypeRef(None, &lt;scala/annotation/strictfp&gt;, List()))</code></td>
-    <td>
-      Declared <code>strictfp</code>; floating-point mode is FP-strict e.g. <code>strictfp class MyClass</code>. Note that this is the default mode as of JDK17, so this deprecated annotation is no longer emitted for JDK17+ bytecode.
-    </td>
+    <td><code>Annotation(TypeRef(None, &lt;NoArgs#&gt;, List()), None)</code></td>
+    <td><code>@NoArgs</code></td>
   </tr>
   <tr>
-    <td>Not supported</td>
-    <td>JLS annotations <a href="https://docs.oracle.com/javase/specs/jls/se8/html/jls-9.html#jls-9.7">[93]</a></td>
+    <td>
+      <code>
+        Annotation(TypeRef(None, &lt;StringArg#&gt;, List()),
+        List(AssignTree(IdTree(&lt;StringArg#value().&gt;),
+          LiteralTree(StringConstant("arg")))))
+      </code>
+    </td>
+    <td><code>@StringArgs("arg")</code></td>
   </tr>
+  <tr>
+    <td>
+      <code>
+        Annotation(TypeRef(None, &lt;ArrayArg#&gt;, List()),
+        List(AssignTree(IdTree(&lt;ArrayArg#value().&gt;),
+          ApplyTree(IdTree(&lt;scala/Array#&gt;), List())))
+      </code>
+    </td>
+    <td><code>@ArrayArg({})</code></code></td>
+  </tr>
+  <tr>
+    <td>
+      <code>
+        Annotation(TypeRef(None, &lt;EnumConstArg#&gt;, List()),
+        List(AssignTree(IdTree(&lt;EnumConstArg#value().&gt;),
+          SelectTree(IdTree(&lt;X#&gt;), IdTree(&lt;X#CONST.&gt;))))
+      </code>
+    </td>
+    <td><code>@EnumConstArg(X.CONST)</code></td>
+  </tr>
+  <tr>
+    <td>
+      <code>
+        Annotation(TypeRef(None, &lt;Get#&gt;, List()),
+        List(AssignTree(IdTree(&lt;Get#route().&gt;),
+          LiteralTree(StringConstant("/")))))
+      </code>
+    </td>
+    <td><code>@Get(route = "/")</code></td>
+  </tr>
+  <tr>
+    <td>
+      <code>
+        Annotation(TypeRef(None, &lt;A#&gt;, List()),
+        List(AssignTree(IdTree(&lt;A#value().&gt;),
+          Annotation(TypeRef(None, &lt;B#&gt;, List()),
+            None))))
+      </code>
+    </td>
+    <td><code>@A(@B)</code></td>
+  </tr>  
 </table>
 
 <a name="java-access"></a>

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/scalacp/SymbolInformationOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/scalacp/SymbolInformationOps.scala
@@ -167,10 +167,14 @@ trait SymbolInformationOps {
 
     private def annotations: List[s.AnnotationTree] = {
       val builder = List.newBuilder[s.AnnotationTree]
-      sym.attributes.foreach(_.typeRef.toSemanticTpe match {
-        case s.TypeRef(_, sym, _) if syntheticAnnotationsSymbols.contains(sym) =>
-        case tpe => builder += s.AnnotationTree(tpe)
-      })
+      def asTree(obj: Any) = s.Constant.opt(obj).fold[s.Tree](s.NoTree)(s.LiteralTree.apply)
+      sym.attributes.foreach(attr =>
+        attr.typeRef.toSemanticTpe match {
+          case s.TypeRef(_, sym, _) if syntheticAnnotationsSymbols.contains(sym) =>
+          case tpe => builder +=
+              s.AnnotationTree(tpe, attr.values.map(x => s.AssignTree(s.IdTree(x._1), asTree(x._2))))
+        }
+      )
       builder.result()
     }
 

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/AnnotationOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/AnnotationOps.scala
@@ -6,6 +6,20 @@ trait AnnotationOps {
   self: SemanticdbOps =>
 
   implicit class XtensionAnnotationInfo(gann: g.AnnotationInfo) {
-    def toSemantic: s.AnnotationTree = s.AnnotationTree(gann.atp.toSemanticTpe)
+    def toSemantic: s.AnnotationTree = s.AnnotationTree(
+      gann.atp.toSemanticTpe,
+      if (gann.args.nonEmpty) gann.args.map(_.toSemanticTree)
+      else gann.assocs.map { case (gname, garg) =>
+        s.AssignTree(s.IdTree(gname.toString()), getClassFileAnnotArg(garg))
+      }
+    )
   }
+
+  private def getClassFileAnnotArg(garg: g.ClassfileAnnotArg): s.Tree = garg match {
+    case garg: g.LiteralAnnotArg => s.LiteralTree(s.Constant(garg.const.value))
+    case garg: g.ArrayAnnotArg => s.ApplyTree(s.NoTree, garg.args.map(getClassFileAnnotArg))
+    case garg: g.NestedAnnotArg => garg.annInfo.toSemantic
+    case _ => s.NoTree
+  }
+
 }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SymbolInformationOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SymbolInformationOps.scala
@@ -168,7 +168,7 @@ trait SymbolInformationOps {
       }
 
     private def annotations: List[s.AnnotationTree] = gsym.annotations.flatMap(gann =>
-      if (gann.atp.typeSymbol == definitions.MacroImplAnnotation) None else Some(gann.toSemantic)
+      if (gann.symbol == definitions.MacroImplAnnotation) None else Some(gann.toSemantic)
     )
 
     private def access: s.Access = kind match {

--- a/semanticdb/semanticdb/shared/src/main/proto/semanticdb.proto
+++ b/semanticdb/semanticdb/shared/src/main/proto/semanticdb.proto
@@ -334,8 +334,10 @@ message Documentation {
   Format format = 2;
 }
 
+// TODO; rename to AnnotationTree
 message Annotation {
   Type tpe = 1;
+  repeated Tree arguments = 2;
 }
 
 message AssignTree {
@@ -418,6 +420,7 @@ message Tree {
     SelectTree select_tree = 7;
     TypeApplyTree type_apply_tree = 8;
     AssignTree assign_tree = 9;
+    Annotation annotation_tree = 10;
   }
 }
 

--- a/semanticdb/semanticdb/shared/src/main/scala/scala/meta/internal/metap/SyntheticPrinter.scala
+++ b/semanticdb/semanticdb/shared/src/main/scala/scala/meta/internal/metap/SyntheticPrinter.scala
@@ -40,6 +40,9 @@ trait SyntheticPrinter extends BasePrinter with RangePrinter with SymbolInformat
   class TreePrinter(notes: InfoNotes, originalRange: Option[Range]) extends InfoPrinter(notes) {
 
     def pprint(tree: Tree): Unit = tree match {
+      case tree: AnnotationTree =>
+        pprint(tree.tpe)
+        rep("(", tree.arguments, ", ", ")")(pprint)
       case tree: ApplyTree =>
         pprint(tree.function)
         out.print("(")

--- a/tests-semanticdb/src/test/resources/metac-metacp.diff_2.12
+++ b/tests-semanticdb/src/test/resources/metac-metacp.diff_2.12
@@ -1239,6 +1239,18 @@ example/ValPattern#x$2.
 +  private_this_access {
 
 
+==============
+example/X.x().
+==============
+--- metac
++++ metacp
+       symbol: "scala/deprecated#"
+-  arguments {
+-  arguments {
+ language: SCALA
+ signature {
+
+
 =============================
 flags/p/package.X.canEqual().
 =============================
@@ -1414,6 +1426,7 @@ types/Test.C#annType1.
 -                type_ref {
 -                  prefix {
 -                  symbol: "scala/Int#"
+-          arguments {
 
 
 ======================

--- a/tests-semanticdb/src/test/resources/metac-metacp.diff_2.13
+++ b/tests-semanticdb/src/test/resources/metac-metacp.diff_2.13
@@ -1544,6 +1544,7 @@ types/Test.C#annType1.
 -                type_ref {
 -                  prefix {
 -                  symbol: "scala/Int#"
+-          arguments {
 
 
 ======================


### PR DESCRIPTION
Also, define AssignTree which is likely to be the parameter for it. Based on #2281, but without the MiMa-incompatible class rename. Helps with #1334.