### PR TITLE
ScalametaParser: fix major bug extracting comments

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
@@ -343,7 +343,7 @@ class DefnSuite extends ParseSuite {
          |  case `object`: ScObject =>
          |    `object`.allFunctionsByName(ScFunction.CommonNames.Apply).nonEmpty
          |  case `class` @ ScClass(`type`) =>
-         |    isCaseOrInScala3File(`class`)
+         |    isCaseOrInScala3File(`class`) // SCL-19992, SCL-21187
          |  case _ =>
          |    false
          |}
@@ -367,10 +367,11 @@ class DefnSuite extends ParseSuite {
             "nonEmpty"
           )
         ),
-        Case(
+        Case.createWithComments(
           Pat.Bind(patvar("class"), Pat.Extract(tname("ScClass"), List(tname("type")))),
           None,
-          tapply(tname("isCaseOrInScala3File"), tname("class"))
+          tapply(tname("isCaseOrInScala3File"), tname("class")),
+          endComment = Seq("// SCL-19992, SCL-21187")
         ),
         Case(patwildcard, None, lit(false))
       )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExtensionMethodsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExtensionMethodsSuite.scala
@@ -180,18 +180,23 @@ class ExtensionMethodsSuite extends BaseDottySuite {
          |    
          |    /** */
          |""".stripMargin,
-      """|extension (a: Int) 
-         |/** */
-         |{
+      """|extension (a: Int) {
+         |  /** */
          |  def double = a * 2
          |}""".stripMargin
     )(Defn.ExtensionGroup(
       Nil,
       List(List(tparam("a", "Int"))),
-      Term.Block.createWithComments(
-        List(Defn.Def(Nil, tname("double"), Nil, Nil, None, tinfix(tname("a"), "*", int(2)))),
-        begComment = Seq("/** */")
-      )
+      blk(Defn.Def.createWithComments(
+        Nil,
+        tname("double"),
+        Nil,
+        Nil,
+        None,
+        tinfix(tname("a"), "*", int(2)),
+        begComment = Seq("/** */"),
+        endComment = None
+      ))
     ))
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
@@ -530,7 +530,8 @@ class InfixSuite extends BaseDottySuite {
          |""".stripMargin,
       """|{
          |  def toBeContinued(altToken: Token): Boolean = {
-         |    inline def canContinue = !in.canStartStatTokens.contains(in.token) || followedByToken(altToken)
+         |    inline def canContinue = !in.canStartStatTokens.contains(in.token) // not statement, so take as continued expr
+         |      || followedByToken(altToken) // scan ahead to see whether we find a `then` or `do`
          |    !in.isNewLine // a newline token means the expression is finished
          |      && !migrateTo3 // old syntax
          |      && canContinue
@@ -547,19 +548,21 @@ class InfixSuite extends BaseDottySuite {
           List(List(tparam("altToken", "Token"))),
           Some(pname("Boolean")),
           blk(
-            Defn.Def(
+            Defn.Def.createWithComments(
               List(Mod.Inline()),
               tname("canContinue"),
-              None,
+              Nil,
               None,
               tinfix(
-                Term.ApplyUnary(
+                Term.ApplyUnary.createWithComments(
                   tname("!"),
-                  tapply(tselect("in", "canStartStatTokens", "contains"), tselect("in", "token"))
+                  tapply(tselect("in", "canStartStatTokens", "contains"), tselect("in", "token")),
+                  endComment = Seq("// not statement, so take as continued expr")
                 ),
                 "||",
                 tapply(tname("followedByToken"), tname("altToken"))
-              )
+              ),
+              endComment = Seq("// scan ahead to see whether we find a `then` or `do`")
             ),
             tinfix(
               Term.ApplyInfix.createWithComments(

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -1529,7 +1529,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |""".stripMargin,
       """|enum Namespace(val uri: String | Null) {
          |  case xhtml extends Namespace // Defn.EnumCase ends here
-         |    ("http://www.w3.org/1999/xhtml")
+         |    ("http://www.w3.org/1999/xhtml") // str
          |}
          |""".stripMargin
     )(Defn.Enum(
@@ -1537,7 +1537,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
       pname("Namespace"),
       Nil,
       ctorp(tparam(List(Mod.ValParam()), "uri", pinfix("String", "|", pname("Null")))),
-      tpl(Defn.EnumCase(
+      tpl(Defn.EnumCase.createWithComments(
         Nil,
         tname("xhtml"),
         Nil,
@@ -1545,7 +1545,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
         List(init(
           Type.Name.createWithComments("Namespace", endComment = Seq("// Defn.EnumCase ends here")),
           List(str("http://www.w3.org/1999/xhtml"))
-        ))
+        )),
+        endComment = Seq("// str")
       ))
     ))
   }
@@ -1777,14 +1778,21 @@ class SignificantIndentationSuite extends BaseDottySuite {
       Nil,
       tpl(
         List(init("Foo")),
-        Template.Body.createWithComments(
+        Template.Body(
           None,
           List(
-            Defn.Def(Nil, tname("foo"), Nil, Nil, Some(pname("Int")), tname("???")),
+            Defn.Def.createWithComments(
+              Nil,
+              tname("foo"),
+              Nil,
+              Nil,
+              Some(pname("Int")),
+              tname("???"),
+              begComment = Seq("/* comment */"),
+              endComment = None
+            ),
             Defn.Def(Nil, tname("bar"), Nil, Nil, Some(pname("Int")), tname("???"))
-          ),
-          begComment = Seq("/* comment */"),
-          endComment = None
+          )
         )
       )
     ))
@@ -1805,14 +1813,21 @@ class SignificantIndentationSuite extends BaseDottySuite {
       Nil,
       tpl(
         List(init("Foo")),
-        Template.Body.createWithComments(
+        Template.Body(
           None,
           List(
-            Defn.Def(Nil, tname("foo"), Nil, Nil, Some(pname("Int")), tname("???")),
+            Defn.Def.createWithComments(
+              Nil,
+              tname("foo"),
+              Nil,
+              Nil,
+              Some(pname("Int")),
+              tname("???"),
+              begComment = Seq("/* multi\n   line\n   comment */"),
+              endComment = None
+            ),
             Defn.Def(Nil, tname("bar"), Nil, Nil, Some(pname("Int")), tname("???"))
-          ),
-          begComment = Seq("/* multi\n   line\n   comment */"),
-          endComment = None
+          )
         )
       )
     ))


### PR DESCRIPTION
We were comparing token indices with token positions which led to likely skipping of trailing comments and unnecessary re-processing of leading.

Will enable merging scalacenter/scalafix#2366.