### PR TITLE
ScalametaParser: allow macro quote to use `this`

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -683,11 +683,13 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
   private object MacroSplicedIdent {
     final def unapply(tok: Ident): Option[Term] =
       if (dialect.allowSpliceAndQuote) {
+        def asTerm(ident: String, isBackquoted: Boolean) =
+          if (isBackquoted || ident != "this") termName(ident) else anonThis()
         val value = tok.text
         if (value.isEmpty || value.charAt(0) != '$') None
         else if (value.length > 1)
           if (QuotedSpliceContext.isInside())
-            Some(autoPos(Term.SplicedMacroExpr(termName(value.substring(1)))))
+            Some(autoPos(Term.SplicedMacroExpr(asTerm(value.substring(1), isBackquoted = false))))
           else None
         else peekToken match {
           case _: LeftBrace => Some(autoPos {
@@ -696,22 +698,26 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
               else Term.SplicedMacroExpr(autoPos(inBracesOnOpen(blockRaw())))
             })
           case t: Ident if t.value.nonEmpty && QuotedSpliceContext.isInside() =>
-            Some(autoPos(next(Term.SplicedMacroExpr(termName(t)))))
+            Some(autoPos(next(Term.SplicedMacroExpr(asTerm(t.value, isBackquoted = t.isBackquoted)))))
+          case t: KwThis if QuotedSpliceContext.isInside() =>
+            Some(autoPos(next(Term.SplicedMacroExpr(anonThis()))))
           case _ => None
         }
       } else None
   }
 
   private object MacroQuoted {
-    final def unapply(tok: MacroQuote): Some[Term] = QuotedSpliceContext.within(Some(autoPos {
+    private def get: Term.QuotedMacroLike = QuotedSpliceContext.within {
       next()
       currToken match {
         case _: LeftBrace => Term.QuotedMacroExpr(autoPos(inBracesOnOpen(blockRaw())))
         case _: LeftBracket => Term.QuotedMacroType(inBracketsOnOpen(typeBlock()))
         case t: Ident => Term.QuotedMacroExpr(termName(t))
+        case _: KwThis => Term.QuotedMacroExpr(anonThis())
         case t => syntaxError("Macro quote must be followed by id, brace or bracket", at = t)
       }
-    }))
+    }
+    final def unapply(tok: MacroQuote): Some[Term] = Some(autoPos(get))
   }
 
   private object InfixTypeIdent {

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
@@ -615,7 +615,7 @@ class LegacyScanner(input: Input, dialect: Dialect) {
         val done = isUnquote ||
           ((ch: @switch) match {
             case '$' => false
-            case '"' if dialect.allowInterpolationDolarQuoteEscape => false
+            case '"' => !dialect.allowInterpolationDolarQuoteEscape
             case _ => true
           })
         if (done) {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
@@ -179,24 +179,10 @@ class MacroSuite extends BaseDottySuite {
 
   test("macro-quote-this-within-splice: ${ 'this }") {
     val code = "${ 'this }"
-    runTestError[Stat](
-      code,
-      """|<input>:1: error: Macro quote must be followed by id, brace or bracket
-         |${ 'this }
-         |    ^""".stripMargin
-    )
-    runTestError[Stat](
-      "$ { 'this }",
-      """|<input>:1: error: Macro quote must be followed by id, brace or bracket
-         |$ { 'this }
-         |     ^""".stripMargin
-    )
-    runTestError[Stat](
-      "$ { ' this }",
-      """|<input>:1: error: Macro quote must be followed by id, brace or bracket
-         |$ { ' this }
-         |      ^""".stripMargin
-    )
+    val tree = Term.SplicedMacroExpr(blk(Term.QuotedMacroExpr(Term.This(anon))))
+    runTestAssert[Stat](code)(tree)
+    runTestAssert[Stat]("$ { 'this }", code)(tree)
+    runTestAssert[Stat]("$ { ' this }", code)(tree)
   }
 
   test("macro-splice-id-within-quote: '{ $x }") {
@@ -213,16 +199,10 @@ class MacroSuite extends BaseDottySuite {
 
   test("macro-splice-this-within-quote: '{ $this }") {
     val code = "'{ $this }"
-    val layout = "'{ $`this` }"
-    val tree = Term.QuotedMacroExpr(blk(Term.SplicedMacroExpr(tname("this"))))
-    runTestAssert[Stat](code, layout)(tree)
-    runTestAssert[Stat]("' { $this }", layout)(tree)
-    runTestError[Stat](
-      "' { $ this }",
-      """|<input>:1: error: `}` expected but `this` found
-         |' { $ this }
-         |      ^""".stripMargin
-    )
+    val tree = Term.QuotedMacroExpr(blk(Term.SplicedMacroExpr(Term.This(anon))))
+    runTestAssert[Stat](code)(tree)
+    runTestAssert[Stat]("' { $this }", code)(tree)
+    runTestAssert[Stat]("' { $ this }", code)(tree)
   }
 
   test("macro-splice-id-within-splice: ${ $x }") {
@@ -444,10 +424,7 @@ class MacroSuite extends BaseDottySuite {
   test("'this with modified dialects") {
     val code = "'this"
     val treeWithSymbol = lit(Symbol("this"))
-    val errorNoThis =
-      """|<input>:1: error: Macro quote must be followed by id, brace or bracket
-         |'this
-         | ^""".stripMargin
+    val treeWithQuote = Term.QuotedMacroExpr(Term.This(Name.Anonymous()))
 
     locally {
       implicit val dialect: Dialect = dialects.Scala3.withAllowSpliceAndQuote(false)
@@ -466,14 +443,14 @@ class MacroSuite extends BaseDottySuite {
     locally {
       implicit val dialect: Dialect = dialects.Scala3.withAllowSymbolLiterals(false)
         .withAllowSpliceAndQuote(true)
-      runTestError[Stat](code, errorNoThis)
+      runTestAssert[Stat](code)(treeWithQuote)
     }
     locally(intercept[invariants.InvariantFailedException](
       dialects.Scala3.withAllowSymbolLiterals(true).withAllowSpliceAndQuote(true)
     ))
 
     // default scala3
-    runTestError[Stat](code, errorNoThis)
+    runTestAssert[Stat](code)(treeWithQuote)
   }
 
 }


### PR DESCRIPTION
Fixes #4527.