### PR TITLE
TextDocumentOps: add SAM methods to symbols and occurrences

### DIFF
--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
@@ -52,6 +52,8 @@ trait TextDocumentOps {
       clearSymbolPointsCache()
       val occurrences = emptyOccurrenceMap()
       val samoccurrences = emptyOccurrenceMap()
+      // SAM methods share positions with their classes.
+      val sammethodoccurrences = emptyOccurrenceMap()
       val symbols = mutable.Map[String, s.SymbolInformation]()
       val synthetics = mutable.ListBuffer[s.Synthetic]()
       val syntheticTreeCache = new mutable.HashMap[g.Tree, Option[s.Synthetic]]
@@ -95,7 +97,7 @@ trait TextDocumentOps {
             }
             ok
           }
-          set(sam, samoccurrences)
+          set(sam, samoccurrences) && set(sam.info.decls.elems.sym, sammethodoccurrences)
         }
         val gsym = gt.symbol
         val gpos = gt.pos
@@ -654,7 +656,7 @@ trait TextDocumentOps {
       val finalOccurrences = {
         val buf = List.newBuilder[s.SymbolOccurrence]
         for {
-          map <- Iterator(occurrences, mpatoccurrences, samoccurrences)
+          map <- Iterator(occurrences, mpatoccurrences, samoccurrences, sammethodoccurrences)
           (pos, (sym, role)) <- map
           flatSym <- sym.asMulti
         } buf += s.SymbolOccurrence(Some(pos.toRange), flatSym, role)

--- a/tests-semanticdb/src/test/resources/example/SingleAbstractMethod.scala
+++ b/tests-semanticdb/src/test/resources/example/SingleAbstractMethod.scala
@@ -7,10 +7,10 @@ class SingleAbstractMethod/*<=example.SingleAbstractMethod#*/ {
   }
   def withSAM/*<=example.SingleAbstractMethod#withSAM().*/(a/*<=example.SingleAbstractMethod#withSAM().(a)*/: SAM/*=>example.SingleAbstractMethod#SAM#*/) = a/*=>example.SingleAbstractMethod#withSAM().(a)*/.foo/*=>example.SingleAbstractMethod#SAM#foo().*/(0)
 
-  withSAM/*=>example.SingleAbstractMethod#withSAM().*/(_ + 1/*<=local0*/)
-  withSAM/*=>example.SingleAbstractMethod#withSAM().*/((x: Int) => x - 1/*<=local2*/)
+  withSAM/*=>example.SingleAbstractMethod#withSAM().*/(_ + 1/*<=local0*//*<=local2*/)
+  withSAM/*=>example.SingleAbstractMethod#withSAM().*/((x: Int) => x - 1/*<=local3*//*<=local4*/)
 
   def funcSAM/*<=example.SingleAbstractMethod#funcSAM().*/(y/*<=example.SingleAbstractMethod#funcSAM().(y)*/: Int/*=>scala.Int#*/) = y/*=>example.SingleAbstractMethod#funcSAM().(y)*/ */*=>scala.Int#`*`(+3).*/ 2
-  withSAM/*=>example.SingleAbstractMethod#withSAM().*/(funcSAM/*=>example.SingleAbstractMethod#funcSAM().*//*<=local4*/)
+  withSAM/*=>example.SingleAbstractMethod#withSAM().*/(funcSAM/*=>example.SingleAbstractMethod#funcSAM().*//*<=local6*//*<=local7*/)
 
 }

--- a/tests-semanticdb/src/test/resources/metac.expect_2.12
+++ b/tests-semanticdb/src/test/resources/metac.expect_2.12
@@ -6,8 +6,8 @@ Schema => SemanticDB v4
 Uri => semanticdb/integration/src/main/scala-2.12/example/SingleAbstractMethod.scala
 Text => non-empty
 Language => Scala
-Symbols => 13 entries
-Occurrences => 30 entries
+Symbols => 16 entries
+Occurrences => 33 entries
 
 Symbols:
 example/SingleAbstractMethod# => class SingleAbstractMethod extends AnyRef { +4 decls }
@@ -34,14 +34,23 @@ example/SingleAbstractMethod#withSAM().(a) => param a: SAM
 local0 => class $anon extends Object with SAM { +1 decls }
   Object => java/lang/Object#
   SAM => example/SingleAbstractMethod#SAM#
-local2 => class $anon extends Object with SAM { +1 decls }
-  Object => java/lang/Object#
-  SAM => example/SingleAbstractMethod#SAM#
-local3 => param x: Int
+local2 => method foo(a: Int): Int <: example/SingleAbstractMethod#SAM#foo().
+  a => example/SingleAbstractMethod#SAM#foo().(a)
   Int => scala/Int#
-local4 => class $anon extends Object with SAM { +1 decls }
+local3 => class $anon extends Object with SAM { +1 decls }
   Object => java/lang/Object#
   SAM => example/SingleAbstractMethod#SAM#
+local4 => method foo(a: Int): Int <: example/SingleAbstractMethod#SAM#foo().
+  a => example/SingleAbstractMethod#SAM#foo().(a)
+  Int => scala/Int#
+local5 => param x: Int
+  Int => scala/Int#
+local6 => class $anon extends Object with SAM { +1 decls }
+  Object => java/lang/Object#
+  SAM => example/SingleAbstractMethod#SAM#
+local7 => method foo(a: Int): Int <: example/SingleAbstractMethod#SAM#foo().
+  a => example/SingleAbstractMethod#SAM#foo().(a)
+  Int => scala/Int#
 
 Occurrences:
 [0:8..0:15): example <= example/
@@ -59,12 +68,14 @@ Occurrences:
 [7:26..7:29): foo => example/SingleAbstractMethod#SAM#foo().
 [9:2..9:9): withSAM => example/SingleAbstractMethod#withSAM().
 [9:10..9:15): _ + 1 <= local0
+[9:10..9:15): _ + 1 <= local2
 [9:12..9:13): + => scala/Int#`+`(+4).
 [10:2..10:9): withSAM => example/SingleAbstractMethod#withSAM().
-[10:10..10:27): (x: Int) => x - 1 <= local2
-[10:11..10:12): x <= local3
+[10:10..10:27): (x: Int) => x - 1 <= local3
+[10:10..10:27): (x: Int) => x - 1 <= local4
+[10:11..10:12): x <= local5
 [10:14..10:17): Int => scala/Int#
-[10:22..10:23): x => local3
+[10:22..10:23): x => local5
 [10:24..10:25): - => scala/Int#`-`(+3).
 [12:6..12:13): funcSAM <= example/SingleAbstractMethod#funcSAM().
 [12:14..12:15): y <= example/SingleAbstractMethod#funcSAM().(y)
@@ -73,7 +84,8 @@ Occurrences:
 [12:26..12:27): * => scala/Int#`*`(+3).
 [13:2..13:9): withSAM => example/SingleAbstractMethod#withSAM().
 [13:10..13:17): funcSAM => example/SingleAbstractMethod#funcSAM().
-[13:10..13:17): funcSAM <= local4
+[13:10..13:17): funcSAM <= local6
+[13:10..13:17): funcSAM <= local7
 
 semanticdb/integration/src/main/scala/example/Access.scala
 ----------------------------------------------------------

--- a/tests-semanticdb/src/test/resources/metac.expect_2.13
+++ b/tests-semanticdb/src/test/resources/metac.expect_2.13
@@ -73,8 +73,8 @@ Schema => SemanticDB v4
 Uri => semanticdb/integration/src/main/scala-2.13/example/SingleAbstractMethod.scala
 Text => non-empty
 Language => Scala
-Symbols => 13 entries
-Occurrences => 30 entries
+Symbols => 16 entries
+Occurrences => 33 entries
 
 Symbols:
 example/SingleAbstractMethod# => class SingleAbstractMethod extends AnyRef { +4 decls }
@@ -101,14 +101,23 @@ example/SingleAbstractMethod#withSAM().(a) => param a: SAM
 local0 => class $anon extends Object with SAM { +1 decls }
   Object => java/lang/Object#
   SAM => example/SingleAbstractMethod#SAM#
-local2 => class $anon extends Object with SAM { +1 decls }
-  Object => java/lang/Object#
-  SAM => example/SingleAbstractMethod#SAM#
-local3 => param x: Int
+local2 => method foo(a: Int): Int <: example/SingleAbstractMethod#SAM#foo().
+  a => example/SingleAbstractMethod#SAM#foo().(a)
   Int => scala/Int#
-local4 => class $anon extends Object with SAM { +1 decls }
+local3 => class $anon extends Object with SAM { +1 decls }
   Object => java/lang/Object#
   SAM => example/SingleAbstractMethod#SAM#
+local4 => method foo(a: Int): Int <: example/SingleAbstractMethod#SAM#foo().
+  a => example/SingleAbstractMethod#SAM#foo().(a)
+  Int => scala/Int#
+local5 => param x: Int
+  Int => scala/Int#
+local6 => class $anon extends Object with SAM { +1 decls }
+  Object => java/lang/Object#
+  SAM => example/SingleAbstractMethod#SAM#
+local7 => method foo(a: Int): Int <: example/SingleAbstractMethod#SAM#foo().
+  a => example/SingleAbstractMethod#SAM#foo().(a)
+  Int => scala/Int#
 
 Occurrences:
 [0:8..0:15): example <= example/
@@ -126,12 +135,14 @@ Occurrences:
 [7:26..7:29): foo => example/SingleAbstractMethod#SAM#foo().
 [9:2..9:9): withSAM => example/SingleAbstractMethod#withSAM().
 [9:10..9:15): _ + 1 <= local0
+[9:10..9:15): _ + 1 <= local2
 [9:12..9:13): + => scala/Int#`+`(+4).
 [10:2..10:9): withSAM => example/SingleAbstractMethod#withSAM().
-[10:10..10:27): (x: Int) => x - 1 <= local2
-[10:11..10:12): x <= local3
+[10:10..10:27): (x: Int) => x - 1 <= local3
+[10:10..10:27): (x: Int) => x - 1 <= local4
+[10:11..10:12): x <= local5
 [10:14..10:17): Int => scala/Int#
-[10:22..10:23): x => local3
+[10:22..10:23): x => local5
 [10:24..10:25): - => scala/Int#`-`(+3).
 [12:6..12:13): funcSAM <= example/SingleAbstractMethod#funcSAM().
 [12:14..12:15): y <= example/SingleAbstractMethod#funcSAM().(y)
@@ -140,7 +151,8 @@ Occurrences:
 [12:26..12:27): * => scala/Int#`*`(+3).
 [13:2..13:9): withSAM => example/SingleAbstractMethod#withSAM().
 [13:10..13:17): funcSAM => example/SingleAbstractMethod#funcSAM().
-[13:10..13:17): funcSAM <= local4
+[13:10..13:17): funcSAM <= local6
+[13:10..13:17): funcSAM <= local7
 
 semanticdb/integration/src/main/scala/example/Access.scala
 ----------------------------------------------------------


### PR DESCRIPTION
This PR builds upon #4112 in an attempt to fix https://github.com/scalameta/metals/issues/4596.

Adding methods to symbols and occurrences allows metals to pick them up in "Go to implementations" of a method (you could previously see SAMs among implementations of a trait, but in my opinion it's more intuitive to search for implementations of a method inside that trait, and the issue above also concerns searching by methods).

Besides autotests, I also tested it with the latest v1 metals (with patched scalameta v4.15.2), and it works as expected.

<details>
<summary>Screenshots of metals with suggested changes</summary>

#### Code lens

<img width="503" height="418" alt="lens" src="https://github.com/user-attachments/assets/56401bd4-106a-4e97-817f-891b7fafd52d" />

#### Go to implementations

<img width="906" height="296" alt="gotoimpl" src="https://github.com/user-attachments/assets/0dbd561c-6aef-4d19-82c9-4d8145733ca2" />
</details>