### PR TITLE
ScalametaParser: prepend Mod.ParamType

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -3333,19 +3333,16 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
     mod.foreach { mod =>
       val clazz = mod.getClass
       mods.find(_.getClass eq clazz) match {
-        case None => mods += mod
+        case None => mods.prepend(mod)
         case Some(x) => if (paramIdx == 0) syntaxError("repeated modifier", at = x)
       }
     }
 
-    val varOrVarParamMod = currToken match {
-      case _: KwVal => Some(atCurPosNext(Mod.ValParam()))
-      case _: KwVar => Some(atCurPosNext(Mod.VarParam()))
-      case _ =>
-        if (hasExplicitMods) syntaxErrorExpected[KwVal]
-        None
+    currToken match {
+      case _: KwVal => mods += atCurPosNext(Mod.ValParam())
+      case _: KwVar => mods += atCurPosNext(Mod.VarParam())
+      case _ => if (hasExplicitMods) syntaxErrorExpected[KwVal]
     }
-    varOrVarParamMod.foreach(mods += _)
 
     def endParamQuasi = at[RightParen, Comma]
     def getParamType: Type = paramType()

--- a/tests/shared/src/test/scala-2/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala-2/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -543,7 +543,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       Nil,
       ctorp(
         Mod.Implicit(),
-        tparam(List(Mod.Override(), Mod.Implicit(), Mod.ValParam()), "x", "Int"),
+        tparam(List(Mod.Implicit(), Mod.Override(), Mod.ValParam()), "x", "Int"),
         tparam(List(Mod.Final(), Mod.Implicit(), Mod.VarParam()), "y", "String")
       ),
       tplNoBody()
@@ -578,7 +578,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       Nil,
       ctorp(
         Mod.Implicit(),
-        tparam(List(Mod.Private(anon), Mod.Implicit(), Mod.ValParam()), "x", "Int"),
+        tparam(List(Mod.Implicit(), Mod.Private(anon), Mod.ValParam()), "x", "Int"),
         tparam(List(Mod.Implicit(), Mod.Final(), Mod.ValParam()), "y", "String"),
         tparam(List(Mod.Protected(anon), Mod.Implicit(), Mod.VarParam()), "z", "Boolean")
       ),

--- a/tests/shared/src/test/scala-2/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala-2/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -568,6 +568,24 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     ))
   }
 
+  test("#1837 class C(implicit private val x: Int, implicit final val y: String, protected implicit var z: Boolean)") {
+    checkTree(
+      templStat("class C(implicit private val x: Int, implicit final val y: String, protected implicit var z: Boolean)"),
+      "class C(implicit private val x: Int, final val y: String, protected var z: Boolean)"
+    )(Defn.Class(
+      Nil,
+      pname("C"),
+      Nil,
+      ctorp(
+        Mod.Implicit(),
+        tparam(List(Mod.Private(anon), Mod.Implicit(), Mod.ValParam()), "x", "Int"),
+        tparam(List(Mod.Implicit(), Mod.Final(), Mod.ValParam()), "y", "String"),
+        tparam(List(Mod.Protected(anon), Mod.Implicit(), Mod.VarParam()), "z", "Boolean")
+      ),
+      tplNoBody()
+    ))
+  }
+
   test("class C(var x: Int)")(
     assertEquals(templStat("class C(var x: Int)").reprint, "class C(var x: Int)")
   )

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ErasedDefsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ErasedDefsSuite.scala
@@ -70,7 +70,7 @@ class ErasedDefsSuite extends BaseDottySuite {
       Nil,
       tname("turnedOn"),
       Nil,
-      List(tparam(List(Mod.Erased(), Mod.Using()), "ev", papply("IsOff", "S")) :: Nil),
+      List(tparam(List(Mod.Using(), Mod.Erased()), "ev", papply("IsOff", "S")) :: Nil),
       Some(papply("Machine", "On")),
       Term.New(init(papply("Machine", "On")))
     ))


### PR DESCRIPTION
This will preserve the order in which modifiers were specified in the source. Helps with #4601.