### PR TITLE
Tokenize: load via ServiceLoader, not hardcoded

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -103,7 +103,15 @@ lazy val nativeSettings = Seq(
   crossScalaVersions := List(LatestScala213, LatestScala212),
   scalaVersion := LatestScala213,
   bspEnabled := false,
-  nativeConfig ~= { _.withMode(scalanative.build.Mode.releaseFast) }
+  nativeConfig ~= {
+    _.withMode(scalanative.build.Mode.releaseFast)
+    /*
+      .withServiceProviders(Map(
+        "scala.meta.tokenizers.Tokenize" ->
+          Seq("scala.meta.internal.tokenizers.ScalametaTokenizer$AsTokenize$")
+      ))
+     */
+  }
 )
 
 val allPlatforms = Seq(JSPlatform, JVMPlatform, NativePlatform)

--- a/scalameta/tokenizers2/shared/src/main/scala/scala/meta/tokenizers/Tokenize.scala
+++ b/scalameta/tokenizers2/shared/src/main/scala/scala/meta/tokenizers/Tokenize.scala
@@ -11,7 +11,10 @@ trait Tokenize {
 object Tokenize {
 
   val global = new SingletonReference[Tokenize](UndefinedTokenize)
-  implicit def scalametaTokenize: Tokenize = global.value
+  implicit def scalametaTokenize: Tokenize = {
+    val obj = global.value
+    if (obj ne UndefinedTokenize) obj else PlatformCompat.loadTokenize.getOrElse(obj)
+  }
 
   def getOpt: Option[Tokenize] = {
     val obj = scalametaTokenize

--- a/scalameta/trees/shared/src/main/resources/META-INF/services/scala.meta.tokenizers.Tokenize
+++ b/scalameta/trees/shared/src/main/resources/META-INF/services/scala.meta.tokenizers.Tokenize
@@ -1,0 +1,1 @@
+scala.meta.internal.tokenizers.ScalametaTokenizer$AsTokenize$

--- a/scalameta/trees2/js/src/main/scala/scala/meta/tokenizers/PlatformCompat.scala
+++ b/scalameta/trees2/js/src/main/scala/scala/meta/tokenizers/PlatformCompat.scala
@@ -1,0 +1,7 @@
+package scala.meta.tokenizers
+
+object PlatformCompat {
+
+  val loadTokenize: Option[Tokenize] = None
+
+}

--- a/scalameta/trees2/jvm/src/main/scala/scala/meta/tokenizers/PlatformCompat.scala
+++ b/scalameta/trees2/jvm/src/main/scala/scala/meta/tokenizers/PlatformCompat.scala
@@ -1,0 +1,12 @@
+package scala.meta.tokenizers
+
+import java.util.ServiceLoader
+
+object PlatformCompat {
+
+  lazy val loadTokenize: Option[Tokenize] = {
+    val factories = ServiceLoader.load(classOf[Tokenize]).iterator()
+    if (factories.hasNext) Some(factories.next()) else None
+  }
+
+}

--- a/scalameta/trees2/native/src/main/scala/scala/meta/tokenizers/PlatformCompat.scala
+++ b/scalameta/trees2/native/src/main/scala/scala/meta/tokenizers/PlatformCompat.scala
@@ -1,0 +1,7 @@
+package scala.meta.tokenizers
+
+object PlatformCompat {
+
+  val loadTokenize: Option[Tokenize] = None
+
+}

--- a/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -183,6 +183,7 @@ class SurfaceSuite extends FunSuite {
          |scala.meta.quasiquotes.Lift
          |scala.meta.quasiquotes.Unlift
          |scala.meta.tokenizers
+         |scala.meta.tokenizers.PlatformCompat *
          |scala.meta.tokenizers.Tokenize *
          |scala.meta.tokenizers.TokenizeException
          |scala.meta.tokenizers.Tokenized


### PR DESCRIPTION
This works in JVM. JS doesn't support ServiceLoader, and Native produces seemingly unrelated exceptions during linking.