### PR TITLE
transversers/Api: add some logic from contrib

### DIFF
--- a/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/TreeOps.scala
+++ b/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/TreeOps.scala
@@ -8,66 +8,24 @@ import scala.language.higherKinds
 
 object TreeOps {
 
-  class SimpleTraverser {
-    def apply(tree: Tree): Unit = tree.children.foreach(apply)
-  }
+  def contains[F[x <: Tree] <: TreeEquality[x]](
+      tree: Tree
+  )(toFind: Tree)(implicit conv: Tree => F[Tree], eqEv: Equal[F[Tree]]): Boolean =
+    exists(tree)(_.isEqual[F](toFind))
 
-  def contains[F[x <: Tree] <: TreeEquality[x]](tree: Tree)(
-      toFind: Tree
-  )(implicit conv: Tree => F[Tree], eqEv: Equal[F[Tree]]): Boolean = find(tree)(_.isEqual[F](toFind))
-    .nonEmpty
+  def find(tree: Tree)(f: Tree => Boolean): Option[Tree] = tree.dfsFind(f)
 
-  def find(tree: Tree)(f: Tree => Boolean): Option[Tree] =
-    collectFirst(tree) { case x if f(x) => x }
+  def forall(tree: Tree)(f: Tree => Boolean): Boolean = tree.dfsForall(f)
 
-  def forall(tree: Tree)(f: Tree => Boolean): Boolean = find(tree)(t => !f(t)).isEmpty
+  def exists(tree: Tree)(f: Tree => Boolean): Boolean = tree.dfsExists(f)
 
-  def exists(tree: Tree)(f: Tree => Boolean): Boolean = find(tree)(t => f(t)).isDefined
+  def collectFirst[B](tree: Tree)(pf: PartialFunction[Tree, B]): Option[B] = tree.dfsCollectFirst(pf)
 
-  def collectFirst[B](tree: Tree)(pf: PartialFunction[Tree, B]): Option[B] = {
-    var result = Option.empty[B]
-    object traverser extends SimpleTraverser {
-      override def apply(t: Tree): Unit =
-        if (result.isEmpty && pf.isDefinedAt(t)) result = Some(pf(t))
-        else if (result.isEmpty) super.apply(t)
-    }
-    traverser(tree)
-    result
-  }
+  def foreach(tree: Tree)(f: Tree => Unit): Unit = tree.dfs(f)
 
-  def foreach(tree: Tree)(f: Tree => Unit): Unit = {
-    object traverser extends SimpleTraverser {
-      override def apply(t: Tree): Unit = {
-        f(t)
-        super.apply(t)
-      }
-    }
-    traverser(tree)
-  }
+  def descendants(tree: Tree): List[Tree] = tree.dfsCollect(t => if (t ne tree) Some(t) else None)
 
-  def descendants(tree: Tree): List[Tree] = {
-    val builder = List.newBuilder[Tree]
-    object traverser extends SimpleTraverser {
-      override def apply(t: Tree): Unit = {
-        if (t ne tree) builder += t
-        super.apply(t)
-      }
-    }
-    traverser(tree)
-    builder.result()
-  }
-
-  def collect[B](tree: Tree)(pf: PartialFunction[Tree, B]): List[B] = {
-    val builder = List.newBuilder[B]
-    object traverser extends SimpleTraverser {
-      override def apply(t: Tree): Unit = {
-        if (pf.isDefinedAt(t)) builder += pf(t)
-        super.apply(t)
-      }
-    }
-    traverser(tree)
-    builder.result()
-  }
+  def collect[B](tree: Tree)(pf: PartialFunction[Tree, B]): List[B] = tree.dfsCollect(pf)
 
   @tailrec
   final def ancestors(tree: Tree, accum: List[Tree] = Nil): List[Tree] = tree.parent match {

--- a/scalameta/transversers/shared/src/main/scala/scala/meta/transversers/Api.scala
+++ b/scalameta/transversers/shared/src/main/scala/scala/meta/transversers/Api.scala
@@ -3,34 +3,14 @@ package transversers
 
 private[meta] trait Api extends VersionSpecificApis {
   implicit class XtensionCollectionLikeUI(tree: Tree) {
-
-    def traverse(fn: PartialFunction[Tree, Unit]): Unit = {
-      object traverser extends SimpleTraverser {
-        override def apply(tree: Tree): Unit = {
-          fn.applyOrElse(tree, (_: Tree) => ())
-          super.apply(tree)
-        }
-      }
-      traverser(tree)
-    }
-
-    def collect[T](fn: PartialFunction[Tree, T]): List[T] = {
-      val buf = scala.collection.mutable.ListBuffer[T]()
-      object traverser extends SimpleTraverser {
-        override def apply(tree: Tree): Unit = {
-          fn.runWith(buf.+=)(tree)
-          super.apply(tree)
-        }
-      }
-      traverser(tree)
-      buf.toList
-    }
+    // legacy calls
+    def traverse(f: PartialFunction[Tree, Unit]): Unit = tree.dfs(f.applyOrElse(_, (_: Tree) => ()))
+    def collect[A](f: PartialFunction[Tree, A]): List[A] = tree.dfsCollect(f)
   }
 
   implicit class XtensionTreeLike[T <: Tree](tree: T) {
     private[meta] def withOriginRecursive(origin: trees.Origin): T = {
-      tree.traverse { case t: Tree => t.privateSetOrigin(origin) }
-      tree.privateSetOrigin(origin)
+      tree.bfs(_.privateSetOrigin(origin))
       tree
     }
 
@@ -39,4 +19,146 @@ private[meta] trait Api extends VersionSpecificApis {
       else if (tree.origin ne trees.Origin.None) tree // only if not set
       else withOriginRecursive(trees.Origin.DialectOnly(dialect))
   }
+
+  implicit class XtensionTreeTraversalOps(tree: Tree) {
+
+    /**
+     * Traverse the tree applying the visitor function.
+     * @param f
+     *   if function returns false, skip subtree
+     */
+    def bfsIf(f: Tree => Boolean): Unit = {
+      val buf = new collection.mutable.Queue[Tree]
+      buf += tree
+      while (buf.nonEmpty) {
+        val elem = buf.dequeue()
+        if (f(elem)) buf ++= elem.children
+      }
+    }
+
+    /**
+     * Traverse the tree using breadth-first-search applying the predicate function.
+     * @param f
+     *   if predicate returns true, stop traversing and return the triggering tree
+     */
+    def bfsFind(f: Tree => Boolean): Option[Tree] = {
+      val buf = new collection.mutable.Queue[Tree]
+      buf += tree
+      while (buf.nonEmpty) {
+        val elem = buf.dequeue()
+        if (f(elem)) return Some(elem)
+        buf ++= elem.children
+      }
+      None
+    }
+
+    /**
+     * Traverse the tree using depth-first-search applying the visitor function.
+     * @param f
+     *   if function returns false, skip subtree
+     */
+    def dfsIf(f: Tree => Boolean): Unit = {
+      val buf = new collection.mutable.ListBuffer[Tree]
+      buf += tree
+      while (buf.nonEmpty) {
+        val elem = buf.remove(0)
+        if (f(elem)) buf.prependAll(elem.children)
+      }
+    }
+
+    /**
+     * Traverse the tree using depth-first-search applying the predicate function.
+     * @param f
+     *   if predicate returns true, stop traversing and return the triggering tree
+     */
+    def dfsFind(f: Tree => Boolean): Option[Tree] = {
+      val buf = new collection.mutable.ListBuffer[Tree]
+      buf += tree
+      while (buf.nonEmpty) {
+        val elem = buf.remove(0)
+        if (f(elem)) return Some(elem)
+        buf.prependAll(elem.children)
+      }
+      None
+    }
+
+    /**
+     * Traverse the tree using breadth-first-search applying the visitor function.
+     * @param f
+     *   if function doesn't match a tree, skip subtree
+     */
+    def bfsIf(f: PartialFunction[Tree, Unit]): Unit = bfsIf(f.runWith(_ => ()))
+
+    /**
+     * Traverse the tree using depth-first-search applying the visitor function.
+     * @param f
+     *   if function doesn't match a tree, skip subtree
+     */
+    def dfsIf(f: PartialFunction[Tree, Unit]): Unit = dfsIf(f.runWith(_ => ()))
+
+    /**
+     * Traverse the tree using breadth-first-search applying the visitor function.
+     */
+    def bfs(f: Tree => Unit): Unit = bfsIf { x =>
+      f(x)
+      true
+    }
+
+    /**
+     * Traverse the tree using depth-first-search applying the visitor function.
+     */
+    def dfs(f: Tree => Unit): Unit = dfsIf { x =>
+      f(x)
+      true
+    }
+
+    def bfsExists(f: Tree => Boolean): Boolean = bfsFind(f).isDefined
+    def dfsExists(f: Tree => Boolean): Boolean = dfsFind(f).isDefined
+
+    def bfsForall(f: Tree => Boolean): Boolean = !bfsExists(!f(_))
+    def dfsForall(f: Tree => Boolean): Boolean = !dfsExists(!f(_))
+
+    def bfsCollectFirst[A](f: PartialFunction[Tree, A]): Option[A] = {
+      var res = Option.empty[A]
+      bfsFind(f.runWith(x => res = Some(x)))
+      res
+    }
+    def dfsCollectFirst[A](f: PartialFunction[Tree, A]): Option[A] = {
+      var res = Option.empty[A]
+      dfsFind(f.runWith(x => res = Some(x)))
+      res
+    }
+
+    def bfsCollect[A](f: Tree => Option[A]): List[A] = {
+      val buf = List.newBuilder[A]
+      bfs(f(_).foreach(buf.+=))
+      buf.result()
+    }
+    def dfsCollect[A](f: Tree => Option[A]): List[A] = {
+      val buf = List.newBuilder[A]
+      dfs(f(_).foreach(buf.+=))
+      buf.result()
+    }
+
+    def bfsCollect[A](f: PartialFunction[Tree, A]): List[A] = bfsCollect(f.lift)
+    def dfsCollect[A](f: PartialFunction[Tree, A]): List[A] = dfsCollect(f.lift)
+
+    def bfsCollectEach[A](f: Tree => Iterable[A]): List[A] = {
+      val buf = List.newBuilder[A]
+      bfs(buf ++= f(_))
+      buf.result()
+    }
+    def dfsCollectEach[A](f: Tree => Iterable[A]): List[A] = {
+      val buf = List.newBuilder[A]
+      dfs(buf ++= f(_))
+      buf.result()
+    }
+
+    def bfsCollectEach[A](f: PartialFunction[Tree, Iterable[A]]): List[A] =
+      bfsCollectEach(f.applyOrElse(_, (_: Tree) => Nil))
+    def dfsCollectEach[A](f: PartialFunction[Tree, Iterable[A]]): List[A] =
+      dfsCollectEach(f.applyOrElse(_, (_: Tree) => Nil))
+
+  }
+
 }

--- a/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -290,7 +290,29 @@ class SurfaceSuite extends FunSuite {
          |* scala.meta.Name.equals(Any): Boolean
          |* scala.meta.Name.hashCode(): Int
          |* scala.meta.Name.isAnonymous: Boolean
-         |* scala.meta.Tree.collect(PartialFunction[scala.meta.Tree,T]): List[T]
+         |* scala.meta.Tree.bfs(scala.meta.Tree => Unit): Unit
+         |* scala.meta.Tree.bfsCollect(PartialFunction[scala.meta.Tree,A]): List[A]
+         |* scala.meta.Tree.bfsCollect(scala.meta.Tree => Option[A]): List[A]
+         |* scala.meta.Tree.bfsCollectEach(PartialFunction[scala.meta.Tree,Iterable[A]]): List[A]
+         |* scala.meta.Tree.bfsCollectEach(scala.meta.Tree => Iterable[A]): List[A]
+         |* scala.meta.Tree.bfsCollectFirst(PartialFunction[scala.meta.Tree,A]): Option[A]
+         |* scala.meta.Tree.bfsExists(scala.meta.Tree => Boolean): Boolean
+         |* scala.meta.Tree.bfsFind(scala.meta.Tree => Boolean): Option[scala.meta.Tree]
+         |* scala.meta.Tree.bfsForall(scala.meta.Tree => Boolean): Boolean
+         |* scala.meta.Tree.bfsIf(PartialFunction[scala.meta.Tree,Unit]): Unit
+         |* scala.meta.Tree.bfsIf(scala.meta.Tree => Boolean): Unit
+         |* scala.meta.Tree.collect(PartialFunction[scala.meta.Tree,A]): List[A]
+         |* scala.meta.Tree.dfs(scala.meta.Tree => Unit): Unit
+         |* scala.meta.Tree.dfsCollect(PartialFunction[scala.meta.Tree,A]): List[A]
+         |* scala.meta.Tree.dfsCollect(scala.meta.Tree => Option[A]): List[A]
+         |* scala.meta.Tree.dfsCollectEach(PartialFunction[scala.meta.Tree,Iterable[A]]): List[A]
+         |* scala.meta.Tree.dfsCollectEach(scala.meta.Tree => Iterable[A]): List[A]
+         |* scala.meta.Tree.dfsCollectFirst(PartialFunction[scala.meta.Tree,A]): Option[A]
+         |* scala.meta.Tree.dfsExists(scala.meta.Tree => Boolean): Boolean
+         |* scala.meta.Tree.dfsFind(scala.meta.Tree => Boolean): Option[scala.meta.Tree]
+         |* scala.meta.Tree.dfsForall(scala.meta.Tree => Boolean): Boolean
+         |* scala.meta.Tree.dfsIf(PartialFunction[scala.meta.Tree,Unit]): Unit
+         |* scala.meta.Tree.dfsIf(scala.meta.Tree => Boolean): Unit
          |* scala.meta.Tree.equals(Any): Boolean
          |* scala.meta.Tree.hashCode(): Int
          |* scala.meta.Tree.maybeParseAs(implicit scala.reflect.ClassTag[A], scala.meta.Dialect, scala.meta.parsers.Parse[A]): scala.meta.package.Parsed[A]

--- a/tests/shared/src/test/scala/scala/meta/tests/transversers/ApiExtensionsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/transversers/ApiExtensionsSuite.scala
@@ -1,0 +1,122 @@
+package scala.meta.tests.transversers
+
+import scala.meta._
+import scala.meta.tests.TreeSuiteBase
+
+import scala.collection.mutable.ListBuffer
+
+class ApiExtensionsSuite extends TreeSuiteBase {
+  val a: Defn.Val = q"val x = 2"
+
+  test("test dfs") {
+    val expected = List(
+      """|Defn.Val(
+         |  Nil,
+         |  List(
+         |    Pat.Var(Term.Name("x"))
+         |  ),
+         |  None,
+         |  Lit.Int(2)
+         |)""".stripMargin.lf2nl,
+      """Pat.Var(Term.Name("x"))""",
+      """Term.Name("x")""",
+      """Lit.Int(2)"""
+    )
+    def dfsTraverse = {
+      val buf = new ListBuffer[String]
+      a.dfs(x => buf.append(x.structure))
+      buf.result()
+    }
+    def dfsCollect = a.dfsCollect(x => Some(x.structure))
+    def dfsCollectEach = a.dfsCollectEach(x => x.structure :: Nil)
+    assertEquals(dfsTraverse, expected)
+    assertEquals(dfsCollect, expected)
+    assertEquals(dfsCollectEach, expected)
+  }
+
+  test("test bfs") {
+    val expected = List(
+      """|Defn.Val(
+         |  Nil,
+         |  List(
+         |    Pat.Var(Term.Name("x"))
+         |  ),
+         |  None,
+         |  Lit.Int(2)
+         |)""".stripMargin.lf2nl,
+      """Pat.Var(Term.Name("x"))""",
+      """Lit.Int(2)""",
+      """Term.Name("x")"""
+    )
+    def bfsTraverse = {
+      val buf = new ListBuffer[String]
+      a.bfs(x => buf.append(x.structure))
+      buf.result()
+    }
+    def bfsCollect = a.bfsCollect(x => Some(x.structure))
+    def bfsCollectEach = a.bfsCollectEach(x => x.structure :: Nil)
+    assertEquals(bfsTraverse, expected)
+    assertEquals(bfsCollect, expected)
+    assertEquals(bfsCollectEach, expected)
+  }
+
+  test("dfsForall") {
+    assert(a.dfsForall(_.is[Tree]))
+    assert(!a.dfsForall(_.is[Term]))
+    assert(!a.dfsForall(_.is[Type]))
+    assert(q"3".dfsForall(_.syntax == "3"))
+  }
+
+  test("bfsForall") {
+    assert(a.bfsForall(_.is[Tree]))
+    assert(!a.bfsForall(_.is[Term]))
+    assert(!a.bfsForall(_.is[Type]))
+    assert(q"3".bfsForall(_.syntax == "3"))
+  }
+
+  test("dfsExists") {
+    assert(a.dfsExists(_.is[Defn.Val]))
+    assert(a.dfsExists(_.is[Lit]))
+    assert(a.dfsExists(_.is[Pat]))
+    assert(!a.dfsExists(_.is[Type.Name]))
+    assert(q"val x = { 2 + 3 }".dfsExists(_.syntax == "3"))
+  }
+
+  test("bfsExists") {
+    assert(a.bfsExists(_.is[Defn.Val]))
+    assert(a.bfsExists(_.is[Lit]))
+    assert(a.bfsExists(_.is[Pat]))
+    assert(!a.bfsExists(_.is[Type.Name]))
+    assert(q"val x = { 2 + 3 }".bfsExists(_.syntax == "3"))
+  }
+
+  test("dfsFind") {
+    a.dfs(t => assert(a.dfsFind(_ eq t).contains(t)))
+    val b: Defn.Object = q"object Foo { def bar: Any = ??? }"
+    b.dfs(t => assert(a.dfsFind(_ eq t).isEmpty))
+  }
+
+  test("bfsFind") {
+    a.bfs(t => assert(a.bfsFind(_ eq t).contains(t)))
+    val b: Defn.Object = q"object Foo { def bar: Any = ??? }"
+    b.bfs(t => assert(a.bfsFind(_ eq t).isEmpty))
+  }
+
+  test("dfsCollectFirst") {
+    assert(a.dfsCollectFirst { case t: Tree => t }.contains(a))
+    assert(a.dfsCollectFirst { case t: Defn.Val => t }.nonEmpty)
+    assert(a.dfsCollectFirst { case t: Lit => t }.nonEmpty)
+    assert(a.dfsCollectFirst { case t: Type => t }.nonEmpty)
+    assert(a.dfsCollectFirst { case t: Defn.Trait => t }.isEmpty)
+    assert(a.dfsCollectFirst { case t: Defn.Def => t }.isEmpty)
+  }
+
+  test("bfsCollectFirst") {
+    assert(a.bfsCollectFirst { case t: Tree => t }.contains(a))
+    assert(a.bfsCollectFirst { case t: Defn.Val => t }.nonEmpty)
+    assert(a.bfsCollectFirst { case t: Lit => t }.nonEmpty)
+    assert(a.bfsCollectFirst { case t: Type => t }.nonEmpty)
+    assert(a.bfsCollectFirst { case t: Defn.Trait => t }.isEmpty)
+    assert(a.bfsCollectFirst { case t: Defn.Def => t }.isEmpty)
+  }
+}


### PR DESCRIPTION
Also, instead of using SimpleTraverser (DFS using stack), implement two iterative versions, for DFS and BFS.