### PR TITLE
SBT: apply MIMA to SemanticDB shared data

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -122,7 +122,6 @@ lazy val semanticdbShared = crossProject(allPlatforms: _*).in(file("semanticdb/s
     libraryDependencies += "org.scala-lang" % "scalap" % scalaVersion.value,
     crossScalaVersions := EarliestScala2Versions,
     protobufSettings,
-    mimaPreviousArtifacts := Set.empty,
     description := "Library defining SemanticDB data structures"
   ).dependsOn(scalameta).nativeSettings(nativeSettings).jsSettings(commonJsSettings)
 


### PR DESCRIPTION
While the rest of semanticdb modules are arguably isolated and would not need MiMa monitoring, this particular component might have to be, as the case of AnnotationTree rename shows.