### PR TITLE
TreeSyntax, Dialect: don't use invariant macros

### DIFF
--- a/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects/shared/src/main/scala/scala/meta/Dialect.scala
@@ -1,6 +1,5 @@
 package scala.meta
 
-import org.scalameta.invariants
 import scala.meta.Dialect.UnquoteType
 import scala.meta.dialects._
 import scala.meta.internal.dialects._
@@ -321,13 +320,13 @@ final class Dialect private[meta] (
   def withAllowTypeMatch(newValue: Boolean): Dialect = privateCopy(allowTypeMatch = newValue)
   def withAllowInfixMods(newValue: Boolean): Dialect = privateCopy(allowInfixMods = newValue)
   def withAllowSpliceAndQuote(newValue: Boolean): Dialect = {
-    if (newValue) invariants.require(!this.allowSymbolLiterals)
+    require(!newValue || !this.allowSymbolLiterals)
     privateCopy(allowSpliceAndQuote = newValue)
   }
   def withAllowQuotedTypeVariables(newValue: Boolean): Dialect =
     privateCopy(allowQuotedTypeVariables = newValue)
   def withAllowSymbolLiterals(newValue: Boolean): Dialect = {
-    if (newValue) invariants.require(!this.allowSpliceAndQuote)
+    require(!newValue || !this.allowSpliceAndQuote)
     privateCopy(allowSymbolLiterals = newValue)
   }
   def withAllowDependentFunctionTypes(newValue: Boolean): Dialect =

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -3,7 +3,7 @@ package internal
 package parsers
 
 import org.scalameta._
-import org.scalameta.invariants._
+import org.scalameta.invariants.InvariantFailedException
 import scala.meta.classifiers._
 import scala.meta.inputs._
 import scala.meta.internal.parsers.Absolutize._

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
@@ -43,7 +43,7 @@ class ScalametaTokenizer(input: Input, dialect: Dialect)(implicit options: Token
       token match {
         case t: Token.HSpace => whitespaceTokenizer.pushHS(t)
         case t: Token.EOL => whitespaceTokenizer.pushVS(t)
-        case t => unreachable(debug(t), "not a whitespace token")
+        case _ =>
       }
       getToken(next) match {
         case nt: Token.Whitespace => emitTokenWhitespace(nt)

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -3,8 +3,6 @@ package internal
 package prettyprinters
 
 import org.scalameta.internal.ScalaCompat.EOL
-import org.scalameta.invariants._
-import org.scalameta.{debug, unreachable}
 import scala.meta.classifiers._
 import scala.meta.inputs.Position
 import scala.meta.internal.tokens.Chars._
@@ -156,21 +154,10 @@ object TreeSyntax {
           })
       }
       def thisLocationAlsoAcceptsPatVars(p: Tree): Boolean = p match {
-        case p: Term.Name => unreachable
-        case _: Term.SelectLike => false
-        case p: Pat.Wildcard => unreachable
-        case p: Pat.Var => false
-        case p: Pat.Repeated => false
-        case p: Pat.Bind => true
-        case p: Pat.Alternative => true
+        case _: Pat.Bind | _: Pat.Alternative | _: Pat.Tuple => true
         case p: Pat.ArgClause => p.values.contains(t)
-        case p: Pat.Tuple => true
-        case p: Pat.Extract => false
         case p: Pat.ExtractInfix => p.lhs eq t
-        case p: Pat.Assign => false
         case p: Pat.Interpolate => p.args.contains(t)
-        case p: Pat.Typed => unreachable
-        case p: Pat => unreachable
         case p: Case => p.pat eq t
         case p: Defn.Val => p.pats.contains(t)
         case p: Defn.Var => p.pats.contains(t)
@@ -221,8 +208,7 @@ object TreeSyntax {
         case Some(p: Pkg.Body) => p.stats.lengthCompare(1) == 0 && isOnlyChildOfOnlyChild(p)
         case Some(p: Pkg) => isOnlyChildOfOnlyChild(p)
         case Some(p: Source) => p.stats.lengthCompare(1) == 0
-        case Some(p) => unreachable(debug(p))
-        case None => true
+        case _ => true
       }
       !isOnlyChildOfOnlyChild(t)
     }
@@ -503,7 +489,6 @@ object TreeSyntax {
       case t: Type.Param =>
         def isVariant(m: Mod) = m.is[Mod.Variant]
         val mods = t.mods.filterNot(isVariant)
-        require(t.mods.length - mods.length <= 1)
         val variance = o(t.mods.find(isVariant))
         val bounds = printBounds(t.bounds, t.vbounds)
         s(w(mods, " "), variance, t.name, t.tparamClause, bounds)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
@@ -1,6 +1,5 @@
 package scala.meta.tests.parsers.dotty
 
-import org.scalameta.invariants
 import scala.meta._
 
 import scala.language.implicitConversions
@@ -413,7 +412,7 @@ class MacroSuite extends BaseDottySuite {
         .withAllowSpliceAndQuote(true)
       runTestAssert[Stat](code)(treeWithQuote)
     }
-    locally(intercept[invariants.InvariantFailedException](
+    locally(intercept[IllegalArgumentException](
       dialects.Scala3.withAllowSymbolLiterals(true).withAllowSpliceAndQuote(true)
     ))
 
@@ -445,7 +444,7 @@ class MacroSuite extends BaseDottySuite {
         .withAllowSpliceAndQuote(true)
       runTestAssert[Stat](code)(treeWithQuote)
     }
-    locally(intercept[invariants.InvariantFailedException](
+    locally(intercept[IllegalArgumentException](
       dialects.Scala3.withAllowSymbolLiterals(true).withAllowSpliceAndQuote(true)
     ))
 


### PR DESCRIPTION
Helps with #4543.