### PR TITLE
Trees: add a `reprint` version of syntax

### DIFF
--- a/scalameta/common2/shared/src/main/scala/scala/meta/prettyprinters/Api.scala
+++ b/scalameta/common2/shared/src/main/scala/scala/meta/prettyprinters/Api.scala
@@ -10,6 +10,9 @@ private[meta] trait Api {
   implicit class XtensionSyntax[T](x: T)(implicit style: Syntax[T]) {
     def syntax: String = style(x).toString
   }
+  implicit class XtensionReprint[T](x: T)(implicit style: Reprint[T]) {
+    def reprint: String = style(x).toString
+  }
   implicit class XtensionStructure[T](x: T)(implicit style: Structure[T]) {
     def structure: String = style(x).toString
   }

--- a/scalameta/common2/shared/src/main/scala/scala/meta/prettyprinters/Reprint.scala
+++ b/scalameta/common2/shared/src/main/scala/scala/meta/prettyprinters/Reprint.scala
@@ -1,0 +1,11 @@
+package scala.meta.prettyprinters
+
+import scala.annotation.implicitNotFound
+
+@implicitNotFound(msg = "don't know how to show[Reprint] for ${T}")
+trait Reprint[-T] extends Show[T]
+object Reprint {
+  def apply[T](f: T => Show.Result): Reprint[T] = new Reprint[T] {
+    def apply(input: T) = f(input)
+  }
+}

--- a/scalameta/trees2/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees2/shared/src/main/scala/scala/meta/Trees.scala
@@ -44,6 +44,8 @@ object Tree extends InternalTreeXtensions {
   implicit def showStructure[T <: Tree]: Structure[T] = TreeStructure.apply[T]
   implicit def showSyntax[T <: Tree](implicit dialect: Dialect): Syntax[T] =
     Syntax[T](TreeSyntax.syntax)
+  implicit def showReprint[T <: Tree](implicit dialect: Dialect): Reprint[T] =
+    Reprint[T](TreeSyntax.reprint)
 
   @branch
   /** brace- or indent-delimited container of statements */

--- a/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -175,6 +175,7 @@ class SurfaceSuite extends FunSuite {
          |scala.meta.parsers.Parsed.Success *
          |scala.meta.parsers.ParserOptions *
          |scala.meta.prettyprinters
+         |scala.meta.prettyprinters.Reprint *
          |scala.meta.prettyprinters.Show *
          |scala.meta.prettyprinters.Structure
          |scala.meta.prettyprinters.Syntax
@@ -272,6 +273,7 @@ class SurfaceSuite extends FunSuite {
          |* T(implicit scala.meta.classifiers.Classifiable[T]).isAny(implicit XtensionClassifiable.this.C[U1], XtensionClassifiable.this.C[U2], XtensionClassifiable.this.C[U3], XtensionClassifiable.this.C[U4]): Boolean
          |* T(implicit scala.meta.classifiers.Classifiable[T]).isAnyOf(XtensionClassifiable.this.C[_]*): Boolean
          |* T(implicit scala.meta.classifiers.Classifiable[T]).isNot(implicit XtensionClassifiable.this.C[U]): Boolean
+         |* T(implicit scala.meta.prettyprinters.Reprint[T]).reprint: String
          |* T(implicit scala.meta.prettyprinters.Structure[T]).structure: String
          |* T(implicit scala.meta.prettyprinters.Syntax[T]).syntax: String
          |* T.parse(implicit scala.meta.common.Convert[T,scala.meta.inputs.Input], scala.meta.parsers.Parse[U], scala.meta.Dialect): scala.meta.parsers.Parsed[U]


### PR DESCRIPTION
This version forces regeneration of syntax rather than taking original input if available.