### PR TITLE
Trees: use only head Mod.ParamType for ParamClause

### DIFF
--- a/scalameta/trees2/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees2/shared/src/main/scala/scala/meta/Trees.scala
@@ -597,13 +597,13 @@ object Term {
   class ParamClause(values: List[Param], mod: Option[Mod.ParamsType] = None)
       extends Member.ParamClause
   object ParamClause {
-    @tailrec
-    private[meta] def getMod(v: Seq[Param]): Option[Mod.ParamsType] = v match {
-      case head +: tail =>
-        if (isQuasi(head)) getMod(tail)
-        else head.mods.collectFirst { case x: Mod.ParamsType => x }.filter {
-          case _: Mod.Implicit => tail.forall(x => isQuasiOr(x, x.mods.exists(_.is[Mod.Implicit])))
-          case _ => true
+    private[meta] def getMod(v: List[Param]): Option[Mod.ParamsType] = v match {
+      case head :: tail if !isQuasi(head) =>
+        head.mods match {
+          case (mod: Mod.ParamsType) :: _
+              if !mod.is[Mod.Implicit] ||
+                tail.forall(x => isQuasiOr(x, x.mods.exists(_.is[Mod.Implicit]))) => Some(mod)
+          case _ => None
         }
       case _ => None
     }

--- a/tests/shared/src/test/scala-2/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala-2/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -551,21 +551,20 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
   )
 
   test("#1837 class C(private implicit val x: Int, implicit final val y: String, protected implicit var z: Boolean)") {
-    checkTree(
-      templStat("class C(private implicit val x: Int, implicit final val y: String, protected implicit var z: Boolean)"),
-      "class C(implicit private val x: Int, final val y: String, protected var z: Boolean)"
-    )(Defn.Class(
+    val code =
+      "class C(private implicit val x: Int, implicit final val y: String, protected implicit var z: Boolean)"
+    val tree = Defn.Class(
       Nil,
       pname("C"),
       Nil,
       ctorp(
-        Mod.Implicit(),
         tparam(List(Mod.Private(anon), Mod.Implicit(), Mod.ValParam()), "x", "Int"),
         tparam(List(Mod.Implicit(), Mod.Final(), Mod.ValParam()), "y", "String"),
         tparam(List(Mod.Protected(anon), Mod.Implicit(), Mod.VarParam()), "z", "Boolean")
       ),
       tplNoBody()
-    ))
+    )
+    checkTree(templStat(code))(tree)
   }
 
   test("#1837 class C(implicit private val x: Int, implicit final val y: String, protected implicit var z: Boolean)") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
@@ -581,4 +581,13 @@ class ModSuite extends ParseSuite {
     assertTree(templStat(code))(expected)
   }
 
+  test("#4601 1: protected implicit") {
+    val code = "class FmtTest(protected implicit val viewConfig: String)(implicit z: Double)"
+    val error =
+      """|<input>:1: error: unexpected opening parenthesis
+         |class FmtTest(protected implicit val viewConfig: String)(implicit z: Double)
+         |                                                        ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
@@ -583,11 +583,21 @@ class ModSuite extends ParseSuite {
 
   test("#4601 1: protected implicit") {
     val code = "class FmtTest(protected implicit val viewConfig: String)(implicit z: Double)"
-    val error =
-      """|<input>:1: error: unexpected opening parenthesis
-         |class FmtTest(protected implicit val viewConfig: String)(implicit z: Double)
-         |                                                        ^""".stripMargin
-    runTestError[Stat](code, error)
+    val tree = Defn.Class(
+      Nil,
+      pname("FmtTest"),
+      Nil,
+      ctorp(
+        List(tparam(
+          List(Mod.Protected(Name.Anonymous()), Mod.Implicit(), Mod.ValParam()),
+          "viewConfig",
+          "String"
+        )),
+        List(tparam(List(Mod.Implicit()), "z", "Double"))
+      ),
+      tplNoBody()
+    )
+    runTestAssert[Stat](code)(tree)
   }
 
 }


### PR DESCRIPTION
Fixes #4601.