### PR TITLE
ScannerTokens: fix outdent before semicolon

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2768,7 +2768,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
       else syntaxError("val in for comprehension must be followed by assignment", at = currToken)
 
     if (hasEq) next() else accept[LeftArrow]
-    val rhs = expr()
+    val rhs = if (at[Indentation.Indent]) blockOnIndent() else expr()
 
     autoEndPos(startPos)(
       if (hasEq) Enumerator.Val(pat, rhs)

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -464,7 +464,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
 
     def nonTrivial(sepRegions: List[SepRegion]) = curr match {
       case _: EOF => getAtEof(sepRegions)
-      case _: Comma | _: Semicolon =>
+      case _: Comma =>
         if (inParens(sepRegions)) {
           def swapWithOutdents(tokenRef: TokenRef) = {
             @tailrec

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -3169,11 +3169,18 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |    sd
          |)
          |""".stripMargin
-    val error =
-      """|<input>:4: error: `)` expected but `;` found
-         |    sd.setFlag(flags);
-         |                     ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout =
+      """|transformAfter(phase, sd => {
+         |  sd.setFlag(flags)
+         |  sd
+         |})
+         |""".stripMargin
+    val tree = tapply(
+      "transformAfter",
+      "phase",
+      tfunc(tparam("sd"))(blk(tapply(tselect("sd", "setFlag"), "flags"), "sd"))
+    )
+    runTestAssert[Stat](code, layout)(tree)
   }
 
 }


### PR DESCRIPTION
Unlike comma, where this outdent is mandatory, with semicolon we should only do it if this outdent would have happened after the semicolon.