### PR TITLE
Inline sourcecode on Scala 2.13

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -25,6 +25,7 @@ project {
     "glob:**/bench/corpus/**"
     "glob:**/semanticdb/integration/src/main/**"
     "glob:**/src/{main,test}/{resources,generated}/**"
+    "glob:**/internal/sourcecode/*"
   ]
   layout = StandardConvention
 }

--- a/bin/inline-sourcecode.sh
+++ b/bin/inline-sourcecode.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Downloads sourcecode sources and vendors them into the scala-2.13 source tree
+# under scala.meta.internal.sourcecode.
+#
+# On Scala 2.13, scalameta uses this vendored copy so that
+# com.lihaoyi:sourcecode does not appear as a transitive dependency of the
+# published artifacts (which conflicts with sourcecode_3 for downstream Scala 3
+# users). On Scala 2.11/2.12 the real library is used directly; compat type
+# aliases in those source trees forward to it.
+#
+# Re-run when upgrading sourcecode.
+#
+# Usage: ./bin/inline-sourcecode.sh <version>
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <version>" >&2
+  exit 1
+fi
+VERSION="$1"
+NEW_PKG="scala.meta.internal.sourcecode"
+DEST_DIR="$REPO_ROOT/scalameta/common/shared/src/main/scala-2.13/scala/meta/internal/sourcecode"
+
+TMP=$(mktemp -d)
+
+JAR_URL="https://repo1.maven.org/maven2/com/lihaoyi/sourcecode_2.13/${VERSION}/sourcecode_2.13-${VERSION}-sources.jar"
+curl -fsSL "$JAR_URL" -o "$TMP/sources.jar"
+(cd "$TMP" && jar xf sources.jar)
+
+mkdir -p "$DEST_DIR"
+find "$DEST_DIR" -name "*.scala" -delete
+
+for SRC in "$TMP/sourcecode/"*.scala; do
+  FNAME=$(basename "$SRC")
+  sed \
+    -e "s/sourcecode/$NEW_PKG/g" \
+    -e '/^package /a import scala.language.implicitConversions\nimport scala.language.existentials\n' \
+    "$SRC" > "$DEST_DIR/$FNAME"
+done
+
+echo "Vendored files written to: $DEST_DIR/"

--- a/build.sbt
+++ b/build.sbt
@@ -208,6 +208,7 @@ lazy val common = crossProject(allPlatforms: _*).in(file("scalameta/common")).se
       List("com.lihaoyi" %%% "sourcecode" % sourceCodeVersion)
     }
   },
+  Compile / doc / scalacOptions ++= Seq("-skip-packages", "scala.meta.internal.sourcecode"),
   description := "Bag of private and public helpers used in scalameta APIs and implementations",
   enableHardcoreMacros,
   buildInfoPackage := "scala.meta.internal",

--- a/build.sbt
+++ b/build.sbt
@@ -199,12 +199,17 @@ lazy val scala3TreeLiftsCodeGen = project.in(file("scala3-tree-lifts/impl")).set
 lazy val common = crossProject(allPlatforms: _*).in(file("scalameta/common")).settings(
   moduleName := "common",
   sharedSettings,
-  libraryDependencies += {
-    val sourceCodeVersion = if (isScala211.value) "0.3.1" else "0.4.4"
-    "com.lihaoyi" %%% "sourcecode" % sourceCodeVersion
+  libraryDependencies ++= {
+    // On Scala 2.13, sourcecode is inlined to avoid depending on a external 2.13 library in
+    // our scala3 artifacts.
+    if (scalaBinaryVersion.value == "2.13") Nil
+    else {
+      val sourceCodeVersion = if (isScala211.value) "0.3.1" else "0.4.4"
+      List("com.lihaoyi" %%% "sourcecode" % sourceCodeVersion)
+    }
   },
   description := "Bag of private and public helpers used in scalameta APIs and implementations",
-  enableMacros,
+  enableHardcoreMacros,
   buildInfoPackage := "scala.meta.internal",
   buildInfoKeys := Seq[BuildInfoKey](version),
   crossScalaVersions := EarliestScala2Versions

--- a/scalameta/common/shared/src/main/scala-2.11/scala/meta/internal/sourcecode/package.scala
+++ b/scalameta/common/shared/src/main/scala-2.11/scala/meta/internal/sourcecode/package.scala
@@ -1,0 +1,7 @@
+package scala.meta.internal
+
+package object sourcecode {
+  type File = _root_.sourcecode.File
+  type Line = _root_.sourcecode.Line
+  type Text[T] = _root_.sourcecode.Text[T]
+}

--- a/scalameta/common/shared/src/main/scala-2.12/scala/meta/internal/sourcecode/package.scala
+++ b/scalameta/common/shared/src/main/scala-2.12/scala/meta/internal/sourcecode/package.scala
@@ -1,0 +1,7 @@
+package scala.meta.internal
+
+package object sourcecode {
+  type File = _root_.sourcecode.File
+  type Line = _root_.sourcecode.Line
+  type Text[T] = _root_.sourcecode.Text[T]
+}

--- a/scalameta/common/shared/src/main/scala-2.13/scala/meta/internal/sourcecode/Compat.scala
+++ b/scalameta/common/shared/src/main/scala-2.13/scala/meta/internal/sourcecode/Compat.scala
@@ -1,0 +1,18 @@
+package scala.meta.internal.sourcecode
+import scala.language.implicitConversions
+import scala.language.existentials
+
+
+object Compat{
+  type Context = scala.reflect.macros.blackbox.Context
+  def enclosingOwner(c: Context) = c.internal.enclosingOwner
+
+  def enclosingParamList(c: Context): List[List[c.Symbol]] = {
+    def nearestEnclosingMethod(owner: c.Symbol): c.Symbol =
+      if (owner.isMethod) owner
+      else if (owner.isClass) owner.asClass.primaryConstructor
+      else nearestEnclosingMethod(owner.owner)
+
+    nearestEnclosingMethod(enclosingOwner(c)).asMethod.paramLists
+  }
+}

--- a/scalameta/common/shared/src/main/scala-2.13/scala/meta/internal/sourcecode/Macros.scala
+++ b/scalameta/common/shared/src/main/scala-2.13/scala/meta/internal/sourcecode/Macros.scala
@@ -1,0 +1,230 @@
+package scala.meta.internal.sourcecode
+import scala.language.implicitConversions
+import scala.language.existentials
+
+
+import java.util.concurrent.ConcurrentHashMap
+import language.experimental.macros
+
+trait NameMacros {
+  implicit def generate: Name = macro Macros.nameImpl
+}
+
+trait NameMachineMacros {
+  implicit def generate: Name.Machine = macro Macros.nameMachineImpl
+}
+
+trait FullNameMacros {
+  implicit def generate: FullName = macro Macros.fullNameImpl
+}
+
+trait FullNameMachineMacros {
+  implicit def generate: FullName.Machine = macro Macros.fullNameMachineImpl
+}
+
+trait FileMacros {
+  implicit def generate: scala.meta.internal.sourcecode.File = macro Macros.fileImpl
+}
+
+trait FileNameMacros {
+  implicit def generate: scala.meta.internal.sourcecode.FileName = macro Macros.fileNameImpl
+}
+
+trait LineMacros {
+  implicit def generate: scala.meta.internal.sourcecode.Line = macro Macros.lineImpl
+}
+
+trait EnclosingMacros {
+  implicit def generate: Enclosing = macro Macros.enclosingImpl
+}
+
+trait EnclosingMachineMacros {
+  implicit def generate: Enclosing.Machine = macro Macros.enclosingMachineImpl
+}
+
+trait PkgMacros {
+  implicit def generate: Pkg = macro Macros.pkgImpl
+}
+
+trait TextMacros {
+  implicit def generate[T](v: T): Text[T] = macro Macros.text[T]
+  def apply[T](v: T): Text[T] = macro Macros.text[T]
+}
+
+trait ArgsMacros {
+  implicit def generate: Args = macro Macros.argsImpl
+}
+
+object Util{
+  def isSynthetic(c: Compat.Context)(s: c.Symbol) = isSyntheticName(getName(c)(s))
+  def isSyntheticName(name: String) = {
+    name == "<init>" || (name.startsWith("<local ") && name.endsWith(">")) || name == "$anonfun"
+  }
+  def getName(c: Compat.Context)(s: c.Symbol) = s.name.decoded.toString.trim
+}
+
+object Macros {
+
+  def nameImpl(c: Compat.Context): c.Expr[Name] = {
+    import c.universe._
+    var owner = Compat.enclosingOwner(c)
+    while(Util.isSynthetic(c)(owner)) owner = owner.owner
+    val simpleName = Util.getName(c)(owner)
+    c.Expr[scala.meta.internal.sourcecode.Name](q"""${c.prefix}($simpleName)""")
+  }
+
+  def nameMachineImpl(c: Compat.Context): c.Expr[Name.Machine] = {
+    import c.universe._
+    val owner = Compat.enclosingOwner(c)
+    val simpleName = Util.getName(c)(owner)
+    c.Expr[Name.Machine](q"""${c.prefix}($simpleName)""")
+  }
+
+  def fullNameImpl(c: Compat.Context): c.Expr[FullName] = {
+    import c.universe._
+    val owner = Compat.enclosingOwner(c)
+    val fullName =
+      owner.fullName.trim
+        .split("\\.", -1)
+        .filterNot(Util.isSyntheticName)
+        .mkString(".")
+    c.Expr[scala.meta.internal.sourcecode.FullName](q"""${c.prefix}($fullName)""")
+  }
+
+  def fullNameMachineImpl(c: Compat.Context): c.Expr[FullName.Machine] = {
+    import c.universe._
+    val owner = Compat.enclosingOwner(c)
+    val fullName = owner.fullName.trim
+    c.Expr[FullName.Machine](q"""${c.prefix}($fullName)""")
+  }
+
+  private val filePrefix = "//SOURCECODE_ORIGINAL_FILE_PATH="
+  private val filePrefixCache =
+    new ConcurrentHashMap[scala.reflect.internal.util.SourceFile, Option[String]]()
+  private def findOriginalFile(chars: Array[Char]): Option[String] = {
+    new String(chars).linesIterator.find(_.contains(filePrefix)).map(_.split(filePrefix).last)
+  }
+
+  def fileImpl(c: Compat.Context): c.Expr[scala.meta.internal.sourcecode.File] = {
+    import c.universe._
+
+    val file = filePrefixCache
+      .computeIfAbsent(c.enclosingPosition.source, source => findOriginalFile(source.content))
+      .getOrElse(c.enclosingPosition.source.path)
+
+    c.Expr[scala.meta.internal.sourcecode.File](q"""${c.prefix}($file)""")
+  }
+
+  def fileNameImpl(c: Compat.Context): c.Expr[scala.meta.internal.sourcecode.FileName] = {
+    import c.universe._
+    val fileName = filePrefixCache
+      .computeIfAbsent(c.enclosingPosition.source, source => findOriginalFile(source.content))
+      .getOrElse(c.enclosingPosition.source.path)
+      .split('/').last
+    c.Expr[scala.meta.internal.sourcecode.FileName](q"""${c.prefix}($fileName)""")
+  }
+
+  private val linePrefix = "//SOURCECODE_ORIGINAL_CODE_START_MARKER"
+  private val linePrefixCache =
+    new ConcurrentHashMap[scala.reflect.internal.util.SourceFile, Int]()
+  
+  def lineImpl(c: Compat.Context): c.Expr[scala.meta.internal.sourcecode.Line] = {
+    import c.universe._
+    val offset = linePrefixCache.computeIfAbsent(
+      c.enclosingPosition.source,
+      source => new String(source.content)
+        .linesIterator
+        .indexWhere(_.contains(linePrefix)) match{
+        case -1 => 0
+        case n => n + 1
+      }
+    )
+
+    val line = c.enclosingPosition.line - offset
+    c.Expr[scala.meta.internal.sourcecode.Line](q"""${c.prefix}($line)""")
+  }
+
+  def enclosingImpl(c: Compat.Context): c.Expr[Enclosing] = enclosing[Enclosing](c)(
+    !Util.isSynthetic(c)(_)
+  )
+
+  def enclosingMachineImpl(c: Compat.Context): c.Expr[Enclosing.Machine] =
+    enclosing[Enclosing.Machine](c)(_ => true)
+
+  def pkgImpl(c: Compat.Context): c.Expr[Pkg] = enclosing[Pkg](c)(_.isPackage)
+
+  def argsImpl(c: Compat.Context): c.Expr[Args] = {
+    import c.universe._
+    val param = Compat.enclosingParamList(c)
+    val texts = param.map(_.map(p => c.Expr[Text[_]](q"""scala.meta.internal.sourcecode.Text($p, ${p.name.toString})""")))
+    val textSeqs = texts.map(s => c.Expr(q"""Seq(..$s)"""))
+    c.Expr[Args](q"""Seq(..$textSeqs)""")
+  }
+
+
+  def text[T: c.WeakTypeTag](c: Compat.Context)(v: c.Expr[T]): c.Expr[scala.meta.internal.sourcecode.Text[T]] = {
+    import c.universe._
+    val fileContent = new String(v.tree.pos.source.content)
+    val start = v.tree.collect {
+      case treeVal => treeVal.pos match {
+        case NoPosition ⇒ Int.MaxValue
+        case p ⇒ p.startOrPoint
+      }
+    }.min
+    val g = c.asInstanceOf[reflect.macros.runtime.Context].global
+    val parser = g.newUnitParser(fileContent.drop(start))
+    parser.expr()
+    val end = parser.in.lastOffset
+    val txt = fileContent.slice(start, start + end)
+    val tree = q"""${c.prefix}(${v.tree}, $txt)"""
+    c.Expr[scala.meta.internal.sourcecode.Text[T]](tree)
+  }
+  sealed trait Chunk
+  object Chunk{
+    case class Pkg(name: String) extends Chunk
+    case class Obj(name: String) extends Chunk
+    case class Cls(name: String) extends Chunk
+    case class Trt(name: String) extends Chunk
+    case class Val(name: String) extends Chunk
+    case class Var(name: String) extends Chunk
+    case class Lzy(name: String) extends Chunk
+    case class Def(name: String) extends Chunk
+
+  }
+
+  def enclosing[T](c: Compat.Context)(filter: c.Symbol => Boolean): c.Expr[T] = {
+
+    import c.universe._
+    var current = Compat.enclosingOwner(c)
+    var path = List.empty[Chunk]
+    while(current != NoSymbol && current.toString != "package <root>"){
+      if (filter(current)) {
+
+        val chunk = current match {
+          case x if x.isPackage => Chunk.Pkg
+          case x if x.isModuleClass => Chunk.Obj
+          case x if x.isClass && x.asClass.isTrait => Chunk.Trt
+          case x if x.isClass => Chunk.Cls
+          case x if x.isMethod => Chunk.Def
+          case x if x.isTerm && x.asTerm.isVar => Chunk.Var
+          case x if x.isTerm && x.asTerm.isLazy => Chunk.Lzy
+          case x if x.isTerm && x.asTerm.isVal => Chunk.Val
+        }
+
+        path = chunk(Util.getName(c)(current)) :: path
+      }
+      current = current.owner
+    }
+    val renderedPath = path.map{
+      case Chunk.Pkg(s) => s + "."
+      case Chunk.Obj(s) => s + "."
+      case Chunk.Cls(s) => s + "#"
+      case Chunk.Trt(s) => s + "#"
+      case Chunk.Val(s) => s + " "
+      case Chunk.Var(s) => s + " "
+      case Chunk.Lzy(s) => s + " "
+      case Chunk.Def(s) => s + " "
+    }.mkString.dropRight(1)
+    c.Expr[T](q"""${c.prefix}($renderedPath)""")
+  }
+}

--- a/scalameta/common/shared/src/main/scala-2.13/scala/meta/internal/sourcecode/SourceContext.scala
+++ b/scalameta/common/shared/src/main/scala-2.13/scala/meta/internal/sourcecode/SourceContext.scala
@@ -1,0 +1,48 @@
+package scala.meta.internal.sourcecode
+import scala.language.implicitConversions
+import scala.language.existentials
+
+
+
+abstract class SourceValue[T]{
+  def value: T
+}
+abstract class SourceCompanion[T, V <: SourceValue[T]](build: T => V){
+  def apply()(implicit s: V): T = s.value
+  implicit def wrap(s: T): V = build(s)
+}
+case class Name(value: String) extends SourceValue[String]
+object Name extends SourceCompanion[String, Name](new Name(_)) with NameMacros {
+  case class Machine(value: String) extends SourceValue[String]
+  object Machine extends SourceCompanion[String, Machine](new Machine(_)) with NameMachineMacros
+}
+case class FullName(value: String) extends SourceValue[String]
+object FullName extends SourceCompanion[String, FullName](new FullName(_)) with FullNameMacros {
+  case class Machine(value: String) extends SourceValue[String]
+  object Machine extends SourceCompanion[String, Machine](new Machine(_)) with FullNameMachineMacros
+}
+
+case class File(value: String) extends SourceValue[String]
+object File extends SourceCompanion[String, File](new File(_)) with FileMacros
+
+case class FileName(value: String) extends SourceValue[String]
+object FileName extends SourceCompanion[String, FileName](new FileName(_)) with FileNameMacros
+
+case class Line(value: Int) extends SourceValue[Int]
+object Line extends SourceCompanion[Int, Line](new Line(_)) with LineMacros
+case class Enclosing(value: String) extends SourceValue[String]
+
+object Enclosing extends SourceCompanion[String, Enclosing](new Enclosing(_)) with EnclosingMacros {
+  case class Machine(value: String) extends SourceValue[String]
+  object Machine extends SourceCompanion[String, Machine](new Machine(_)) with EnclosingMachineMacros
+}
+
+
+case class Pkg(value: String) extends SourceValue[String]
+object Pkg extends SourceCompanion[String, Pkg](new Pkg(_)) with PkgMacros
+
+case class Text[T](value: T, source: String)
+object Text extends TextMacros
+
+case class Args(value: Seq[Seq[Text[_]]]) extends SourceValue[Seq[Seq[Text[_]]]]
+object Args extends SourceCompanion[Seq[Seq[Text[_]]], Args](new Args(_)) with ArgsMacros

--- a/scalameta/common/shared/src/main/scala/org/scalameta/logger.scala
+++ b/scalameta/common/shared/src/main/scala/org/scalameta/logger.scala
@@ -1,5 +1,7 @@
 package org.scalameta
 
+import scala.meta.internal.sourcecode
+
 class FileLine(val file: sourcecode.File, val line: sourcecode.Line) extends Ordered[FileLine] {
   override def toString: String = {
     val shortFilename = file.value.replaceAll("(.*/|\\.scala)", "")


### PR DESCRIPTION
This inline the sourcecode package for scala 2.13 this means that the scalameta published for Scala 3 will no longer depend on `sourcecode_2.13` which avoid conflicts for users that depend on s`sourcecode_3`

Fixes #4543
