### PR TITLE
ScalametaParser: allow many implicit ParamClauses

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -3285,13 +3285,8 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
   ): List[Term.ParamClause] = listBy[Term.ParamClause] { paramss =>
     first.foreach(paramss += _)
     while ({
-      val clause = termParamClauseOnParen(ellipsisMaxRank = ellipsisMaxRank)
-      paramss += clause
-      val hasModImplicit = clause match {
-        case _: Quasi => false
-        case x => x.mod.exists(_.is[Mod.Implicit])
-      }
-      !hasModImplicit && isAfterOptNewLine[LeftParen]
+      paramss += termParamClauseOnParen(ellipsisMaxRank = ellipsisMaxRank)
+      isAfterOptNewLine[LeftParen]
     }) {}
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
@@ -600,4 +600,13 @@ class ModSuite extends ParseSuite {
     runTestAssert[Stat](code)(tree)
   }
 
+  test("#4601 2: implicit protected") {
+    val code = "class FmtTest(implicit protected val viewConfig: String)(implicit z: Double)"
+    val error =
+      """|<input>:1: error: unexpected opening parenthesis
+         |class FmtTest(implicit protected val viewConfig: String)(implicit z: Double)
+         |                                                        ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
@@ -602,11 +602,21 @@ class ModSuite extends ParseSuite {
 
   test("#4601 2: implicit protected") {
     val code = "class FmtTest(implicit protected val viewConfig: String)(implicit z: Double)"
-    val error =
-      """|<input>:1: error: unexpected opening parenthesis
-         |class FmtTest(implicit protected val viewConfig: String)(implicit z: Double)
-         |                                                        ^""".stripMargin
-    runTestError[Stat](code, error)
+    val tree = Defn.Class(
+      Nil,
+      pname("FmtTest"),
+      Nil,
+      ctorp(
+        List(tparam(
+          List(Mod.Implicit(), Mod.Protected(Name.Anonymous()), Mod.ValParam()),
+          "viewConfig",
+          "String"
+        )),
+        List(tparam(List(Mod.Implicit()), "z", "Double"))
+      ),
+      tplNoBody()
+    )
+    runTestAssert[Stat](code)(tree)
   }
 
 }


### PR DESCRIPTION
As usual, we relax syntax checking rules, deferring to the compiler. Improves on #4601.