### PR TITLE
ScannerTokens: no LF past Outdent unless new expr

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -383,7 +383,8 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
       else if (head eq null) Left(xs)
       else {
         if (currNonTrivial) last.next = currRef(xs)
-        else if (multiEOL) last.next = eofRefAt(xs, last.pointPos, multiEOL = true)
+        else if (multiEOL && mightStartStat(next, closeDelimOK = false))
+          last.next = eofRefAt(xs, last.pointPos, multiEOL = true)
         Right((head, last))
       }
 
@@ -817,7 +818,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
 
           /**
            * Indent is needed in the following cases:
-           *   - Indetation on new line is greater and previous token can start indentation and
+           *   - Indentation on new line is greater and previous token can start indentation and
            *     token can start indentation
            *   - Indentation on the new line is the same and the next token is the first `case`
            *     clause in match. Example:

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -2280,7 +2280,6 @@ class Scala3PositionSuite extends BasePositionSuite {
        |RightArrow [93..95)
        |Ident(qux) [96..99)
        |Indentation.Outdent [114..114)
-       |LFLF [114..138)
        |RightBrace [140..141)
        |Indentation.Outdent [141..141)
        |EOF [142..142)
@@ -2452,7 +2451,6 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Ident(qux) [114..117)
        |Indentation.Outdent [135..135)
        |Indentation.Outdent [150..150)
-       |LFLF [150..174)
        |RightBrace [176..177)
        |Indentation.Outdent [177..177)
        |EOF [178..178)
@@ -2644,7 +2642,6 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Indentation.Outdent [149..149)
        |Indentation.Outdent [162..162)
        |Indentation.Outdent [173..173)
-       |LFLF [173..182)
        |RightBrace [182..183)
        |EOF [184..184)
        |""".stripMargin,
@@ -2833,7 +2830,6 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Indentation.Outdent [161..161)
        |Indentation.Outdent [172..172)
        |Indentation.Outdent [180..180)
-       |LFLF [180..181)
        |EOF [181..181)
        |""".stripMargin,
     showFieldName = true
@@ -2875,7 +2871,6 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Ident(*) [53..54)
        |Constant.Int(2) [55..56)
        |Indentation.Outdent [68..68)
-       |LFLF [68..69)
        |EOF [69..69)
        |""".stripMargin,
     showFieldName = true
@@ -3320,7 +3315,6 @@ class Scala3PositionSuite extends BasePositionSuite {
          |Indentation.Indent [4..4)
          |Ident(bar) [9..12)
          |Indentation.Outdent [13..13)
-         |LFLF [13..14)
          |KwMatch [14..19)
          |Indentation.Indent [19..19)
          |KwCase [24..28)
@@ -3362,7 +3356,6 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Indentation.Indent [8..8)
        |Ident(bar) [13..16)
        |Indentation.Outdent [17..17)
-       |LFLF [17..18)
        |RightBrace [18..19)
        |KwMatch [21..26)
        |Indentation.Indent [26..26)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
@@ -2578,12 +2578,7 @@ class FewerBracesSuite extends BaseDottySuite {
          |    case bar =>
          |""".stripMargin
 
-    val errorWithBlank =
-      """|<input>:4: error: illegal start of definition `match`
-         |match
-         |^""".stripMargin
-    runTestError[Stat](codeWithBlank, errorWithBlank)
-
+    runTestAssert[Stat](codeWithBlank, layout)(tree)
     runTestAssert[Stat](codeWithoutBlank, layout)(tree)
   }
 


### PR DESCRIPTION
Fixes #4497. Follow-on to #4014.