### PR TITLE
AnnotationOps: support symbol/type arguments, too

### DIFF
--- a/semanticdb/integration/src/main/scala/example/Issue4505.scala
+++ b/semanticdb/integration/src/main/scala/example/Issue4505.scala
@@ -1,0 +1,13 @@
+package example
+
+object Issue4505 {
+
+  import Issue4505J._
+
+  @AnnotationWithEnum(AnnotationEnum.Val1)
+  class A
+
+  @AnnotationWithClass(classOf[String])
+  class B
+
+}

--- a/semanticdb/integration/src/main/scala/example/Issue4505J.java
+++ b/semanticdb/integration/src/main/scala/example/Issue4505J.java
@@ -1,0 +1,17 @@
+package example;
+
+public class Issue4505J {
+
+    public @interface AnnotationWithEnum {
+        AnnotationEnum value();
+    }
+
+    public @interface AnnotationWithClass {
+        Class<?> value();
+    }
+
+    public enum AnnotationEnum {
+        Val1
+    }
+
+}

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/AnnotationOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/AnnotationOps.scala
@@ -10,16 +10,37 @@ trait AnnotationOps {
       gann.atp.toSemanticTpe,
       if (gann.args.nonEmpty) gann.args.map(_.toSemanticTree)
       else gann.assocs.map { case (gname, garg) =>
-        s.AssignTree(s.IdTree(gname.toString()), getClassFileAnnotArg(garg))
+        s.AssignTree(s.IdTree(gname.toString()), toTree(garg))
       }
     )
   }
 
-  private def getClassFileAnnotArg(garg: g.ClassfileAnnotArg): s.Tree = garg match {
-    case garg: g.LiteralAnnotArg => s.LiteralTree(s.Constant(garg.const.value))
-    case garg: g.ArrayAnnotArg => s.ApplyTree(s.NoTree, garg.args.map(getClassFileAnnotArg))
+  private def toTree(garg: g.ClassfileAnnotArg): s.Tree = garg match {
+    case garg: g.LiteralAnnotArg => toTree(garg.const)
+    case garg: g.ArrayAnnotArg => s.ApplyTree(s.NoTree, garg.args.map(toTree))
     case garg: g.NestedAnnotArg => garg.annInfo.toSemantic
     case _ => s.NoTree
+  }
+
+  private def toTree(garg: g.Constant): s.Tree = garg.value match {
+    case x: g.Symbol => s.IdTree(x.toSemantic)
+    case x: g.Type => toTree(x.toSemanticTpe)
+    case x => s.Constant.opt(x).fold[s.Tree](s.NoTree)(s.LiteralTree.apply)
+  }
+
+  private def toTree(sarg: s.Type): s.Tree = sarg match {
+    case sarg: s.ConstantType => s.LiteralTree(sarg.constant)
+    case sarg: s.SingleType => typeToTree(sarg.prefix, sarg.symbol)
+    case sarg: s.TypeRef =>
+      val func = typeToTree(sarg.prefix, sarg.symbol)
+      if (sarg.typeArguments.isEmpty) func else s.TypeApplyTree(func, sarg.typeArguments)
+    case _ => s.NoTree
+  }
+
+  private def typeToTree(sarg: s.Type, ssym: String): s.Tree = {
+    val pre = toTree(sarg)
+    val sym = s.IdTree(ssym)
+    if (pre eq s.NoTree) sym else s.SelectTree(pre, Some(sym))
   }
 
 }

--- a/tests-semanticdb/src/test/resources/example/Issue4505.scala
+++ b/tests-semanticdb/src/test/resources/example/Issue4505.scala
@@ -1,0 +1,13 @@
+package example
+
+object Issue4505/*<=example.Issue4505.*/ {
+
+  import Issue4505J/*=>example.Issue4505J#*/._
+
+  @AnnotationWithEnum/*=>example.Issue4505J#AnnotationWithEnum#*/(AnnotationEnum.Val1)
+  class A/*<=example.Issue4505.A#*/
+
+  @AnnotationWithClass/*=>example.Issue4505J#AnnotationWithClass#*/(classOf[String])
+  class B/*<=example.Issue4505.B#*/
+
+}

--- a/tests-semanticdb/src/test/resources/metac.expect_2.12
+++ b/tests-semanticdb/src/test/resources/metac.expect_2.12
@@ -2611,6 +2611,40 @@ Synthetics:
 [5:22..5:22):  => *.apply
   apply => scala/StringContext.apply().
 
+semanticdb/integration/src/main/scala/example/Issue4505.scala
+-------------------------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => semanticdb/integration/src/main/scala/example/Issue4505.scala
+Text => non-empty
+Language => Scala
+Symbols => 5 entries
+Occurrences => 9 entries
+
+Symbols:
+example/Issue4505. => final object Issue4505 extends AnyRef { +2 decls }
+  AnyRef => scala/AnyRef#
+example/Issue4505.A# => @AnnotationWithEnum class A extends AnyRef { +1 decls }
+  AnnotationWithEnum => example/Issue4505J#AnnotationWithEnum#
+  AnyRef => scala/AnyRef#
+example/Issue4505.A#`<init>`(). => primary ctor <init>()
+example/Issue4505.B# => @AnnotationWithClass class B extends AnyRef { +1 decls }
+  AnnotationWithClass => example/Issue4505J#AnnotationWithClass#
+  AnyRef => scala/AnyRef#
+example/Issue4505.B#`<init>`(). => primary ctor <init>()
+
+Occurrences:
+[0:8..0:15): example <= example/
+[2:7..2:16): Issue4505 <= example/Issue4505.
+[4:9..4:19): Issue4505J => example/Issue4505J#
+[6:3..6:21): AnnotationWithEnum => example/Issue4505J#AnnotationWithEnum#
+[7:8..7:9): A <= example/Issue4505.A#
+[7:9..7:9):  <= example/Issue4505.A#`<init>`().
+[9:3..9:22): AnnotationWithClass => example/Issue4505J#AnnotationWithClass#
+[10:8..10:9): B <= example/Issue4505.B#
+[10:9..10:9):  <= example/Issue4505.B#`<init>`().
+
 semanticdb/integration/src/main/scala/example/Issue5939Metals.scala
 -------------------------------------------------------------------
 

--- a/tests-semanticdb/src/test/resources/metac.expect_2.13
+++ b/tests-semanticdb/src/test/resources/metac.expect_2.13
@@ -2834,6 +2834,40 @@ Synthetics:
 [5:22..5:22):  => *.apply
   apply => scala/StringContext.apply().
 
+semanticdb/integration/src/main/scala/example/Issue4505.scala
+-------------------------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => semanticdb/integration/src/main/scala/example/Issue4505.scala
+Text => non-empty
+Language => Scala
+Symbols => 5 entries
+Occurrences => 9 entries
+
+Symbols:
+example/Issue4505. => final object Issue4505 extends AnyRef { +2 decls }
+  AnyRef => scala/AnyRef#
+example/Issue4505.A# => @AnnotationWithEnum class A extends AnyRef { +1 decls }
+  AnnotationWithEnum => example/Issue4505J#AnnotationWithEnum#
+  AnyRef => scala/AnyRef#
+example/Issue4505.A#`<init>`(). => primary ctor <init>()
+example/Issue4505.B# => @AnnotationWithClass class B extends AnyRef { +1 decls }
+  AnnotationWithClass => example/Issue4505J#AnnotationWithClass#
+  AnyRef => scala/AnyRef#
+example/Issue4505.B#`<init>`(). => primary ctor <init>()
+
+Occurrences:
+[0:8..0:15): example <= example/
+[2:7..2:16): Issue4505 <= example/Issue4505.
+[4:9..4:19): Issue4505J => example/Issue4505J#
+[6:3..6:21): AnnotationWithEnum => example/Issue4505J#AnnotationWithEnum#
+[7:8..7:9): A <= example/Issue4505.A#
+[7:9..7:9):  <= example/Issue4505.A#`<init>`().
+[9:3..9:22): AnnotationWithClass => example/Issue4505J#AnnotationWithClass#
+[10:8..10:9): B <= example/Issue4505.B#
+[10:9..10:9):  <= example/Issue4505.B#`<init>`().
+
 semanticdb/integration/src/main/scala/example/Issue5939Metals.scala
 -------------------------------------------------------------------
 

--- a/tests-semanticdb/src/test/resources/metacp.expect_2.12
+++ b/tests-semanticdb/src/test/resources/metacp.expect_2.12
@@ -2284,6 +2284,69 @@ example/Issue2882.FooFailure.unapply(). => method unapply(x$0: FooFailure): Opti
 example/Issue2882.FooFailure.unapply().(x$0) => param x$0: FooFailure
   FooFailure => example/Issue2882.FooFailure#
 
+example/Issue4505.class
+-----------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => example/Issue4505.class
+Text => empty
+Language => Scala
+Symbols => 5 entries
+
+Symbols:
+example/Issue4505. => final object Issue4505 extends AnyRef { +2 decls }
+  AnyRef => scala/AnyRef#
+example/Issue4505.A# => @AnnotationWithEnum class A extends AnyRef { +1 decls }
+  AnnotationWithEnum => example/Issue4505J#AnnotationWithEnum#
+  AnyRef => scala/AnyRef#
+example/Issue4505.A#`<init>`(). => primary ctor <init>()
+example/Issue4505.B# => @AnnotationWithClass class B extends AnyRef { +1 decls }
+  AnnotationWithClass => example/Issue4505J#AnnotationWithClass#
+  AnyRef => scala/AnyRef#
+example/Issue4505.B#`<init>`(). => primary ctor <init>()
+
+example/Issue4505J.class
+------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => example/Issue4505J.class
+Text => empty
+Language => Java
+Symbols => 12 entries
+
+Symbols:
+example/Issue4505J# => class Issue4505J extends Object { +4 decls }
+  Object => java/lang/Object#
+example/Issue4505J#AnnotationEnum# => final static enum class AnnotationEnum extends Enum[AnnotationEnum] { +4 decls }
+  Enum => java/lang/Enum#
+  AnnotationEnum => example/Issue4505J#AnnotationEnum#
+example/Issue4505J#AnnotationEnum#Val1. => final static enum field Val1: AnnotationEnum
+  AnnotationEnum => example/Issue4505J#AnnotationEnum#
+example/Issue4505J#AnnotationEnum#`<init>`(). => private ctor <init>()
+example/Issue4505J#AnnotationEnum#valueOf(). => static method valueOf(name: String): AnnotationEnum
+  name => example/Issue4505J#AnnotationEnum#valueOf().(name)
+  String => java/lang/String#
+  AnnotationEnum => example/Issue4505J#AnnotationEnum#
+example/Issue4505J#AnnotationEnum#valueOf().(name) => param name: String
+  String => java/lang/String#
+example/Issue4505J#AnnotationEnum#values(). => static method values(): Array[AnnotationEnum]
+  Array => scala/Array#
+  AnnotationEnum => example/Issue4505J#AnnotationEnum#
+example/Issue4505J#AnnotationWithClass# => abstract static interface AnnotationWithClass extends Object with Annotation { +1 decls }
+  Object => java/lang/Object#
+  Annotation => java/lang/annotation/Annotation#
+example/Issue4505J#AnnotationWithClass#value(). => abstract method value(): Class[local_wildcard]
+  Class => java/lang/Class#
+  local_wildcard => local_wildcard
+example/Issue4505J#AnnotationWithEnum# => abstract static interface AnnotationWithEnum extends Object with Annotation { +1 decls }
+  Object => java/lang/Object#
+  Annotation => java/lang/annotation/Annotation#
+example/Issue4505J#AnnotationWithEnum#value(). => abstract method value(): AnnotationEnum
+  AnnotationEnum => example/Issue4505J#AnnotationEnum#
+example/Issue4505J#`<init>`(). => ctor <init>()
+
 example/local$minusfile.class
 -----------------------------
 

--- a/tests-semanticdb/src/test/resources/metacp.expect_2.13
+++ b/tests-semanticdb/src/test/resources/metacp.expect_2.13
@@ -2306,6 +2306,69 @@ example/Issue2882.FooFailure.unapply().(x$0) => param x$0: FooFailure
 example/Issue2882.FooFailure.writeReplace(). => private method writeReplace(): Object
   Object => java/lang/Object#
 
+example/Issue4505.class
+-----------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => example/Issue4505.class
+Text => empty
+Language => Scala
+Symbols => 5 entries
+
+Symbols:
+example/Issue4505. => final object Issue4505 extends AnyRef { +2 decls }
+  AnyRef => scala/AnyRef#
+example/Issue4505.A# => @AnnotationWithEnum class A extends AnyRef { +1 decls }
+  AnnotationWithEnum => example/Issue4505J#AnnotationWithEnum#
+  AnyRef => scala/AnyRef#
+example/Issue4505.A#`<init>`(). => primary ctor <init>()
+example/Issue4505.B# => @AnnotationWithClass class B extends AnyRef { +1 decls }
+  AnnotationWithClass => example/Issue4505J#AnnotationWithClass#
+  AnyRef => scala/AnyRef#
+example/Issue4505.B#`<init>`(). => primary ctor <init>()
+
+example/Issue4505J.class
+------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => example/Issue4505J.class
+Text => empty
+Language => Java
+Symbols => 12 entries
+
+Symbols:
+example/Issue4505J# => class Issue4505J extends Object { +4 decls }
+  Object => java/lang/Object#
+example/Issue4505J#AnnotationEnum# => final static enum class AnnotationEnum extends Enum[AnnotationEnum] { +4 decls }
+  Enum => java/lang/Enum#
+  AnnotationEnum => example/Issue4505J#AnnotationEnum#
+example/Issue4505J#AnnotationEnum#Val1. => final static enum field Val1: AnnotationEnum
+  AnnotationEnum => example/Issue4505J#AnnotationEnum#
+example/Issue4505J#AnnotationEnum#`<init>`(). => private ctor <init>()
+example/Issue4505J#AnnotationEnum#valueOf(). => static method valueOf(name: String): AnnotationEnum
+  name => example/Issue4505J#AnnotationEnum#valueOf().(name)
+  String => java/lang/String#
+  AnnotationEnum => example/Issue4505J#AnnotationEnum#
+example/Issue4505J#AnnotationEnum#valueOf().(name) => param name: String
+  String => java/lang/String#
+example/Issue4505J#AnnotationEnum#values(). => static method values(): Array[AnnotationEnum]
+  Array => scala/Array#
+  AnnotationEnum => example/Issue4505J#AnnotationEnum#
+example/Issue4505J#AnnotationWithClass# => abstract static interface AnnotationWithClass extends Object with Annotation { +1 decls }
+  Object => java/lang/Object#
+  Annotation => java/lang/annotation/Annotation#
+example/Issue4505J#AnnotationWithClass#value(). => abstract method value(): Class[local_wildcard]
+  Class => java/lang/Class#
+  local_wildcard => local_wildcard
+example/Issue4505J#AnnotationWithEnum# => abstract static interface AnnotationWithEnum extends Object with Annotation { +1 decls }
+  Object => java/lang/Object#
+  Annotation => java/lang/annotation/Annotation#
+example/Issue4505J#AnnotationWithEnum#value(). => abstract method value(): AnnotationEnum
+  AnnotationEnum => example/Issue4505J#AnnotationEnum#
+example/Issue4505J#`<init>`(). => ctor <init>()
+
 example/LeadingInfixTest.class
 ------------------------------
 


### PR DESCRIPTION
Also, we no longer fail on unknown constants but return NoTree. Fixes #4505.