### PR TITLE
scalafmt: format trailing commas

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -14,3 +14,6 @@ f8e0a2b3ee89c4dd7da94aefe2732bfc8a19f80c
 
 # Scala Steward: Reformat with scalafmt 3.10.7
 e87e56075da52034557212b07f91145ca8cffadd
+
+# scalafmt: enabled trailing commas
+0bcf128e753cdd6ae0d99d11eecd69511a6724b4

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -61,5 +61,6 @@ rewrite {
     preset = all
   }
   sortModifiers.preset = styleGuide
+  trailingCommas.style = "always"
 }
 onTestFailure = "Please run ./bin/scalafmt from the project root"

--- a/build.sbt
+++ b/build.sbt
@@ -38,8 +38,8 @@ commands += Command.command("releaseSemanticdb")(s =>
     "semanticdbMetac",
     "semanticdbMetap",
     "semanticdbMetacp",
-    "semanticdbScalacCore"
-  ).map(s => s + "/publishSigned") ::: s
+    "semanticdbScalacCore",
+  ).map(s => s + "/publishSigned") ::: s,
 )
 commands += Command.command("mima")(s => "mimaReportBinaryIssues" :: "doc" :: s)
 commands += Command.command("download-scala-library") { s =>
@@ -47,7 +47,7 @@ commands += Command.command("download-scala-library") { s =>
   IO.unzipURL(
     url(s"https://github.com/scala/scala/archive/v$LatestScala213.zip"),
     toDirectory = out,
-    filter = s"scala-$LatestScala213/src/library/*"
+    filter = s"scala-$LatestScala213/src/library/*",
   )
   s
 }
@@ -56,16 +56,16 @@ commands += Command.command("save-expect")(s =>
     s"++$version" :: "semanticdbScalacPlugin/compile" :: "semanticdbIntegration/clean" ::
       "semanticdbIntegration/compile" ::
       "testsSemanticdb/Test/runMain scala.meta.tests.semanticdb.SaveExpectTest" :: s
-  }
+  },
 )
 commands += Command.command("save-manifest")(s =>
-  "testsJVM/test:runMain scala.meta.tests.semanticdb.SaveManifestTest" :: s
+  "testsJVM/test:runMain scala.meta.tests.semanticdb.SaveManifestTest" :: s,
 )
 def helloContributor(): Unit = println(
   """Welcome to the Scalameta build! You probably don't want to run `sbt test` since
     |that will take a long time to complete.  More likely, you want to run `testsJVM/test`.
     |For more productivity tips, please read CONTRIBUTING.md.
-    |""".stripMargin
+    |""".stripMargin,
 )
 test := helloContributor()
 test / aggregate := false
@@ -84,7 +84,7 @@ val commonJsSettings = Seq(
       case "2.13" => Some(LatestScala213ForJS)
       case "3" => Some(v)
       case _ => None
-    }
+    },
   ).distinct,
   scalaVersion := LatestScala213ForJS,
   bspEnabled := false,
@@ -98,7 +98,7 @@ val commonJsSettings = Seq(
       val prefix = if (isScala3.value) "-scalajs-mapSourceURI" else "-P:scalajs:mapSourceURI"
       Seq(s"$prefix:$localDir->$githubDir/v${version.value}/")
     }
-  }
+  },
 )
 
 lazy val nativeSettings = Seq(
@@ -113,7 +113,7 @@ lazy val nativeSettings = Seq(
           Seq("scala.meta.internal.tokenizers.ScalametaTokenizer$AsTokenize$")
       ))
      */
-  }
+  },
 )
 
 val allPlatforms = Seq(JSPlatform, JVMPlatform, NativePlatform)
@@ -128,7 +128,7 @@ lazy val semanticdbScalacCore = project.in(file("semanticdb/scalac/library")).se
   buildInfoPackage := "scala.meta.internal.semanticdb.scalac",
   buildInfoKeys := Seq[BuildInfoKey](scalaVersion),
   description := "Library to generate SemanticDB from Scalac 2.x internal data structures",
-  libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value
+  libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value,
 ).dependsOn(semanticdbShared.jvm, io.jvm).enablePlugins(BuildInfoPlugin)
 
 lazy val semanticdbShared = crossProject(allPlatforms: _*).in(file("semanticdb/semanticdb"))
@@ -142,7 +142,7 @@ lazy val semanticdbShared = crossProject(allPlatforms: _*).in(file("semanticdb/s
     },
     crossScalaVersions := EarliestScalaVersions,
     protobufSettings,
-    description := "Library defining SemanticDB data structures"
+    description := "Library defining SemanticDB data structures",
   ).dependsOn(scalameta).nativeSettings(nativeSettings).jsSettings(commonJsSettings)
 
 lazy val semanticdbScalacPlugin = project.in(file("semanticdb/scalac/plugin")).settings(
@@ -167,7 +167,7 @@ lazy val semanticdbScalacPlugin = project.in(file("semanticdb/scalac/plugin")).s
         case _ => node
       }
     }).transform(node).head
-  }
+  },
 ).dependsOn(semanticdbScalacCore)
 
 lazy val semanticdbMetac = project.in(file("semanticdb/metac")).settings(
@@ -178,7 +178,7 @@ lazy val semanticdbMetac = project.in(file("semanticdb/metac")).settings(
   mimaPreviousArtifacts := Set.empty,
   description := "Scalac 2.x launcher that generates SemanticDB on compile",
   libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value,
-  mainClass := Some("scala.meta.cli.Metac")
+  mainClass := Some("scala.meta.cli.Metac"),
 ).dependsOn(semanticdbScalacPlugin)
 
 lazy val semanticdbMetap = project.in(file("semanticdb/metap")).settings(
@@ -188,7 +188,7 @@ lazy val semanticdbMetap = project.in(file("semanticdb/metap")).settings(
   fullCrossVersionSettings,
   mimaPreviousArtifacts := Set.empty,
   description := "Prints SemanticDB files",
-  mainClass := Some("scala.meta.cli.Metap")
+  mainClass := Some("scala.meta.cli.Metap"),
 ).dependsOn(semanticdbShared.jvm)
 
 lazy val semanticdbMetacp = project.in(file("semanticdb/metacp")).settings(
@@ -198,7 +198,7 @@ lazy val semanticdbMetacp = project.in(file("semanticdb/metacp")).settings(
   fullCrossVersionSettings,
   mimaPreviousArtifacts := Set.empty,
   description := "Generates SemanticDB files for a classpath",
-  mainClass := Some("scala.meta.cli.Metacp")
+  mainClass := Some("scala.meta.cli.Metacp"),
 ).dependsOn(semanticdbScalacCore)
 
 /* ============== CODEGEN FOR SCALA 3 QUASIQUOTES ============= */
@@ -206,13 +206,13 @@ lazy val scala3TreeLiftsMacro = project.in(file("scala3-tree-lifts/macro")).sett
   crossScalaVersions := List(LatestScala213),
   scalaVersion := LatestScala213,
   enableMacros,
-  nonPublishableSettings
+  nonPublishableSettings,
 ).dependsOn(trees.jvm, common.jvm)
 
 lazy val scala3TreeLiftsCodeGen = project.in(file("scala3-tree-lifts/impl")).settings(
   crossScalaVersions := List(LatestScala213),
   scalaVersion := LatestScala213,
-  nonPublishableSettings
+  nonPublishableSettings,
 ).dependsOn(scala3TreeLiftsMacro)
 
 /* ======================== SCALAMETA ======================== */
@@ -222,7 +222,7 @@ lazy val common2 = crossProject(allPlatforms: _*).in(file("scalameta/common2")).
   enableMacros,
   buildInfoPackage := "scala.meta.internal",
   buildInfoKeys := Seq[BuildInfoKey](version),
-  crossScalaVersions := EarliestScala2Versions
+  crossScalaVersions := EarliestScala2Versions,
 ).configureCross(crossPlatformPublishSettings).jsSettings(commonJsSettings)
   .enablePlugins(BuildInfoPlugin).nativeSettings(nativeSettings)
 
@@ -232,7 +232,7 @@ lazy val common = crossProject(allPlatforms: _*).in(file("scalameta/common")).se
   libraryDependencies += "com.lihaoyi" %%% "sourcecode" % "0.4.4",
   description := "Bag of private and public helpers used in scalameta APIs and implementations",
   enableMacros,
-  crossScalaVersions := EarliestScalaVersions
+  crossScalaVersions := EarliestScalaVersions,
 ).configureCross(crossPlatformPublishSettings).jsSettings(commonJsSettings)
   .enablePlugins(BuildInfoPlugin).nativeSettings(nativeSettings).dependsOn(common2)
 
@@ -241,7 +241,7 @@ lazy val io = crossProject(allPlatforms: _*).in(file("scalameta/io"))
     moduleName := "io",
     sharedSettings,
     description := "Scalameta IO abstractions",
-    crossScalaVersions := EarliestScala2Versions
+    crossScalaVersions := EarliestScala2Versions,
   ).jsSettings(commonJsSettings).nativeSettings(nativeSettings)
 
 lazy val trees2 = crossProject(allPlatforms: _*).in(file("scalameta/trees2")).settings(
@@ -254,7 +254,7 @@ lazy val trees2 = crossProject(allPlatforms: _*).in(file("scalameta/trees2")).se
   mergedModule(projects2 = { base =>
     val scalameta = base / "scalameta"
     List("tokenizers2", "tokens2", "dialects2", "inputs2").map(scalameta / _)
-  })
+  }),
 ).configureCross(crossPlatformPublishSettings, crossPlatformShading).jsSettings(commonJsSettings)
   .nativeSettings(nativeSettings).dependsOn(common2, io)
 
@@ -273,7 +273,7 @@ lazy val trees = crossProject(allPlatforms: _*).in(file("scalameta/trees")).sett
   mergedModule(projects = { base =>
     val scalameta = base / "scalameta"
     List("tokenizers").map(scalameta / _)
-  })
+  }),
 ) // NOTE: tokenizers needed for Tree.tokens when Tree.pos.isEmpty
   .configureCross(crossPlatformPublishSettings, crossPlatformShading).jsSettings(commonJsSettings)
   .nativeSettings(nativeSettings).dependsOn(common, io, trees2)
@@ -286,7 +286,7 @@ lazy val parsers = crossProject(allPlatforms: _*).in(file("scalameta/parsers")).
   crossScalaVersions := EarliestScalaVersions,
   mergedModule(
     base => List(base / "scalameta" / "quasiquotes", base / "scalameta" / "transversers"),
-    base => List(base / "scalameta" / "transversers2")
+    base => List(base / "scalameta" / "transversers2"),
   ),
   Compile / sourceGenerators += Def.taskDyn {
     val outFile = (Compile / sourceManaged).value / "generated" / "TreeLifts.scala"
@@ -294,9 +294,9 @@ lazy val parsers = crossProject(allPlatforms: _*).in(file("scalameta/parsers")).
       if (scalaVersion.value.startsWith("3")) {
         (Compile / (scala3TreeLiftsCodeGen / run)).toTask(" " + outFile.getAbsolutePath).value
         Seq(outFile)
-      } else Seq()
+      } else Seq(),
     )
-  }.taskValue
+  }.taskValue,
 ).configureCross(crossPlatformPublishSettings, crossPlatformShading)
   .jsConfigure(_.enablePlugins(NpmPackagePlugin)).jsSettings(
     commonJsSettings,
@@ -310,13 +310,13 @@ lazy val parsers = crossProject(allPlatforms: _*).in(file("scalameta/parsers")).
     npmPackageStage := org.scalajs.sbtplugin.Stage.FullOpt,
     npmPackageAdditionalNpmConfig :=
       Map("homepage" -> _root_.io.circe.Json.fromString("https://scalameta.org/")),
-    npmPackageREADME := Some(file("README.npm.md"))
+    npmPackageREADME := Some(file("README.npm.md")),
   ).nativeSettings(nativeSettings).dependsOn(trees)
 
 def mergedModule(
     projects: File => List[File] = _ => Nil,
     projects2: File => List[File] = _ => Nil,
-    projects3: File => List[File] = _ => Nil
+    projects3: File => List[File] = _ => Nil,
 ): List[Setting[_]] = List {
   Compile / unmanagedSourceDirectories ++= {
     val base = (ThisBuild / baseDirectory).value
@@ -340,7 +340,7 @@ lazy val scalameta = crossProject(allPlatforms: _*).in(file("scalameta/scalameta
   sharedSettings,
   description := "Scalameta umbrella module that includes all public APIs",
   crossScalaVersions := EarliestScalaVersions,
-  mergedModule(base => List(base / "scalameta" / "contrib"))
+  mergedModule(base => List(base / "scalameta" / "contrib")),
 ).configureCross(crossPlatformPublishSettings, crossPlatformShading).jsSettings(commonJsSettings)
   .nativeSettings(nativeSettings).dependsOn(parsers)
 
@@ -358,7 +358,7 @@ lazy val semanticdbIntegration = project.in(file("semanticdb/integration")).sett
   scalacOptions ++= {
     if (scalaVersion.value >= "2.13.14") Seq(
       // "-Xsource:3",
-      "-Xsource-features:leading-infix"
+      "-Xsource-features:leading-infix",
     )
     else Nil
   },
@@ -374,7 +374,7 @@ lazy val semanticdbIntegration = project.in(file("semanticdb/integration")).sett
       "-P:semanticdb:failures:error", // fail fast during development.
       "-P:semanticdb:exclude:Exclude.scala",
       s"-P:semanticdb:sourceroot:${(ThisBuild / baseDirectory).value}",
-      "-P:semanticdb:synthetics:on"
+      "-P:semanticdb:synthetics:on",
     )
   },
   Compile / javaHome := {
@@ -384,14 +384,14 @@ lazy val semanticdbIntegration = project.in(file("semanticdb/integration")).sett
       if (System.getProperty("java.version").startsWith("1.8")) home.getParentFile else home
     Some(actualHome)
   },
-  javacOptions += "-parameters"
+  javacOptions += "-parameters",
 ).dependsOn(semanticdbIntegrationMacros, semanticdbScalacPlugin)
 
 lazy val semanticdbIntegrationMacros = project.in(file("semanticdb/integration-macros")).settings(
   sharedSettings,
   crossScalaVersions := AllScala2Versions,
   nonPublishableSettings,
-  enableMacros
+  enableMacros,
 )
 
 lazy val testkit = crossProject(allPlatforms: _*).in(file("scalameta/testkit")).settings(
@@ -399,7 +399,7 @@ lazy val testkit = crossProject(allPlatforms: _*).in(file("scalameta/testkit")).
   sharedSettings,
   crossScalaVersions := EarliestScalaVersions,
   hasLargeIntegrationTests,
-  description := "Testing utilities for scalameta APIs"
+  description := "Testing utilities for scalameta APIs",
 ).dependsOn(scalameta, io).configureCross(crossPlatformPublishSettings)
   .jvmSettings(libraryDependencies += "org.rauschig" % "jarchivelib" % "1.2.0")
   .jsSettings(commonJsSettings).nativeSettings(nativeSettings)
@@ -411,7 +411,7 @@ lazy val tests = crossProject(allPlatforms: _*).in(file("tests")).settings(
     if (isScala3.value)
       List("-Wconf:msg=pattern binding uses refutable extractor:s", "-Xcheck-macros")
     else Nil
-  }
+  },
 ).jvmSettings(
   libraryDependencies ++=
     { if (!isScala3.value) List("org.scala-lang" % "scala-reflect" % scalaVersion.value) else Nil },
@@ -419,16 +419,16 @@ lazy val tests = crossProject(allPlatforms: _*).in(file("tests")).settings(
   libraryDependencies ++= {
     if (isScala213.value) List(
       "org.scala-lang" % "scala-compiler" % scalaVersion.value % Test,
-      "org.scala-lang.modules" %% "scala-parallel-collections" % "1.2.0" % Test
+      "org.scala-lang.modules" %% "scala-parallel-collections" % "1.2.0" % Test,
     )
     else Nil
-  }
+  },
 ).jsSettings(
   commonJsSettings,
-  scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
+  scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
 ).nativeSettings(
   nativeSettings,
-  nativeConfig ~= { _.withMode(scalanative.build.Mode.debug).withLinkStubs(true) }
+  nativeConfig ~= { _.withMode(scalanative.build.Mode.debug).withLinkStubs(true) },
 ).enablePlugins(BuildInfoPlugin).dependsOn(scalameta, testkit)
 
 lazy val testsSemanticdb = project.in(file("tests-semanticdb")).settings(
@@ -441,7 +441,7 @@ lazy val testsSemanticdb = project.in(file("tests-semanticdb")).settings(
     (Test / fullClasspath).value
   },
   // Needed because some tests rely on the --usejavacp option
-  Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat
+  Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,
 ).dependsOn(
   scalameta.jvm,
   testkit.jvm,
@@ -449,7 +449,7 @@ lazy val testsSemanticdb = project.in(file("tests-semanticdb")).settings(
   semanticdbMetac,
   semanticdbMetacp,
   semanticdbMetap,
-  semanticdbIntegration
+  semanticdbIntegration,
 ).enablePlugins(BuildInfoPlugin)
 
 lazy val sharedTestSettings = Def.settings(
@@ -458,7 +458,7 @@ lazy val sharedTestSettings = Def.settings(
   testFrameworks := List(TestFrameworks.MUnit),
   dependencyOverrides ++=
     { if (isScala3.value) Nil else Seq("org.scala-lang" % "scala-library" % scalaVersion.value) },
-  libraryDependencies += "org.scalameta" %%% "munit" % munit.sbtmunit.BuildInfo.munitVersion
+  libraryDependencies += "org.scalameta" %%% "munit" % munit.sbtmunit.BuildInfo.munitVersion,
 )
 
 lazy val testSettings = Def.settings(
@@ -478,12 +478,12 @@ lazy val testSettings = Def.settings(
     "resourcesDirectory" -> (Test / resourceDirectory).value.getAbsolutePath,
     "classDirectories" -> Seq(
       (common2.jvm / Compile / classDirectory).value.getAbsolutePath,
-      (common.jvm / Compile / classDirectory).value.getAbsolutePath
+      (common.jvm / Compile / classDirectory).value.getAbsolutePath,
     ),
     "databaseClasspath" -> (semanticdbIntegration / Compile / classDirectory).value.getAbsolutePath,
-    "integrationSourceDirectories" -> (semanticdbIntegration / Compile / sourceDirectories).value
+    "integrationSourceDirectories" -> (semanticdbIntegration / Compile / sourceDirectories).value,
   ),
-  buildInfoPackage := "scala.meta.tests"
+  buildInfoPackage := "scala.meta.tests",
 )
 
 lazy val communitytest = project.in(file("community-test"))
@@ -508,7 +508,7 @@ lazy val benchSemanticdb = project.in(file("bench/semanticdb")).enablePlugins(Bu
       buf += "-p"
       buf += s"semanticdbScalacJar=$semanticdbScalacJar"
       (Jmh / runMain).toTask(s"  ${buf.result.mkString(" ")}")
-    }.evaluated
+    }.evaluated,
   ).dependsOn(testsSemanticdb)
 
 lazy val benchScalameta = project.in(file("bench/scalameta")).enablePlugins(BuildInfoPlugin)
@@ -525,7 +525,7 @@ lazy val benchScalameta = project.in(file("bench/scalameta")).enablePlugins(Buil
       buf += "org.openjdk.jmh.Main"
       buf ++= spaceDelimited("<arg>").parsed
       (Jmh / runMain).toTask(s"  ${buf.result.mkString(" ")}")
-    }.evaluated
+    }.evaluated,
   ).dependsOn(scalameta.jvm)
 
 // ==========================================
@@ -543,7 +543,7 @@ def isScala213or3 = Def.setting(isScala213.value || isScala3.value)
 //   val isJVM = platformDepsCrossVersion.value == CrossVersion.binary
 def isPlatform(platform: Platform) = Def.settingDyn(
   if (crossProjectPlatform.?.value.isEmpty) Def.setting(platform == JVMPlatform)
-  else Def.setting(crossProjectPlatform.value == platform)
+  else Def.setting(crossProjectPlatform.value == platform),
 )
 
 lazy val sharedSettings = Def.settings(
@@ -575,7 +575,7 @@ lazy val sharedSettings = Def.settings(
       "-Wconf:msg=.*no longer supported for vararg splices.*:silent",
       "-Wconf:msg=.*Implicit parameters should be provided.*:silent",
       "-Wconf:msg=.* deprecated.*:silent", // covers several
-      "-Wconf:cat=deprecation:silent"
+      "-Wconf:cat=deprecation:silent",
     )
     else Nil
   },
@@ -587,7 +587,7 @@ lazy val sharedSettings = Def.settings(
   updateOptions := updateOptions.value.withCachedResolution(true),
   ThisBuild / watchTriggeredMessage := Watch.clearScreenOnTrigger,
   evictionErrorLevel := sbt.util.Level.Warn,
-  incOptions := incOptions.value.withLogRecompileOnMacro(false)
+  incOptions := incOptions.value.withLogRecompileOnMacro(false),
 )
 
 lazy val mergeSettings = Def.settings(
@@ -619,7 +619,7 @@ lazy val mergeSettings = Def.settings(
       val oldStrategy = (assembly / assemblyMergeStrategy).value
       oldStrategy(x)
   },
-  mimaCurrentClassfiles := (Compile / Keys.`package`).value
+  mimaCurrentClassfiles := (Compile / Keys.`package`).value,
 )
 
 lazy val protobufSettings = Def.settings(
@@ -632,8 +632,8 @@ lazy val protobufSettings = Def.settings(
     generator = PB.gens.plugin("scala"),
     outputPath = (Compile / sourceManaged).value / "protobuf",
     options = scalapb.gen(flatPackage =
-      true // Don't append filename to package
-    )._2
+      true, // Don't append filename to package
+    )._2,
   )),
   Compile / PB.protoSources := Seq(file("semanticdb/semanticdb/shared/src/main/proto")),
   PB.additionalDependencies := Nil,
@@ -647,10 +647,10 @@ lazy val protobufSettings = Def.settings(
       ("com.thesamet.scalapb" % "protoc-gen-scala" % scalapbVersion % "protobuf").artifacts(
         if (scala.util.Properties.isWin)
           Artifact("protoc-gen-scala", PB.ProtocPlugin, "bat", "windows")
-        else Artifact("protoc-gen-scala", PB.ProtocPlugin, "sh", "unix")
-      )
+        else Artifact("protoc-gen-scala", PB.ProtocPlugin, "sh", "unix"),
+      ),
     )
-  }
+  },
 )
 
 lazy val adhocRepoUri = sys.props("scalameta.repository.uri")
@@ -735,7 +735,7 @@ lazy val publishableSettings = Def.settings(
         <name>Denys Shabalin</name>
         <url>http://den.sh</url>
       </developer>
-    </developers>
+    </developers>,
 )
 
 lazy val nonPublishableSettings = Seq(
@@ -746,7 +746,7 @@ lazy val nonPublishableSettings = Seq(
   Compile / doc / sources := Seq.empty,
   publishArtifact := false,
   PgpKeys.publishSigned := {},
-  publish := {}
+  publish := {},
 )
 
 def compatibilityPolicyViolation(ticket: String) = Seq(mimaPreviousArtifacts := Set.empty)
@@ -762,7 +762,7 @@ lazy val fullCrossVersionSettings = Seq(
     val base = (Compile / sourceDirectory).value
     val versionDir = scalaVersion.value.replaceAll("-.*", "")
     base / ("scala-" + versionDir)
-  }
+  },
 )
 
 lazy val hasLargeIntegrationTests =
@@ -798,7 +798,7 @@ def exposePaths(projectName: String, config: Configuration) = {
       val classpath = defaultValue.files.map(_.getAbsolutePath)
       System.setProperty(prefix + "classes", classpath.mkString(java.io.File.pathSeparator))
       defaultValue
-    }
+    },
   )
 }
 
@@ -829,20 +829,20 @@ lazy val docs = project.in(file("scalameta-docs")).settings(
   mdocVariables := Map(
     "VERSION" -> version.value.replaceFirst("\\+.*", ""),
     "SCALA_BINARY_VERSION" -> scalaBinaryVersion.value,
-    "SCALA_VERSION" -> scalaVersion.value
+    "SCALA_VERSION" -> scalaVersion.value,
   ),
   mdocOut := (ThisBuild / baseDirectory).value / "website" / "target" / "docs",
-  mimaPreviousArtifacts := Set.empty
+  mimaPreviousArtifacts := Set.empty,
 ).enablePlugins(BuildInfoPlugin, DocusaurusPlugin)
 
 lazy val shadingSettings = Def.settings(
   shadedDependencies ++= ShadedDependency.all.map(x =>
     if (x.isPlatformSpecific) x.groupID %%% x.artifactID % "foo"
-    else x.groupID %% x.artifactID % "foo"
+    else x.groupID %% x.artifactID % "foo",
   ).toSet,
   shadingRules ++=
     ShadedDependency.all.map(x => ShadingRule.moveUnder(x.namespace, "scala.meta.shaded.internal")),
-  validNamespaces ++= Set("org", "scala", "java")
+  validNamespaces ++= Set("org", "scala", "java"),
 )
 
 def platformPublishSettings(platform: sbtcrossproject.Platform) =

--- a/community-test/src/test/scala/CommunityDottySuite.scala
+++ b/community-test/src/test/scala/CommunityDottySuite.scala
@@ -45,14 +45,14 @@ class CommunityDottySuite extends FunSuite {
       excluded: List[String],
       checkedFiles: Int,
       dialect: Dialect,
-      dialectAlt: Option[Dialect] = None
+      dialectAlt: Option[Dialect] = None,
   )
   case class TestStats(
       checkedFiles: Int,
       errors: Int,
       lastError: Option[Throwable],
       timeTaken: Long,
-      linesParsed: Int
+      linesParsed: Int,
   )
 
   final val InitTestStats = TestStats(0, 0, None, 0, 0)
@@ -62,7 +62,7 @@ class CommunityDottySuite extends FunSuite {
     s1.errors + s2.errors,
     s1.lastError.orElse(s2.lastError),
     s1.timeTaken + s2.timeTaken,
-    s1.linesParsed + s2.linesParsed
+    s1.linesParsed + s2.linesParsed,
   )
 
   val communityBuilds = List(
@@ -79,7 +79,7 @@ class CommunityDottySuite extends FunSuite {
     sparkBuild("v2.4.8", dialects.Scala213, 3165),
     sparkBuild("v3.4.1", dialects.Scala213, 4491),
     // latest commit from 30.03.2021
-    munitBuild("06346adfe3519c384201eec531762dad2f4843dc", dialects.Scala213, 102)
+    munitBuild("06346adfe3519c384201eec531762dad2f4843dc", dialects.Scala213, 102),
   )
 
   for (build <- communityBuilds) test(s"community-build-${build.name}-${build.commit}")(check(build))
@@ -128,7 +128,7 @@ class CommunityDottySuite extends FunSuite {
     }
 
   def checkAbsPath(absPath: Path, absPathString: String)(implicit
-      build: CommunityBuild
+      build: CommunityBuild,
   ): TestStats = {
     val fileContent = Input.File(absPath)
     implicit val dialect: Dialect =

--- a/project/Platforms.scala
+++ b/project/Platforms.scala
@@ -5,12 +5,12 @@ object Platforms {
   private val platforms: Map[String, sbtcrossproject.Platform] = Map(
     "jvm" -> sbtcrossproject.JVMPlatform,
     "js" -> scalajscrossproject.JSPlatform,
-    "native" -> scalanativecrossproject.NativePlatform
+    "native" -> scalanativecrossproject.NativePlatform,
   )
 
   private val platformOpt = Option(System.getenv(envPlatform)).map(_.trim.toLowerCase)
     .filter(_.nonEmpty).map(x =>
-      platforms.get(x).getOrElse(throw new NoSuchElementException(s"Platform '$x' is unknown'"))
+      platforms.get(x).getOrElse(throw new NoSuchElementException(s"Platform '$x' is unknown'")),
     )
 
   def shouldBuildPlatform(platform: sbtcrossproject.Platform): Boolean = platformOpt.isEmpty ||

--- a/project/ShadedDependency.scala
+++ b/project/ShadedDependency.scala
@@ -2,7 +2,7 @@ case class ShadedDependency(
     groupID: String,
     artifactID: String,
     namespace: String,
-    isPlatformSpecific: Boolean
+    isPlatformSpecific: Boolean,
 )
 
 object ShadedDependency {
@@ -12,7 +12,7 @@ object ShadedDependency {
 
   val all = Seq(
     ShadedDependency("com.lihaoyi", "geny", "geny", true),
-    ShadedDependency("com.lihaoyi", "fastparse", "fastparse", true)
+    ShadedDependency("com.lihaoyi", "fastparse", "fastparse", true),
   )
 
 }

--- a/scala3-tree-lifts/macro/src/main/scala/org/scalameta/adt/TreeLiftsGenerate.scala
+++ b/scala3-tree-lifts/macro/src/main/scala/org/scalameta/adt/TreeLiftsGenerate.scala
@@ -46,7 +46,7 @@ class TreeLiftsGenerateMacros(val c: Context) extends AdtReflection with CommonN
       adt: Adt,
       defName: String,
       localName: TermName,
-      body: String
+      body: String,
   ): Option[String] = {
     def specialcaseTermApply: String =
       s"""|
@@ -114,7 +114,7 @@ class TreeLiftsGenerateMacros(val c: Context) extends AdtReflection with CommonN
               val moduleNames = adt.sym.companion.info.decls
                 .flatMap(x => if (x.isModule) Some(x.name.toString) else None)
               val latestAfterVersion = AstNamerMacros.getLatestAfterName(moduleNames).getOrElse(
-                c.abort(c.enclosingPosition, s"no latest version ${adt.sym.fullName}: $moduleNames")
+                c.abort(c.enclosingPosition, s"no latest version ${adt.sym.fullName}: $moduleNames"),
               )
               latestAfterVersion :: Nil
             } else Nil

--- a/scalameta/common2/shared/src/main/scala/org/scalameta/UnreachableError.scala
+++ b/scalameta/common2/shared/src/main/scala/org/scalameta/UnreachableError.scala
@@ -18,7 +18,7 @@ object UnreachableError {
         sb.append(EOL)
         ExceptionHelpers.formatDebuggees(sb, debuggees)
         sb.result()
-      }
+      },
     )
   }
 }

--- a/scalameta/common2/shared/src/main/scala/org/scalameta/adt/Adt.scala
+++ b/scalameta/common2/shared/src/main/scala/org/scalameta/adt/Adt.scala
@@ -46,7 +46,7 @@ class AdtNamerMacros(val c: Context) extends MacroHelpers {
           mods @ Modifiers(flags, privateWithin, anns),
           name,
           tparams,
-          Template(parents, self, stats)
+          Template(parents, self, stats),
         ) = cdef
         val ModuleDef(mmods, mname, Template(mparents, mself, mstats)) = mdef
         val classRef = typeRef(cdef, requireHk = false, requireWildcards = true)
@@ -65,7 +65,7 @@ class AdtNamerMacros(val c: Context) extends MacroHelpers {
           Modifiers(flags1, privateWithin, anns1),
           name,
           tparams,
-          Template(parents1, self, stats1.toList)
+          Template(parents1, self, stats1.toList),
         )
         val mdef1 = ModuleDef(mmods, mname, Template(mparents, mself, mstats1.toList))
         List(cdef1, mdef1)
@@ -86,7 +86,7 @@ class AdtNamerMacros(val c: Context) extends MacroHelpers {
           mods @ Modifiers(flags, privateWithin, anns),
           name,
           tparams,
-          Template(parents, self, stats)
+          Template(parents, self, stats),
         ) = cdef
         val ModuleDef(mmods, mname, Template(mparents, mself, mstats)) = mdef
         val classRef = typeRef(cdef, requireHk = false, requireWildcards = true)
@@ -103,7 +103,7 @@ class AdtNamerMacros(val c: Context) extends MacroHelpers {
           Modifiers(flags1, privateWithin, anns1),
           name,
           tparams,
-          Template(parents, self, stats1.toList)
+          Template(parents, self, stats1.toList),
         )
         val mdef1 = ModuleDef(mmods, mname, Template(mparents, mself, mstats1.toList))
         List(cdef1, mdef1)

--- a/scalameta/common2/shared/src/main/scala/org/scalameta/adt/Liftables.scala
+++ b/scalameta/common2/shared/src/main/scala/org/scalameta/adt/Liftables.scala
@@ -72,7 +72,7 @@ class LiftableMacros(val c: Context) extends AdtReflection {
               case _ => Nil
             }
             val args = fields.map(f =>
-              q"_root_.scala.Predef.implicitly[$u.Liftable[${f.tpe}]].apply($localName.${f.name})"
+              q"_root_.scala.Predef.implicitly[$u.Liftable[${f.tpe}]].apply($localName.${f.name})",
               // NOTE: we can't really use AssignOrNamedArg here, sorry
               // Test.scala:10: warning: type-checking the invocation of method apply checks if the named argument expression 'stats = ...' is a valid assignment
               // in the current scope. The resulting type inference error (see above) can be fixed by providing an explicit type in the local definition for stats.
@@ -85,7 +85,7 @@ class LiftableMacros(val c: Context) extends AdtReflection {
                 val latestAfterVersion = AstNamerMacros.getLatestAfterName(moduleNames)
                   .getOrElse(c.abort(
                     c.enclosingPosition,
-                    s"no latest version ${adt.sym.fullName}: $moduleNames"
+                    s"no latest version ${adt.sym.fullName}: $moduleNames",
                   ))
                 latestAfterVersion :: Nil
               } else Nil
@@ -102,7 +102,7 @@ class LiftableMacros(val c: Context) extends AdtReflection {
         matcher.tparams,
         matcher.vparamss,
         matcher.tpt,
-        body
+        body,
       )
     }
     val clauses = adts.map { case (adt, name) =>

--- a/scalameta/common2/shared/src/main/scala/org/scalameta/adt/Reflection.scala
+++ b/scalameta/common2/shared/src/main/scala/org/scalameta/adt/Reflection.scala
@@ -154,7 +154,7 @@ trait Reflection {
     if (roots.isEmpty && sym.isLeaf) fail(s"rootless leaf is disallowed")
     else if (roots.length > 1) fail(
       s"multiple roots for a $designation: " + roots.map(_.fullName).init.mkString(", ") + " and " +
-        roots.last.fullName
+        roots.last.fullName,
     )
     val root = roots.headOption.getOrElse(NoSymbol)
     sym.baseClasses.map(_.asClass).foreach { bsym =>

--- a/scalameta/common2/shared/src/main/scala/org/scalameta/data/data.scala
+++ b/scalameta/common2/shared/src/main/scala/org/scalameta/data/data.scala
@@ -51,7 +51,7 @@ class DataMacros(val c: Context) extends MacroHelpers {
           def mkByneed = Modifiers(
             mods.flags,
             mods.privateWithin,
-            mods.annotations :+ q"new $AdtMetadataModule.byNeedField"
+            mods.annotations :+ q"new $AdtMetadataModule.byNeedField",
           )
         }
         def needs(name: Name, companion: Boolean, duplicate: Boolean) = {
@@ -88,7 +88,7 @@ class DataMacros(val c: Context) extends MacroHelpers {
           def unapply(tree: ValDef): Option[(Modifiers, TermName, Tree, Tree)] = tree.tpt match {
             case Annotated(
                   Apply(Select(New(Ident(TypeName("byNeed"))), termNames.CONSTRUCTOR), List()),
-                  tpt
+                  tpt,
                 ) =>
               if (Vararg.unapply(tree.tpt).nonEmpty) c
                 .abort(cdef.pos, "vararg parameters cannot be by-need")

--- a/scalameta/common2/shared/src/main/scala/org/scalameta/explore/Macros.scala
+++ b/scalameta/common2/shared/src/main/scala/org/scalameta/explore/Macros.scala
@@ -20,7 +20,7 @@ class ExploreMacros(val c: Context) extends MacroHelpers {
           "scala.Enumeration",
           "scala.math",
           "scala.Int",
-          "scala.meta.inline.Api"
+          "scala.meta.inline.Api",
         )
         banned.exists(prefix => sym.fullName.startsWith(prefix))
       }
@@ -69,7 +69,7 @@ class ExploreMacros(val c: Context) extends MacroHelpers {
 
   private def staticClassesObjectsAndVals(
       pkg: Symbol,
-      onlyImmediatelyAccessible: Boolean
+      onlyImmediatelyAccessible: Boolean,
   ): List[Symbol] = {
     val visited = Set[Symbol]()
 

--- a/scalameta/common2/shared/src/main/scala/org/scalameta/invariants/InvariantFailedException.scala
+++ b/scalameta/common2/shared/src/main/scala/org/scalameta/invariants/InvariantFailedException.scala
@@ -12,7 +12,7 @@ object InvariantFailedException {
       invariant: String,
       clue: String,
       failures: List[String],
-      debuggees: Map[String, Any]
+      debuggees: Map[String, Any],
   ): Nothing = {
     val clueStr = if (clue eq null) "" else s" ($clue)"
     val sb = new StringBuilder()
@@ -20,7 +20,7 @@ object InvariantFailedException {
       s"""|invariant failed$clueStr:
           |when verifying $invariant
           |found that ${failures.mkString(s"\nand also ")}
-          |""".stripMargin.replace("\n", EOL)
+          |""".stripMargin.replace("\n", EOL),
     )
     ExceptionHelpers.formatDebuggees(sb, debuggees)
     throw new InvariantFailedException(sb.result())

--- a/scalameta/common2/shared/src/main/scala/scala/meta/internal/SingletonReference.scala
+++ b/scalameta/common2/shared/src/main/scala/scala/meta/internal/SingletonReference.scala
@@ -17,6 +17,6 @@ class SingletonReference[A](init: A) {
 object SingletonReference {
   private class Ref[A](
       @volatile
-      var ref: A
+      var ref: A,
   )
 }

--- a/scalameta/common2/shared/src/main/scala/scala/meta/internal/transversers/transverser.scala
+++ b/scalameta/common2/shared/src/main/scala/scala/meta/internal/transversers/transverser.scala
@@ -73,7 +73,7 @@ trait TransverserMacros extends MacroHelpers with AstReflection {
       else if (l <:< TermAdt) termBuilder += l
       else if (l <:< TypeAdt) typeBuilder += l
       else if (l <:< DefnAdt) defnBuilder += l
-      else restBuilder += l
+      else restBuilder += l,
     )
 
     val termPriority = Seq("Term.Name", "Term.Apply", "Lit", "Term.Param", "Term.ApplyInfix")

--- a/scalameta/common2/shared/src/main/scala/scala/meta/internal/trees/Liftables.scala
+++ b/scalameta/common2/shared/src/main/scala/scala/meta/internal/trees/Liftables.scala
@@ -41,7 +41,7 @@ class LiftableMacros(override val c: Context) extends AdtLiftableMacros(c) with 
       adt: Adt,
       defName: TermName,
       localName: TermName,
-      body: Tree
+      body: Tree,
   ): Option[Tree] = {
     // NOTE: See #277 and #405 to understand why this special-casing is necessary.
     def specialcaseTermApply: Tree =

--- a/scalameta/common2/shared/src/main/scala/scala/meta/internal/trees/NamerMacros.scala
+++ b/scalameta/common2/shared/src/main/scala/scala/meta/internal/trees/NamerMacros.scala
@@ -53,7 +53,7 @@ trait CommonNamerMacros extends MacroHelpers {
       name: TypeName,
       parents: List[Tree],
       params: List[ValDef] = Nil,
-      extraAbstractDefs: Iterable[Tree] = Nil
+      extraAbstractDefs: Iterable[Tree] = Nil,
   )(extraStubs: String*): ClassDef = {
     val qmods = Modifiers(NoFlags, TypeName("meta"), List(q"new $AstAnnotation"))
     val qparents = tq"$name" +: tq"$QuasiClass" +: parents.map(mkQuasiParent)
@@ -113,7 +113,7 @@ trait CommonNamerMacros extends MacroHelpers {
       parent: PrivateField,
       origin: PrivateField,
       begComment: PrivateField,
-      endComment: PrivateField
+      endComment: PrivateField,
   ) {
     def asList = prototype :: parent :: origin :: begComment :: endComment :: Nil
   }
@@ -121,19 +121,19 @@ trait CommonNamerMacros extends MacroHelpers {
   protected def getPrivateFields(iname: TypeName): PrivateFields = PrivateFields(
     prototype = PrivateField(
       q"@$TransientAnnotation private[meta] override val privatePrototype: $iname = null",
-      version = null
+      version = null,
     ),
     parent =
       PrivateField(q"override val parent: $OptionClass[$TreeClass] = $NoneModule", version = null),
     origin = PrivateField(q"override val origin: $OriginClass = $OriginModule.None", Version.zero),
     begComment = PrivateField(
       q"override val begComment: $OptionClass[$CommentsClass] = $NoneModule",
-      Version(4, 14, 2)
+      Version(4, 14, 2),
     ),
     endComment = PrivateField(
       q"override val endComment: $OptionClass[$CommentsClass] = $NoneModule",
-      Version(4, 14, 2)
-    )
+      Version(4, 14, 2),
+    ),
   )
 
 }

--- a/scalameta/common2/shared/src/main/scala/scala/meta/internal/trees/TyperMacros.scala
+++ b/scalameta/common2/shared/src/main/scala/scala/meta/internal/trees/TyperMacros.scala
@@ -32,7 +32,7 @@ class CommonTyperMacrosBundle(val c: Context) extends AdtReflection with MacroHe
   }
 
   def interfaceToApi[I, A](
-      interface: c.Tree
+      interface: c.Tree,
   )(implicit I: c.WeakTypeTag[I], A: c.WeakTypeTag[A]): c.Tree = q"$interface.asInstanceOf[$A]"
 
   def productPrefix[T](implicit T: c.WeakTypeTag[T]): c.Tree = q"${T.tpe.typeSymbol.asLeaf.prefix}"

--- a/scalameta/common2/shared/src/main/scala/scala/meta/internal/trees/ast.scala
+++ b/scalameta/common2/shared/src/main/scala/scala/meta/internal/trees/ast.scala
@@ -25,7 +25,7 @@ class AstNamerMacros(val c: Context) extends Reflection with CommonNamerMacros {
 
   private class Mstats(
       val primary: ListBuffer[Tree] = ListBuffer.empty[Tree],
-      val lowPrio: ListBuffer[Tree] = ListBuffer.empty[Tree]
+      val lowPrio: ListBuffer[Tree] = ListBuffer.empty[Tree],
   )
 
   def impl(annottees: Tree*): Tree = annottees.transformAnnottees {
@@ -86,7 +86,7 @@ class AstNamerMacros(val c: Context) extends Reflection with CommonNamerMacros {
         val (versionedParams, paramsVersions) =
           if (isQuasi) (Nil, Nil) else getVersionedParams(params, stats)
         val replacedFields = versionedParams.flatMap(_.replaced.flatMap(field =>
-          field.oldDefs.map { case (oldDef, _) => field.version -> oldDef }
+          field.oldDefs.map { case (oldDef, _) => field.version -> oldDef },
         ))
         val mstatsPerVersion = paramsVersions.map(ver => (ver, new Mstats()))
         def paramsForVersion(v: Version): List[ValDef] =
@@ -315,7 +315,7 @@ class AstNamerMacros(val c: Context) extends Reflection with CommonNamerMacros {
         def addCopy(
             paramsToCopy: List[ValOrDefDef],
             withDefault: Boolean,
-            version: Option[Version] = None
+            version: Option[Version] = None,
         ): Unit = {
           val mods =
             getDeferredModifiers(version.fold(List.empty[Tree])(v => getDeprecatedAnno(v) :: Nil))
@@ -331,7 +331,7 @@ class AstNamerMacros(val c: Context) extends Reflection with CommonNamerMacros {
             istatsAdd(q"$mods def copyWithComments(..$copyWithCommentsParams): $iname")
 
           val privateCopyParams = version.flatMap(v =>
-            privateApplyParamss.reverseIterator.collectFirst { case (pv, pp) if pv < v => pp }
+            privateApplyParamss.reverseIterator.collectFirst { case (pv, pp) if pv < v => pp },
           ).getOrElse(privateApplyParamss.last._2)
           val args = (privateCopyParams ++ paramsToCopy).map(getParamArg)
 
@@ -469,7 +469,7 @@ class AstNamerMacros(val c: Context) extends Reflection with CommonNamerMacros {
                 hasErrors = true
                 c.error(
                   tree.pos,
-                  "cannot refer to parent in @ast field checks; use checkParent instead"
+                  "cannot refer to parent in @ast field checks; use checkParent instead",
                 )
               case _ => super.traverse(tree)
             }
@@ -491,7 +491,7 @@ class AstNamerMacros(val c: Context) extends Reflection with CommonNamerMacros {
                  $OriginModule.DialectOnly.getFromArgs(..$internalArgs)
                )
              """
-          else getParamArg(p)
+          else getParamArg(p),
         )
         internalBody +=
           q"""
@@ -860,7 +860,7 @@ class AstNamerMacros(val c: Context) extends Reflection with CommonNamerMacros {
   private class VersionedParam(
       val param: ValDef,
       val appended: Option[Version],
-      val replaced: Seq[ReplacedField]
+      val replaced: Seq[ReplacedField],
   ) {
     appended.foreach(aver =>
       replaced.headOption.foreach(rfield =>
@@ -869,10 +869,10 @@ class AstNamerMacros(val c: Context) extends Reflection with CommonNamerMacros {
           c.abort(
             param.pos,
             s"$aver [@newField for ${param.name}] must must precede " +
-              s"${rfield.version} [@replacedField for ${oldDef.name}]"
+              s"${rfield.version} [@replacedField for ${oldDef.name}]",
           )
-        }
-      )
+        },
+      ),
     )
 
     def getApplyDeclDefnBefore(version: Version): (List[(ValDef, Int)], Option[ValDef]) = {
@@ -904,7 +904,7 @@ class AstNamerMacros(val c: Context) extends Reflection with CommonNamerMacros {
 
   private def getVersionedParams(
       params: List[ValDef],
-      stats: List[Tree]
+      stats: List[Tree],
   ): (List[VersionedParam], List[Version]) = {
     val appendedFields: Map[String, Version] = getNewFieldVersions(params)
     val replacedFields: Map[String, Seq[ReplacedField]] = ReplacedField.getMap(params, stats)
@@ -963,7 +963,7 @@ class AstNamerMacros(val c: Context) extends Reflection with CommonNamerMacros {
       val version: Version,
       val newVal: ValDef,
       ctor: Tree,
-      val oldDefs: List[(ValOrDefDef, Int)]
+      val oldDefs: List[(ValOrDefDef, Int)],
   ) {
     def newValDefn: ValDef = {
       def bodyForSingleOldDef(oldDef: ValOrDefDef) =
@@ -1045,7 +1045,7 @@ class AstNamerMacros(val c: Context) extends Reflection with CommonNamerMacros {
         case _ => None
       }
       iter(oldDef.rhs).getOrElse(
-        c.abort(oldDef.pos, s"@replacedField: can't find new field name (${showRaw(oldDef.rhs)})")
+        c.abort(oldDef.pos, s"@replacedField: can't find new field name (${showRaw(oldDef.rhs)})"),
       )
     }
   }
@@ -1093,7 +1093,7 @@ object AstNamerMacros {
           if (v > maxVersion) {
             maxName = Some(name)
             maxVersion = v
-          }
+          },
         )
     }
     maxName

--- a/scalameta/common2/shared/src/main/scala/scala/meta/internal/trees/quasiquote.scala
+++ b/scalameta/common2/shared/src/main/scala/scala/meta/internal/trees/quasiquote.scala
@@ -31,7 +31,7 @@ class QuasiquoteMacros(val c: Context) extends MacroHelpers {
         val qmodule = {
           val qtypesLub = lub(qtypes.map(qtype =>
             try c.typecheck(qtype.duplicate, c.TYPEmode).tpe
-            catch { case c.TypecheckException(pos, msg) => c.abort(pos.asInstanceOf[c.Position], msg) }
+            catch { case c.TypecheckException(pos, msg) => c.abort(pos.asInstanceOf[c.Position], msg) },
           ))
           q"""
             object ${TermName(qname)} {
@@ -45,14 +45,14 @@ class QuasiquoteMacros(val c: Context) extends MacroHelpers {
           val qmonadicResult = qtypes.map(qtype =>
             q"""
               _root_.scala.Predef.implicitly[Parse[$qtype]].apply(input, dialect)
-            """
+            """,
           ).reduce((acc, curr) =>
             q"""
               ($acc) match {
                 case _: Parsed.Error => $curr
                 case x => x
               }
-            """
+            """,
           )
           q"""
             private[meta] def parse(input: _root_.scala.meta.inputs.Input, dialect: _root_.scala.meta.Dialect) = {

--- a/scalameta/common2/shared/src/main/scala/scala/meta/internal/trees/registry.scala
+++ b/scalameta/common2/shared/src/main/scala/scala/meta/internal/trees/registry.scala
@@ -26,7 +26,7 @@ class RegistryMacros(val c: Context) extends AstReflection with MacroHelpers {
         val ModuleDef(
           mods @ Modifiers(flags, privateWithin, anns),
           name,
-          Template(parents, self, stats)
+          Template(parents, self, stats),
         ) = mdef
         val enclosingUnit = c.asInstanceOf[{ def enclosingUnit: { def body: Tree } }].enclosingUnit
           .body

--- a/scalameta/common2/shared/src/main/scala/scala/meta/prettyprinters/Structure.scala
+++ b/scalameta/common2/shared/src/main/scala/scala/meta/prettyprinters/Structure.scala
@@ -13,7 +13,7 @@ object Structure {
   }
 
   implicit def structureList[T: Structure]: Structure[List[T]] = Structure(xs =>
-    Sequence(Str("List("), r(xs.map(x => implicitly[Structure[T]].apply(x)), ", "), Str(")"))
+    Sequence(Str("List("), r(xs.map(x => implicitly[Structure[T]].apply(x)), ", "), Str(")")),
   )
 
   implicit def structureOption[T: Structure]: Structure[Option[T]] = Structure {

--- a/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/TreeOps.scala
+++ b/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/TreeOps.scala
@@ -9,7 +9,7 @@ import scala.language.higherKinds
 object TreeOps {
 
   def contains[F[x <: Tree] <: TreeEquality[x]](
-      tree: Tree
+      tree: Tree,
   )(toFind: Tree)(implicit conv: Tree => F[Tree], eqEv: Equal[F[Tree]]): Boolean =
     exists(tree)(_.isEqual[F](toFind))
 

--- a/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/implicits/Equality.scala
+++ b/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/implicits/Equality.scala
@@ -17,7 +17,7 @@ trait Equality {
 
     @inline
     def isEqual[F[x <: Tree] <: TreeEquality[x]](
-        b: A
+        b: A,
     )(implicit conv: Tree => F[Tree], eqEv: Equal[F[Tree]]): Boolean =
       (a eq b) || eqEv.isEqual(conv(a), conv(b))
   }

--- a/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/implicits/TreeExtensions.scala
+++ b/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/implicits/TreeExtensions.scala
@@ -31,7 +31,7 @@ trait TreeExtensions {
 
     @inline
     def contains[F[x <: Tree] <: TreeEquality[x]](
-        toFind: Tree
+        toFind: Tree,
     )(implicit conv: Tree => F[Tree], eqEv: Equal[F[Tree]]): Boolean = TreeOps.contains(a)(toFind)
   }
 }

--- a/scalameta/dialects2/shared/src/main/scala/scala/meta/Dialect.scala
+++ b/scalameta/dialects2/shared/src/main/scala/scala/meta/Dialect.scala
@@ -184,7 +184,7 @@ final class Dialect private[meta] (
     private[meta] val unquoteParentDialect: Dialect = null,
     // Are unquotes ($x) and splices (..$xs, ...$xss) allowed?
     // If yes, they will be parsed as patterns or terms.
-    private[meta] val unquoteType: UnquoteType = UnquoteType.None
+    private[meta] val unquoteType: UnquoteType = UnquoteType.None,
 ) extends Product with Serializable {
 
   // NOTE(olafur) checklist for adding a new dialect field in a binary compatible way:
@@ -215,7 +215,7 @@ final class Dialect private[meta] (
       allowTypeLambdas: Boolean,
       allowViewBounds: Boolean, // unused
       allowXmlLiterals: Boolean,
-      toplevelSeparator: String // unused
+      toplevelSeparator: String, // unused
   ) = this(
     allowAtForExtractorVarargs = allowAtForExtractorVarargs,
     allowCaseClassWithoutParameterList = allowCaseClassWithoutParameterList,
@@ -230,7 +230,7 @@ final class Dialect private[meta] (
     allowTrailingCommas = allowTrailingCommas,
     allowTraitParameters = allowTraitParameters,
     allowTypeLambdas = allowTypeLambdas,
-    allowXmlLiterals = allowXmlLiterals
+    allowXmlLiterals = allowXmlLiterals,
   )
 
   // Are unquotes ($x) and splices (..$xs, ...$xss) allowed?
@@ -466,7 +466,7 @@ final class Dialect private[meta] (
       allowImprovedTypeClassesSyntax: Boolean = this.allowImprovedTypeClassesSyntax,
       treatUnicodeEscapesAsOrdinary: Boolean = this.treatUnicodeEscapesAsOrdinary,
       // NOTE(olafur): add the next parameter above this comment.
-      unquoteType: UnquoteType = UnquoteType.None
+      unquoteType: UnquoteType = UnquoteType.None,
   ): Dialect = {
     val notForUnquote = unquoteType eq UnquoteType.None
     val that = new Dialect(
@@ -537,7 +537,7 @@ final class Dialect private[meta] (
       treatUnicodeEscapesAsOrdinary = treatUnicodeEscapesAsOrdinary,
       // NOTE(olafur): add the next argument above this comment.
       unquoteType = unquoteType,
-      unquoteParentDialect = if (notForUnquote) null else this
+      unquoteParentDialect = if (notForUnquote) null else this,
     )
     val equivalent = notForUnquote && isEquivalentToInternal(that)
     if (equivalent) this else that
@@ -655,7 +655,7 @@ final class Dialect private[meta] (
       allowTypeLambdas: Boolean = this.allowTypeLambdas,
       allowViewBounds: Boolean = true, // unused
       allowXmlLiterals: Boolean = this.allowXmlLiterals,
-      toplevelSeparator: String = "" // unused
+      toplevelSeparator: String = "", // unused
   ): Dialect = privateCopy(
     unquoteType = UnquoteType.None,
     allowAtForExtractorVarargs = allowAtForExtractorVarargs,
@@ -671,7 +671,7 @@ final class Dialect private[meta] (
     allowTrailingCommas = allowTrailingCommas,
     allowTraitParameters = allowTraitParameters,
     allowTypeLambdas = allowTypeLambdas,
-    allowXmlLiterals = allowXmlLiterals
+    allowXmlLiterals = allowXmlLiterals,
   )
 
   private[meta] def unquoteParentOrThis(): Dialect =
@@ -719,7 +719,7 @@ object Dialect extends InternalDialect {
       allowViewBounds: Boolean,
       allowXmlLiterals: Boolean,
       @deprecated("toplevelSeparator has never been used", ">4.4.35")
-      toplevelSeparator: String // unused
+      toplevelSeparator: String, // unused
   ): Dialect = new Dialect(
     allowAtForExtractorVarargs = allowAtForExtractorVarargs,
     allowCaseClassWithoutParameterList = allowCaseClassWithoutParameterList,
@@ -734,7 +734,7 @@ object Dialect extends InternalDialect {
     allowTrailingCommas = allowTrailingCommas,
     allowTraitParameters = allowTraitParameters,
     allowTypeLambdas = allowTypeLambdas,
-    allowXmlLiterals = allowXmlLiterals
+    allowXmlLiterals = allowXmlLiterals,
   )
 
   private[meta] lazy val standards: Map[String, Dialect] = Map(
@@ -764,7 +764,7 @@ object Dialect extends InternalDialect {
     "Scala213Source3" -> Scala213Source3,
     "Scala212Source3" -> Scala212Source3,
     "Typelevel211" -> Typelevel211,
-    "Typelevel212" -> Typelevel212
+    "Typelevel212" -> Typelevel212,
   )
   private[meta] lazy val inverseStandards: Map[Dialect, String] = standards.view.map(_.swap)
     .groupBy(_._1).map { case (k, v) =>

--- a/scalameta/dialects2/shared/src/main/scala/scala/meta/dialects/package.scala
+++ b/scalameta/dialects2/shared/src/main/scala/scala/meta/dialects/package.scala
@@ -5,7 +5,7 @@ package object dialects {
     allowAtForExtractorVarargs = true,
     allowCaseClassWithoutParameterList = true,
     allowInlineIdents = true,
-    allowXmlLiterals = true // Not even deprecated yet, so we need to support xml literals
+    allowXmlLiterals = true, // Not even deprecated yet, so we need to support xml literals
   )
 
   implicit val Scala211: Dialect = Scala210.withAllowCaseClassWithoutParameterList(false)

--- a/scalameta/inputs2/shared/src/main/scala/scala/meta/inputs/Input.scala
+++ b/scalameta/inputs2/shared/src/main/scala/scala/meta/inputs/Input.scala
@@ -72,7 +72,7 @@ object Input {
     @SerialVersionUID(1L)
     private class SerializationProxy(
         @transient
-        private var orig: Stream
+        private var orig: Stream,
     ) extends Serializable {
       private def writeObject(out: java.io.ObjectOutputStream): Unit = {
         out.writeObject(orig.chars)
@@ -118,7 +118,7 @@ object Input {
     @SerialVersionUID(1L)
     private class SerializationProxy(
         @transient
-        private var orig: UriLike
+        private var orig: UriLike,
     ) extends Serializable {
       private def writeObject(out: java.io.ObjectOutputStream): Unit = {
         out.writeObject(orig.uri)

--- a/scalameta/io/js/src/main/scala/java/io/File.scala
+++ b/scalameta/io/js/src/main/scala/java/io/File.scala
@@ -11,7 +11,7 @@ class File(path: String) {
   def this(parent: File, child: String) = this(parent.getPath, child)
   def this(uri: URI) = this(
     if (uri.getScheme != "file") throw new IllegalArgumentException("URI scheme is not \"file\"")
-    else uri.getPath
+    else uri.getPath,
   )
   def toPath: Path = NodeNIOPath(path)
   def toURI: URI = {

--- a/scalameta/io/js/src/main/scala/scala/meta/internal/io/JSIO.scala
+++ b/scalameta/io/js/src/main/scala/scala/meta/internal/io/JSIO.scala
@@ -44,7 +44,7 @@ object JSFs extends js.Any {
   def readFile(
       path: String,
       encoding: String,
-      callback: js.Function2[js.Error, String, Unit]
+      callback: js.Function2[js.Error, String, Unit],
   ): Unit = js.native
 
   /** Writes file contents using blocking apis */
@@ -58,7 +58,7 @@ object JSFs extends js.Any {
       path: String,
       data: String,
       encoding: String,
-      callback: js.Function1[js.Error, Unit]
+      callback: js.Function1[js.Error, Unit],
   ): Unit = js.native
 
   /** Returns an array of filenames excluding '.' and '..'. */
@@ -76,7 +76,7 @@ object JSFs extends js.Any {
       path: String, // real path
       link: String, // link path
       /** type is file, dir, junction (windows) */
-      `type`: js.UndefOr[String] = js.undefined
+      `type`: js.UndefOr[String] = js.undefined,
   ): Unit = js.native
 
   /** Synchronously creates a directory. */
@@ -187,7 +187,7 @@ object JSIO {
         promise.tryFailure(new RuntimeException(err match {
           case e: js.Error => e.message
           case _ => err.toString
-        }))
+        })),
     )
 
     promise.future

--- a/scalameta/io/js/src/main/scala/scala/meta/internal/io/NodeNIOPath.scala
+++ b/scalameta/io/js/src/main/scala/scala/meta/internal/io/NodeNIOPath.scala
@@ -22,12 +22,12 @@ case class NodeNIOPath(filename: String) extends Path {
   override def getNameCount: Int = parts.length
   override def getName(idx: Int): Path = NodeNIOPath(
     if (idx < parts.length) parts(idx)
-    else throw new IllegalArgumentException(s"Path doesn't contain part #$idx: $filename")
+    else throw new IllegalArgumentException(s"Path doesn't contain part #$idx: $filename"),
   )
   override def subpath(beg: Int, end: Int): Path = {
     require(
       0 <= beg && beg < end && end <= parts.length,
-      s"0 <= $beg && $beg < $end && $end <= ${parts.length}"
+      s"0 <= $beg && $beg < $end && $end <= ${parts.length}",
     )
     val sb = new StringBuilder
     for (idx <- beg until end) {

--- a/scalameta/io/js/src/main/scala/scala/meta/internal/io/PlatformFileIO.scala
+++ b/scalameta/io/js/src/main/scala/scala/meta/internal/io/PlatformFileIO.scala
@@ -58,7 +58,7 @@ object PlatformFileIO {
         curr += 1
       }
       ListFiles(path, builder.result())
-    }
+    },
   )
 
   def isFile(path: AbsolutePath): Boolean = JSIO.isFile(path.toString)
@@ -77,6 +77,6 @@ object PlatformFileIO {
     throw new UnsupportedOperationException("Can't expand jar file in Scala.js")
 
   def withJarFileSystem[T](path: AbsolutePath, create: Boolean, close: Boolean = false)(
-      f: AbsolutePath => T
+      f: AbsolutePath => T,
   ): T = throw new UnsupportedOperationException("Can't expand jar file in Scala.js")
 }

--- a/scalameta/io/jvm/src/main/scala/scala/meta/internal/io/PlatformFileIO.scala
+++ b/scalameta/io/jvm/src/main/scala/scala/meta/internal/io/PlatformFileIO.scala
@@ -26,7 +26,7 @@ object PlatformFileIO {
   }
 
   def write[A](path: AbsolutePath, msg: A, openOptions: OpenOption*)(implicit
-      osio: OutputStreamIO[A]
+      osio: OutputStreamIO[A],
   ): Unit = {
     Files.createDirectories(path.toNIO.getParent)
     val os = Files.newOutputStream(path.toNIO, openOptions: _*)
@@ -60,7 +60,7 @@ object PlatformFileIO {
   }
 
   def withJarFileSystem[T](path: AbsolutePath, create: Boolean, close: Boolean = false)(
-      f: AbsolutePath => T
+      f: AbsolutePath => T,
   ): T = {
     val fs = newJarFileSystem(path, create)
     val root = AbsolutePath(fs.getPath("/"))

--- a/scalameta/io/native/src/main/scala/scala/meta/internal/io/PlatformFileIO.scala
+++ b/scalameta/io/native/src/main/scala/scala/meta/internal/io/PlatformFileIO.scala
@@ -73,6 +73,6 @@ object PlatformFileIO {
   }
   def jarRootPath(jarFile: AbsolutePath): AbsolutePath = throw new UnsupportedOperationException()
   def withJarFileSystem[T](path: AbsolutePath, create: Boolean, close: Boolean = false)(
-      f: AbsolutePath => T
+      f: AbsolutePath => T,
   ): T = throw new UnsupportedOperationException()
 }

--- a/scalameta/io/shared/src/main/scala/scala/meta/internal/io/ClasspathFile.scala
+++ b/scalameta/io/shared/src/main/scala/scala/meta/internal/io/ClasspathFile.scala
@@ -15,7 +15,7 @@ import scala.meta.io.AbsolutePath
 final case class ClasspathFile(
     path: AbsolutePath,
     enclosingJar: Option[AbsolutePath],
-    enclosingManifestJar: Option[ClasspathFile]
+    enclosingManifestJar: Option[ClasspathFile],
 ) {
   def pathOnDisk: AbsolutePath = enclosingJar.getOrElse(path)
 }

--- a/scalameta/io/shared/src/main/scala/scala/meta/internal/io/FileIO.scala
+++ b/scalameta/io/shared/src/main/scala/scala/meta/internal/io/FileIO.scala
@@ -29,6 +29,6 @@ object FileIO {
   def jarRootPath(jarFile: AbsolutePath): AbsolutePath = PlatformFileIO.jarRootPath(jarFile)
 
   def withJarFileSystem[T](path: AbsolutePath, create: Boolean, close: Boolean = false)(
-      f: AbsolutePath => T
+      f: AbsolutePath => T,
   ): T = PlatformFileIO.withJarFileSystem[T](path, create, close)(f)
 }

--- a/scalameta/parsers/js/src/main/scala/scala/meta/parsers/JSFacade.scala
+++ b/scalameta/parsers/js/src/main/scala/scala/meta/parsers/JSFacade.scala
@@ -84,7 +84,7 @@ object JSFacade {
               "error" -> x.message,
               "pos" -> toPosition(x.pos),
               "lineNumber" -> x.pos.startLine,
-              "columnNumber" -> x.pos.startColumn
+              "columnNumber" -> x.pos.startColumn,
             )
         }
     }

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/LazyTokenIterator.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/LazyTokenIterator.scala
@@ -16,7 +16,7 @@ object LazyTokenIterator {
 private[parsers] class LazyTokenIterator private (
     private val scannerTokens: ScannerTokens,
     private var prev: TokenRef,
-    private var curr: TokenRef
+    private var curr: TokenRef,
 ) extends TokenIterator {
 
   import scannerTokens._

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -321,7 +321,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
 
   private def typeClauseInBrackets[A <: Tree: AstInfo: ClassTag, B <: Tree: AstInfo](
       part: => A,
-      f: List[A] => B
+      f: List[A] => B,
   ): B = TypeBracketsContext.within(autoPos(inBrackets(commaSeparated(part).reduceWith(f))))
 
   /* ------------- POSITION HANDLING ------------------------------------------- */
@@ -589,7 +589,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
     syntaxError(syntaxExpectedMessage[T](tok), at = tok)
   private def expectAt[T <: Token: ClassTag](
       tok: Token,
-      exists: Boolean
+      exists: Boolean,
   )(msg: => String, prefix: => String): Unit = if (tok.is[T] != exists)
     syntaxError(Option(prefix).filter(_.nonEmpty).fold(msg)(p => s"$p: $msg"), at = tok)
 
@@ -773,7 +773,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
       // This is an artifact of the current implementation, so we just need to keep it mind and work around it.
       assert(
         classTag[T].runtimeClass.isAssignableFrom(tree.pt),
-        s"ellipsis: $ell,\ntree: $tree,\nstructure: ${tree.structure}"
+        s"ellipsis: $ell,\ntree: $tree,\nstructure: ${tree.structure}",
       )
       quasi[T](ell.rank, tree)
     }
@@ -821,7 +821,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
 
   final def tokenSeparated[Sep: ClassTag, T <: Tree: AstInfo: ClassTag](
       sepFirst: Boolean,
-      part: Int => T
+      part: Int => T,
   ): List[T] = listBy[T] { ts =>
     @tailrec
     def iter(sep: Boolean): Unit = currToken match {
@@ -846,7 +846,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
     tokenSeparated[Comma, T](sepFirst = false, part)
 
   private def makeTuple[A <: Tree](lpPos: Int, body: List[A], zero: => A, tuple: List[A] => A)(
-      single: A => Either[List[A], A]
+      single: A => Either[List[A], A],
   ): A = body match {
     case Nil => autoEndPos(lpPos)(zero)
     case (q: Quasi) :: Nil if q.rank == 1 => copyPos(q)(tuple(body))
@@ -867,7 +867,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
   }
 
   private def makeTupleTerm(
-      single: Term => Either[List[Term], Term]
+      single: Term => Either[List[Term], Term],
   )(lpPos: Int, body: List[Term]): Term =
     makeTuple(lpPos, body, Lit.Unit(), Term.Tuple.apply)(single)
 
@@ -894,7 +894,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
   private def inParensOrTupleOrUnitExpr(allowRepeated: Boolean): Term = {
     val lpPos = currIndex
     val maybeTupleArgs = inParensOnOpenOr(
-      commaSeparated(expr(location = PostfixStat, allowRepeated = allowRepeated))
+      commaSeparated(expr(location = PostfixStat, allowRepeated = allowRepeated)),
     )(Nil)
     if (maybeTupleArgs.lengthCompare(1) > 0) maybeTupleArgs.foreach {
       case arg: Term.Repeated =>
@@ -1042,7 +1042,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
 
     private def namedTypeOpt(
         fmods: => List[Mod],
-        allowFunctionType: Boolean
+        allowFunctionType: Boolean,
     ): Option[Type.TypedParam] = currToken match {
       case t: Ident if peek[Colon] =>
         val startPos = currIndex
@@ -1059,7 +1059,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
       // TypeBlock, https://dotty.epfl.ch/docs/internals/syntax.html#expressions-3
       if (dialect.allowQuotedTypeVariables && at[KwType]) autoPos {
         val typeDefs = listBy[Stat.TypeDef](buf =>
-          doWhile(buf += typeDefOrDcl(Nil))(acceptIfStatSep() && at[KwType])
+          doWhile(buf += typeDefOrDcl(Nil))(acceptIfStatSep() && at[KwType]),
         )
         Type.Block(typeDefs, typ())
       }
@@ -1080,44 +1080,44 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
             else inBracesAfterOpen(commaSeparated(path() match {
               case x: Term.Name => ifCaret(autoEndPos(x)(Term.CapSetName(x.value)), x)
               case x => x
-            }))
+            })),
           )))
         if (!needCaret) capturesOnBrace()
         else ifCaret(capturesOnBrace().orElse(Some(atCurPosEmpty(Type.CapturesAny()))), None)
       } else None
 
     private def withTypeCapturesOpt(startPos: Int, needCaret: Boolean, allowCaptures: Boolean = true)(
-        capturedType: => Type
+        capturedType: => Type,
     ): Option[Type] = typeCaptures(needCaret = needCaret, allowCaptures = allowCaptures)
       .map(captures => autoEndPos(startPos)(Type.Capturing(capturedType, captures)))
 
     private def withTypeCaptures(
         startPos: Int,
         needCaret: Boolean = false,
-        allowCaptures: Boolean = true
+        allowCaptures: Boolean = true,
     )(capturedType: => Type): Type =
       withTypeCapturesOpt(startPos, needCaret = needCaret, allowCaptures = allowCaptures)(
-        capturedType
+        capturedType,
       ).getOrElse(capturedType)
 
     private def typeFuncOnArrow(
         paramPos: Int,
         params: List[Type],
         allowCaptures: Boolean = false,
-        inParam: Boolean = false
+        inParam: Boolean = false,
     )(ctor: (Type.FuncParamClause, Type) => Type): Type = {
       val funcParams =
         autoEndPos(paramPos)(params.map(typeVar).reduceWith(Type.FuncParamClause.apply))
       next()
       withTypeCaptures(paramPos, allowCaptures = allowCaptures)(autoEndPos(paramPos)(
-        ctor(funcParams, maybeIndented(if (inParam) paramValueType() else typ()))
+        ctor(funcParams, maybeIndented(if (inParam) paramValueType() else typ())),
       ))
     }
 
     private def typeFuncOnArrowOpt(
         paramPos: Int,
         params: List[Type],
-        inParam: Boolean = false
+        inParam: Boolean = false,
     ): Option[Type] = {
       def func(caps: Boolean = true)(ctor: (Type.FuncParamClause, Type) => Type): Option[Type] =
         Some(typeFuncOnArrow(paramPos, params, inParam = inParam, allowCaptures = caps)(ctor))
@@ -1143,7 +1143,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
             TypeCase(pat, typeIndentedOpt())
           }
           newLinesOpt()
-        }
+        },
       )
       (if (at[Indentation.Indent]) indentedOnOpen(cases()) else inBraces(cases()))
         .reduceWith(Type.CasesBlock.apply)
@@ -1173,7 +1173,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
       maybeAnonymousLambda(infixTypeRest(
         compoundType(inMatchType = inMatchType, inGivenSig = inGivenSig),
         inMatchType = inMatchType,
-        inGivenSig = inGivenSig
+        inGivenSig = inGivenSig,
       ))
 
     @inline
@@ -1187,7 +1187,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
         t: Type,
         f: Type => Type,
         inMatchType: Boolean = false,
-        inGivenSig: Boolean = false
+        inGivenSig: Boolean = false,
     ): Type = {
       val ok = currToken match {
         case _: Unquote | InfixTypeIdent() => true
@@ -1208,7 +1208,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
     private final def infixTypeRestWithPrecedence(
         t: Type,
         inMatchType: Boolean = false,
-        inGivenSig: Boolean = false
+        inGivenSig: Boolean = false,
     ): Type = {
       import TypeInfixContext._
       val base = stack
@@ -1360,7 +1360,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
       .within(if (allowInfix) infixPatternTypeImpl() else compoundType())
 
     def patternTypeArgs() = PatternTypeContext.within(
-      typeClauseInBrackets(typeVar(infixPatternTypeImpl(), prevToken.text), Type.ArgClause.apply)
+      typeClauseInBrackets(typeVar(infixPatternTypeImpl(), prevToken.text), Type.ArgClause.apply),
     )
 
     private def typeVar(t: Type, text: => String): Type = t match {
@@ -1518,7 +1518,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
 
   private def interpolateWith[Ctx, Ret <: Tree](
       arg: => Ctx,
-      result: (Term.Name, List[Lit], List[Ctx]) => Ret
+      result: (Term.Name, List[Lit], List[Ctx]) => Ret,
   ): Ret = autoPos {
     val partsBuf = new ListBuffer[Lit]
     val argsBuf = new ListBuffer[Ctx]
@@ -1610,7 +1610,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
       if (at[At] && peek[Ident]) {
         val startPos = currIndex
         outPattern.annotTypeRest(autoEndPos(startPos)(Type.AnonymousName()), startPos)
-      } else typ()
+      } else typ(),
     )
     else None
 
@@ -1638,7 +1638,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
     case _: KwThis => anonThis()
     case _ => syntaxError(
         "error in interpolated string: identifier, `this' or block expected",
-        at = currToken
+        at = currToken,
       )
   }
 
@@ -1757,12 +1757,12 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
           def tryWithCases(cases: Option[Term.CasesBlock]) = Term.Try(body, cases, finallyopt)
           def tryWithHandler(handler: Term) = Term.TryWithHandler(body, handler, finallyopt)
           def tryInDelims(
-              f: (=> Either[Term, Term.CasesBlock]) => Either[Term, Term.CasesBlock]
+              f: (=> Either[Term, Term.CasesBlock]) => Either[Term, Term.CasesBlock],
           ): Term = {
             val catchPos = currIndex
             f(casesBlockIfAny().toRight(blockRaw())).fold(
               x => tryWithHandler(autoEndPos(catchPos)(x)),
-              x => tryWithCases(Some(autoEndPos(catchPos)(x)))
+              x => tryWithCases(Some(autoEndPos(catchPos)(x))),
             )
           }
 
@@ -1834,7 +1834,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
       prefix: Term,
       startPos: Int,
       location: Location,
-      allowRepeated: Boolean
+      allowRepeated: Boolean,
   ): Term = {
     @inline
     def addPos[T <: Tree](body: T) = autoEndPos(startPos)(body)
@@ -1935,7 +1935,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
       case t => convertToParam(t).filter(p =>
           if (p.decltpe.nonEmpty) allowParam(hasType = true)
           else if (p.mods.nonEmpty) allowParam(hasType = false)
-          else allowName
+          else allowName,
         ).map(_ :: Nil)
     }
 
@@ -2016,10 +2016,10 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
     def getTypeFunction(t: Term.Function): Option[Type.Function] = t.becomeOrOpt[Type.Function](t =>
       getType(t.body).map { tpe =>
         val pc = t.paramClause.becomeOr[Type.FuncParamClause](pc =>
-          copyPos(pc)(Type.FuncParamClause(pc.values.map(convertTermParamToType)))
+          copyPos(pc)(Type.FuncParamClause(pc.values.map(convertTermParamToType))),
         )
         copyPos(t)(Type.Function(pc, tpe))
-      }
+      },
     )
 
     tree.becomeOrOpt[Term.Param] {
@@ -2037,7 +2037,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
       term: Term,
       startPos: Int,
       location: Location = NoStat,
-      allowRepeated: Boolean = false
+      allowRepeated: Boolean = false,
   ): Term = {
     val postfix = postfixExpr(term, startPos, allowRepeated = allowRepeated)
     exprOtherRest(postfix, startPos, location, allowRepeated = allowRepeated)
@@ -2048,7 +2048,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
       startPos: Int,
       location: Location = NoStat,
       canApply: Boolean = false,
-      allowRepeated: Boolean = false
+      allowRepeated: Boolean = false,
   ): Term = {
     val simple = simpleExprRest(term, canApply = canApply, startPos = startPos)
     exprAfterSimple(simple, startPos, location, allowRepeated = allowRepeated)
@@ -2091,7 +2091,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
     def isDone(base: List[UnfinishedInfix]): Boolean = this.stack == base
     def push(unfinishedInfix: UnfinishedInfix): Unit = stack ::= unfinishedInfix
     def reduceAndPush(base: List[UnfinishedInfix], rhs: Typ, op: Op)(
-        f: (Typ, Op) => UnfinishedInfix
+        f: (Typ, Op) => UnfinishedInfix,
     ): Unit = push(f(reduceStack(base, rhs, rhs, op), op))
 
     def drainStack(base: List[UnfinishedInfix], curr: Typ, currEnd: EndPos): Typ = {
@@ -2170,7 +2170,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
               case _ => true
             }) => args
         case _ => rhs :: Nil
-      }).reduceWith(Term.ArgClause(_))
+      }).reduceWith(Term.ArgClause(_)),
     )
 
     protected def finishInfixExpr(unf: UnfinishedInfix, rhs: Typ, rhsEnd: EndPos): Typ = {
@@ -2211,7 +2211,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
                 case _ => true
               }) => args
           case _ => rhs :: Nil
-        }).reduceWith(Pat.ArgClause.apply)
+        }).reduceWith(Pat.ArgClause.apply),
       )
       atPos(lhsExt, rhsEnd)(Pat.ExtractInfix(lhs, op, args))
     }
@@ -2549,7 +2549,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
             val pt = if (at[KwImplicit]) Some(atCurPosNext(Mod.Implicit())) else None
             val mods = pt.toList
             commaSeparated(getParamWithPos(mods, fullTypeOK = true)).reduceWith(toParamClause(pt))
-          }(Term.ParamClause(Nil))
+          }(Term.ParamClause(Nil)),
         ))
       case _: LeftBracket => getPolyFunction(typeParamClauseOnBracket())
       case t: Ellipsis if t.rank == 2 => getFunctionTerm(ellipsis[Term.ParamClause](t))
@@ -2562,7 +2562,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
   private def getFewerBracesApplyOnColon(
       fun: Term,
       startPos: Int,
-      okSingleLineLambda: Boolean = false
+      okSingleLineLambda: Boolean = false,
   ): Option[Term] = {
     val colonPos = currIndex
     getFewerBracesArgOnColon(okSingleLineLambda).map { arg =>
@@ -2620,7 +2620,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
         val using = x.text == soft.KwUsing.name && mightStartStat(peekToken)
         val mod = if (using) Some(atCurPosNext(Mod.Using())) else None
         argumentExprsInParens(location).reduceWith(Term.ArgClause(_, mod))
-    })(Term.ArgClause(Nil))
+    })(Term.ArgClause(Nil)),
   )
 
   private def argumentExprsInParens(location: Location = NoStat): List[Term] =
@@ -2673,7 +2673,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
     blockOnBrace(blockStatSeq(allowRepeated = allowRepeated))
   private def blockExprOnBrace(allowRepeated: Boolean = false, isOptional: Boolean = false): Term =
     blockExprPartial[RightBrace](
-      if (isOptional) blockOnOther(allowRepeated) else blockOnBrace(allowRepeated)
+      if (isOptional) blockOnOther(allowRepeated) else blockOnBrace(allowRepeated),
     )
 
   private def blockOnOther(allowRepeated: Boolean = false): Term = {
@@ -2749,7 +2749,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
       while (at[KwIf]) enums += enumeratorGuardOnIf()
     }(
       if (StatSep(currToken)) nextIf(notEnumsEnd(peekToken))
-      else isImplicitStatSep() && notEnumsEnd(currToken)
+      else isImplicitStatSep() && notEnumsEnd(currToken),
     )
   }
 
@@ -2782,7 +2782,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
     autoEndPos(startPos)(
       if (hasEq) Enumerator.Val(pat, rhs)
       else if (isCase) Enumerator.CaseGenerator(pat, rhs)
-      else Enumerator.Generator(pat, rhs)
+      else Enumerator.Generator(pat, rhs),
     )
   }
 
@@ -2934,7 +2934,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
     def simplePattern(
         onError: Token => Nothing,
         isRhs: Boolean = false,
-        isForComprehension: Boolean = false
+        isForComprehension: Boolean = false,
     ): Pat = PatternContext.within {
       val startPos = currIndex
       autoEndPos(startPos) {
@@ -2947,11 +2947,11 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
               val ref = sid.become[Term]
               Pat.Extract(
                 targs.fold(ref)(x => autoEndPos(sid)(Term.ApplyType(ref, x))),
-                autoPos(argumentPatterns().reduceWith(Pat.ArgClause.apply))
+                autoPos(argumentPatterns().reduceWith(Pat.ArgClause.apply)),
               )
             } else {
               targs.foreach(x =>
-                syntaxError(s"pattern must be a value or have parens: $sid$x", at = currToken)
+                syntaxError(s"pattern must be a value or have parens: $sid$x", at = currToken),
               )
               sid match {
                 case name: Term.Name if isNamedTupleOk && acceptOpt[Equals] =>
@@ -2971,7 +2971,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
                     "token" -> currToken,
                     "tokenStructure" -> currToken.structure,
                     "sid" -> sid,
-                    "sidStructure" -> sid.structure
+                    "sidStructure" -> sid.structure,
                   ))
               }
             }
@@ -3062,7 +3062,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
     else {
       val result = mod(
         if (at[KwThis]) anonThis()
-        else termName().becomeOr[Ref](x => copyPos(x)(Name.Indeterminate(x.value)))
+        else termName().becomeOr[Ref](x => copyPos(x)(Name.Indeterminate(x.value))),
       )
       accept[RightBracket]
       result
@@ -3157,7 +3157,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
   def modifiersBuf(
       buf: ListBuffer[Mod],
       isLocal: Boolean = false,
-      isParams: Boolean = false
+      isParams: Boolean = false,
   ): Unit = {
     def append(mod: Mod): Unit = {
       buf += mod
@@ -3204,12 +3204,12 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
       annots: ListBuffer[T],
       skipNewLines: Boolean,
       insidePrimaryCtorAnnot: Boolean = false,
-      allowArgss: Boolean = true
+      allowArgss: Boolean = true,
   ): Unit = while (currToken match {
       case _: At =>
         next()
         annots += unquoteOpt[Mod.Annot].getOrElse(autoEndPos(prevIndex)(
-          Mod.Annot(initRest(exprSimpleType(), allowArgss, insidePrimaryCtorAnnot))
+          Mod.Annot(initRest(exprSimpleType(), allowArgss, insidePrimaryCtorAnnot)),
         ))
         true
       case t: Ellipsis if peek[At] =>
@@ -3273,7 +3273,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
           pcg.is[Quasi] ||
           pcg.paramClauses.lastOption.exists(pc => pc.is[Quasi] || !pc.mod.is[Mod.Implicit])
         }
-      }) {}
+      }) {},
   )
 
   def termParamClauses(): List[Term.ParamClause] =
@@ -3281,7 +3281,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
 
   private def termParamClausesOnParen(
       first: Option[Term.ParamClause] = None,
-      ellipsisMaxRank: Int = 2
+      ellipsisMaxRank: Int = 2,
   ): List[Term.ParamClause] = listBy[Term.ParamClause] { paramss =>
     first.foreach(paramss += _)
     while ({
@@ -3433,7 +3433,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
     val cbounds =
       if (acceptOpt[Colon]) listBy[Type] { buf =>
         def addContextBounds[T: ClassTag]: Unit = doWhile(
-          buf += contextBoundOrAlias(allowAlias = dialect.allowImprovedTypeClassesSyntax)
+          buf += contextBoundOrAlias(allowAlias = dialect.allowImprovedTypeClassesSyntax),
         )(acceptOpt[T])
         if (acceptOpt[LeftBrace]) inBracesAfterOpen(addContextBounds[Comma])
         else addContextBounds[Colon]
@@ -3603,10 +3603,10 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
     } else {
       lhs.foreach(x =>
         if (!x.is[Quasi] && !x.is[Pat.Var])
-          syntaxError("pattern definition may not be abstract", at = x)
+          syntaxError("pattern definition may not be abstract", at = x),
       )
       tpOpt.fold(syntaxError("declaration requires a type", at = currToken))(tp =>
-        if (isVal) Decl.Val(mods, lhs, tp) else Decl.Var(mods, lhs, tp)
+        if (isVal) Decl.Val(mods, lhs, tp) else Decl.Var(mods, lhs, tp),
       )
     }
   }
@@ -3786,7 +3786,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
   private def givenSigAfterArrow(
       name: Name,
       tpc: Type.ParamClause,
-      pc: Term.ParamClause = null
+      pc: Term.ParamClause = null,
   ): Option[GivenSig] = {
     val pcbuf = new ListBuffer[Term.ParamClause]
     if (pc ne null) pcbuf += pc
@@ -3798,7 +3798,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
   private def givenSigAfterArrow(
       name: Name,
       tpc: Type.ParamClause,
-      pcbuf: ListBuffer[Term.ParamClause]
+      pcbuf: ListBuffer[Term.ParamClause],
   )(implicit pcgbuf: ListBuffer[Member.ParamClauseGroup]): Option[GivenSig] = {
     val arrowPos = prevIndex
     def flushPcBuf(): Unit = {
@@ -3851,7 +3851,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
     def name = nameAsType(x.name)
     x.decltpe.fold[Type](name)(tpe =>
       if (x.mods.isEmpty && x.name.isAnonymous) tpe
-      else copyPos(x)(Type.TypedParam(name, tpe, x.mods))
+      else copyPos(x)(Type.TypedParam(name, tpe, x.mods)),
     )
   }
 
@@ -3860,11 +3860,11 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
       case Nil => copyPos(x)(Lit.Unit())
       case v :: Nil if !keepTupleType(v) => v
       case vs => copyPos(x)(Type.Tuple(vs))
-    }
+    },
   )
 
   private def convertTypeToTermParamClause(tpe: Type) = tpe.becomeOr[Term.ParamClause](x =>
-    copyPos(x)(Term.ParamClause(copyPos(x)(Term.Param(Nil, anonNameAt(x), Some(x), None)) :: Nil))
+    copyPos(x)(Term.ParamClause(copyPos(x)(Term.Param(Nil, anonNameAt(x), Some(x), None)) :: Nil)),
   )
 
   // TmplDef           ::= ‘extension’ [DefTypeParamClause] ‘(’ DefParam ‘)’ {UsingParamClause} ExtMethods
@@ -3949,7 +3949,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
     next()
     val traitName = typeName()
     TemplateOwnerContext.within(OwnedByTrait)(
-      Defn.Trait(mods, traitName, typeParamClauseOpt(), primaryCtor(), templateOpt())
+      Defn.Trait(mods, traitName, typeParamClauseOpt(), primaryCtor(), templateOpt()),
     )
   }
 
@@ -3966,7 +3966,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
       if (modCase && !dialect.allowCaseClassWithoutParameterList && ctor.paramClauses.isEmpty)
         syntaxError(
           s"case classes must have a parameter list; try 'case class $className()' or 'case object $className'",
-          at = currToken
+          at = currToken,
         )
 
       Defn.Class(mods, className, typeParams, ctor, templateOpt())
@@ -4040,7 +4040,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
   def secondaryCtorRest(
       mods: List[Mod],
       name: Name.This,
-      paramss: Seq[Term.ParamClause]
+      paramss: Seq[Term.ParamClause],
   ): Ctor.Secondary = {
     val hasLeftBrace = isAfterOptNewLine[LeftBrace] || {
       accept[Equals]
@@ -4048,7 +4048,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
     }
     val body = autoPos(
       if (hasLeftBrace) inBracesOnOpen(constrInternal())
-      else indentedOr(constrInternal())(Ctor.Block(initInsideConstructor(), Nil))
+      else indentedOr(constrInternal())(Ctor.Block(initInsideConstructor(), Nil)),
     )
     Ctor.Secondary(mods, name, paramss, body)
   }
@@ -4087,7 +4087,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
   def initRestAt(startPos: StartPos, tpe: Type)(
       allowArgss: Boolean,
       insidePrimaryCtorAnnot: Boolean = false,
-      allowBraces: Boolean = false
+      allowBraces: Boolean = false,
   ): Init = {
     def getArgss = listBy[Term.ArgClause] { argss =>
       def allowParens: Boolean = peekToken match {
@@ -4124,12 +4124,12 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
       typeParser: => Type,
       allowArgss: Boolean,
       insidePrimaryCtorAnnot: Boolean = false,
-      allowBraces: Boolean = false
+      allowBraces: Boolean = false,
   ): Init = unquoteOpt[Init](!(peek[LeftParen] || allowBraces && peek[LeftBrace]))
     .getOrElse(initRestAt(currIndex, typeParser)(
       allowArgss = allowArgss,
       insidePrimaryCtorAnnot = insidePrimaryCtorAnnot,
-      allowBraces = allowBraces
+      allowBraces = allowBraces,
     ))
 
   /* ---------- SELFS --------------------------------------------- */
@@ -4200,7 +4200,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
   }
 
   def templateParentsWithFirst(allowComma: Boolean, allowWithBody: Boolean = false)(
-      first: Init
+      first: Init,
   ): List[Init] = {
     def impl(isSeparator: => Boolean) =
       if (!isSeparator) None
@@ -4234,7 +4234,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
 
   private def templateAfterExtends(
       parents: List[Init] = Nil,
-      edefs: Option[Stat.Block] = None
+      edefs: Option[Stat.Block] = None,
   ): Template = {
     val derived = derivesClasses()
     val body = templateBodyOpt()
@@ -4275,7 +4275,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
       val onExtends =
         acceptOpt[KwExtends] || (TemplateOwnerContext.owner eq OwnedByTrait) && acceptOpt[Subtype]
       if (onExtends) template(afterExtend = true) else templateAfterExtends()
-    }
+    },
   )
 
   @inline
@@ -4333,7 +4333,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
     if (notRefined) innerType
     else refinementInBraces(
       Some(refineWith(innerType, currIndex, inBraces(refineStatSeq()))),
-      minIndent
+      minIndent,
     )
   }
 
@@ -4390,13 +4390,13 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
 
   def statSeq[T <: Tree](
       statpf: PartialFunction[Token, T],
-      errorMsg: String = "illegal start of definition"
+      errorMsg: String = "illegal start of definition",
   ): List[T] = listBy[T](statSeqBuf(_, statpf, errorMsg))
 
   def statSeqBuf[T <: Tree](
       stats: ListBuffer[T],
       statpf: PartialFunction[Token, T],
-      errorMsg: String = "illegal start of definition"
+      errorMsg: String = "illegal start of definition",
   ): Boolean = {
     val isIndented = acceptOpt[Indentation.Indent]
     val statpfAdd = statpf.runWith(stats += _)
@@ -4450,7 +4450,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
         val stat = defOrDclOrSecondaryCtor(Nil)
         if (stat.isRefineStat) stats += stat else fail("is not a valid refinement declaration")
       } else if (ReturnTypeContext.isInside()) fail(
-        "illegal start of declaration (possible cause: missing `=' in front of current method body)"
+        "illegal start of declaration (possible cause: missing `=' in front of current method body)",
       )
       else fail("illegal start of declaration")
       acceptExtendedStatSepOpt()
@@ -4521,7 +4521,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
       .within(OwnedByObject)(Pkg.Object(Nil, termName(), templateOpt()))
     else {
       def packageBody = toPkgBody(currIndex)(
-        if (nextIfColonIndent()) indentedOnOpen(statSeq(statpf)) else inBracesOrNil(statSeq(statpf))
+        if (nextIfColonIndent()) indentedOnOpen(statSeq(statpf)) else inBracesOrNil(statSeq(statpf)),
       )
       Pkg(qualId(), packageBody)
     }
@@ -4584,7 +4584,7 @@ object ScalametaParser {
   private def maybeAnonymousFunction(
       t: Term,
       location: Location = NoStat,
-      includeArg: => Boolean = false
+      includeArg: => Boolean = false,
   ): Term = {
     val ok = location.anonFuncOK && PlaceholderChecks.hasPlaceholder(t, includeArg = includeArg)
     if (ok) copyPos(t)(Term.AnonymousFunction(t)) else t
@@ -4640,7 +4640,7 @@ object ScalametaParser {
   private def reduceAs[A <: Tree, B <: Tree, C <: B: AstInfo](
       list: List[A],
       f: List[A] => B,
-      reduceRank: Int = 1
+      reduceRank: Int = 1,
   ): B = list match {
     case (t: Quasi) :: Nil if t.rank >= reduceRank => reellipsis[C](t, t.rank - reduceRank)
     case v => f(v)
@@ -4701,7 +4701,7 @@ object ScalametaParser {
       name: Name,
       pcg: List[Member.ParamClauseGroup] = Nil,
       declType: Option[Type] = None,
-      declPos: Option[Int] = None
+      declPos: Option[Int] = None,
   )
 
 }
@@ -4710,7 +4710,7 @@ class Location private (
     val value: Int,
     val anonFuncOK: Boolean = true,
     val funcParamOK: Boolean = false,
-    val fullTypeOK: Boolean = false
+    val fullTypeOK: Boolean = false,
 )
 object Location {
   val NoStat = new Location(0, funcParamOK = true, fullTypeOK = true)

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -279,7 +279,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
       prevPos: Int,
       currPos: Int,
       outdent: Int,
-      okBlank: Boolean
+      okBlank: Boolean,
   ): Int = {
     @tailrec
     def iter(i: Int, pos: Int, indent: Int, numEOL: Int = 0): Int =
@@ -329,7 +329,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
       prevToken: Token,
       prevPos: Int,
       currPos: Int,
-      sepRegionsOrig: List[SepRegion]
+      sepRegionsOrig: List[SepRegion],
   ): TokenRef = {
     val prev = if (prevPos >= 0) tokens(prevPos) else null
     val curr = tokens(currPos)
@@ -362,7 +362,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
         wasDone: Boolean = false,
         head: TokenRef = null,
         last: TokenRef = null,
-        multiEOL: Boolean = false
+        multiEOL: Boolean = false,
     )(implicit f: List[SepRegion] => OutdentInfo): Either[List[SepRegion], (TokenRef, TokenRef)] =
       if (!wasDone) f(xs) match {
         case null => mkOutdentsOpt(xs, true, head, last, multiEOL)
@@ -389,12 +389,12 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
       }
 
     def mkOutdentsT[A](xs: List[SepRegion], multiEOL: Boolean = false)(lt: List[SepRegion] => A)(
-        rt: (TokenRef, TokenRef) => A
+        rt: (TokenRef, TokenRef) => A,
     )(implicit f: List[SepRegion] => OutdentInfo): A = mkOutdentsOpt(xs, multiEOL = multiEOL)
       .fold(lt, rt.tupled)
 
     def mkOutdents(xs: List[SepRegion], multiEOL: Boolean = false)(implicit
-        f: List[SepRegion] => OutdentInfo
+        f: List[SepRegion] => OutdentInfo,
     ): TokenRef = mkOutdentsT(xs, multiEOL)(currRef)((x, _) => x)
 
     def currRef(regions: List[SepRegion]): TokenRef = currAndNextRef(regions, null)
@@ -414,7 +414,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
     def outdentThenCurrRef(
         ri: RegionIndent,
         rs: List[SepRegion],
-        rn: Option[SepRegion] = None
+        rn: Option[SepRegion] = None,
     ): TokenRef = {
       val ref = mkOutdentTo(ri, rs)
       ref.next = currRef(rn.fold(rs)(_ :: rs))
@@ -585,7 +585,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
               new RegionCaseBody(bodyIndent, curr) :: rs
             case RegionColonMaybeFewerBraces :: rs => rs
             case _ => sepRegions
-          }
+          },
         )
       case _: KwFor if !isPrevEndMarker() => currRef(RegionFor(next) :: sepRegions)
       case _: KwWhile if dialect.allowQuietSyntax && !isPrevEndMarker() =>
@@ -782,7 +782,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
           def getOutdentOnIndent(
               r: SepRegionIndented,
               rs: List[SepRegion],
-              ctrlOnly: Boolean
+              ctrlOnly: Boolean,
           ): OutdentInfo = dropRegionLine(nextIndent + 1, rs) match {
             case RegionTry :: xs =>
               if (nextIndent < r.indent || nextIndent == r.indent && next.isAny[KwCatch, KwFinally]) {
@@ -1016,7 +1016,7 @@ object ScannerTokens {
   private[parsers] case class OutdentInfo(
       outdent: SepRegionIndented,
       regions: List[SepRegion],
-      done: Boolean = false
+      done: Boolean = false,
   )
 
   private[parsers] def multilineCommentIndent(t: Comment): Int = {

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SoftKeywords.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SoftKeywords.scala
@@ -26,7 +26,7 @@ class SoftKeywords(dialect: Dialect) {
   object KwPureFunctionLikeArrow
       extends IsWithPred(
         dialect.allowPureFunctions,
-        x => x == Token.pureFunctionArrow || x == Token.pureContextFunctionArrow
+        x => x == Token.pureFunctionArrow || x == Token.pureContextFunctionArrow,
       )
 
   object StarSplice extends IsWithName(dialect.allowPostfixStarVarargSplices, "*")
@@ -38,7 +38,7 @@ class SoftKeywords(dialect: Dialect) {
           case "+*" => Some(Some(Mod.Covariant()))
           case "-*" => Some(Some(Mod.Contravariant()))
           case _ => None
-        }
+        },
       )
   object QuestionMarkAsTypeWildcard extends IsWithName(dialect.allowQuestionMarkAsTypeWildcard, "?")
 

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/TokenRef.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/TokenRef.scala
@@ -8,7 +8,7 @@ private[parsers] class TokenRef private (
     val pos: Int,
     val nextPos: Int,
     val pointPos: Int,
-    var next: TokenRef = null
+    var next: TokenRef = null,
 ) {
   def withRegions(regions: List[SepRegion]): TokenRef =
     if (regions eq this.regions) this else new TokenRef(regions, token, pos, nextPos, pointPos)
@@ -23,6 +23,6 @@ private[parsers] object TokenRef {
       pos: Int,
       nextPos: Int,
       pointPos: Int,
-      next: TokenRef = null
+      next: TokenRef = null,
   ): TokenRef = new TokenRef(regions, token, pos, nextPos, pointPos, next)
 }

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/parsers/Api.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/parsers/Api.scala
@@ -9,7 +9,7 @@ private[meta] trait Api {
     def parse[U](implicit
         convert: Convert[T, Input],
         parse: Parse[U],
-        dialect: Dialect
+        dialect: Dialect,
     ): Parsed[U] = (dialect, convert(inputLike)).parse[U]
   }
   implicit class XtensionParsersDialectInput(dialect: Dialect) {

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/parsers/ParserOptions.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/parsers/ParserOptions.scala
@@ -5,7 +5,7 @@ import scala.meta.internal.tokenizers.ScalametaTokenizer
 
 final class ParserOptions private[meta] (
     // options which control parsing
-    val captureComments: Boolean = true
+    val captureComments: Boolean = true,
 ) {
   def withCaptureComments(value: Boolean): ParserOptions = privateCopy(captureComments = value)
 

--- a/scalameta/quasiquotes/shared/src/main/scala-2/scala/meta/internal/quasiquotes/ReificationMacros.scala
+++ b/scalameta/quasiquotes/shared/src/main/scala-2/scala/meta/internal/quasiquotes/ReificationMacros.scala
@@ -94,7 +94,7 @@ class ReificationMacros(val c: Context) extends AstReflection with AdtLiftables 
       catch {
         case ex: Exception => c.abort(
             c.macroApplication.pos,
-            s"fatal error initializing quasiquote macro: ${showRaw(c.macroApplication)}"
+            s"fatal error initializing quasiquote macro: ${showRaw(c.macroApplication)}",
           )
       }
     val metaInput = {
@@ -248,7 +248,7 @@ class ReificationMacros(val c: Context) extends AstReflection with AdtLiftables 
                     if (isTerm) q"$currElement +: $alreadyLiftedList"
                     else pq"$currElement +: $alreadyLiftedList"
                   },
-                  Nil
+                  Nil,
                 )
               else {
                 require(prefix.isEmpty && debug(trees, acc, prefix))
@@ -277,7 +277,7 @@ class ReificationMacros(val c: Context) extends AstReflection with AdtLiftables 
           else c.abort(
             tripleDotQuasis(0).pos,
             "implementation restriction: can't mix ...$ with anything else in parameter lists." +
-              EOL + "See https://github.com/scalameta/scalameta/issues/406 for details."
+              EOL + "See https://github.com/scalameta/scalameta/issues/406 for details.",
           )
         else c.abort(tripleDotQuasis(1).pos, Messages.QuasiquoteAdjacentEllipsesInPattern(2))
       }
@@ -349,7 +349,7 @@ class ReificationMacros(val c: Context) extends AstReflection with AdtLiftables 
         val $sourceName = new $OriginModule.ParsedSource(
           _root_.scala.meta.inputs.Input.String(${TokensToString.quasi(meta.tokens, input)})
         )
-      """
+      """,
     ).filter(_ ne null)
     mode match {
       case Mode.Term(_, _) =>

--- a/scalameta/quasiquotes/shared/src/main/scala-2/scala/meta/quasiquotes/Lift.scala
+++ b/scalameta/quasiquotes/shared/src/main/scala-2/scala/meta/quasiquotes/Lift.scala
@@ -40,7 +40,7 @@ object Lift {
     Lift(_.map(lift.apply))
 
   implicit def liftListViaImplicit[O <: Tree, I <: Tree](implicit
-      conv: List[O] => I
+      conv: List[O] => I,
   ): Lift[List[O], I] = Lift(conv)
 
 }

--- a/scalameta/quasiquotes/shared/src/main/scala-2/scala/meta/quasiquotes/Unlift.scala
+++ b/scalameta/quasiquotes/shared/src/main/scala-2/scala/meta/quasiquotes/Unlift.scala
@@ -32,11 +32,11 @@ object Unlift {
   implicit def unliftIdentity[I, O <: I: ClassTag]: Unlift[I, O] = Unlift { case x: O => x }
 
   implicit def unliftListToList[I, O: ClassTag](implicit
-      unlift: Unlift[I, O]
+      unlift: Unlift[I, O],
   ): Unlift[List[I], List[O]] = Unlift { case x: List[I] => x.flatMap(unlift.apply) }
 
   implicit def unliftListViaImplicit[I <: Tree: ClassTag, O <: Tree](implicit
-      conv: I => List[O]
+      conv: I => List[O],
   ): Unlift[I, List[O]] = Unlift { case x: I => conv(x) }
 
 }

--- a/scalameta/quasiquotes/shared/src/main/scala-3/scala/meta/internal/quasiquotes/ConversionMacros.scala
+++ b/scalameta/quasiquotes/shared/src/main/scala-3/scala/meta/internal/quasiquotes/ConversionMacros.scala
@@ -38,7 +38,7 @@ object ConversionMacros {
   def unliftApplyImpl[O: Type](using Quotes)(inside: Expr[Any]) = new ConversionMacros(using quotes)
     .unliftApply[O](inside)
   def unliftUnapplyImpl[O: Type](using Quotes)(inside: Expr[Any]) = new ConversionMacros(using
-    quotes
+    quotes,
   ).unliftUnapply[O](inside)
 }
 

--- a/scalameta/quasiquotes/shared/src/main/scala-3/scala/meta/internal/quasiquotes/ReificationMacros.scala
+++ b/scalameta/quasiquotes/shared/src/main/scala-3/scala/meta/internal/quasiquotes/ReificationMacros.scala
@@ -37,53 +37,53 @@ object ReificationMacros {
     new ReificationMacros().expandApply(scExpr, argsExpr, QuasiquoteType.TypeParam)
       .asExprOf[scala.meta.Type.Param]
   def caseOrPatternImpl(using
-      Quotes
+      Quotes,
   )(scExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]]): Expr[scala.meta.Tree] =
     new ReificationMacros().expandApply(scExpr, argsExpr, QuasiquoteType.CaseOrPattern)
       .asExprOf[scala.meta.Tree]
   def initImpl(using
-      Quotes
+      Quotes,
   )(scExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]]): Expr[scala.meta.Init] =
     new ReificationMacros().expandApply(scExpr, argsExpr, QuasiquoteType.Init)
       .asExprOf[scala.meta.Init]
   def selfImpl(using
-      Quotes
+      Quotes,
   )(scExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]]): Expr[scala.meta.Self] =
     new ReificationMacros().expandApply(scExpr, argsExpr, QuasiquoteType.Self)
       .asExprOf[scala.meta.Self]
   def templateImpl(using
-      Quotes
+      Quotes,
   )(scExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]]): Expr[scala.meta.Template] =
     new ReificationMacros().expandApply(scExpr, argsExpr, QuasiquoteType.Template)
       .asExprOf[scala.meta.Template]
   def modImpl(using
-      Quotes
+      Quotes,
   )(scExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]]): Expr[scala.meta.Mod] =
     new ReificationMacros().expandApply(scExpr, argsExpr, QuasiquoteType.Mod)
       .asExprOf[scala.meta.Mod]
   def enumeratorImpl(using
-      Quotes
+      Quotes,
   )(scExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]]): Expr[scala.meta.Enumerator] =
     new ReificationMacros().expandApply(scExpr, argsExpr, QuasiquoteType.Enumerator)
       .asExprOf[scala.meta.Enumerator]
   def importerImpl(using
-      Quotes
+      Quotes,
   )(scExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]]): Expr[scala.meta.Importer] =
     new ReificationMacros().expandApply(scExpr, argsExpr, QuasiquoteType.Importer)
       .asExprOf[scala.meta.Importer]
   def importeeImpl(using
-      Quotes
+      Quotes,
   )(scExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]]): Expr[scala.meta.Importee] =
     new ReificationMacros().expandApply(scExpr, argsExpr, QuasiquoteType.Importee)
       .asExprOf[scala.meta.Importee]
   def sourceImpl(using
-      Quotes
+      Quotes,
   )(scExpr: Expr[StringContext], argsExpr: Expr[Seq[Any]]): Expr[scala.meta.Source] =
     new ReificationMacros().expandApply(scExpr, argsExpr, QuasiquoteType.Source)
       .asExprOf[scala.meta.Source]
 
   def unapplyImpl(using
-      Quotes
+      Quotes,
   )(scCallExpr: Expr[QuasiquoteUnapply], scrutineeExpr: Expr[Any]): Expr[Any] =
     val (stringContext, quasiquoteType) = scCallExpr match
       case '{ ($sc: StringContext).q } => (sc, QuasiquoteType.Stat)
@@ -137,7 +137,7 @@ class ReificationMacros(using val internalQuotes: Quotes) extends HasInternalQuo
       posEnd: Int,
       tpe: Option[TypeRepr],
       var symbol: Option[Symbol],
-      var reifier: Option[Term]
+      var reifier: Option[Term],
   )
 
   lazy val ListClass = TypeRepr.of[scala.List]
@@ -145,7 +145,7 @@ class ReificationMacros(using val internalQuotes: Quotes) extends HasInternalQuo
   def expandUnapply(
       strCtx: Expr[StringContext],
       unapplySelector: Expr[Any],
-      qType: QuasiquoteType
+      qType: QuasiquoteType,
   ): Expr[Any] = {
     given strCtxExpr: Expr[StringContext] = strCtx
     expand(qType, extractModePattern(unapplySelector))
@@ -154,7 +154,7 @@ class ReificationMacros(using val internalQuotes: Quotes) extends HasInternalQuo
   def expandApply(
       strCtx: Expr[StringContext],
       args: Expr[Seq[Any]],
-      qType: QuasiquoteType
+      qType: QuasiquoteType,
   ): Expr[Any] = {
     given strCtxExpr: Expr[StringContext] = strCtx
     expand(qType, extractModeTerm(args))
@@ -183,7 +183,7 @@ class ReificationMacros(using val internalQuotes: Quotes) extends HasInternalQuo
   }
 
   private def extractModeTerm(
-      argsExpr: Expr[Seq[Any]]
+      argsExpr: Expr[Seq[Any]],
   )(using strCtxExpr: Expr[StringContext]): Mode = {
     val Varargs(args) = argsExpr: @unchecked
     val argsIter = args.iterator
@@ -202,7 +202,7 @@ class ReificationMacros(using val internalQuotes: Quotes) extends HasInternalQuo
   }
 
   private def extractModePattern(
-      selectorExpr: Expr[Any]
+      selectorExpr: Expr[Any],
   )(using strCtxExpr: Expr[StringContext]): Mode = {
     val '{ StringContext(${ Varargs(parts) }: _*) } = strCtxExpr: @unchecked
     val partPosIter = parts.iterator.map(_.asTerm.pos)
@@ -259,7 +259,7 @@ class ReificationMacros(using val internalQuotes: Quotes) extends HasInternalQuo
         _.asTerm.tpe match
           case termRef @ TermRef(prefix, _) => // TermRef(scala.meta.Dialect, method current)
             instantiateStandardDialect(prefix.memberType(termRef.termSymbol).termSymbol)
-          case _ => None
+          case _ => None,
       )
 
       standardDialectReference.orElse(standardDialectSingleton).getOrElse {
@@ -273,7 +273,7 @@ class ReificationMacros(using val internalQuotes: Quotes) extends HasInternalQuo
     (
       if (mode.isTerm) underlyingDialect.unquoteTerm(mode.multiline)
       else underlyingDialect.unquotePat(mode.multiline),
-      dialectExpr.get
+      dialectExpr.get,
     )
   }
   private def instantiateParser(qType: QuasiquoteType): MetaParser = {
@@ -302,7 +302,7 @@ class ReificationMacros(using val internalQuotes: Quotes) extends HasInternalQuo
       mode: Mode,
       qType: QuasiquoteType,
       dialectExpr: Expr[Dialect],
-      input: Input
+      input: Input,
   ): Expr[Any] = {
     val pendingQuasis = mutable.Stack[Quasi]()
 
@@ -328,16 +328,16 @@ class ReificationMacros(using val internalQuotes: Quotes) extends HasInternalQuo
             if mode.isTerm then
               Apply(
                 TypeApply(Select.unique('{ scala.Some }.asTerm, "apply"), List(TypeTree.of[T])),
-                List(liftTree(otherTree).asInstanceOf[Term])
+                List(liftTree(otherTree).asInstanceOf[Term]),
               )
             else
               TypedOrTest(
                 Unapply(
                   TypeApply(Select.unique(Ref(defn.SomeModule), "unapply"), List(TypeTree.of[T])),
                   Nil,
-                  List(liftTree(otherTree))
+                  List(liftTree(otherTree)),
                 ),
-                TypeTree.of[Some[T]]
+                TypeTree.of[Some[T]],
               )
           case None => '{ scala.None }.asTerm match
               case Inlined(_, _, none) => none
@@ -364,18 +364,18 @@ class ReificationMacros(using val internalQuotes: Quotes) extends HasInternalQuo
                       if (mode.isTerm) Apply(
                         TypeApply(
                           Select.unique(alreadyLiftedList.asInstanceOf[Term], "+:"),
-                          List(TypeTree.of[T])
+                          List(TypeTree.of[T]),
                         ),
-                        List(currElement.asInstanceOf[Term])
+                        List(currElement.asInstanceOf[Term]),
                       )
                       else Unapply(
                         TypeApply(
                           Select.unique('{ +: }.asTerm, "unapply"),
-                          List(TypeTree.of[T], TypeTree.of[List], TypeTree.of[List[T]])
+                          List(TypeTree.of[T], TypeTree.of[List], TypeTree.of[List[T]]),
                         ),
                         Nil,
-                        List(currElement, alreadyLiftedList)
-                      )
+                        List(currElement, alreadyLiftedList),
+                      ),
                     )
                   }
                   loop(rest, acc, Nil)
@@ -383,7 +383,7 @@ class ReificationMacros(using val internalQuotes: Quotes) extends HasInternalQuo
                   Predef.require(prefix.isEmpty && debug(trees, acc, prefix))
                   val tree = Apply(
                     TypeApply(Select.unique(x, "++"), List(TypeTree.of[T])),
-                    List(liftQuasi(quasi).asInstanceOf[Term])
+                    List(liftQuasi(quasi).asInstanceOf[Term]),
                   )
                   loop(rest, Some(tree), Nil)
                 case _ => report
@@ -398,19 +398,19 @@ class ReificationMacros(using val internalQuotes: Quotes) extends HasInternalQuo
                     if mode.isTerm then
                       Apply(
                         TypeApply(Select.unique(x.asInstanceOf[Term], ":+"), List(TypeTree.of[T])),
-                        List(otherTree.asInstanceOf[Term])
+                        List(otherTree.asInstanceOf[Term]),
                       )
                     else
                       TypedOrTest(
                         Unapply(
                           TypeApply(
                             Select.unique('{ :+ }.asTerm, "unapply"),
-                            List(TypeTree.of[T], TypeTree.of[List], TypeTree.of[List[T]])
+                            List(TypeTree.of[T], TypeTree.of[List], TypeTree.of[List[T]]),
                           ),
                           Nil,
-                          List(x, otherTree)
+                          List(x, otherTree),
                         ),
-                        TypeTree.of[List[Any]]
+                        TypeTree.of[List[Any]],
                       )
                   loop(rest, Some(tree), Nil)
             case _ => acc.getOrElse {
@@ -421,16 +421,16 @@ class ReificationMacros(using val internalQuotes: Quotes) extends HasInternalQuo
                     '{ List }.asTerm,
                     "apply",
                     List(TypeRepr.of[T]),
-                    args.asInstanceOf[List[Term]]
+                    args.asInstanceOf[List[Term]],
                   )
                 else
                   TypedOrTest(
                     Unapply(
                       TypeApply(Select.unique('{ List }.asTerm, "unapplySeq"), List(TypeTree.of[T])),
                       Nil,
-                      args
+                      args,
                     ),
-                    TypeTree.of[List[T]]
+                    TypeTree.of[List[T]],
                   )
               }
           }
@@ -445,22 +445,22 @@ class ReificationMacros(using val internalQuotes: Quotes) extends HasInternalQuo
               '{ List }.asTerm,
               "apply",
               List(TypeRepr.of[Any]),
-              args.asInstanceOf[List[Term]]
+              args.asInstanceOf[List[Term]],
             )
           else
             TypedOrTest(
               Unapply(
                 TypeApply(Select.unique('{ List }.asTerm, "unapplySeq"), List(TypeTree.of[Any])),
                 Nil,
-                args
+                args,
               ),
-              TypeTree.of[List[Any]]
+              TypeTree.of[List[Any]],
             )
         } else if (tripleDotQuasis.length == 1)
           if (treess.flatten.length == 1) liftQuasi(tripleDotQuasis(0))
           else report.errorAndAbort(
             "implementation restriction: can't mix ...$ with anything else in parameter lists." +
-              EOL + "See https://github.com/scalameta/scalameta/issues/406 for details."
+              EOL + "See https://github.com/scalameta/scalameta/issues/406 for details.",
           )
         else report.errorAndAbort(Messages.QuasiquoteAdjacentEllipsesInPattern(2))
       }
@@ -493,20 +493,20 @@ class ReificationMacros(using val internalQuotes: Quotes) extends HasInternalQuo
                   Symbol.spliceOwner,
                   hole.name,
                   Flags.EmptyFlags,
-                  inferredPt.asInstanceOf[TypeRepr]
+                  inferredPt.asInstanceOf[TypeRepr],
                 )
                 val reifier = hole.tpe match
                   case Some(tpe) => Select.overloaded(
                       '{ scala.meta.internal.quasiquotes.Unlift }.asTerm,
                       "unapply",
                       List(tpe.asInstanceOf[TypeRepr]),
-                      List(Ref(symbol))
+                      List(Ref(symbol)),
                     )
                   case None => Select.overloaded(
                       '{ scala.meta.internal.quasiquotes.Unlift }.asTerm,
                       "unapply",
                       List(inferredPt.asInstanceOf[TypeRepr]),
-                      List(Ref(symbol))
+                      List(Ref(symbol)),
                     )
                 hole.symbol = Some(symbol).asInstanceOf[Option[rei.internalQuotes.reflect.Symbol]]
                 hole.reifier = Some(reifier).asInstanceOf[Option[rei.internalQuotes.reflect.Term]]
@@ -614,7 +614,7 @@ class ReificationMacros(using val internalQuotes: Quotes) extends HasInternalQuo
         val args = holes.map(hole => hole.reifier.get.asInstanceOf[Term])
         val argsContents = args.flatMap(
           _.tpe match
-            case AppliedType(tpe, content) if tpe =:= TypeRepr.of[Option] => content
+            case AppliedType(tpe, content) if tpe =:= TypeRepr.of[Option] => content,
         )
         val lst = Select.overloaded('{ List }.asTerm, "apply", List(TypeRepr.of[Option[Any]]), args)
           .asExprOf[List[Option[Any]]]
@@ -632,9 +632,9 @@ class ReificationMacros(using val internalQuotes: Quotes) extends HasInternalQuo
               Ref(defn.TupleClass(n).companionModule),
               "apply",
               argsContents,
-              args.map(arg => '{ ${ arg.asExprOf[Option[Any]] }.get }.asTerm)
+              args.map(arg => '{ ${ arg.asExprOf[Option[Any]] }.get }.asTerm),
             ).asExpr,
-            false
+            false,
           )
         returned.asTerm.tpe.asType match
           case '[t] =>
@@ -656,8 +656,8 @@ class ReificationMacros(using val internalQuotes: Quotes) extends HasInternalQuo
                 input.asTerm,
                 List(
                   CaseDef(pattern, None, thenp(input).asTerm),
-                  CaseDef(Wildcard(), None, elsep.asTerm)
-                )
+                  CaseDef(Wildcard(), None, elsep.asTerm),
+                ),
               )
               if (isBooleanExtractor) matchTerm.asExprOf[Boolean] else matchTerm.asExprOf[Option[t]]
             }
@@ -667,11 +667,11 @@ class ReificationMacros(using val internalQuotes: Quotes) extends HasInternalQuo
             val internalResult =
               if (isBooleanExtractor) Block(
                 valDefsAsStatements,
-                '{ ${ matchp(unapplySelector) }.asInstanceOf[Boolean] }.asTerm
+                '{ ${ matchp(unapplySelector) }.asInstanceOf[Boolean] }.asTerm,
               ).asExprOf[Boolean]
               else Block(
                 valDefsAsStatements,
-                '{ ${ matchp(unapplySelector) }.asInstanceOf[Option[t]] }.asTerm
+                '{ ${ matchp(unapplySelector) }.asInstanceOf[Option[t]] }.asTerm,
               ).asExprOf[Option[t]]
 
             if (sys.props("quasiquote.debug") != null) println(internalResult)

--- a/scalameta/quasiquotes/shared/src/main/scala-3/scala/meta/quasiquotes/Api.scala
+++ b/scalameta/quasiquotes/shared/src/main/scala-3/scala/meta/quasiquotes/Api.scala
@@ -38,55 +38,55 @@ private[meta] trait Api {
   // unapply methods
   extension (stringContext: scala.StringContext)
     @annotation.compileTimeOnly(
-      ".q should not be called directly. Use q\"...\" string interpolation."
+      ".q should not be called directly. Use q\"...\" string interpolation.",
     )
     def q: QuasiquoteUnapply = ???
     @annotation.compileTimeOnly(
-      ".param should not be called directly. Use param\"...\" string interpolation."
+      ".param should not be called directly. Use param\"...\" string interpolation.",
     )
     def param: QuasiquoteUnapply = ???
     @annotation.compileTimeOnly(
-      ".t should not be called directly. Use t\"...\" string interpolation."
+      ".t should not be called directly. Use t\"...\" string interpolation.",
     )
     def t: QuasiquoteUnapply = ???
     @annotation.compileTimeOnly(
-      ".tparam should not be called directly. Use tparam\"...\" string interpolation."
+      ".tparam should not be called directly. Use tparam\"...\" string interpolation.",
     )
     def tparam: QuasiquoteUnapply = ???
     @annotation.compileTimeOnly(
-      ".p should not be called directly. Use p\"...\" string interpolation."
+      ".p should not be called directly. Use p\"...\" string interpolation.",
     )
     def p: QuasiquoteUnapply = ???
     @annotation.compileTimeOnly(
-      ".init should not be called directly. Use init\"...\" string interpolation."
+      ".init should not be called directly. Use init\"...\" string interpolation.",
     )
     def init: QuasiquoteUnapply = ???
     @annotation.compileTimeOnly(
-      ".self should not be called directly. Use self\"...\" string interpolation."
+      ".self should not be called directly. Use self\"...\" string interpolation.",
     )
     def self: QuasiquoteUnapply = ???
     @annotation.compileTimeOnly(
-      ".template should not be called directly. Use template\"...\" string interpolation."
+      ".template should not be called directly. Use template\"...\" string interpolation.",
     )
     def template: QuasiquoteUnapply = ???
     @annotation.compileTimeOnly(
-      ".mod should not be called directly. Use mod\"...\" string interpolation."
+      ".mod should not be called directly. Use mod\"...\" string interpolation.",
     )
     def mod: QuasiquoteUnapply = ???
     @annotation.compileTimeOnly(
-      ".enumerator should not be called directly. Use enumerator\"...\" string interpolation."
+      ".enumerator should not be called directly. Use enumerator\"...\" string interpolation.",
     )
     def enumerator: QuasiquoteUnapply = ???
     @annotation.compileTimeOnly(
-      ".importer should not be called directly. Use importer\"...\" string interpolation."
+      ".importer should not be called directly. Use importer\"...\" string interpolation.",
     )
     def importer: QuasiquoteUnapply = ???
     @annotation.compileTimeOnly(
-      ".importee should not be called directly. Use importee\"...\" string interpolation."
+      ".importee should not be called directly. Use importee\"...\" string interpolation.",
     )
     def importee: QuasiquoteUnapply = ???
     @annotation.compileTimeOnly(
-      ".source should not be called directly. Use source\"...\" string interpolation."
+      ".source should not be called directly. Use source\"...\" string interpolation.",
     )
     def source: QuasiquoteUnapply = ???
 
@@ -148,7 +148,7 @@ private[meta] object Api {
       input: inputs.Input,
       dialect: Dialect,
       parserA: Parse[A],
-      parserB: Parse[B]
+      parserB: Parse[B],
   ) = parse[A].orElse(parse[B]).get
 
   def parseAny[A <: Tree](implicit input: inputs.Input, dialect: Dialect, parser: Parse[A]) =

--- a/scalameta/quasiquotes/shared/src/main/scala-3/scala/meta/quasiquotes/Lift.scala
+++ b/scalameta/quasiquotes/shared/src/main/scala-3/scala/meta/quasiquotes/Lift.scala
@@ -40,7 +40,7 @@ object Lift {
     Lift(_.map(lift.apply))
 
   implicit def liftListViaImplicit[O <: Tree, I <: Tree](implicit
-      conv: List[O] => I
+      conv: List[O] => I,
   ): Lift[List[O], I] = Lift(conv)
 
 }

--- a/scalameta/quasiquotes/shared/src/main/scala-3/scala/meta/quasiquotes/Unlift.scala
+++ b/scalameta/quasiquotes/shared/src/main/scala-3/scala/meta/quasiquotes/Unlift.scala
@@ -32,11 +32,11 @@ object Unlift {
   implicit def unliftIdentity[I, O <: I: ClassTag]: Unlift[I, O] = Unlift { case x: O => x }
 
   implicit def unliftListToList[I, O: ClassTag](implicit
-      unlift: Unlift[I, O]
+      unlift: Unlift[I, O],
   ): Unlift[List[I], List[O]] = Unlift { case x: List[I] => x.flatMap(unlift.apply) }
 
   implicit def unliftListViaImplicit[I <: Tree: ClassTag, O <: Tree](implicit
-      conv: I => List[O]
+      conv: I => List[O],
   ): Unlift[I, List[O]] = Unlift { case x: I => conv(x) }
 
 }

--- a/scalameta/scalameta/shared/src/main/scala/scala/meta/package.scala
+++ b/scalameta/scalameta/shared/src/main/scala/scala/meta/package.scala
@@ -79,7 +79,7 @@ package object meta
 
   implicit class XtensionDialectApply(private val dialect: Dialect) extends AnyVal {
     def apply[T](value: T)(implicit
-        convert: common.Convert[T, inputs.Input]
+        convert: common.Convert[T, inputs.Input],
     ): (Dialect, inputs.Input) = (dialect, convert(value))
     def apply(value: tokens.Token): (Dialect, tokens.Token) = (dialect, value)
     def apply(value: tokens.Tokens): (Dialect, tokens.Tokens) = (dialect, value)
@@ -120,7 +120,7 @@ package object meta
   implicit class XtensionTree(private val tree: Tree) extends AnyVal {
     def maybeParseAs[A <: Tree: ClassTag](implicit
         dialect: Dialect,
-        parse: parsers.Parse[A]
+        parse: parsers.Parse[A],
     ): Parsed[A] = tree match {
       case t: A => t.maybeParse
       case _ => reparseAs[A]

--- a/scalameta/testkit/jvm/src/main/scala/scala/meta/testkit/Corpus.scala
+++ b/scalameta/testkit/jvm/src/main/scala/scala/meta/testkit/Corpus.scala
@@ -73,8 +73,8 @@ object Corpus {
         "target/repos/scala/src/scaladoc/scala/tools/nsc/doc/html/HtmlPage.scala",
         "target/repos/scala/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala",
         // transformer fails with StackOverflow - https://github.com/scalameta/scalameta/issues/2509
-        "target/repos/kafka/core/src/main/scala/kafka/server/KafkaConfig.scala"
-      ).exists(x.startsWith)
+        "target/repos/kafka/core/src/main/scala/kafka/server/KafkaConfig.scala",
+      ).exists(x.startsWith),
   )
 
   /** If necessary, downloads and extracts the corpus files */
@@ -111,8 +111,8 @@ object Corpus {
     val repos = createReposDir(corpus)
     val files = Option(repos.listFiles()).getOrElse(
       throw new IllegalStateException(
-        s"${repos.getAbsolutePath} is not a directory! Please delete if it's a file and retry."
-      )
+        s"${repos.getAbsolutePath} is not a directory! Please delete if it's a file and retry.",
+      ),
     )
     files.iterator.flatMap { repo =>
       val commit = FileOps.readFile(new File(repo, "COMMIT")).trim

--- a/scalameta/testkit/jvm/src/main/scala/scala/meta/testkit/SyntaxAnalysis.scala
+++ b/scalameta/testkit/jvm/src/main/scala/scala/meta/testkit/SyntaxAnalysis.scala
@@ -25,7 +25,7 @@ object SyntaxAnalysis {
    *   The aggregate sum of all analysis results.
    */
   def run[T](
-      corpus: GenTraversableOnce[CorpusFile]
+      corpus: GenTraversableOnce[CorpusFile],
   )(f: CorpusFile => List[T]): mutable.Buffer[(CorpusFile, T)] = Phase.run("syntax analysis") {
     val results = new CopyOnWriteArrayList[(CorpusFile, T)]
     val counter = new AtomicInteger()
@@ -48,7 +48,7 @@ object SyntaxAnalysis {
           stack.foreach(println)
           val i = errors.incrementAndGet()
           if (i > 10) throw new IllegalStateException(
-            "Too many unexpected errors (printed to console), fix your analysis."
+            "Too many unexpected errors (printed to console), fix your analysis.",
           )
       }
     }
@@ -57,7 +57,7 @@ object SyntaxAnalysis {
   }
 
   def onParsed[A](corpus: GenIterable[CorpusFile])(
-      f: Source => List[A]
+      f: Source => List[A],
   ): mutable.Buffer[(CorpusFile, A)] = SyntaxAnalysis.run[A](corpus)(_.jFile.parse[Source] match {
     case parsers.Parsed.Success(ast: Source) => f(ast)
     case _ => Nil

--- a/scalameta/testkit/shared/src/main/scala/scala/meta/testkit/StringFS.scala
+++ b/scalameta/testkit/shared/src/main/scala/scala/meta/testkit/StringFS.scala
@@ -35,7 +35,7 @@ object StringFS {
   def fromString(
       layout: String,
       root: AbsolutePath = AbsolutePath(Files.createTempDirectory("scalameta")),
-      charset: Charset = StandardCharsets.UTF_8
+      charset: Charset = StandardCharsets.UTF_8,
   ): AbsolutePath = {
     if (layout.trim.nonEmpty) layout.split("(?=\n/)").foreach { row =>
       row.stripPrefix("\n").split("\n", 2).toList match {
@@ -46,7 +46,7 @@ object StringFS {
             file.toNIO,
             contents.getBytes(charset),
             StandardOpenOption.CREATE,
-            StandardOpenOption.TRUNCATE_EXISTING
+            StandardOpenOption.TRUNCATE_EXISTING,
           )
         case els =>
           throw new IllegalArgumentException(s"Unable to split argument info path/contents! \n$els")
@@ -78,7 +78,7 @@ object StringFS {
   def asString(
       root: AbsolutePath,
       includePath: RelativePath => Boolean = _ => true,
-      charset: Charset = StandardCharsets.UTF_8
+      charset: Charset = StandardCharsets.UTF_8,
   ): String = FileIO.listAllFilesRecursively(root).files.filter(includePath).sortBy(_.toNIO)
     .map { path =>
       val contents = FileIO.slurp(root.resolve(path), charset)

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/CharArrayReader.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/CharArrayReader.scala
@@ -15,7 +15,7 @@ private[meta] case class CharArrayReader(
     /** The start offset of the current line */
     var lineStartOffset: Int = 0,
     /** The start offset of the line before the current one */
-    private var lastLineStartOffset: Int = 0
+    private var lastLineStartOffset: Int = 0,
 ) {
 
   // see details in https://github.com/scala/scala/pull/8282
@@ -107,7 +107,7 @@ object CharArrayReader {
   private def readUnicodeChar(
       buf: Array[Char],
       offset: Int,
-      noUnicodeEscape: Boolean
+      noUnicodeEscape: Boolean,
   ): (Char, Int) = {
     val c = buf(offset)
     val firstOffset = offset + 1 // offset after a single character

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
@@ -400,7 +400,7 @@ class LegacyScanner(input: Input, dialect: Dialect) {
         def unclosed(): Unit = setInvalidToken(curr)("unclosed character literal")
         def unsupported(): Unit = setInvalidToken(curr)(
           if (dialect.allowSpliceAndQuote) "Macro quote must be followed by brace or bracket"
-          else "Symbol literals are no longer allowed"
+          else "Symbol literals are no longer allowed",
         )
         def symLitOr(getRest: => Unit)(orElse: => Unit): Unit =
           if (dialect.allowSymbolLiterals) {
@@ -423,7 +423,7 @@ class LegacyScanner(input: Input, dialect: Dialect) {
               setTokStrVal(CHARLIT)
             } else unclosed()
           } else if (isIdentifierStart(ch)) symLitOr(getIdentRest())(
-            if (dialect.allowSpliceAndQuote) setTokStrVal(MACROQUOTE) else unsupported()
+            if (dialect.allowSpliceAndQuote) setTokStrVal(MACROQUOTE) else unsupported(),
           )
           else if (isOperatorPart(ch)) symLitOr(getOperatorRest())(unsupported())
           else if (dialect.allowSpliceAndQuote) setTokStrVal(MACROQUOTE)
@@ -652,7 +652,7 @@ class LegacyScanner(input: Input, dialect: Dialect) {
         if (x.token != IDENTIFIER && x.token != THIS) {
           val message = "invalid unquote: `$'ident, `$'BlockExpr, `$'this or `$'_ expected"
           setInvalidToken(next, offset)(message)
-        }
+        },
       )
     }
 

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyToken.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyToken.scala
@@ -192,6 +192,6 @@ object LegacyToken {
     "then" -> THEN,
     "enum" -> ENUM,
     "given" -> GIVEN,
-    "export" -> EXPORT
+    "export" -> EXPORT,
   )
 }

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyTokenData.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyTokenData.scala
@@ -45,7 +45,7 @@ class LegacyTokenData {
   private def toBigInt(
       prevToken: Token,
       maxBitLength: Int,
-      what: String
+      what: String,
   ): Either[String, Either[BigInt, BigInt]] =
     try {
       val value = BigInt(strVal, base)
@@ -86,7 +86,7 @@ class LegacyTokenData {
   }
 
   def setIdentifier(ident: String, dialect: Dialect, check: Boolean = true)(
-      fCheck: LegacyTokenData => Unit
+      fCheck: LegacyTokenData => Unit,
   ): Unit = {
     strVal = ident
     token = IDENTIFIER

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
@@ -175,24 +175,24 @@ class ScalametaTokenizer(input: Input, dialect: Dialect)(implicit options: Token
           getInvalid(curr, _),
           _.fold(
             Token.Constant.IntXL(input, dialect, curr.offset, curr.endOffset, _),
-            Token.Constant.Int(input, dialect, curr.offset, curr.endOffset, _)
-          )
+            Token.Constant.Int(input, dialect, curr.offset, curr.endOffset, _),
+          ),
         )
       case LONGLIT => curr.longVal(lastEmittedToken).fold(
           getInvalid(curr, _),
-          Token.Constant.Long(input, dialect, curr.offset, curr.endOffset, _)
+          Token.Constant.Long(input, dialect, curr.offset, curr.endOffset, _),
         )
       case FLOATLIT => curr.floatVal.fold(
           getInvalid(curr, _),
-          Token.Constant.Float(input, dialect, curr.offset, curr.endOffset, _)
+          Token.Constant.Float(input, dialect, curr.offset, curr.endOffset, _),
         )
       case DOUBLELIT => curr.doubleVal.fold(
           getInvalid(curr, _),
-          Token.Constant.Double(input, dialect, curr.offset, curr.endOffset, _)
+          Token.Constant.Double(input, dialect, curr.offset, curr.endOffset, _),
         )
       case DECIMALLIT => curr.doubleOrDecimalVal.fold(
           Token.Constant.FloatXL(input, dialect, curr.offset, curr.endOffset, _),
-          Token.Constant.Double(input, dialect, curr.offset, curr.endOffset, _)
+          Token.Constant.Double(input, dialect, curr.offset, curr.endOffset, _),
         )
       case CHARLIT => Token.Constant.Char(input, dialect, curr.offset, curr.endOffset, curr.charVal)
       case SYMBOLLIT => Token.Constant

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/WhitespaceTokenizer.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/WhitespaceTokenizer.scala
@@ -18,7 +18,7 @@ object WhitespaceTokenizer {
 
   def apply(input: Input, dialect: Dialect)(implicit
       options: TokenizerOptions,
-      tokens: java.util.Collection[Token]
+      tokens: java.util.Collection[Token],
   ): WhitespaceTokenizer =
     if (options.groupWhitespace) new Grouping(input, dialect) else new Granular
 
@@ -34,7 +34,7 @@ object WhitespaceTokenizer {
     private val bufVS = new ListBuffer[Token.EOL] // consecutive EOL, without embedded horizontal space
 
     private def flushWS[A <: Token](
-        buf: ListBuffer[A]
+        buf: ListBuffer[A],
     )(f: (Int, Int, List[A]) => Token.Whitespace): Unit = buf.lastOption.foreach { last =>
       if (buf.length == 1) tokens.add(last)
       else {

--- a/scalameta/tokenizers2/shared/src/main/scala/scala/meta/internal/tokenizers/package.scala
+++ b/scalameta/tokenizers2/shared/src/main/scala/scala/meta/internal/tokenizers/package.scala
@@ -58,7 +58,7 @@ package object tokenizers {
     "#",
     "@",
     "\u21D2",
-    "\u2190"
+    "\u2190",
   )
 
   def keywords(dialect: Dialect) = {

--- a/scalameta/tokenizers2/shared/src/main/scala/scala/meta/tokenizers/Api.scala
+++ b/scalameta/tokenizers2/shared/src/main/scala/scala/meta/tokenizers/Api.scala
@@ -9,7 +9,7 @@ private[meta] trait Api {
     def tokenize(implicit
         convert: Convert[T, Input],
         tokenize: Tokenize,
-        dialect: Dialect
+        dialect: Dialect,
     ): Tokenized = (dialect, convert(inputLike)).tokenize
   }
   implicit class XtensionTokenizersDialectApply(dialect: Dialect) {

--- a/scalameta/tokenizers2/shared/src/main/scala/scala/meta/tokenizers/TokenizerOptions.scala
+++ b/scalameta/tokenizers2/shared/src/main/scala/scala/meta/tokenizers/TokenizerOptions.scala
@@ -5,7 +5,7 @@ import scala.meta.internal.SingletonReference
 final class TokenizerOptions private[meta] (
     // options which control how tokens are emitted
     val groupWhitespace: Boolean = false,
-    val tokenize: Option[Tokenize] = None
+    val tokenize: Option[Tokenize] = None,
 ) {
   def getTokenize(implicit tokenize: Tokenize): Tokenize = this.tokenize.getOrElse(tokenize)
 
@@ -14,7 +14,7 @@ final class TokenizerOptions private[meta] (
 
   private def privateCopy(
       tokenize: Option[Tokenize] = this.tokenize,
-      groupWhitespace: Boolean = this.groupWhitespace
+      groupWhitespace: Boolean = this.groupWhitespace,
   ): TokenizerOptions = new TokenizerOptions(tokenize = tokenize, groupWhitespace = groupWhitespace)
 }
 

--- a/scalameta/tokens2/shared/src/main/scala/scala/meta/tokens/Tokens.scala
+++ b/scalameta/tokens2/shared/src/main/scala/scala/meta/tokens/Tokens.scala
@@ -230,7 +230,7 @@ object Tokens {
       tokens: Array[Token],
       p: Token => Boolean,
       rangeBeg: Int,
-      rangeEnd: Int
+      rangeEnd: Int,
   ): Int = {
     var i = rangeBeg
     while (i < rangeEnd && p(tokens(i))) i += 1
@@ -241,7 +241,7 @@ object Tokens {
       tokens: Array[Token],
       p: Token => Boolean,
       rangeBeg: Int,
-      rangeEnd: Int
+      rangeEnd: Int,
   ): Int = {
     var i = rangeBeg
     while (i > rangeEnd && p(tokens(i))) i -= 1

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/Scaladoc.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/Scaladoc.scala
@@ -134,7 +134,7 @@ object Scaladoc {
   sealed abstract class TagType(
       val tag: String,
       val hasLabel: Boolean = false,
-      val optDesc: Boolean = true
+      val optDesc: Boolean = true,
   )
 
   /**
@@ -278,7 +278,7 @@ object Scaladoc {
       Deprecated,
       Migration,
       InheritDoc,
-      Documentable
+      Documentable,
     )
 
     lazy val tagTypeMap = predefined.map(x => x.tag -> x).toMap

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
@@ -121,7 +121,7 @@ object ScaladocParser {
         // Heading description and delimiter
         (title.! ~ delim ~ &(nl)).map(x => Heading(level, x.trim))
       }
-    }
+    },
   )
 
   private def linkParser[$: P]: P[Link] = P {
@@ -138,7 +138,7 @@ object ScaladocParser {
       def mdCodeBlockPrefix = if (offset <= getMdOffsetMax(mdOffset)) mdCodeBlockFence else Fail
       dedented | CharIn("@=") | codePrefix ~ nl | mdCodeBlockPrefix | tableSep | tableDelim |
         listPrefix ~ &(" ")
-    }
+    },
   )
 
   private def textParser[$: P](indent: Int, mdOffset: Int = 0): P[Text] = P {
@@ -211,7 +211,7 @@ object ScaladocParser {
   private def listItemParser[$: P](indent: Int, mdOffset: Int, prefix: String) = P(
     (textParser(indent, mdOffset) ~ embeddedTermsParser(indent, mdOffset)).map { case (x, terms) =>
       ListItem(prefix, x, terms)
-    }
+    },
   )
 
   private def tableParser[$: P]: P[Table] = P {

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/SyntacticTrees.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/trees/SyntacticTrees.scala
@@ -21,7 +21,7 @@ object Syntactic {
       @tailrec
       private final def unapplyImpl(
           tree: Term,
-          prev: List[Term.ArgClause]
+          prev: List[Term.ArgClause],
       ): (Term, List[Term.ArgClause]) = tree match {
         case t: Term.Apply => unapplyImpl(t.fun, t.argClause :: prev)
         case _ => (tree, prev)

--- a/scalameta/trees2/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees2/shared/src/main/scala/scala/meta/Trees.scala
@@ -440,7 +440,7 @@ object Term {
       thenp: Term,
       elsep: Term,
       @newField("4.4.0")
-      mods: List[Mod] = Nil
+      mods: List[Mod] = Nil,
   ) extends Term with Tree.WithCond with Stat.WithMods
 
   @branch
@@ -481,7 +481,7 @@ object Term {
       expr: Term,
       casesBlock: CasesBlock,
       @newField("4.4.5")
-      mods: List[Mod] = Nil
+      mods: List[Mod] = Nil,
   ) extends MatchLike {
     @replacedField("4.9.9")
     override final def cases: List[Case] = casesBlock.cases
@@ -686,7 +686,7 @@ object Type {
   class Function(
       @replacesFields("4.6.0", FuncParamClause)
       paramClause: FuncParamClause,
-      res: Type
+      res: Type,
   ) extends FunctionType {
     @replacedField("4.6.0")
     override final def params: List[Type] = paramClause.values
@@ -705,7 +705,7 @@ object Type {
   class ContextFunction(
       @replacesFields("4.6.0", FuncParamClause)
       paramClause: FuncParamClause,
-      res: Type
+      res: Type,
   ) extends FunctionType {
     @replacedField("4.6.0")
     override final def params: List[Type] = paramClause.values
@@ -803,7 +803,7 @@ object Type {
       @newField("4.12.3")
       context: List[sm.Type] = Nil,
       @newField("4.12.3")
-      view: List[Type] = Nil
+      view: List[Type] = Nil,
   ) extends Tree
   object Bounds {
     val empty: Bounds = Bounds(None, None)
@@ -862,7 +862,7 @@ object Type {
       name: Name,
       typ: Type,
       @newField("4.7.8")
-      mods: List[Mod] = Nil
+      mods: List[Mod] = Nil,
   ) extends FunctionParamOrArg with Member.Type {
     override def nameOpt: Option[Name] = Some(name)
     override def tpe: Type = typ
@@ -889,7 +889,7 @@ object Type {
       name: meta.Name,
       tparamClause: ParamClause,
       @replacesFields("4.12.3", ParamBoundsCtor)
-      bounds: Bounds
+      bounds: Bounds,
   ) extends Member.Param with Tree.WithTParamClause {
     @replacedField("4.6.0")
     final def tparams: List[Param] = tparamClause.values
@@ -928,7 +928,7 @@ object Type {
   @ast
   class Capturing(
       tpe: Type,
-      caps: Captures // [cap]tures or [cap]abilities
+      caps: Captures, // [cap]tures or [cap]abilities
   ) extends Type
 
   def fresh(): Type.Name = fresh("fresh")
@@ -1018,7 +1018,7 @@ object Pat {
   class Macro(body: Term) extends Pat with Tree.WithBody {
     checkField(
       body,
-      body.isInstanceOf[Term.QuotedMacroExpr] || body.isInstanceOf[Term.QuotedMacroType]
+      body.isInstanceOf[Term.QuotedMacroExpr] || body.isInstanceOf[Term.QuotedMacroType],
     )
   }
   @ast
@@ -1076,18 +1076,18 @@ object Member {
       toTparams(paramClauseGroups.headOption)
 
     private[meta] def toParamss(
-        paramClauseGroup: Option[ParamClauseGroup]
+        paramClauseGroup: Option[ParamClauseGroup],
     ): List[List[sm.Term.Param]] = paramClauseGroup
       .fold(List.empty[List[sm.Term.Param]])(_.paramClauses.map(_.values))
     private[meta] def toParamss(
-        paramClauseGroups: List[ParamClauseGroup]
+        paramClauseGroups: List[ParamClauseGroup],
     ): List[List[sm.Term.Param]] = toParamss(paramClauseGroups.headOption)
   }
 
   private[meta] object ParamClauseGroupCtor {
     def apply(
         tparams: List[sm.Type.Param],
-        paramss: List[List[sm.Term.Param]]
+        paramss: List[List[sm.Term.Param]],
     ): Option[ParamClauseGroup] =
       if (tparams.isEmpty && paramss.isEmpty) None
       else Some(ParamClauseGroup(tparamClause = tparams, paramClauses = paramss))
@@ -1096,14 +1096,14 @@ object Member {
   private[meta] object ParamClauseGroupsCtorGiven {
     def apply(
         tparams: List[sm.Type.Param],
-        sparams: List[List[sm.Term.Param]]
+        sparams: List[List[sm.Term.Param]],
     ): List[Member.ParamClauseGroup] = ParamClauseGroupsCtor(tparams, sparams)
   }
 
   private[meta] object ParamClauseGroupsCtor {
     def apply(
         tparams: List[sm.Type.Param],
-        paramss: List[List[sm.Term.Param]]
+        paramss: List[List[sm.Term.Param]],
     ): List[ParamClauseGroup] =
       if (tparams.isEmpty && paramss.isEmpty) Nil
       else ParamClauseGroup(tparamClause = tparams, paramClauses = paramss) :: Nil
@@ -1157,7 +1157,7 @@ object Decl {
       @replacesFields("4.6.0", Member.ParamClauseGroupsCtor)
       @replacesFields("4.7.3", Member.ParamClauseGroupsCtor)
       paramClauseGroups: List[Member.ParamClauseGroup],
-      decltpe: sm.Type
+      decltpe: sm.Type,
   ) extends Decl
       with Member.Term
       with Stat.WithMods
@@ -1178,7 +1178,7 @@ object Decl {
       mods: List[Mod],
       name: sm.Type.Name,
       tparamClause: sm.Type.ParamClause,
-      bounds: sm.Type.Bounds
+      bounds: sm.Type.Bounds,
   ) extends Decl with Stat.TypeDef {
     @replacedField("4.6.0")
     final def tparams: List[sm.Type.Param] = tparamClause.values
@@ -1196,7 +1196,7 @@ object Decl {
       mods: List[Mod],
       name: Name.Anonymous,
       paramClauseGroups: List[Member.ParamClauseGroup],
-      decltpe: sm.Type
+      decltpe: sm.Type,
   ) extends GivenLike
   @ast
   class Given(
@@ -1205,7 +1205,7 @@ object Decl {
       @replacesFields("4.6.0", Member.ParamClauseGroupsCtorGiven)
       @replacesFields("4.12.0", Member.ParamClauseGroupsCtor)
       paramClauseGroups: List[Member.ParamClauseGroup],
-      decltpe: sm.Type
+      decltpe: sm.Type,
   ) extends GivenLike with Member.Term with Tree.WithParamClauseGroup {
     @replacedField("4.6.0", pos = 2)
     final def tparams: List[sm.Type.Param] = Member.ParamClauseGroup.toTparams(paramClauseGroups)
@@ -1238,12 +1238,12 @@ object Defn {
       pats: List[Pat] @nonEmpty,
       decltpe: Option[sm.Type],
       @replacesFields("4.7.2", VarRhsCtor)
-      body: Term
+      body: Term,
   ) extends Defn with Stat.WithMods with Tree.WithPats with Tree.WithDeclTpeOpt with Tree.WithBody {
     checkFields(
       if (body.isInstanceOf[Term.Placeholder]) decltpe.nonEmpty &&
       pats.forall(_.isInstanceOf[Pat.Var])
-      else !pats.exists(_.isInstanceOf[Term.Name])
+      else !pats.exists(_.isInstanceOf[Term.Name]),
     )
     @replacedField("4.7.2")
     final def rhs: Option[Term] = VarRhsCtor.toOpt(body)
@@ -1255,7 +1255,7 @@ object Defn {
       @replacesFields("4.6.0", Member.ParamClauseGroupsCtorGiven)
       @replacesFields("4.12.0", Member.ParamClauseGroupsCtor)
       paramClauseGroups: List[Member.ParamClauseGroup],
-      templ: Template
+      templ: Template,
   ) extends Defn with Stat.GivenLike with Tree.WithParamClauseGroup with Stat.WithTemplate {
     @replacedField("4.6.0", pos = 2)
     final def tparams: List[sm.Type.Param] = Member.ParamClauseGroup.toTparams(paramClauseGroups)
@@ -1270,7 +1270,7 @@ object Defn {
       name: sm.Type.Name,
       tparamClause: sm.Type.ParamClause,
       ctor: Ctor.Primary,
-      templ: Template
+      templ: Template,
   ) extends Defn
       with Member.Type
       with Stat.WithMods
@@ -1286,7 +1286,7 @@ object Defn {
       name: Term.Name,
       tparamClause: sm.Type.ParamClause,
       ctor: Ctor.Primary,
-      inits: List[Init]
+      inits: List[Init],
   ) extends Defn with Member.Term with Stat.WithMods with Tree.WithTParamClause with Stat.WithCtor {
     private def checkParent(destination: String): Boolean = ParentChecks.EnumCase(this, destination)
     @replacedField("4.6.0")
@@ -1304,7 +1304,7 @@ object Defn {
       @replacesFields("4.12.0", Member.ParamClauseGroupsCtor)
       paramClauseGroups: List[Member.ParamClauseGroup],
       decltpe: sm.Type,
-      body: Term
+      body: Term,
   ) extends Defn
       with Stat.GivenLike
       with Tree.WithParamClauseGroup
@@ -1321,7 +1321,7 @@ object Defn {
   class ExtensionGroup(
       @replacesFields("4.6.0", Member.ParamClauseGroupCtor)
       paramClauseGroup: Option[Member.ParamClauseGroup],
-      body: Stat
+      body: Stat,
   ) extends Defn with Tree.WithParamClauseGroup with Tree.WithBody {
     @replacedField("4.6.0", pos = 0)
     final def tparams: List[sm.Type.Param] = Member.ParamClauseGroup.toTparams(paramClauseGroup)
@@ -1337,7 +1337,7 @@ object Defn {
       @replacesFields("4.7.3", Member.ParamClauseGroupsCtor)
       paramClauseGroups: List[Member.ParamClauseGroup],
       decltpe: Option[sm.Type],
-      body: Term
+      body: Term,
   ) extends Defn
       with Member.Term
       with Stat.WithMods
@@ -1362,7 +1362,7 @@ object Defn {
       @replacesFields("4.7.3", Member.ParamClauseGroupsCtor)
       paramClauseGroups: List[Member.ParamClauseGroup],
       decltpe: Option[sm.Type],
-      body: Term
+      body: Term,
   ) extends Defn
       with Member.Term
       with Stat.WithMods
@@ -1386,7 +1386,7 @@ object Defn {
       tparamClause: sm.Type.ParamClause,
       body: sm.Type,
       @newField("4.4.0")
-      bounds: sm.Type.Bounds = sm.Type.Bounds.empty
+      bounds: sm.Type.Bounds = sm.Type.Bounds.empty,
   ) extends Defn with Stat.TypeDef with Tree.WithBody {
     @replacedField("4.6.0")
     final def tparams: List[sm.Type.Param] = tparamClause.values
@@ -1397,7 +1397,7 @@ object Defn {
       name: sm.Type.Name,
       tparamClause: sm.Type.ParamClause,
       ctor: Ctor.Primary,
-      templ: Template
+      templ: Template,
   ) extends Defn
       with Member.Type
       with Stat.WithMods
@@ -1413,7 +1413,7 @@ object Defn {
       name: sm.Type.Name,
       tparamClause: sm.Type.ParamClause,
       ctor: Ctor.Primary,
-      templ: Template
+      templ: Template,
   ) extends Defn
       with Member.Type
       with Stat.WithMods
@@ -1479,7 +1479,7 @@ object Ctor {
       name: Name,
       paramClauses: Seq[Term.ParamClause] @nonEmpty,
       @replacesFields("4.9.9", BlockCtor)
-      body: Block
+      body: Block,
   ) extends Ctor with Stat with Stat.WithMods with Tree.WithParamClauses with Tree.WithStats {
     @replacedField("4.6.0")
     final def paramss: List[List[Term.Param]] = paramClauses.map(_.values).toList
@@ -1526,7 +1526,7 @@ class Template(
     @replacesFields("4.9.9", Template.BodyCtor)
     body: Template.Body,
     @newField("4.4.0")
-    derives: List[Type] = Nil
+    derives: List[Type] = Nil,
 ) extends Tree with Tree.WithStats {
   checkFields(inits.isEmpty || earlyClause.forall(x => isQuasiOr(x, x.stats.forall(_.isEarlyStat))))
   @replacedField("4.9.9")

--- a/scalameta/trees2/shared/src/main/scala/scala/meta/internal/prettyprinters/TreePositions.scala
+++ b/scalameta/trees2/shared/src/main/scala/scala/meta/internal/prettyprinters/TreePositions.scala
@@ -33,7 +33,7 @@ object Positions {
 
   implicit def positionsTree[T <: Tree: Syntax](implicit
       positionStyle: PositionStyle,
-      sliceStyle: SliceStyle
+      sliceStyle: SliceStyle,
   ): Positions[T] = Positions { x =>
     def loopTree(x: Tree): Show.Result = {
       implicit class XtensionString(s: String) {
@@ -50,7 +50,7 @@ object Positions {
         case el: ::[_] => s(
             "List(".colored(color),
             r(el.map(el => loopField(el, color)), ", ".colored(color)),
-            ")".colored(color)
+            ")".colored(color),
           )
         case el: None.type => s("None".colored(color))
         case el: Some[_] => s("Some(".colored(color), loopField(el.get, color), ")".colored(color))

--- a/scalameta/trees2/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntacticGroup.scala
+++ b/scalameta/trees2/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntacticGroup.scala
@@ -108,14 +108,14 @@ object TreeSyntacticGroup {
   def opNeedsParens(
       outerPrecedence: Int,
       innerPrecedence: Int,
-      ifSamePrecedence: => Boolean
+      ifSamePrecedence: => Boolean,
   ): Boolean = {
     val diffPrecedence = outerPrecedence - innerPrecedence
     diffPrecedence > 0 || diffPrecedence == 0 && ifSamePrecedence
   }
 
   def opNeedsParens(outerOp: Name, innerOp: Name, isLhs: => Boolean)(implicit
-      dialect: Dialect
+      dialect: Dialect,
   ): Boolean = {
     val outerIsLeftAssoc = outerOp.isLeftAssoc
     @inline
@@ -130,7 +130,7 @@ object TreeSyntacticGroup {
     opNeedsParens(outer.op, inner.op, outer.lhs eq inner)
 
   def groupNeedsParens(outer: TreeSyntacticGroup, inner: TreeSyntacticGroup)(implicit
-      dialect: Dialect
+      dialect: Dialect,
   ): Boolean = {
     require((outer.categories & inner.categories) != 0)
     (outer, inner) match {

--- a/scalameta/trees2/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees2/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -329,11 +329,11 @@ object TreeSyntax {
         t match {
           case Block(
                 Function
-                  .Initial(Term.Param(mods, name: Term.Name, tptopt, _) :: Nil, Block(stats)) :: Nil
+                  .Initial(Term.Param(mods, name: Term.Name, tptopt, _) :: Nil, Block(stats)) :: Nil,
               ) if mods.exists(_.is[Mod.Implicit]) =>
             block(s("implicit ", name, o(": ", tptopt), " =>"), stats)
           case Block(
-                Function.Initial(Term.Param(_, name: Name, None, _) :: Nil, Block(stats)) :: Nil
+                Function.Initial(Term.Param(_, name: Name, None, _) :: Nil, Block(stats)) :: Nil,
               ) => block(s(name, " =>"), stats)
           case Block(Function.Initial(params, Block(stats)) :: Nil) =>
             block(s("(", r(params, ", "), ") =>"), stats)
@@ -353,8 +353,8 @@ object TreeSyntax {
             t.cond,
             ") ",
             p(Expr, t.thenp, force = needParens),
-            if (guessHasElsep(t)) s(" ", kw("else"), " ", p(Expr, t.elsep)) else s()
-          )
+            if (guessHasElsep(t)) s(" ", kw("else"), " ", p(Expr, t.elsep)) else s(),
+          ),
         )
       case t: Term.SelectMatch if dialect.allowMatchAsOperator =>
         val mods = t.mods
@@ -377,8 +377,8 @@ object TreeSyntax {
             " ",
             if (needParensAroundExpr) s("(", i(showExpr), n(")")) else showExpr,
             t.catchClause.fold(s())(x => s(" ", kw("catch"), " ", x)),
-            t.finallyp.fold(s())(finallyp => s(" ", kw("finally"), " ", finallyp))
-          )
+            t.finallyp.fold(s())(finallyp => s(" ", kw("finally"), " ", finallyp)),
+          ),
         )
       case t: Term.AnonymousFunction => s(t.body)
       case t: Term.FunctionTerm =>
@@ -556,15 +556,15 @@ object TreeSyntax {
           Literal,
           s(
             "ByteLiterals.",
-            if (value == 0) "Zero" else if (value > 0) "Plus" + value else "Minus" + value
-          )
+            if (value == 0) "Zero" else if (value > 0) "Plus" + value else "Minus" + value,
+          ),
         )
       case Lit.Short(value) => m(
           Literal,
           s(
             "ShortLiterals.",
-            if (value == 0) "Zero" else if (value > 0) "Plus" + value else "Minus" + value
-          )
+            if (value == 0) "Zero" else if (value > 0) "Plus" + value else "Minus" + value,
+          ),
         )
       case Lit.Int(value) => m(Literal, s(value.toString))
       case Lit.Long(value) => m(Literal, s(value.toString + "L"))
@@ -622,20 +622,20 @@ object TreeSyntax {
           " ",
           kw("="),
           " ",
-          t.body
+          t.body,
         )
       case t: Defn.Class => r(" ")(
           t.mods,
           kw("class"),
           s(t.name, t.tparamClause, w(" ", t.ctor, t.ctor.mods.nonEmpty)),
-          t.templ
+          t.templ,
         )
       case t: Defn.Trait =>
         if (dialect.allowTraitParameters || t.ctor.mods.isEmpty) r(" ")(
           t.mods,
           kw("trait"),
           s(t.name, t.tparamClause, w(" ", t.ctor, t.ctor.mods.nonEmpty)),
-          t.templ
+          t.templ,
         )
         else throw new UnsupportedOperationException(s"$dialect doesn't support trait parameters")
 
@@ -686,8 +686,8 @@ object TreeSyntax {
           case Some(p: Defn.Given) =>
             val isNew = givenSigUsesNewSyntax(p.paramClauseGroups)(
               t.inits.forall(_.argClauses.isEmpty) && !t.body.origin.tokensOpt.forall(
-                _.rfindWideNot(_.is[Token.Trivia], -1).is[Token.KwWith] // still old syntax
-              )
+                _.rfindWideNot(_.is[Token.Trivia], -1).is[Token.KwWith], // still old syntax
+              ),
             )
             if (isNew) Decl.Given else Defn.Given
           case Some(_: Term.NewAnonymous) => Term.NewAnonymous
@@ -849,7 +849,7 @@ object TreeSyntax {
     }
 
     private def givenSigUsesNewSyntax(
-        pcgs: List[Member.ParamClauseGroup]
+        pcgs: List[Member.ParamClauseGroup],
     )(ifEmpty: => Boolean): Boolean = dialect.allowImprovedTypeClassesSyntax &&
       (pcgs match {
         case Nil => ifEmpty
@@ -923,7 +923,7 @@ object TreeSyntax {
     private def printFunctionLikeType(
         t: Type.FunctionLikeType,
         params: Show.Result,
-        arrow: String
+        arrow: String,
     ): Show.Result = {
       val caps = t.parent match {
         case Some(p: Type.Capturing) if p.tpe eq t => s(p.caps)
@@ -992,7 +992,7 @@ object TreeSyntax {
   }
 
   def syntax(x: Tree, comments: Boolean = true, useOriginal: Boolean = true)(implicit
-      dialect: Dialect
+      dialect: Dialect,
   ): Show.Result = x.origin match {
     case o: Origin.Parsed if useOriginal && o.dialect.isEquivalentTo(dialect) =>
       original(x, o, comments = comments)
@@ -1003,7 +1003,7 @@ object TreeSyntax {
     printComments(x, _.begComment, tc => w(n(), tc.text, n())),
     x.pos.text,
     printComments(x, _.endComment, tc => w(" ", tc.text, n())),
-    comments && o.begTokenIdx > 0 && !x.is[Source]
+    comments && o.begTokenIdx > 0 && !x.is[Source],
   )
   def reprint(x: Tree, comments: Boolean = true)(implicit dialect: Dialect): Show.Result =
     new SyntaxInstances(comments = comments).reprint(x)
@@ -1011,7 +1011,7 @@ object TreeSyntax {
   private def printComments(
       tree: Tree,
       f: Tree => Option[Tree.Comments],
-      out: Tree.Comments => Show.Result
+      out: Tree.Comments => Show.Result,
   ): Show.Result = f(tree) match {
     case Some(tc) // skip if the parent refers to the same comments
         if tc.values.nonEmpty && tree.parent.flatMap(f).forall(ptc =>
@@ -1020,7 +1020,7 @@ object TreeSyntax {
               case (otc: Origin.Partial, optc: Origin.Partial) =>
                 otc.begTokenIdx != optc.begTokenIdx || otc.endTokenIdx != optc.endTokenIdx
               case _ => true
-            })
+            }),
         ) => out(tc)
     case _ => s()
   }
@@ -1034,6 +1034,6 @@ object TreeSyntax {
   private[prettyprinters] def withComments(tree: Tree)(syntax: Show.Result): Show.Result = s(
     printComments(tree, _.begComment, printBegComments),
     syntax,
-    printComments(tree, _.endComment, printEndComments)
+    printComments(tree, _.endComment, printEndComments),
   )
 }

--- a/scalameta/trees2/shared/src/main/scala/scala/meta/internal/trees/InternalTrees.scala
+++ b/scalameta/trees2/shared/src/main/scala/scala/meta/internal/trees/InternalTrees.scala
@@ -55,13 +55,13 @@ trait InternalTree extends Product {
   private[meta] def privateCopyOrigin(
       origin: Origin,
       begComment: Option[Tree.Comments] = this.begComment,
-      endComment: Option[Tree.Comments] = this.endComment
+      endComment: Option[Tree.Comments] = this.endComment,
   ): Tree
 
   private[meta] def privateSetOrigin(
       origin: Origin,
       begComment: Option[Tree.Comments] = this.begComment,
-      endComment: Option[Tree.Comments] = this.endComment
+      endComment: Option[Tree.Comments] = this.endComment,
   ): Unit
 
   private[meta] def privateSetOrigin(tree: Tree): Unit =
@@ -76,8 +76,8 @@ trait InternalTree extends Product {
 
   def tokens: Tokens = tokensOpt.getOrElse(
     throw new Error.MissingDialectException(
-      "Tree missing a dialect; update root tree `.withDialectIfRootAndNotSet` first, or call `.tokenizeFor`."
-    )
+      "Tree missing a dialect; update root tree `.withDialectIfRootAndNotSet` first, or call `.tokenizeFor`.",
+    ),
   )
 
   def tokenizeFor(dialect: Dialect): Tokens =
@@ -89,11 +89,11 @@ trait InternalTree extends Product {
   private[meta] def retokenize(implicit
       tokenize: Tokenize,
       dialect: Dialect,
-      tokenizerOptions: TokenizerOptions
+      tokenizerOptions: TokenizerOptions,
   ): Tokens = retokenizeFor(dialect)
 
   private[meta] def retokenizeFor(
-      dialect: Dialect
+      dialect: Dialect,
   )(implicit tokenize: Tokenize, tokenizerOptions: TokenizerOptions): Tokens = this match {
     case Lit.String(value) =>
       val input = Input.VirtualFile("<InternalTrees.tokens>", value)
@@ -104,7 +104,7 @@ trait InternalTree extends Product {
 
   private[meta] def textAsInput(implicit
       dialect: Dialect,
-      tokenizerOptions: TokenizerOptions
+      tokenizerOptions: TokenizerOptions,
   ): Input = Input.VirtualFile("<InternalTrees.text>", printSyntaxFor(dialect))
     .withTokenizerOptions(tokenizerOptions)
 
@@ -114,8 +114,8 @@ trait InternalTree extends Product {
 
   def text: String = textOpt.getOrElse(
     throw new Error.MissingDialectException(
-      "Tree missing a dialect; update root tree `.withDialectIfRootAndNotSet` first, or call `.printSyntaxFor`."
-    )
+      "Tree missing a dialect; update root tree `.withDialectIfRootAndNotSet` first, or call `.printSyntaxFor`.",
+    ),
   )
 
   def printSyntaxFor(dialect: Dialect): String =

--- a/scalameta/trees2/shared/src/main/scala/scala/meta/internal/trees/package.scala
+++ b/scalameta/trees2/shared/src/main/scala/scala/meta/internal/trees/package.scala
@@ -222,9 +222,9 @@ package object trees {
         var hadRepeated = false
         pc.values.exists(v =>
           try hadRepeated
-          finally hadRepeated = !v.is[Quasi] && v.decltpe.is[Type.Repeated]
+          finally hadRepeated = !v.is[Quasi] && v.decltpe.is[Type.Repeated],
         )
-      }
+      },
     )
   }
 

--- a/scalameta/trees2/shared/src/main/scala/scala/meta/trees/Api.scala
+++ b/scalameta/trees2/shared/src/main/scala/scala/meta/trees/Api.scala
@@ -30,67 +30,67 @@ private[meta] trait ApiLowPriority {
 private[meta] trait Api extends ApiLowPriority {
   implicit def typeParamClauseToValues(v: Type.ParamClause): List[Type.Param] = v.values
   implicit def typeValuesToParamClauseWithDialect(v: List[Type.Param])(implicit
-      dialect: Dialect
+      dialect: Dialect,
   ): Type.ParamClause = Type.ParamClause(v)
 
   implicit def termParamClauseToValues(v: Term.ParamClause): List[Term.Param] = v.values
   implicit def termValuesToParamClauseWithDialect(v: List[Term.Param])(implicit
-      dialect: Dialect
+      dialect: Dialect,
   ): Term.ParamClause = Term.ParamClause(v, Term.ParamClause.getMod(v))
   implicit def termListValuesToListParamClauseWithDialect(v: List[List[Term.Param]])(implicit
-      dialect: Dialect
+      dialect: Dialect,
   ): List[Term.ParamClause] = v.map(termValuesToParamClauseWithDialect)
 
   implicit def typeArgsToValues(v: Type.ArgClause): List[Type] = v.values
   implicit def typeValuesToArgClauseWithDialect(v: List[Type])(implicit
-      dialect: Dialect
+      dialect: Dialect,
   ): Type.ArgClause = Type.ArgClause(v)
 
   implicit def typeFuncParamsToValues(v: Type.FuncParamClause): List[Type] = v.values
   implicit def typeValuesToFuncParamClauseWithDialect(v: List[Type])(implicit
-      dialect: Dialect
+      dialect: Dialect,
   ): Type.FuncParamClause = Type.FuncParamClause(v)
 
   implicit def termArgsToValues(v: Term.ArgClause): List[Term] = v.values
   implicit def termValuesToArgClauseWithDialect(v: List[Term])(implicit
-      dialect: Dialect
+      dialect: Dialect,
   ): Term.ArgClause = Term.ArgClause(v, None)
   implicit def termListValuesToListArgClauseWithDialect(v: List[List[Term]])(implicit
-      dialect: Dialect
+      dialect: Dialect,
   ): List[Term.ArgClause] = v.map(termValuesToArgClauseWithDialect)
 
   implicit def patArgsToValues(v: Pat.ArgClause): List[Pat] = v.values
   implicit def patValuesToArgClauseWithDialect(v: List[Pat])(implicit
-      dialect: Dialect
+      dialect: Dialect,
   ): Pat.ArgClause = Pat.ArgClause(v)
   implicit def patListValuesToListArgClauseWithDialect(v: List[List[Pat]])(implicit
-      dialect: Dialect
+      dialect: Dialect,
   ): List[Pat.ArgClause] = v.map(patValuesToArgClauseWithDialect)
 
   implicit def typeCasesBlockToValues(v: Type.CasesBlock): List[TypeCase] = v.cases
   implicit def typeCaseValuesToCasesBlockWithDialect(v: List[TypeCase])(implicit
-      dialect: Dialect
+      dialect: Dialect,
   ): Type.CasesBlock = Type.CasesBlock(v)
 
   implicit def casesBlockToValues(v: Term.CasesBlock): List[Case] = v.cases
   implicit def caseValuesToCasesBlockWithDialect(v: List[Case])(implicit
-      dialect: Dialect
+      dialect: Dialect,
   ): Term.CasesBlock = Term.CasesBlock(v)
   implicit def caseValuesToOptionCasesBlockWithDialect(v: List[Case])(implicit
-      dialect: Dialect
+      dialect: Dialect,
   ): Option[Term.CasesBlock] = if (v.isEmpty) None else Some(Term.CasesBlock(v))
 
   implicit def enumsBlockToValues(v: Term.EnumeratorsBlock): List[Enumerator] = v.enums
   implicit def enumValuesToEnumsBlockWithDialect(v: List[Enumerator])(implicit
-      dialect: Dialect
+      dialect: Dialect,
   ): Term.EnumeratorsBlock = Term.EnumeratorsBlock(v)
 
   implicit def statsBlockToValues(v: Stat.Block): List[Stat] = v.stats
   implicit def statValuesToStatBlockWithDialect(v: List[Stat])(implicit
-      dialect: Dialect
+      dialect: Dialect,
   ): Stat.Block = Stat.Block(v)
   implicit def statValuesToOptionStatBlockWithDialect(v: List[Stat])(implicit
-      dialect: Dialect
+      dialect: Dialect,
   ): Option[Stat.Block] = if (v.isEmpty) None else Some(Stat.Block(v))
 
   implicit def pkgBodyToValues(v: Pkg.Body): List[Stat] = v.stats

--- a/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/Main.scala
+++ b/semanticdb/metacp/src/main/scala/scala/meta/internal/metacp/Main.scala
@@ -21,7 +21,7 @@ class Main(settings: Settings, reporter: Reporter) {
 
   val classpathIndex = ClasspathIndex(
     settings.classpath ++ settings.dependencyClasspath ++ detectJavacp,
-    includeJdk = settings.includeJdk
+    includeJdk = settings.includeJdk,
   )
   private val missingSymbols = mutable.Set.empty[String]
 
@@ -64,7 +64,7 @@ class Main(settings: Settings, reporter: Reporter) {
 
     if (missingSymbols.nonEmpty) reporter.err.println(
       "NOTE. To fix 'missing symbol' errors please provide a complete --classpath or --dependency-classpath. " +
-        "The provided classpath or classpaths should include the Scala library as well as JDK jars such as rt.jar."
+        "The provided classpath or classpaths should include the Scala library as well as JDK jars such as rt.jar.",
     )
 
     reporter.out.println("{")

--- a/semanticdb/scalac/library/src/main/scala-2.12/scala/meta/internal/semanticdb/scalac/SymbolOpsCompat.scala
+++ b/semanticdb/scalac/library/src/main/scala-2.12/scala/meta/internal/semanticdb/scalac/SymbolOpsCompat.scala
@@ -12,7 +12,7 @@ trait SymbolOpsCompat {
       g.termNames.toInt,
       g.termNames.toLong,
       g.termNames.toFloat,
-      g.termNames.toDouble
+      g.termNames.toDouble,
     )
 
     // See comment in scala-2.13/.../SymbolOpsCompat.scala

--- a/semanticdb/scalac/library/src/main/scala-2.13/scala/meta/internal/semanticdb/scalac/SemanticdbReporter.scala
+++ b/semanticdb/scalac/library/src/main/scala-2.13/scala/meta/internal/semanticdb/scalac/SemanticdbReporter.scala
@@ -11,7 +11,7 @@ class SemanticdbReporter(underlying: FilteringReporter)
       pos: Position,
       msg: String,
       severity: Severity,
-      actions: List[CodeAction]
+      actions: List[CodeAction],
   ): Unit = {
     super.doReport(pos, msg, severity, actions)
     underlying.doReport(pos, msg, severity, actions)

--- a/semanticdb/scalac/library/src/main/scala-2.13/scala/meta/internal/semanticdb/scalac/SymbolOpsCompat.scala
+++ b/semanticdb/scalac/library/src/main/scala-2.13/scala/meta/internal/semanticdb/scalac/SymbolOpsCompat.scala
@@ -12,7 +12,7 @@ trait SymbolOpsCompat {
       g.termNames.toInt,
       g.termNames.toLong,
       g.termNames.toFloat,
-      g.termNames.toDouble
+      g.termNames.toDouble,
     )
 
     // Returns true if the `this.sym` resolves to a primitive conversion method like toInt/toLong

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/classpath/ClasspathIndex.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/classpath/ClasspathIndex.scala
@@ -106,7 +106,7 @@ object ClasspathIndex {
           val element = entries.nextElement()
           if (!element.getName.startsWith("META-INF")) {
             val parent = getClassdir(
-              if (element.isDirectory) element.getName else PathIO.dirname(element.getName)
+              if (element.isDirectory) element.getName else PathIO.dirname(element.getName),
             )
             val inJar = CompressedClassfile(element, file)
             addMember(parent, PathIO.basename(element.getName), inJar)
@@ -141,7 +141,7 @@ object ClasspathIndex {
         }
         override def preVisitDirectory(dir: Path, attrs: BasicFileAttributes): FileVisitResult =
           if (dir.endsWith("META-INF")) FileVisitResult.SKIP_SUBTREE else FileVisitResult.CONTINUE
-      }
+      },
     )
   }
 }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/javacp/JavaTypeSignature.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/javacp/JavaTypeSignature.scala
@@ -52,7 +52,7 @@ sealed trait ReferenceTypeSignature extends JavaTypeSignature
 
 case class ClassTypeSignature(
     simpleClassTypeSignature: SimpleClassTypeSignature,
-    classTypeSignatureSuffix: List[ClassTypeSignatureSuffix]
+    classTypeSignatureSuffix: List[ClassTypeSignatureSuffix],
 ) extends ReferenceTypeSignature with ThrowsSignature {
   override def print(sb: StringBuilder): Unit = {
     sb.append('L')
@@ -113,7 +113,7 @@ case object WildcardTypeArgument extends TypeArgument {
 }
 case class ReferenceTypeArgument(
     wildcard: Option[WildcardIndicator],
-    referenceTypeSignature: ReferenceTypeSignature
+    referenceTypeSignature: ReferenceTypeSignature,
 ) extends TypeArgument {
   override def print(sb: StringBuilder): Unit = {
     wildcard match {
@@ -145,7 +145,7 @@ case class ClassTypeSignatureSuffix(simpleClassTypeSignature: SimpleClassTypeSig
 case class ClassSignature(
     typeParameters: Option[TypeParameters],
     superclassSignature: ClassTypeSignature,
-    superinterfaceSignatures: List[ClassTypeSignature]
+    superinterfaceSignatures: List[ClassTypeSignature],
 ) extends Printable {
   def parents: List[ClassTypeSignature] = superclassSignature :: superinterfaceSignatures
   override def print(sb: StringBuilder): Unit = {
@@ -161,7 +161,7 @@ object ClassSignature {
   def simple(superClass: String, interfaces: List[String]): ClassSignature = ClassSignature(
     None,
     ClassTypeSignature.simple(superClass),
-    interfaces.map(ClassTypeSignature.simple)
+    interfaces.map(ClassTypeSignature.simple),
   )
 }
 
@@ -178,7 +178,7 @@ case class TypeParameters(head: TypeParameter, tail: List[TypeParameter]) extend
 case class TypeParameter(
     identifier: String,
     classBound: ClassBound,
-    interfaceBounds: List[InterfaceBound]
+    interfaceBounds: List[InterfaceBound],
 ) extends Printable {
   def upperBounds: List[ReferenceTypeSignature] = classBound match {
     case ClassBound(Some(sig)) => sig :: interfaceBounds.map(_.referenceTypeSignature)
@@ -212,7 +212,7 @@ case class MethodSignature(
     typeParameters: Option[TypeParameters],
     params: List[JavaTypeSignature],
     result: JavaTypeSignature,
-    throws: List[ThrowsSignature]
+    throws: List[ThrowsSignature],
 ) extends Printable {
   override def print(sb: StringBuilder): Unit = {
     typeParameters match {

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/javacp/Javacp.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/javacp/Javacp.scala
@@ -26,7 +26,7 @@ object Javacp {
       node: ClassNode,
       classpathIndex: ClasspathIndex,
       access: Int,
-      scope: Scope
+      scope: Scope,
   ): collection.Seq[s.SymbolInformation] = {
 
     val buf = ArrayBuffer.empty[s.SymbolInformation]
@@ -37,7 +37,7 @@ object Javacp {
         kind: s.SymbolInformation.Kind,
         displayName: String,
         sig: s.Signature,
-        access: Int
+        access: Int,
     ): s.SymbolInformation = {
       val info = s.SymbolInformation(
         symbol = symbol,
@@ -47,7 +47,7 @@ object Javacp {
         displayName = displayName,
         signature = sig,
         annotations = sannotations(access),
-        access = saccess(access, symbol, kind)
+        access = saccess(access, symbol, kind),
       )
       buf += info
       info
@@ -91,14 +91,14 @@ object Javacp {
         val fieldDisplayName = field.name
         val fieldSignature = JavaTypeSignature.parse(
           if (field.signature == null) field.desc else field.signature,
-          new FieldSignatureVisitor
+          new FieldSignatureVisitor,
         )
         val fieldInfo = addInfo(
           fieldSymbol,
           k.FIELD,
           fieldDisplayName,
           s.ValueSignature(fieldSignature.toSemanticTpe(classScope)),
-          field.access
+          field.access,
         )
 
         decls += fieldInfo.symbol
@@ -109,7 +109,7 @@ object Javacp {
       .map { method /* MethodNode */ =>
         val signature = JavaTypeSignature.parse(
           if (method.signature == null) method.desc else method.signature,
-          new MethodSignatureVisitor
+          new MethodSignatureVisitor,
         )
         MethodInfo(method, signature)
       }
@@ -194,7 +194,7 @@ object Javacp {
               k.PARAMETER,
               paramDisplayName,
               s.ValueSignature(paramTpe),
-              o.ACC_PUBLIC
+              o.ACC_PUBLIC,
             )
           }
 
@@ -208,7 +208,7 @@ object Javacp {
         val methodSig = s.MethodSignature(
           typeParameters = Some(s.Scope(methodTypeParameters.map(_.symbol))),
           parameterLists = List(s.Scope(parameters.map(_.symbol))),
-          returnType = returnType
+          returnType = returnType,
         )
 
         val methodInfo =
@@ -233,7 +233,7 @@ object Javacp {
       typeParameters = Some(s.Scope(classTypeParameters.map(_.symbol))),
       parents = classParents,
       self = s.NoType,
-      declarations = Some(s.Scope(decls.toScalaSeq))
+      declarations = Some(s.Scope(decls.toScalaSeq)),
     )
 
     addInfo(classSymbol, classKind, classDisplayName, classSig, classAccess)
@@ -262,7 +262,7 @@ object Javacp {
           styperef(
             prefix = accum,
             symbol = symbol,
-            args = s.simpleClassTypeSignature.typeArguments.toSemanticTpe(scope)
+            args = s.simpleClassTypeSignature.typeArguments.toSemanticTpe(scope),
           ) -> symbol
         }
       result
@@ -275,7 +275,7 @@ object Javacp {
   private def addTypeParameters(
       typeParameters: TypeParameters,
       ownerSymbol: String,
-      scope: Scope
+      scope: Scope,
   ): (Scope, List[s.SymbolInformation]) = {
     var nextScope = scope
     // Enter all type variables before computing types for right hand side type parameter bounds.
@@ -293,7 +293,7 @@ object Javacp {
   private def addTypeParameter(
       typeParameter: TypeParameterInfo,
       ownerSymbol: String,
-      scope: Scope
+      scope: Scope,
   ): s.SymbolInformation = {
     val typeParameters = typeParameter.value.upperBounds.map(fromJavaTypeSignature(_, scope))
     val upperBounds = typeParameters match {
@@ -308,7 +308,7 @@ object Javacp {
       language = l.JAVA,
       kind = k.TYPE_PARAMETER,
       displayName = displayName,
-      signature = sig
+      signature = sig,
     )
   }
 
@@ -395,7 +395,7 @@ object Javacp {
   private def styperef(
       symbol: String,
       args: List[s.Type] = Nil,
-      prefix: s.Type = s.NoType
+      prefix: s.Type = s.NoType,
   ): s.Type = s.TypeRef(prefix, symbol, args)
 
   private implicit class XtensionTypeArgument(private val self: TypeArgument) extends AnyVal {

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/javacp/Scope.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/javacp/Scope.scala
@@ -13,7 +13,7 @@ class Scope(bindings: Map[String, String]) {
     name,
     // FIXME: fix https://github.com/scalameta/scalameta/issues/1365
     // There are still a handful of cases in spark-sql where resolution fails for some reason.
-    name
+    name,
   )
 
   /** Returns new scope where name resolves to symbol, shadowing previous binding of name if any */

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/javacp/asm/MethodSignatureVisitor.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/javacp/asm/MethodSignatureVisitor.scala
@@ -20,7 +20,7 @@ class MethodSignatureVisitor
         case cts: ClassTypeSignature => ThrowsSignature.ClassType(cts)
         case tvs: TypeVariableSignature => ThrowsSignature.TypeVariable(tvs)
         case els => throw new IllegalArgumentException(s"Expected ThrowsSignature, obtained $els")
-      }
+      },
     )
   }
 

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/javacp/asm/ReferenceTypeSignatureVisitor.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/javacp/asm/ReferenceTypeSignatureVisitor.scala
@@ -20,7 +20,7 @@ class ReferenceTypeSignatureVisitor extends TypedSignatureVisitor[Option[Referen
     else simpleClassTypeSignatures.result() match {
       case Nil => None
       case simpleClass :: suffix => Some(
-          ClassTypeSignature(simpleClass.result(), suffix.map(s => ClassTypeSignatureSuffix(s.result())))
+          ClassTypeSignature(simpleClass.result(), suffix.map(s => ClassTypeSignatureSuffix(s.result()))),
         )
     }
 

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/javacp/asm/TypeParameterVisitor.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/javacp/asm/TypeParameterVisitor.scala
@@ -10,7 +10,7 @@ class TypeParameterVisitor(identifier: String) extends TypedSignatureVisitor[Typ
   override def result(): TypeParameter = TypeParameter(
     identifier,
     ClassBound(classBound.result()),
-    interfaceBounds.result().map(ib => InterfaceBound(ib.result().get))
+    interfaceBounds.result().map(ib => InterfaceBound(ib.result().get)),
   )
 
   override def visitClassBound: SignatureVisitor = classBound

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/metacp/ClassfileInfos.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/metacp/ClassfileInfos.scala
@@ -17,14 +17,14 @@ import scala.tools.asm.tree.ClassNode
 final case class ClassfileInfos(
     relativeUri: String,
     language: s.Language,
-    infos: List[s.SymbolInformation]
+    infos: List[s.SymbolInformation],
 ) {
   def toTextDocuments: s.TextDocuments = {
     val semanticdbDocument = s.TextDocument(
       schema = s.Schema.SEMANTICDB4,
       uri = relativeUri,
       language = language,
-      symbols = infos
+      symbols = infos,
     )
     s.TextDocuments(List(semanticdbDocument))
   }
@@ -42,7 +42,7 @@ object ClassfileInfos {
       node: ClassNode,
       classpathIndex: ClasspathIndex,
       settings: Settings,
-      reporter: Reporter
+      reporter: Reporter,
   ): Option[ClassfileInfos] = node.scalaSig match {
     case Some(scalaSig) => Some(Scalacp.parse(scalaSig, classpathIndex, settings, reporter))
     case None =>

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/metacp/package.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/metacp/package.scala
@@ -31,7 +31,7 @@ package object metacp {
       } yield ScalaSigNode(node.name + ".class", scalaSig)
     private def fromScalaSigAnnotation: Option[ScalaSig] = Option(node.visibleAnnotations).flatMap {
       _.toScala.iterator.filter(annot =>
-        annot.desc == Main.SCALA_SIG_ANNOTATION || annot.desc == Main.SCALA_LONG_SIG_ANNOTATION
+        annot.desc == Main.SCALA_SIG_ANNOTATION || annot.desc == Main.SCALA_LONG_SIG_ANNOTATION,
       ).map(_.values.toScala).collectFirst { case collection.Seq("bytes", anyBytes) =>
         val baos = new ByteArrayOutputStream()
         val bytes: Array[Byte] = anyBytes match {
@@ -73,7 +73,7 @@ package object metacp {
         Array(ScalaSigAttribute),
         // NOTE(olafur): don't use SKIP_DEBUG field since it strips away Java
         // method parameter names since 2.12.11.
-        SKIP_CODE | SKIP_FRAMES
+        SKIP_CODE | SKIP_FRAMES,
       )
       node
     } finally in.close()

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/scalacp/ScalaSigAttribute.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/scalacp/ScalaSigAttribute.scala
@@ -12,7 +12,7 @@ object ScalaSigAttribute extends Attribute(Main.SCALA_SIG) {
       len: Int,
       buf: Array[Char],
       codeOff: Int,
-      labels: Array[Label]
+      labels: Array[Label],
   ): Attribute = {
     val bytecode = new ByteCode(cr.b, off, len)
     val scalaSig = ScalaSigAttributeParsers.parse(bytecode)

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/scalacp/Scalacp.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/scalacp/Scalacp.scala
@@ -12,7 +12,7 @@ final class Scalacp private (
     val node: ScalaSigNode,
     val symbolIndex: SymbolIndex,
     val settings: Settings,
-    val reporter: Reporter
+    val reporter: Reporter,
 ) extends AnnotationOps with SymbolInformationOps with SymbolOps with TypeOps {
   def parse: ClassfileInfos = {
     val sinfos = node.scalaSig.symbols.toList.flatMap {
@@ -40,6 +40,6 @@ object Scalacp {
       node: ScalaSigNode,
       classpathIndex: ClasspathIndex,
       settings: Settings,
-      reporter: Reporter
+      reporter: Reporter,
   ): ClassfileInfos = new Scalacp(node, SymbolIndex(classpathIndex), settings, reporter).parse
 }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/scalacp/Scalalib.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/scalacp/Scalalib.scala
@@ -17,7 +17,7 @@ object Scalalib {
     Scalalib.anyRefClass,
     Scalalib.nothingClass,
     Scalalib.nullClass,
-    Scalalib.singletonTrait
+    Scalalib.singletonTrait,
   )
   private def anyClass: ClassfileInfos = {
     val symbols = List(
@@ -27,7 +27,7 @@ object Scalalib {
         "equals",
         Nil,
         List("that" -> "scala/Any#"),
-        "scala/Boolean#"
+        "scala/Boolean#",
       ),
       builtinMethod("Any", List(p.FINAL), "==", Nil, List("that" -> "scala/Any#"), "scala/Boolean#"),
       builtinMethod("Any", List(p.FINAL), "!=", Nil, List("that" -> "scala/Any#"), "scala/Boolean#"),
@@ -44,8 +44,8 @@ object Scalalib {
         "asInstanceOf",
         List("A"),
         Nil,
-        "scala/Any#asInstanceOf().[A]"
-      )
+        "scala/Any#asInstanceOf().[A]",
+      ),
     )
     builtin(k.CLASS, List(p.ABSTRACT), "Any", Nil, symbols.flatten)
   }
@@ -62,7 +62,7 @@ object Scalalib {
         "eq",
         Nil,
         List("that" -> "scala/AnyRef#"),
-        "scala/Boolean#"
+        "scala/Boolean#",
       ),
       builtinMethod(
         "AnyRef",
@@ -70,7 +70,7 @@ object Scalalib {
         "ne",
         Nil,
         List("that" -> "scala/AnyRef#"),
-        "scala/Boolean#"
+        "scala/Boolean#",
       ),
       builtinMethod(
         "AnyRef",
@@ -78,8 +78,8 @@ object Scalalib {
         "synchronized",
         List("T"),
         List("body" -> "scala/AnyRef#synchronized().[T]"),
-        "scala/AnyRef#synchronized().[T]"
-      )
+        "scala/AnyRef#synchronized().[T]",
+      ),
     )
     builtin(k.CLASS, Nil, "AnyRef", List("scala/Any#"), symbols.flatten)
   }
@@ -100,7 +100,7 @@ object Scalalib {
       props: List[s.SymbolInformation.Property],
       className: String,
       bases: List[String],
-      symbols: List[s.SymbolInformation]
+      symbols: List[s.SymbolInformation],
   ): ClassfileInfos = {
     val parents = bases.map(base => s.TypeRef(s.NoType, base, Nil))
     val symbol = Symbols.Global(scalaPackage, d.Type(className))
@@ -112,7 +112,7 @@ object Scalalib {
       properties = p.PRIMARY.value,
       displayName = dn.Constructor,
       signature = ctorSig,
-      access = s.PublicAccess()
+      access = s.PublicAccess(),
     )
     val builtinSig = {
       val tparams = Some(s.Scope(Nil))
@@ -127,7 +127,7 @@ object Scalalib {
       properties = props.foldLeft(0)((acc, prop) => acc | prop.value),
       displayName = className,
       signature = builtinSig,
-      access = s.PublicAccess()
+      access = s.PublicAccess(),
     )
     val infos = builtin :: (if (kind.isClass) ctor :: symbols else symbols)
     val relativeUri = "scala/" + NameTransformer.encode(className) + ".class"
@@ -141,7 +141,7 @@ object Scalalib {
       methodName: String,
       tparamDsls: List[String],
       paramDsls: List[(String, String)],
-      retTpeSymbol: String
+      retTpeSymbol: String,
   ): List[s.SymbolInformation] = {
     val classSymbol = Symbols.Global(scalaPackage, d.Type(className))
     val methodSymbol = Symbols.Global(classSymbol, d.Method(methodName, "()"))
@@ -155,7 +155,7 @@ object Scalalib {
         properties = 0,
         displayName = tparamName,
         signature = tparamSig,
-        access = s.NoAccess
+        access = s.NoAccess,
       )
     }
     val params = paramDsls.map { case (paramName, paramTpeSymbol) =>
@@ -167,7 +167,7 @@ object Scalalib {
         kind = k.PARAMETER,
         properties = 0,
         displayName = paramName,
-        signature = paramSig
+        signature = paramSig,
       )
     }
     val methodSig = {
@@ -182,7 +182,7 @@ object Scalalib {
       properties = props.foldLeft(0)((acc, prop) => acc | prop.value),
       displayName = methodName,
       signature = methodSig,
-      access = s.PublicAccess()
+      access = s.PublicAccess(),
     )
     List(method) ++ tparams ++ params
   }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/scalacp/SymbolIndex.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/scalacp/SymbolIndex.scala
@@ -30,7 +30,7 @@ final class SymbolIndex private (classpathIndex: ClasspathIndex) {
           case otherLookup => otherLookup
         }
       case _ => MissingLookup
-    }
+    },
   )
 
   private implicit class XtensionSymbolOps(sym: Symbol) {

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/scalacp/SymbolInformationOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/scalacp/SymbolInformationOps.scala
@@ -194,7 +194,7 @@ trait SymbolInformationOps {
       displayName = displayName,
       signature = sig(linkMode),
       annotations = annotations,
-      access = access
+      access = access,
     )
   }
 }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/scalacp/Synthetics.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/scalacp/Synthetics.scala
@@ -9,7 +9,7 @@ import scala.meta.internal.{semanticdb => s}
 object Synthetics {
   def setterInfos(
       getterInfo: s.SymbolInformation,
-      linkMode: LinkMode
+      linkMode: LinkMode,
   ): List[s.SymbolInformation] = {
     val getterSym = getterInfo.symbol
     val setterSym =
@@ -32,7 +32,7 @@ object Synthetics {
       displayName = "x$1",
       signature = paramSig,
       annotations = Nil,
-      access = s.NoAccess
+      access = s.NoAccess,
     )
 
     val setterSig = {
@@ -51,7 +51,7 @@ object Synthetics {
       displayName = getterInfo.displayName + "_=",
       signature = setterSig,
       annotations = getterInfo.annotations,
-      access = getterInfo.access
+      access = getterInfo.access,
     )
 
     linkMode match {

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/AnnotationOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/AnnotationOps.scala
@@ -11,7 +11,7 @@ trait AnnotationOps {
       if (gann.args.nonEmpty) gann.args.map(_.toSemanticTree)
       else gann.assocs.map { case (gname, garg) =>
         s.AssignTree(s.IdTree(gname.toString()), toTree(garg))
-      }
+      },
     )
   }
 

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/ConfigOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/ConfigOps.scala
@@ -19,7 +19,7 @@ case class SemanticdbConfig(
     symbols: SymbolMode,
     diagnostics: BinaryMode,
     synthetics: BinaryMode,
-    overrides: BinaryMode
+    overrides: BinaryMode,
 ) {
   private[scalac] lazy val realSourceRoot = sourceroot.toNIO.toRealPath()
 
@@ -37,7 +37,7 @@ case class SemanticdbConfig(
       "symbols" -> symbols.name,
       "diagnostics" -> diagnostics.name,
       "synthetics" -> synthetics.name,
-      "overrides" -> overrides.name
+      "overrides" -> overrides.name,
     ).map { case (k, v) => s"-P:$p:$k:$v" }.mkString(" ")
   }
 
@@ -57,7 +57,7 @@ object SemanticdbConfig {
     symbols = SymbolMode.All,
     diagnostics = BinaryMode.On,
     synthetics = BinaryMode.Off,
-    overrides = BinaryMode.On
+    overrides = BinaryMode.On,
   )
 
   private val prefix = "-P:semanticdb:"
@@ -88,7 +88,7 @@ object SemanticdbConfig {
       scalacOptions: List[String],
       errFn: String => Unit,
       reporter: Reporter,
-      base: SemanticdbConfig
+      base: SemanticdbConfig,
   ): SemanticdbConfig = {
     def deprecated(option: String, instead: String): Unit = reporter
       .warning(NoPosition, s"$prefix$option is deprecated. Use -$prefix$instead instead.")

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/InputOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/InputOps.scala
@@ -62,7 +62,7 @@ trait InputOps {
           val uri = URLEncoder.encode(gfile.path, UTF_8.name)
           m.Input.VirtualFile(uri, gsource.content.mkString)
         case _ => m.Input.None
-      }
+      },
     )
   }
 
@@ -106,7 +106,7 @@ private object InputOps {
         // We could attempt to return a ".." URI, but java.net doesn't provide facilities for that. While nio's Path
         // does contain facilities for that, such relative paths cannot then be used to produce a percent-encoded,
         // relative URI. It doesn't seem worth fighting this battle at the moment, so:
-        sys.error(s"'$file' is not located within sourceroot '${config.sourceroot}'.")
+        sys.error(s"'$file' is not located within sourceroot '${config.sourceroot}'."),
       )
 
   }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/RemoveOrphanSemanticdbFiles.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/RemoveOrphanSemanticdbFiles.scala
@@ -35,7 +35,7 @@ object RemoveOrphanSemanticdbFiles {
           if (isEmpty) Files.delete(dir)
           FileVisitResult.CONTINUE
         }
-      }
+      },
     )
   }
 }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SemanticdbPaths.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SemanticdbPaths.scala
@@ -16,7 +16,7 @@ object SemanticdbPaths {
   def toScala(
       semanticdb: AbsolutePath,
       sourceroot: AbsolutePath,
-      targetroot: AbsolutePath
+      targetroot: AbsolutePath,
   ): AbsolutePath = sourceroot.resolve(toScala(semanticdb.toRelative(targetroot)))
 
   def toScala(path: RelativePath): RelativePath = {

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SymbolInformationOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SymbolInformationOps.scala
@@ -168,7 +168,7 @@ trait SymbolInformationOps {
       }
 
     private def annotations: List[s.AnnotationTree] = gsym.annotations.flatMap(gann =>
-      if (gann.symbol == definitions.MacroImplAnnotation) None else Some(gann.toSemantic)
+      if (gann.symbol == definitions.MacroImplAnnotation) None else Some(gann.toSemantic),
     )
 
     private def access: s.Access = kind match {
@@ -203,7 +203,7 @@ trait SymbolInformationOps {
       overriddenSymbols = overriddenSymbols,
       signature = sig(linkMode),
       annotations = annotations,
-      access = access
+      access = access,
     )
     def toSymbolInformation(linkMode: LinkMode): s.SymbolInformation =
       toSymbolInfo(linkMode, gsym.ssym)

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SyntheticOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SyntheticOps.scala
@@ -13,11 +13,11 @@ trait SyntheticOps {
     def toSemanticTree: s.Tree = gTree match {
       case gTree: g.Apply => s.ApplyTree(
           function = gTree.fun.toSemanticQualifierTree,
-          arguments = gTree.args.map(_.toSemanticTree)
+          arguments = gTree.args.map(_.toSemanticTree),
         )
       case gTree: g.TypeApply => s.TypeApplyTree(
           function = gTree.fun.toSemanticQualifierTree,
-          typeArguments = gTree.args.map(_.tpe.toSemanticTpe)
+          typeArguments = gTree.args.map(_.tpe.toSemanticTpe),
         )
       case gTree: g.Select => gTree.toSemanticId
       case gTree: g.Ident => gTree.toSemanticId

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
@@ -390,7 +390,7 @@ trait TextDocumentOps {
               case gtree: g.Import if gtree.expr != null && gtree.expr.tpe != null =>
                 val sels = gtree.selectors.flatMap(sel =>
                   if (sel.name == g.nme.WILDCARD) Nil
-                  else mstarts.get(sel.namePos).map(mname => (sel.name, mname))
+                  else mstarts.get(sel.namePos).map(mname => (sel.name, mname)),
                 )
                 sels.foreach { case (gname, mname) =>
                   val gexpr = gtree.expr
@@ -462,7 +462,7 @@ trait TextDocumentOps {
               case t: g.Function =>
                 addSamOccurrence(t)
                 t.vparams.foreach(p =>
-                  if (!(p.symbol.isSynthetic || p.name.decoded.startsWith("x$"))) traverse(p)
+                  if (!(p.symbol.isSynthetic || p.name.decoded.startsWith("x$"))) traverse(p),
                 )
                 traverse(t.body)
                 tryFindMtree(t)
@@ -547,7 +547,7 @@ trait TextDocumentOps {
               val v = res
               v.foreach(s => if (s.range.isDefined) synthetics += s)
               v
-            }
+            },
           )
 
         def getCached(gt: g.Tree): Option[s.Synthetic] = cached(gt) {
@@ -676,7 +676,7 @@ trait TextDocumentOps {
         symbols = finalSymbols.sortBy(_.symbol),
         occurrences = finalOccurrences.sortBy(_.range),
         diagnostics = diagnostics.sortBy(_.range),
-        synthetics = synthetics.toScalaSeq.sortBy(_.range)
+        synthetics = synthetics.toScalaSeq.sortBy(_.range),
       )
     }
   }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/symtab/GlobalSymbolTable.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/symtab/GlobalSymbolTable.scala
@@ -52,7 +52,7 @@ final class GlobalSymbolTable private (classpath: Classpath, includeJdk: Boolean
         val info = SymbolInformation(
           symbol = symbol,
           kind = SymbolInformation.Kind.PACKAGE,
-          displayName = symbol.desc.value
+          displayName = symbol.desc.value,
         )
         Some(info)
       } else None

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/metacp/Result.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/metacp/Result.scala
@@ -6,7 +6,7 @@ import scala.collection.immutable.ListMap
 
 final class Result private (
     val status: ListMap[AbsolutePath, Option[AbsolutePath]],
-    val scalaLibrarySynthetics: Option[AbsolutePath]
+    val scalaLibrarySynthetics: Option[AbsolutePath],
 ) {
   def isSuccess: Boolean = status.forall(_._2.nonEmpty)
 
@@ -19,6 +19,6 @@ final class Result private (
 object Result {
   def apply(
       status: ListMap[AbsolutePath, Option[AbsolutePath]],
-      scalaLibrarySynthetics: Option[AbsolutePath]
+      scalaLibrarySynthetics: Option[AbsolutePath],
   ): Result = new Result(status, scalaLibrarySynthetics)
 }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/metacp/Settings.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/metacp/Settings.scala
@@ -16,7 +16,7 @@ final class Settings private (
     val usejavacp: Boolean,
     val includeJdk: Boolean,
     val stubBrokenSignatures: Boolean,
-    val logBrokenSignatures: Boolean
+    val logBrokenSignatures: Boolean,
 ) {
   private def this() = this(
     out = Settings.defaultOut,
@@ -28,7 +28,7 @@ final class Settings private (
     usejavacp = false,
     includeJdk = false,
     stubBrokenSignatures = false,
-    logBrokenSignatures = false
+    logBrokenSignatures = false,
   )
 
   def withOut(out: AbsolutePath): Settings = copy(out = out)
@@ -66,7 +66,7 @@ final class Settings private (
       usejavacp: Boolean = usejavacp,
       includeJdk: Boolean = includeJdk,
       stubBrokenSignatures: Boolean = stubBrokenSignatures,
-      logBrokenSignatures: Boolean = logBrokenSignatures
+      logBrokenSignatures: Boolean = logBrokenSignatures,
   ): Settings = new Settings(
     out = out,
     classpath = classpath,
@@ -77,7 +77,7 @@ final class Settings private (
     usejavacp = usejavacp,
     includeJdk = includeJdk,
     stubBrokenSignatures = stubBrokenSignatures,
-    logBrokenSignatures = logBrokenSignatures
+    logBrokenSignatures = logBrokenSignatures,
   )
 }
 

--- a/semanticdb/scalac/plugin/src/main/scala/scala/meta/interactive/InteractiveSemanticdb.scala
+++ b/semanticdb/scalac/plugin/src/main/scala/scala/meta/interactive/InteractiveSemanticdb.scala
@@ -39,7 +39,7 @@ object InteractiveSemanticdb extends VersionCompilerOps {
       compiler: Global,
       code: String,
       filename: String,
-      timeout: Long
+      timeout: Long,
   ): s.TextDocument = toTextDocument(compiler, code, filename, timeout, Nil)
 
   /**
@@ -65,7 +65,7 @@ object InteractiveSemanticdb extends VersionCompilerOps {
       code: String,
       filename: String,
       timeout: Long,
-      options: List[String]
+      options: List[String],
   ): s.TextDocument = {
     val unit = addCompilationUnit(compiler, code, filename)
     // reload seems to be necessary before askLoadedType.
@@ -103,7 +103,7 @@ object InteractiveSemanticdb extends VersionCompilerOps {
   def addCompilationUnit(
       global: Global,
       code: String,
-      filename: String
+      filename: String,
   ): global.RichCompilationUnit = {
     val unit = global.newCompilationUnit(code, filename)
     val richUnit = new global.RichCompilationUnit(unit.source)

--- a/semanticdb/scalac/plugin/src/main/scala/scala/meta/internal/semanticdb/scalac/SemanticdbPipeline.scala
+++ b/semanticdb/scalac/plugin/src/main/scala/scala/meta/internal/semanticdb/scalac/SemanticdbPipeline.scala
@@ -102,7 +102,7 @@ trait SemanticdbPipeline extends SemanticdbOps {
                 schema = s.Schema.SEMANTICDB4,
                 uri = unit.source.toUri,
                 language = s.Language.SCALA,
-                diagnostics = diagnostics
+                diagnostics = diagnostics,
               )
               sdoc.append(config.targetroot)
             }

--- a/semanticdb/scalac/plugin/src/main/scala/scala/meta/internal/semanticdb/scalac/SemanticdbPlugin.scala
+++ b/semanticdb/scalac/plugin/src/main/scala/scala/meta/internal/semanticdb/scalac/SemanticdbPlugin.scala
@@ -30,7 +30,7 @@ class SemanticdbPlugin(val global: Global) extends Plugin with SemanticdbPipelin
     if (isAmmonite) PathIO.workingDirectory.resolve("out/semanticdb-scalac")
     else AbsolutePath(
       global.settings.outputDirs.getSingleOutput.flatMap(so => Option(so.file))
-        .map(_.getAbsolutePath).getOrElse(global.settings.d.value)
+        .map(_.getAbsolutePath).getOrElse(global.settings.d.value),
     )
 
 }

--- a/semanticdb/semanticdb/shared/src/main/scala/scala/meta/internal/cli/Args.scala
+++ b/semanticdb/semanticdb/shared/src/main/scala/scala/meta/internal/cli/Args.scala
@@ -11,6 +11,6 @@ object Args {
       val argPath = Paths.get(arg.substring(1))
       val argText = new String(Files.readAllBytes(argPath), UTF_8)
       argText.split(EOL).map(_.trim).filter(_.nonEmpty).toList
-    } else List(arg)
+    } else List(arg),
   )
 }

--- a/semanticdb/semanticdb/shared/src/main/scala/scala/meta/internal/metap/BasePrinter.scala
+++ b/semanticdb/semanticdb/shared/src/main/scala/scala/meta/internal/metap/BasePrinter.scala
@@ -10,7 +10,7 @@ abstract class BasePrinter(
     val settings: Settings,
     val reporter: Reporter,
     val doc: TextDocument,
-    val symtab: PrinterSymtab
+    val symtab: PrinterSymtab,
 ) {
   def out: PrintStream = reporter.out
 

--- a/semanticdb/semanticdb/shared/src/main/scala/scala/meta/internal/metap/DocumentPrinter.scala
+++ b/semanticdb/semanticdb/shared/src/main/scala/scala/meta/internal/metap/DocumentPrinter.scala
@@ -9,7 +9,7 @@ class DocumentPrinter(
     settings: Settings,
     reporter: Reporter,
     doc: TextDocument,
-    symtab: PrinterSymtab
+    symtab: PrinterSymtab,
 ) extends BasePrinter(settings, reporter, doc, symtab)
     with SymbolInformationPrinter
     with OccurrencePrinter

--- a/semanticdb/semanticdb/shared/src/main/scala/scala/meta/internal/metap/SymbolInformationPrinter.scala
+++ b/semanticdb/semanticdb/shared/src/main/scala/scala/meta/internal/metap/SymbolInformationPrinter.scala
@@ -28,7 +28,7 @@ trait SymbolInformationPrinter extends BasePrinter {
           out.print(info.displayName)
           out.print(" => ")
           out.println(info.symbol)
-        }
+        },
       )
     }
   }

--- a/semanticdb/semanticdb/shared/src/main/scala/scala/meta/internal/metap/SyntheticPrinter.scala
+++ b/semanticdb/semanticdb/shared/src/main/scala/scala/meta/internal/metap/SyntheticPrinter.scala
@@ -30,7 +30,7 @@ trait SyntheticPrinter extends BasePrinter with RangePrinter with SymbolInformat
           out.print(info.displayName)
           out.print(" => ")
           out.println(info.symbol)
-        }
+        },
       )
     }
   }

--- a/semanticdb/semanticdb/shared/src/main/scala/scala/meta/internal/semanticdb/Implicits.scala
+++ b/semanticdb/semanticdb/shared/src/main/scala/scala/meta/internal/semanticdb/Implicits.scala
@@ -9,7 +9,7 @@ object Implicits {
       startLine = pos.startLine,
       startCharacter = pos.startColumn,
       endLine = pos.endLine,
-      endCharacter = pos.endColumn
+      endCharacter = pos.endColumn,
     )
   }
 
@@ -19,7 +19,7 @@ object Implicits {
       startLine = range.startLine,
       startColumn = range.startCharacter,
       endLine = range.endLine,
-      endColumn = range.endCharacter
+      endColumn = range.endCharacter,
     )
     def toSemanticOriginal: OriginalTree = OriginalTree(range = Some(range))
   }

--- a/semanticdb/semanticdb/shared/src/main/scala/scala/meta/internal/semanticdb/Print.scala
+++ b/semanticdb/semanticdb/shared/src/main/scala/scala/meta/internal/semanticdb/Print.scala
@@ -33,14 +33,14 @@ object Print {
       format: Format,
       doc: TextDocument,
       synthetic: Synthetic,
-      symtab: PrinterSymtab
+      symtab: PrinterSymtab,
   ): String = withPrinter(format, doc, symtab)(printer => printer.pprint(synthetic)).trim
 
   def tree(format: Format, doc: TextDocument, tree: Tree, symtab: PrinterSymtab): String =
     withPrinter(format, doc, symtab)(printer => printer.pprint(tree, None)).trim
 
   private def withInfoPrinter(format: Format, doc: TextDocument, symtab: PrinterSymtab)(
-      fn: DocumentPrinter#InfoPrinter => Unit
+      fn: DocumentPrinter#InfoPrinter => Unit,
   ): String = withPrinter(format, TextDocument(), symtab) { printer =>
     val notes = new printer.InfoNotes()
     val infoPrinter = new printer.InfoPrinter(notes)
@@ -48,7 +48,7 @@ object Print {
   }.trim
 
   private def withPrinter(format: Format, doc: TextDocument, symtab: PrinterSymtab)(
-      fn: DocumentPrinter => Unit
+      fn: DocumentPrinter => Unit,
   ): String = {
     val baos = new ByteArrayOutputStream()
     val ps = new PrintStream(baos)

--- a/tests-semanticdb/src/main/scala/scala/meta/tests/metacp/Jars.scala
+++ b/tests-semanticdb/src/main/scala/scala/meta/tests/metacp/Jars.scala
@@ -20,7 +20,7 @@ object ModuleID {
     moduleId.split(":") match {
       case Array(org, name, rev) => ModuleID(org, name, rev) :: Nil
       case _ => Nil
-    }
+    },
   ).toList
 }
 object Jars {
@@ -31,13 +31,13 @@ object Jars {
       out: PrintStream = System.out,
       // If true, fetches the -sources.jar files instead of regular jar with classfiles.
       fetchSourceJars: Boolean = false,
-      provided: List[ModuleID] = Nil
+      provided: List[ModuleID] = Nil,
   ): List[AbsolutePath] = fetch(ModuleID(org, artifact, version) :: provided, out, fetchSourceJars)
 
   def fetch(
       modules: Iterable[ModuleID],
       out: PrintStream,
-      fetchSourceJars: Boolean
+      fetchSourceJars: Boolean,
   ): List[AbsolutePath] = Fetch().addDependencies(modules.map(_.toCoursier).toList: _*)
     .addClassifiers((if (fetchSourceJars) Classifier.sources :: Nil else Nil): _*)
     .addRepositories(MavenRepository("https://scala-ci.typesafe.com/artifactory/scala-integration/"))

--- a/tests-semanticdb/src/main/scala/scala/meta/tests/metacp/Libraries.scala
+++ b/tests-semanticdb/src/main/scala/scala/meta/tests/metacp/Libraries.scala
@@ -11,7 +11,7 @@ object Libraries {
       "org.scalameta",
       "scalameta_2.12",
       "3.2.0",
-      provided = List(ModuleID.scalaReflect("2.12.8"))
+      provided = List(ModuleID.scalaReflect("2.12.8")),
     )
     buf += Library("com.typesafe.akka", "akka-testkit_2.12", "2.5.9")
     buf += Library("com.typesafe.akka", "akka-actor_2.11", "2.5.9")
@@ -19,7 +19,7 @@ object Libraries {
       "org.apache.spark",
       "spark-sql_2.11",
       "2.2.1",
-      provided = List(ModuleID("org.eclipse.jetty", "jetty-servlet", "9.3.11.v20160721"))
+      provided = List(ModuleID("org.eclipse.jetty", "jetty-servlet", "9.3.11.v20160721")),
     )
     buf += Library("org.apache.kafka", "kafka_2.12", "1.0.0")
     buf += Library("org.apache.flink", "flink-parent", "1.4.1")
@@ -49,19 +49,19 @@ object Library {
       organization: String,
       artifact: String,
       version: String,
-      provided: List[ModuleID] = Nil
+      provided: List[ModuleID] = Nil,
   ): Library = Library(
     List(organization, artifact, version).mkString(":"),
     { () =>
       val jars = Jars.fetch(organization, artifact, version, provided = provided)
       Classpath(jars)
-    }
+    },
   )
   lazy val scalaLibrary: Library = Library(
     "scala-library",
     () => {
       val version = BuildInfo.scalaVersion
       Classpath(Jars.fetch("org.scala-lang", "scala-library", version))
-    }
+    },
   )
 }

--- a/tests-semanticdb/src/test/scala-2.12/scala/meta/tests/cli/CliSuite.scala
+++ b/tests-semanticdb/src/test/scala-2.12/scala/meta/tests/cli/CliSuite.scala
@@ -22,7 +22,7 @@ class CliSuite extends FunSuite {
          |  def main(args: Array[String]): Unit = {
          |    println("hello world")
          |  }
-         |}""".stripMargin.getBytes(UTF_8)
+         |}""".stripMargin.getBytes(UTF_8),
     )
     val target = Files.createTempDirectory("target_")
     val semanticdb = target.resolve("META-INF/semanticdb/HelloWorld.scala.semanticdb")
@@ -38,7 +38,7 @@ class CliSuite extends FunSuite {
         "-P:semanticdb:text:on",
         "-d",
         target.toString,
-        scalaFile.toString
+        scalaFile.toString,
       )
       val settings = scala.meta.metac.Settings().withScalacArgs(scalacArgs)
       val reporter = Reporter()
@@ -90,7 +90,7 @@ class CliSuite extends FunSuite {
          |[1:23..1:29): String => scala/Predef.String#
          |[1:33..1:37): Unit => scala/Unit#
          |[2:4..2:11): println => scala/Predef.println(+1).
-         |""".stripMargin
+         |""".stripMargin,
     )
     assert(err.isEmpty)
   }
@@ -101,7 +101,7 @@ class CliSuite extends FunSuite {
          |object Left { def right = 42 }
          |/not_sourceroot_/Right.scala
          |object Right { def left = 41 }
-         |""".stripMargin
+         |""".stripMargin,
     ).toNIO
     val sourceroot = projectroot.resolve("sourceroot_")
     val notSourceroot = projectroot.resolve("not_sourceroot_")
@@ -120,7 +120,7 @@ class CliSuite extends FunSuite {
         "-d",
         target.toString,
         inSourcerootScala.toString,
-        notInSourcerootScala.toString
+        notInSourcerootScala.toString,
       )
       val settings = scala.meta.metac.Settings().withScalacArgs(scalacArgs)
       val reporter = Reporter()

--- a/tests-semanticdb/src/test/scala-2.12/scala/meta/tests/metacp/MetacpErrorSuite.scala
+++ b/tests-semanticdb/src/test/scala-2.12/scala/meta/tests/metacp/MetacpErrorSuite.scala
@@ -27,8 +27,8 @@ class MetacpErrorSuite extends FunSuite {
           "3.2.0",
           // Scalameta has public signatures that reference scala-reflect APIs even if scala-reflect not
           // declared as a provided dependency in pom.xml.
-          provided = Nil
-        ).classpath()
+          provided = Nil,
+        ).classpath(),
       )
       Metacp.process(scalametaSettings, reporter)
     }
@@ -43,7 +43,7 @@ class MetacpErrorSuite extends FunSuite {
          |missing symbol: scala.reflect.macros.Universe
          |missing symbol: scala.reflect.macros.blackbox
          |missing symbol: scala.reflect.macros.whitebox
-         |""".stripMargin
+         |""".stripMargin,
     )
   }
 
@@ -69,14 +69,14 @@ class MetacpErrorSuite extends FunSuite {
           |  },
           |  "scalaLibrarySynthetics": ""
           |}
-          |""".stripMargin
+          |""".stripMargin,
     )
 
     assertNoDiff(
       err,
       s"""|missing symbol: scala in $tmp
           |NOTE. To fix 'missing symbol' errors please provide a complete --classpath or --dependency-classpath. The provided classpath or classpaths should include the Scala library as well as JDK jars such as rt.jar.
-          |""".stripMargin
+          |""".stripMargin,
     )
   }
 
@@ -97,13 +97,13 @@ class MetacpErrorSuite extends FunSuite {
           |  },
           |  "scalaLibrarySynthetics": ""
           |}
-          |""".stripMargin
+          |""".stripMargin,
     )
     assertNoDiff(
       err,
       s"""|missing symbol: scala in ${AbsolutePath(manifest)}
           |NOTE. To fix 'missing symbol' errors please provide a complete --classpath or --dependency-classpath. The provided classpath or classpaths should include the Scala library as well as JDK jars such as rt.jar.
-          |""".stripMargin
+          |""".stripMargin,
     )
     // TODO(olafurpg) fix this assertion before merging PR!
     // assert(!Files.list(output).iterator.hasNext)
@@ -128,7 +128,7 @@ class MetacpErrorSuite extends FunSuite {
       err,
       s"""|broken signature for _empty_/A#: missing symbol: scala
           |broken signature for _empty_/A#b().: missing symbol: <empty>.B
-          |""".stripMargin
+          |""".stripMargin,
     )
   }
 }

--- a/tests-semanticdb/src/test/scala-2.12/scala/meta/tests/metacp/SignatureSuite.scala
+++ b/tests-semanticdb/src/test/scala-2.12/scala/meta/tests/metacp/SignatureSuite.scala
@@ -53,7 +53,7 @@ class SignatureSuite extends FunSuite {
     if (failingSignatures.nonEmpty) {
       Files.write(
         java.nio.file.Paths.get("signatures.txt"),
-        failingSignatures.mkString("\n").getBytes(StandardCharsets.UTF_8)
+        failingSignatures.mkString("\n").getBytes(StandardCharsets.UTF_8),
       )
       fail("failures! See signatures.txt")
     }
@@ -74,7 +74,7 @@ class SignatureSuite extends FunSuite {
   def checkClass(node: ClassNode): List[(String, () => Unit)] =
     if (node.signature == null) Nil
     else List(
-      (node.signature, { () => assertSignatureRoundtrip(node.signature, new ClassSignatureVisitor) })
+      (node.signature, { () => assertSignatureRoundtrip(node.signature, new ClassSignatureVisitor) }),
     )
 
   def checkAllSignatures(node: ClassNode): List[(String, () => Unit)] = checkFields(node) :::

--- a/tests-semanticdb/src/test/scala-2.12/scala/meta/tests/semanticdb/JavacpSuite.scala
+++ b/tests-semanticdb/src/test/scala-2.12/scala/meta/tests/semanticdb/JavacpSuite.scala
@@ -11,15 +11,15 @@ class JavacpSuite extends JavacpSuiteBase {
     List(
       "com/javacp/MetacJava#overload().",
       "com/javacp/MetacJava#overload(+2).",
-      "com/javacp/MetacJava#overload(+1)."
-    )
+      "com/javacp/MetacJava#overload(+1).",
+    ),
   )
 
   checkOrder(
     "fields",
     "com/javacp/Test#",
     s => s.desc.value == "Int" || s.desc.value == "Long" || s.desc.value == "Float",
-    List("com/javacp/Test#Int.", "com/javacp/Test#Long.", "com/javacp/Test#Float.")
+    List("com/javacp/Test#Int.", "com/javacp/Test#Long.", "com/javacp/Test#Float."),
   )
 
 }

--- a/tests-semanticdb/src/test/scala-2.12/scala/meta/tests/semanticdb/PrintSuite.scala
+++ b/tests-semanticdb/src/test/scala-2.12/scala/meta/tests/semanticdb/PrintSuite.scala
@@ -17,12 +17,12 @@ class PrintSuite extends PrintSuiteBase {
 
   checkInfo(
     "scala/Predef.assert(+1).",
-    """scala/Predef.assert(+1). => @inline @elidable final method assert(assertion: Boolean, message: => Any): Unit"""
+    """scala/Predef.assert(+1). => @inline @elidable final method assert(assertion: Boolean, message: => Any): Unit""",
   )
   checkInfo("scala/Any#", """scala/Any# => abstract class Any { +10 decls }""")
   checkInfo(
     "java/util/Collections#singletonList().",
-    """java/util/Collections#singletonList(). => static method singletonList[T](param0: T): List[T]"""
+    """java/util/Collections#singletonList(). => static method singletonList[T](param0: T): List[T]""",
   )
 
   checkSynthetics(
@@ -30,7 +30,7 @@ class PrintSuite extends PrintSuiteBase {
     """|[2:0..2:11): List(1).map => *[Int, List[Int]]
        |[2:0..2:18): List(1).map(_ + 2) => *(List.canBuildFrom[Int])
        |[2:0..2:4): List => *.apply[Int]
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkTrees(
@@ -38,7 +38,7 @@ class PrintSuite extends PrintSuiteBase {
     """|orig(List(1).map)[Int, List[Int]]
        |orig(List(1).map(_ + 2))(List.canBuildFrom[Int])
        |orig(List).apply[Int]
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkSynthetics(
@@ -49,7 +49,7 @@ class PrintSuite extends PrintSuiteBase {
        |""".stripMargin,
     """|[4:4..4:9): xs.to => *(List.canBuildFrom[Int])
        |[4:4..4:9): xs.to => *[List]
-       |""".stripMargin
+       |""".stripMargin,
   )
 
 }

--- a/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -213,7 +213,7 @@ class SurfaceSuite extends FunSuite {
          |scala.meta.trees.Origin.ParsedSpliced *
          |scala.meta.trees.Origin.Partial *
          |scala.meta.trees.Origin.PartialProxy *
-         |""".stripMargin.lf2nl
+         |""".stripMargin.lf2nl,
     )
   }
 
@@ -324,7 +324,7 @@ class SurfaceSuite extends FunSuite {
          |* scala.meta.tokens.Token.isBackquoted: Boolean
          |* scala.meta.tokens.Token.isIdentSymbolicInfixOperator: Boolean
          |* scala.meta.tokens.Token.isSymbolicInfixOperator: Boolean
-         |""".stripMargin.lf2nl
+         |""".stripMargin.lf2nl,
     )
   }
 
@@ -617,7 +617,7 @@ class SurfaceSuite extends FunSuite {
          |scala.meta.Type.Wildcard
          |scala.meta.Type.With
          |scala.meta.TypeCase
-         |""".stripMargin.lf2nl
+         |""".stripMargin.lf2nl,
     )
   }
 
@@ -730,7 +730,7 @@ class SurfaceSuite extends FunSuite {
          |scala.meta.tokens.Token.Xml.SpliceEnd
          |scala.meta.tokens.Token.Xml.SpliceStart
          |scala.meta.tokens.Token.Xml.Start
-         |""".stripMargin.lf2nl
+         |""".stripMargin.lf2nl,
     )
   }
 }

--- a/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/semanticdb/JavacpSuite.scala
+++ b/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/semanticdb/JavacpSuite.scala
@@ -11,15 +11,15 @@ class JavacpSuite extends JavacpSuiteBase {
     List(
       "com/javacp/MetacJava#overload().",
       "com/javacp/MetacJava#overload(+2).",
-      "com/javacp/MetacJava#overload(+1)."
-    )
+      "com/javacp/MetacJava#overload(+1).",
+    ),
   )
 
   checkOrder(
     "fields",
     "com/javacp/Test#",
     s => s.desc.value == "Int" || s.desc.value == "Long" || s.desc.value == "Float",
-    List("com/javacp/Test#Int.", "com/javacp/Test#Long.", "com/javacp/Test#Float.")
+    List("com/javacp/Test#Int.", "com/javacp/Test#Long.", "com/javacp/Test#Float."),
   )
 
 }

--- a/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/semanticdb/PrintSuite.scala
+++ b/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/semanticdb/PrintSuite.scala
@@ -17,25 +17,25 @@ class PrintSuite extends PrintSuiteBase {
 
   checkInfo(
     "scala/Predef.assert(+1).",
-    """scala/Predef.assert(+1). => @elidable @inline final method assert(assertion: Boolean, message: => Any): Unit"""
+    """scala/Predef.assert(+1). => @elidable @inline final method assert(assertion: Boolean, message: => Any): Unit""",
   )
   checkInfo("scala/Any#", """scala/Any# => abstract class Any { +10 decls }""")
   checkInfo(
     "java/util/Collections#singletonList().",
-    """java/util/Collections#singletonList(). => static method singletonList[T](param0: T): List[T]"""
+    """java/util/Collections#singletonList(). => static method singletonList[T](param0: T): List[T]""",
   )
 
   checkSynthetics(
     "List(1).map(_ + 2)",
     """|[2:0..2:11): List(1).map => *[Int]
        |[2:0..2:4): List => *.apply[Int]
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkTrees(
     "List(1).map(_ + 2)",
     """|orig(List(1).map)[Int]
        |orig(List).apply[Int]
-       |""".stripMargin
+       |""".stripMargin,
   )
 }

--- a/tests-semanticdb/src/test/scala/scala/meta/tests/metacp/MetacpOps.scala
+++ b/tests-semanticdb/src/test/scala/scala/meta/tests/metacp/MetacpOps.scala
@@ -15,7 +15,7 @@ object MetacpOps {
       for {
         doc <- docs.documents
         sym <- doc.symbols
-      } allSymbols += sym.symbol
+      } allSymbols += sym.symbol,
     )
     allSymbols
   }
@@ -101,7 +101,7 @@ object MetacpOps {
       } {
         val references = collectAllSymbolReferences(sym)
         errors ++= references.filterNot(isPersistedGlobalSymbol)
-      }
+      },
     )
     errors
   }

--- a/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/ConfigSuite.scala
+++ b/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/ConfigSuite.scala
@@ -29,7 +29,7 @@ class ConfigSuite extends FunSuite {
       scalacArgs: List[String],
       input: String,
       fn: s.TextDocument => Unit,
-      targetroot: AbsolutePath = generateTargetroot()
+      targetroot: AbsolutePath = generateTargetroot(),
   )(implicit loc: munit.Location): Unit = test(topt) {
     val sourceroot = StringFS.fromString(input)
     val (metacIsSuccess, metacOut, metacErr) = CliTestUtils.withReporter { reporter =>
@@ -40,8 +40,8 @@ class ConfigSuite extends FunSuite {
           "-P:semanticdb:sourceroot:" + sourceroot.toString,
           "-cp",
           Library.scalaLibrary.classpath().syntax,
-          sourceroot.resolve(A).toString
-        )
+          sourceroot.resolve(A).toString,
+        ),
       )
       Metac.process(settings, reporter)
     }
@@ -73,9 +73,9 @@ class ConfigSuite extends FunSuite {
         symbols,
         """|local0
            |local1
-           |""".stripMargin
+           |""".stripMargin,
       )
-    }
+    },
   )
 
   check(
@@ -86,7 +86,7 @@ class ConfigSuite extends FunSuite {
        |object A {
        |}
        |""".stripMargin,
-    doc => assert(doc.symbols.isEmpty)
+    doc => assert(doc.symbols.isEmpty),
   )
 
   check(
@@ -110,7 +110,7 @@ class ConfigSuite extends FunSuite {
            |""".stripMargin
 
       assertNoDiff(obtained, expected)
-    }
+    },
   )
 
   private val customTargetroot = generateTargetroot()
@@ -124,7 +124,7 @@ class ConfigSuite extends FunSuite {
       val Seq(occurrence) = doc.occurrences
       assertEquals(occurrence.symbol, "_empty_/A.")
     },
-    targetroot = customTargetroot
+    targetroot = customTargetroot,
   )
 
   check(
@@ -133,7 +133,7 @@ class ConfigSuite extends FunSuite {
     """|/A.scala
        |object A
        |""".stripMargin,
-    doc => assert(doc.md5.isEmpty)
+    doc => assert(doc.md5.isEmpty),
   )
 
   check(
@@ -144,7 +144,7 @@ class ConfigSuite extends FunSuite {
        |   List(1).map(_ + 1)
        |}
        |""".stripMargin,
-    doc => assert(doc.synthetics.isEmpty)
+    doc => assert(doc.synthetics.isEmpty),
   )
 
   check(
@@ -155,7 +155,7 @@ class ConfigSuite extends FunSuite {
        |   List(1).map(_ + 1)
        |}
        |""".stripMargin,
-    doc => assert(doc.synthetics.nonEmpty)
+    doc => assert(doc.synthetics.nonEmpty),
   )
 
 }

--- a/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/ExpectSuite.scala
+++ b/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/ExpectSuite.scala
@@ -39,7 +39,7 @@ class ExpectSuite extends FunSuite {
           """|com/javacp/Test#strictfpMethod(). => @strictfp private[javacp] method strictfpMethod(): Unit
              |  strictfp => scala/annotation/strictfp#""".stripMargin,
           "com/javacp/Test#strictfpMethod(). => private[javacp] method strictfpMethod(): Unit"
-            .stripMargin
+            .stripMargin,
         )
       else loadExpected
     this.assertNoDiff(loadObtained, expected)
@@ -91,7 +91,7 @@ trait ExpectHelpers extends munit.Assertions {
       originalTitle: String,
       revisedTitle: String,
       original: String,
-      revised: String
+      revised: String,
   ): String = {
     val originalLines = original.split("\n").toSeq.asJava
     val revisedLines = revised.split("\n").toSeq.asJava
@@ -102,7 +102,7 @@ trait ExpectHelpers extends munit.Assertions {
         revisedTitle,
         originalLines,
         DiffUtils.diff(originalLines, revisedLines),
-        3
+        3,
       ).asScala
       if (lines.lengthCompare(2) > 0) lines.remove(2) // remove lines like "@@ -3,18 +3,16 @@"
       lines.filterNot(line => OnlyCurlyBrace.findFirstIn(line).isDefined)
@@ -223,13 +223,13 @@ object MetacMetacpDiffExpect extends ExpectHelpers {
   // Presevering the source ordering of declarations is important for documentation tools
   // so we should eventually stop sorting them here.
   private def sortDeclarations(
-      symtab: Map[String, SymbolInformation]
+      symtab: Map[String, SymbolInformation],
   ): Map[String, SymbolInformation] = symtab.map { case (key, sym) =>
     val newSymbol = sym.signature match {
       case c: ClassSignature if sym.language.isJava =>
         val sortedJavaDeclarations = c.declarations.get.symlinks.sorted
         sym.copy(signature =
-          c.copy(declarations = Some(c.declarations.get.copy(symlinks = sortedJavaDeclarations)))
+          c.copy(declarations = Some(c.declarations.get.copy(symlinks = sortedJavaDeclarations))),
         )
       case _ => sym
     }
@@ -257,7 +257,7 @@ object MetacpUndefined extends ExpectHelpers {
       // that have no SymbolInformation. It's expected that references to the packages
       // scala/ and java/ package have no SymbolInformation because we only process
       // databaseClasspath, scala-library and the JDK are only --dependency-classpath.
-      symbol.startsWith("scala/") || symbol.startsWith("java/") || symbol == "local_wildcard"
+      symbol.startsWith("scala/") || symbol.startsWith("java/") || symbol == "local_wildcard",
     )
     interesting.toSeq.sorted.mkString("", "\n", "\n")
   }
@@ -303,7 +303,7 @@ object SaveManifestTest {
         jos.putNextEntry(new JarEntry(classes.relativize(classfile).toString))
         jos.write(Files.readAllBytes(classfile))
         jos.closeEntry()
-      }
+      },
     )
 
     val emptySemanticdbRelPath =

--- a/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/InteractiveSuite.scala
+++ b/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/InteractiveSuite.scala
@@ -17,7 +17,7 @@ class InteractiveSuite extends FunSuite {
   def check(
       original: String,
       expected: String,
-      compat: List[(ScalaVersion.Version, String)] = List.empty
+      compat: List[(ScalaVersion.Version, String)] = List.empty,
   )(implicit loc: munit.Location): Unit = test(logger.revealWhitespace(original)) {
     val options = List("-P:semanticdb:synthetics:on", "-P:semanticdb:text:on")
     val document = toTextDocument(compiler, original, options)
@@ -78,13 +78,13 @@ class InteractiveSuite extends FunSuite {
     11,
     """|[3:17..3:22): scala => scala/
        |[3:23..3:27): List => scala/package.List.""".stripMargin,
-    "apply => scala/collection/IterableFactory#apply()."
+    "apply => scala/collection/IterableFactory#apply().",
   )
 
   val expectedPrevious = expected(
     10,
     "[3:23..3:27): List => scala/collection/immutable/List.",
-    "apply => scala/collection/immutable/List.apply()."
+    "apply => scala/collection/immutable/List.apply().",
   )
 
   check(
@@ -98,7 +98,7 @@ class InteractiveSuite extends FunSuite {
     // Note that scala don't resolve to a symbol, this is a sign that the
     // typer hijacking is not working as expected with interactive.Global.
     expectedPrevious,
-    compat = List(ScalaVersion.Scala213 -> expectedLatest)
+    compat = List(ScalaVersion.Scala213 -> expectedLatest),
   )
 
   // This tests a case where SymbolOps.toSemantic crashes
@@ -135,6 +135,6 @@ class InteractiveSuite extends FunSuite {
        |
        |Diagnostics:
        |[2:13..2:15) [error] not found: type In
-       |""".stripMargin
+       |""".stripMargin,
   )
 }

--- a/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/Issue2024Suite.scala
+++ b/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/Issue2024Suite.scala
@@ -20,6 +20,6 @@ class Issue2024Suite extends SemanticdbSuite {
       assertEquals(impl1, "a/root.impl.")
       assertEquals(impl2, "a/root.impl.")
       assertEquals(impl3, "a/root.impl.")
-    }
+    },
   )
 }

--- a/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/JavacpSuiteBase.scala
+++ b/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/JavacpSuiteBase.scala
@@ -8,7 +8,7 @@ abstract class JavacpSuiteBase extends FunSuite {
   private val infos = MetacMetacpDiffExpect.metacpSymbols
 
   def checkOrder(name: String, symbol: String, filter: String => Boolean, expected: List[String])(
-      implicit loc: munit.Location
+      implicit loc: munit.Location,
   ): Unit = test(name) {
     val info = infos(symbol)
     val ClassSignature(_, _, _, Some(declarations)) = info.signature

--- a/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/MD5Suite.scala
+++ b/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/MD5Suite.scala
@@ -49,7 +49,7 @@ class MD5Suite extends FunSuite {
       assertEquals(
         doc.md5,
         fromFile,
-        "TextDocument.md5 does not match fileMD5(Paths.get(TextDocument.uri))"
+        "TextDocument.md5 does not match fileMD5(Paths.get(TextDocument.uri))",
       )
       assert(!md5Fingerprints.contains(doc.md5), "Fingerprint was not unique")
       md5Fingerprints += doc.md5

--- a/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/MacroAnnotationSuite.scala
+++ b/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/MacroAnnotationSuite.scala
@@ -22,7 +22,7 @@ class MacroAnnotationSuite extends SemanticdbSuite {
       assert(symbols.contains("a/A#productElement()."))
       assert(symbols.contains("a/A.unapply()."))
       assert(symbols.contains("a/A.apply()."))
-    }
+    },
   )
 
 }

--- a/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/MetacScalaLibrary.scala
+++ b/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/MetacScalaLibrary.scala
@@ -23,7 +23,7 @@ class MetacScalaLibrary extends FunSuite {
     assume(!Properties.isWin, "Test is not checked on windows")
     assume(
       Files.isDirectory(MetacScalaLibrary.library),
-      s"${MetacScalaLibrary.library} is not a directory! Run `sbt download-scala-library`"
+      s"${MetacScalaLibrary.library} is not a directory! Run `sbt download-scala-library`",
     )
     val exit = MetacScalaLibrary.process(Array())
     require(exit == 0, "failed to compile scala-library")
@@ -38,7 +38,7 @@ object MetacScalaLibrary {
   def process(args: Array[String]): Int = {
     assert(
       Files.isDirectory(library),
-      s"$library is not a directory! Run `sbt download-scala-library`"
+      s"$library is not a directory! Run `sbt download-scala-library`",
     )
     val classpath = ClasspathUtils.getClassPathEntries(this.getClass.getClassLoader).map(_.toString)
       .filter(_.contains("scala-library")).mkString(File.pathSeparator)

--- a/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/OccurrenceSuite.scala
+++ b/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/OccurrenceSuite.scala
@@ -19,7 +19,7 @@ class OccurrenceSuite extends FunSuite {
     assertNoDiff(body.obtained, body.expected)
 
   ScalaVersion.doIf("OccurrenceSuite", ScalaVersion.is212 || ScalaVersion.is213)(
-    OccurrenceSuite.testCases.foreach(t => test(t.name)(t.body.fold(fail(_), testBody)))
+    OccurrenceSuite.testCases.foreach(t => test(t.name)(t.body.fold(fail(_), testBody))),
   )
 }
 
@@ -45,7 +45,7 @@ object OccurrenceSuite {
       val expectpathOpt = Utils.getFirstAbsResourceOpt(
         forVer(BuildInfo.scalaVersion),
         forVer(BuildInfo.scalaBinaryVersion),
-        relpathstr
+        relpathstr,
       )
       new TestCase(relpath.toURI(false).toString)(
         expectpathOpt.toRight(s"// missing expect file: $relpathstr\n").right.map { expectpath =>
@@ -62,12 +62,12 @@ object OccurrenceSuite {
               ScalaVersion.Full("2.13.15") -> expectedPrevious213,
               ScalaVersion.Full("2.13.14") -> expectedPrevious213,
               ScalaVersion.Scala212 -> expectedPrevious213,
-              ScalaVersion.Scala211 -> expectedPrevious213
+              ScalaVersion.Scala211 -> expectedPrevious213,
             ),
-            expected
+            expected,
           )
           TestBody(obtained, expectedCompat, expectpath)
-        }
+        },
       )
     }
   }

--- a/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/PrintSuiteBase.scala
+++ b/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/PrintSuiteBase.scala
@@ -22,7 +22,7 @@ abstract class PrintSuiteBase extends FunSuite {
       name: String,
       original: String,
       expected: String,
-      fn: s.TextDocument => Unit
+      fn: s.TextDocument => Unit,
   ): Unit = test(name) {
     val wrapped =
       s"""
@@ -33,7 +33,7 @@ $original
     val doc = InteractiveSemanticdb.toTextDocument(
       compiler = compiler,
       code = wrapped,
-      options = List("-P:semanticdb:synthetics:on", "-P:semanticdb:text:on")
+      options = List("-P:semanticdb:synthetics:on", "-P:semanticdb:text:on"),
     )
     fn(doc)
   }
@@ -79,7 +79,7 @@ $original
         val obtained = doc.synthetics
           .map(synthetic => Print.synthetic(Format.Compact, doc, synthetic, printerSymtab))
         assertNoDiff(obtained.mkString("\n"), expected)
-      }
+      },
     )
 
   def checkTrees(original: String, expected: String)(implicit loc: munit.Location): Unit =
@@ -91,7 +91,7 @@ $original
         val obtained = doc.synthetics
           .map(synthetic => Print.tree(Format.Compact, doc, synthetic.tree, printerSymtab))
         assertNoDiff(obtained.mkString("\n"), expected)
-      }
+      },
     )
 
 }

--- a/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/SemanticdbSuite.scala
+++ b/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/SemanticdbSuite.scala
@@ -71,7 +71,7 @@ abstract class SemanticdbSuite extends FunSuite {
     val diagnostics = errors.map(error =>
       s"""|<input>:${error.pos.line}:${error.pos.column}: error ${error.msg}
           |${error.pos.lineContent}
-          |${error.pos.lineCaret}""".stripMargin
+          |${error.pos.lineCaret}""".stripMargin,
     )
     if (errors.nonEmpty) fail(diagnostics.mkString("\n"))
   }
@@ -136,10 +136,10 @@ abstract class SemanticdbSuite extends FunSuite {
     computeSectionFromPayload(computePayloadFromSnippet(code), sectionName)
 
   def checkSection(code: String, expected: String, section: String)(implicit
-      loc: munit.Location
+      loc: munit.Location,
   ): Unit = checkSection(code, code, expected, section)
   def checkSection(name: TestOptions, code: String, expected: String, section: String)(implicit
-      loc: munit.Location
+      loc: munit.Location,
   ): Unit = test(name) {
     val obtained = computeDatabaseSectionFromSnippet(code, section)
     assertNoDiff(obtained, expected)
@@ -150,7 +150,7 @@ abstract class SemanticdbSuite extends FunSuite {
 
   def diagnostics(code: String, expected: String)(implicit loc: munit.Location): Unit =
     throw new UnsupportedOperationException(
-      "SemanticdbSuite is not able to test against diagnostics. Use ExpectSuite instead."
+      "SemanticdbSuite is not able to test against diagnostics. Use ExpectSuite instead.",
     )
 
   def symbols(code: String, expected: String)(implicit loc: munit.Location): Unit =
@@ -160,7 +160,7 @@ abstract class SemanticdbSuite extends FunSuite {
     checkSection(code, expected, "Synthetics")
 
   private def computeDatabaseAndOccurrencesFromMarkup(
-      markup: String
+      markup: String,
   ): (s.TextDocument, List[String]) = {
     val chevrons = "<<(.*?)>>".r
     val ps0 = chevrons.findAllIn(markup).matchData.map(m => (m.start, m.end)).toList
@@ -205,7 +205,7 @@ abstract class SemanticdbSuite extends FunSuite {
     }
 
   def targeted(markup: String, fn: (s.TextDocument, String) => Unit)(implicit
-      hack: OverloadHack2
+      hack: OverloadHack2,
   ): Unit = test(markup) {
     val (database, occurrences) = computeDatabaseAndOccurrencesFromMarkup(markup)
     occurrences match {
@@ -215,7 +215,7 @@ abstract class SemanticdbSuite extends FunSuite {
   }
 
   def targeted(markup: String, fn: (s.TextDocument, String, String) => Unit)(implicit
-      hack: OverloadHack3
+      hack: OverloadHack3,
   ): Unit = test(markup) {
     val (database, occurrences) = computeDatabaseAndOccurrencesFromMarkup(markup)
     occurrences match {
@@ -225,7 +225,7 @@ abstract class SemanticdbSuite extends FunSuite {
   }
 
   def targeted(markup: String, fn: (s.TextDocument, String, String, String) => Unit)(implicit
-      hack: OverloadHack4
+      hack: OverloadHack4,
   ): Unit = test(markup) {
     val (database, occurrences) = computeDatabaseAndOccurrencesFromMarkup(markup)
     occurrences match {
@@ -235,7 +235,7 @@ abstract class SemanticdbSuite extends FunSuite {
   }
 
   def targeted(markup: String, fn: (s.TextDocument, String, String, String, String) => Unit)(
-      implicit hack: OverloadHack5
+      implicit hack: OverloadHack5,
   ): Unit = test(markup) {
     val (database, occurrences) = computeDatabaseAndOccurrencesFromMarkup(markup)
     occurrences match {
@@ -245,7 +245,7 @@ abstract class SemanticdbSuite extends FunSuite {
   }
 
   def targeted(markup: String, fn: (s.TextDocument, String, String, String, String, String) => Unit)(
-      implicit hack: OverloadHack5
+      implicit hack: OverloadHack5,
   ): Unit = test(markup) {
     val (database, occurrences) = computeDatabaseAndOccurrencesFromMarkup(markup)
     occurrences match {
@@ -256,7 +256,7 @@ abstract class SemanticdbSuite extends FunSuite {
 
   def targeted(
       markup: String,
-      fn: (s.TextDocument, String, String, String, String, String, String) => Unit
+      fn: (s.TextDocument, String, String, String, String, String, String) => Unit,
   )(implicit hack: OverloadHack5): Unit = test(markup) {
     val (database, occurrences) = computeDatabaseAndOccurrencesFromMarkup(markup)
     occurrences match {

--- a/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/Source3Suite.scala
+++ b/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/Source3Suite.scala
@@ -19,7 +19,7 @@ class Source3Suite extends FunSuite {
   def check(
       original: String,
       expected: String,
-      compat: List[(ScalaVersion.Version, String)] = List.empty
+      compat: List[(ScalaVersion.Version, String)] = List.empty,
   )(implicit loc: munit.Location): Unit = test(logger.revealWhitespace(original)) {
     val options = List("-P:semanticdb:synthetics:on", "-P:semanticdb:text:on")
     val document = toTextDocument(compiler, original, options)
@@ -84,8 +84,8 @@ class Source3Suite extends FunSuite {
     expected,
     compat = List(
       ScalaVersion.Scala212 ->
-        expected.replace("scala/package.List.", "scala/collection/immutable/List.")
-    )
+        expected.replace("scala/package.List.", "scala/collection/immutable/List."),
+    ),
   )
 
 }

--- a/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/TargetedSuite.scala
+++ b/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/TargetedSuite.scala
@@ -19,7 +19,7 @@ class TargetedSuite extends SemanticdbSuite {
        |  <<bar>>(children = 4)(3)
        |}
        |""".stripMargin,
-    (_, second) => assertEquals(second, "a/Curry.bar().")
+    (_, second) => assertEquals(second, "a/Curry.bar()."),
   )
 
   targeted(
@@ -34,7 +34,7 @@ class TargetedSuite extends SemanticdbSuite {
     { (_, copy, age) =>
       assertEquals(copy, "b/User#copy().")
       assertEquals(age, "b/User#copy().(age)")
-    }
+    },
   )
 
   // Checks def macros that we can't test in expect tests because expect tests have no dependencies.
@@ -73,7 +73,7 @@ class TargetedSuite extends SemanticdbSuite {
        |[8:9..8:10): x => e/x.x.
        |[8:11..8:16): value => scala/meta/Term.Name#value().
        |[8:17..8:19): == => java/lang/Object#`==`().
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   targeted(
@@ -89,7 +89,7 @@ class TargetedSuite extends SemanticdbSuite {
     { (db, j) =>
       val denot = db.symbols.find(_.symbol == j).get
       assert(denot.symbol.startsWith("local"))
-    }
+    },
   )
 
   targeted(
@@ -104,7 +104,7 @@ class TargetedSuite extends SemanticdbSuite {
       assertEquals(foo1, "g/ao.foo.")
       assertEquals(foo2, "g/ao.foo().")
       assertEquals(foo3, "g/ao.foo(+1).")
-    }
+    },
   )
 
   targeted(
@@ -119,7 +119,7 @@ class TargetedSuite extends SemanticdbSuite {
       assertEquals(foo1, "h/ao.foo().")
       assertEquals(local, "h/ao.local.")
       assertEquals(c, "h/ao.foo().(c)")
-    }
+    },
   )
 
   targeted(
@@ -137,7 +137,7 @@ class TargetedSuite extends SemanticdbSuite {
       assertEquals(local2, "i/ao.local.")
       assertEquals(c1, "i/ao.foo().(c)")
       assertEquals(c2, "i/ao.foo().(c)")
-    }
+    },
   )
 
   targeted(
@@ -151,7 +151,7 @@ class TargetedSuite extends SemanticdbSuite {
     (doc, msg, bodyText) => {
       assertEquals(msg, "j/ao.Msg.")
       assertEquals(bodyText, "j/ao.bodyText.")
-    }
+    },
   )
 
   targeted(
@@ -167,7 +167,7 @@ class TargetedSuite extends SemanticdbSuite {
     (doc, foo, c) => {
       assertEquals(foo, "k/target#foo().")
       assertEquals(c, "k/target#foo().(c)")
-    }
+    },
   )
 
   targeted(
@@ -190,14 +190,14 @@ class TargetedSuite extends SemanticdbSuite {
       assertEquals(overriddenSymbols("l/Child#method()."), None)
       assertEquals(
         overriddenSymbols("l/Max.method()."),
-        Some(List("l/Parent#method().", "l/GrandParent#method()."))
+        Some(List("l/Parent#method().", "l/GrandParent#method().")),
       )
       assertEquals(
         overriddenSymbols("l/Max.toString()."),
-        Some(List("java/lang/Object#toString().", "scala/Any#toString()."))
+        Some(List("java/lang/Object#toString().", "scala/Any#toString().")),
       )
 
-    }
+    },
   )
 
   targeted(
@@ -217,7 +217,7 @@ class TargetedSuite extends SemanticdbSuite {
       assertEquals(double, "m/ImplicitConversion.a.")
       assertEquals(float, "m/ImplicitConversion.a.")
       assertEquals(toInt, "scala/Int#toLong().")
-    }
+    },
   )
 
   targeted(
@@ -234,7 +234,7 @@ class TargetedSuite extends SemanticdbSuite {
     (_, foo1, foo2) => {
       assertEquals(foo1, "n/ForCompWithFilter.foo.")
       assertEquals(foo2, "n/ForCompWithFilter.foo.")
-    }
+    },
   )
 
   targeted(
@@ -244,7 +244,7 @@ class TargetedSuite extends SemanticdbSuite {
        |  val Some(<<a>>) = Some(123)
        |}
        |""".stripMargin,
-    (_, foo1) => assertEquals(foo1, "o/O.a.")
+    (_, foo1) => assertEquals(foo1, "o/O.a."),
   )
 
   test("named-args") {
@@ -304,7 +304,7 @@ class TargetedSuite extends SemanticdbSuite {
            |local1 => val local x$2: String
            |  String => scala/Predef.String#
            |
-           |Occurrences:""".stripMargin
+           |Occurrences:""".stripMargin,
       )
 
     val expected212 = expectedPrevious213
@@ -314,7 +314,7 @@ class TargetedSuite extends SemanticdbSuite {
            |""".stripMargin,
         """|local0 => val local x$1: String
            |  String => java/lang/String#
-           |""".stripMargin
+           |""".stripMargin,
       ) +
       """|
          |Diagnostics:
@@ -331,14 +331,14 @@ class TargetedSuite extends SemanticdbSuite {
         ScalaVersion.Full("2.13.16") -> expectedPrevious213,
         ScalaVersion.Scala212 -> expected212,
         ScalaVersion.Scala211 -> expected212,
-        ScalaVersion.Scala213 -> expected
+        ScalaVersion.Scala213 -> expected,
       ),
-      expected
+      expected,
     )
     assertEquals(
       computePayloadFromSnippet(code).linesIterator.drop(3).filter(!_.startsWith("Uri => "))
         .mkString("", "\n", "\n"),
-      expectedCompat
+      expectedCompat,
     )
   }
 
@@ -368,7 +368,7 @@ class TargetedSuite extends SemanticdbSuite {
            |Occurrences:
            |[0:6..0:19): AmbiguousMend <= _empty_/AmbiguousMend#
            |[1:6..1:7): x <= _empty_/AmbiguousMend#x().
-           |""".stripMargin
+           |""".stripMargin,
       )
     }
   }

--- a/tests-semanticdb/src/test/scala/scala/meta/tests/vfs/RemoveOrphanSemantidbFilesSuite.scala
+++ b/tests-semanticdb/src/test/scala/scala/meta/tests/vfs/RemoveOrphanSemantidbFilesSuite.scala
@@ -44,7 +44,7 @@ class RemoveOrphanSemantidbFilesSuite extends FunSuite {
     val config = SemanticdbConfig.default.copy(
       sourceroot = AbsolutePath(sourceroot),
       targetroot = AbsolutePath(targetroot),
-      fileFilter = FileFilter(".*", "Hello")
+      fileFilter = FileFilter(".*", "Hello"),
     )
 
     val hello = Paths.get("src").resolve("Hello.scala")

--- a/tests/js/src/test/scala/scala/meta/tests/parsers/JSFacadeSuite.scala
+++ b/tests/js/src/test/scala/scala/meta/tests/parsers/JSFacadeSuite.scala
@@ -84,14 +84,14 @@ class JSFacadeSuite extends FunSuite {
                                   "values" -> a(d(
                                     "type" -> "Type.Name",
                                     "pos" -> pos(37, 43),
-                                    "value" -> "String"
-                                  ))
-                                )
-                              )
+                                    "value" -> "String",
+                                  )),
+                                ),
+                              ),
                             )
-                          }
+                          },
                         )
-                      }
+                      },
                     )
                   },
                   "decltpe" -> d("type" -> "Type.Name", "pos" -> pos(47, 51), "value" -> "Unit"),
@@ -106,17 +106,17 @@ class JSFacadeSuite extends FunSuite {
                         "type" -> "Lit.String",
                         "pos" -> pos(66, 80),
                         "value" -> "Hello, World",
-                        "syntax" -> """"Hello, World""""
-                      ))
-                    )
-                  )
+                        "syntax" -> """"Hello, World"""",
+                      )),
+                    ),
+                  ),
                 )
-              }
+              },
             ),
-            "derives" -> a()
-          )
+            "derives" -> a(),
+          ),
         )
-      }
+      },
     )
 
     check(parsed, expected)
@@ -188,10 +188,10 @@ class JSFacadeSuite extends FunSuite {
       "pats" -> a(d(
         "type" -> "Pat.Var",
         "pos" -> pos(4, 5),
-        "name" -> d("type" -> "Term.Name", "pos" -> pos(4, 5), "value" -> "x")
+        "name" -> d("type" -> "Term.Name", "pos" -> pos(4, 5), "value" -> "x"),
       )),
       "decltpe" -> d("type" -> "Lit.Int", "pos" -> pos(7, 8), "value" -> 1, "syntax" -> "1"),
-      "rhs" -> d("type" -> "Lit.Int", "pos" -> pos(11, 12), "value" -> 1, "syntax" -> "1")
+      "rhs" -> d("type" -> "Lit.Int", "pos" -> pos(11, 12), "value" -> 1, "syntax" -> "1"),
     )
     check(parsedDefaultDialect, expected)
   }
@@ -221,8 +221,8 @@ class JSFacadeSuite extends FunSuite {
       "argClause" -> d(
         "type" -> "Term.ArgClause",
         "pos" -> pos(4, 17),
-        "values" -> a(lit("Lit.Int", 1, "1", pos(8, 9)), lit("Lit.Int", 2, "2", pos(13, 14)))
-      )
+        "values" -> a(lit("Lit.Int", 1, "1", pos(8, 9)), lit("Lit.Int", 2, "2", pos(13, 14))),
+      ),
     )
     check(parsedDefaultDialect, expected)
   }

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/testkit/ScalacParser.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/testkit/ScalacParser.scala
@@ -16,7 +16,7 @@ object ScalacParser {
   val files: mutable.Buffer[File] = collection.mutable.Buffer.empty[java.io.File]
   val settings = new Settings()
   Seq("sun.boot.class.path", "java.class.path").foreach(prop =>
-    System.getProperty(prop).split(File.pathSeparator).foreach(entry => files.append(new File(entry)))
+    System.getProperty(prop).split(File.pathSeparator).foreach(entry => files.append(new File(entry))),
   )
   while (current != null) {
     current match {

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/testkit/ScalametaParserProperties.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/testkit/ScalametaParserProperties.scala
@@ -50,7 +50,7 @@ object ScalametaParserProperties {
       file.jFile.parse[Source] match {
         case Parsed.Success(s) => onParseSuccess(s)
         case e: Parsed.Error => onParseError(file, e)
-      }
+      },
     )
   }
 
@@ -71,7 +71,7 @@ class ScalametaParserPropertyTest extends FunSuite {
     val prettyPrinterBroken = result.count(_._2.kind == PrettyPrinterBroken)
     println(
       s"""|Parser broken: $parserBroken
-          |Pretty printer broken: $prettyPrinterBroken""".stripMargin
+          |Pretty printer broken: $prettyPrinterBroken""".stripMargin,
     )
     assert(parserBroken <= 4)
     assert(prettyPrinterBroken <= 1888)

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/testkit/prettyprinters/PrettyPrinterSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/testkit/prettyprinters/PrettyPrinterSuite.scala
@@ -23,7 +23,7 @@ class PrettyPrinterSuite extends FunSuite {
           s"""|Not Structurally equal: ${err.toString}:
               |before: ${before.structure}
               |after : ${after.structure}
-              |""".stripMargin
+              |""".stripMargin,
         )
       case _ => Nil
     }

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
@@ -35,8 +35,8 @@ class ReflectionSuite extends TreeSuiteBase {
         "field Term.If.cond: scala.meta.Term",
         "field Term.If.thenp: scala.meta.Term",
         "field Term.If.elsep: scala.meta.Term",
-        "field Term.If.mods: List[scala.meta.Mod]"
-      )
+        "field Term.If.mods: List[scala.meta.Mod]",
+      ),
     )
     assertEquals(
       iff.allFields.map(_.toString),
@@ -47,8 +47,8 @@ class ReflectionSuite extends TreeSuiteBase {
         "field Term.If.cond: scala.meta.Term",
         "field Term.If.thenp: scala.meta.Term",
         "field Term.If.elsep: scala.meta.Term",
-        "field Term.If.mods: List[scala.meta.Mod]"
-      )
+        "field Term.If.mods: List[scala.meta.Mod]",
+      ),
     )
   }
 
@@ -56,7 +56,7 @@ class ReflectionSuite extends TreeSuiteBase {
     val iff = symbolOf[scala.meta.Term.Name].asLeaf
     assertEquals(
       iff.fields.map(_.toString),
-      List("field Term.Name.value: String @org.scalameta.invariants.nonEmpty")
+      List("field Term.Name.value: String @org.scalameta.invariants.nonEmpty"),
     )
     assertEquals(
       iff.allFields.map(_.toString),
@@ -64,8 +64,8 @@ class ReflectionSuite extends TreeSuiteBase {
         "field Term.Name.origin: scala.meta.trees.Origin",
         "field Term.Name.begComment: Option[meta.Tree.Comments]",
         "field Term.Name.endComment: Option[meta.Tree.Comments]",
-        "field Term.Name.value: String @org.scalameta.invariants.nonEmpty"
-      )
+        "field Term.Name.value: String @org.scalameta.invariants.nonEmpty",
+      ),
     )
   }
 
@@ -79,7 +79,7 @@ class ReflectionSuite extends TreeSuiteBase {
     // NOTE: we can't just do `duplicateRelevantFieldTpes.distinct`, because that doesn't account for `=:=`
     val distinctRelevantFieldTpes = ListBuffer[Type]()
     duplicateRelevantFieldTpes.foreach(tpe =>
-      if (!distinctRelevantFieldTpes.exists(_ =:= tpe)) distinctRelevantFieldTpes += tpe
+      if (!distinctRelevantFieldTpes.exists(_ =:= tpe)) distinctRelevantFieldTpes += tpe,
     )
     val obtained = distinctRelevantFieldTpes.sortBy(_.toString).mkString(EOL)
     assertNoDiff(
@@ -156,7 +156,7 @@ class ReflectionSuite extends TreeSuiteBase {
          |scala.meta.Type.CasesBlock
          |scala.meta.Type.FuncParamClause
          |scala.meta.Type.Name
-         |""".stripMargin.lf2nl
+         |""".stripMargin.lf2nl,
     )
   }
 }

--- a/tests/jvm/src/test/scala-2/scala/meta/tests/api/PublicSuite.scala
+++ b/tests/jvm/src/test/scala-2/scala/meta/tests/api/PublicSuite.scala
@@ -11,9 +11,9 @@ class PublicSuite extends FunSuite {
     typecheckError(
       """
              q"hello"
-           """
+           """,
     ),
-    "value q is not a member of StringContext"
+    "value q is not a member of StringContext",
   ))
 
   test("quasiquotes without static dialect") {
@@ -24,9 +24,9 @@ class PublicSuite extends FunSuite {
              import scala.meta._
              implicit val dialect: scala.meta.Dialect = ???
              q"hello"
-           """
+           """,
       ),
-      s"dialect of type scala.meta.Dialect is not supported by quasiquotes (to fix this, import something from scala.meta.dialects, e.g. scala.meta.dialects.$currentDialect)"
+      s"dialect of type scala.meta.Dialect is not supported by quasiquotes (to fix this, import something from scala.meta.dialects, e.g. scala.meta.dialects.$currentDialect)",
     )
   }
 
@@ -36,18 +36,18 @@ class PublicSuite extends FunSuite {
              import scala.meta._
              import scala.meta.dialects.Scala211
              q"hello"
-           """
+           """,
     ),
-    ""
+    "",
   ))
 
   test("InputLike.parse without import")(assertEquals(
     typecheckError(
       """
              "".parse[scala.meta.Term]
-           """
+           """,
     ),
-    "value parse is not a member of String"
+    "value parse is not a member of String",
   ))
 
   test("InputLike.parse without input-likeness")(assertEquals(
@@ -55,9 +55,9 @@ class PublicSuite extends FunSuite {
       """
              import scala.meta._
              1.parse[Term]
-           """
+           """,
     ),
-    "don't know how to convert Int to scala.meta.inputs.Input"
+    "don't know how to convert Int to scala.meta.inputs.Input",
   ))
 
   test("InputLike.parse without parseability")(assertEquals(
@@ -66,9 +66,9 @@ class PublicSuite extends FunSuite {
              import scala.meta._
              import scala.meta.dialects.Scala211
              "".parse[Int]
-           """
+           """,
     ),
-    "don't know how to parse into Int"
+    "don't know how to parse into Int",
   ))
 
   test("InputLike.parse when everything's correct (static dialect)")(assertEquals(
@@ -77,9 +77,9 @@ class PublicSuite extends FunSuite {
              import scala.meta._
              import scala.meta.dialects.Scala211
              "".parse[Term]
-           """
+           """,
     ),
-    ""
+    "",
   ))
 
   test("InputLike.parse when everything's correct (dynamic dialect)")(assertEquals(
@@ -88,9 +88,9 @@ class PublicSuite extends FunSuite {
              import scala.meta._
              implicit val dialect: scala.meta.Dialect = ???
              "".parse[Term]
-           """
+           """,
     ),
-    ""
+    "",
   ))
 
   test("InputLike.parse with various input types") {
@@ -108,7 +108,7 @@ class PublicSuite extends FunSuite {
              (??? : Array[Char]).parse[Term]
            """
       },
-      ""
+      "",
     )
   }
 
@@ -117,27 +117,27 @@ class PublicSuite extends FunSuite {
     typecheckError(
       """
              scala.meta.dialects.Scala211("").parse[scala.meta.Term]
-           """
+           """,
     ),
-    ""
+    "",
   ))
 
   test("Dialect.parse without input-likeness")(assertEquals(
     typecheckError(
       """
              scala.meta.dialects.Scala211(1).parse[scala.meta.Term]
-           """
+           """,
     ),
-    "don't know how to convert Int to scala.meta.inputs.Input"
+    "don't know how to convert Int to scala.meta.inputs.Input",
   ))
 
   test("Dialect.parse without parseability")(assertEquals(
     typecheckError(
       """
              scala.meta.dialects.Scala211("").parse[Int]
-           """
+           """,
     ),
-    "don't know how to parse into Int"
+    "don't know how to parse into Int",
   ))
 
   test("Dialect.parse with various input types") {
@@ -151,7 +151,7 @@ class PublicSuite extends FunSuite {
              scala.meta.dialects.Scala211(??? : Array[Char]).parse[scala.meta.Term]
            """
       },
-      ""
+      "",
     )
   }
 
@@ -159,9 +159,9 @@ class PublicSuite extends FunSuite {
     typecheckError(
       """
              "".tokenize
-           """
+           """,
     ),
-    "value tokenize is not a member of String"
+    "value tokenize is not a member of String",
   ))
 
   test("tokenize without input-likeness")(assertEquals(
@@ -169,9 +169,9 @@ class PublicSuite extends FunSuite {
       """
              import scala.meta._
              1.tokenize
-           """
+           """,
     ),
-    "don't know how to convert Int to scala.meta.inputs.Input"
+    "don't know how to convert Int to scala.meta.inputs.Input",
   ))
 
   test("tokenize when everything's correct (static dialect)")(assertEquals(
@@ -180,9 +180,9 @@ class PublicSuite extends FunSuite {
              import scala.meta._
              import scala.meta.dialects.Scala211
              "".tokenize
-           """
+           """,
     ),
-    ""
+    "",
   ))
 
   test("tokenize when everything's correct (dynamic dialect)")(assertEquals(
@@ -191,9 +191,9 @@ class PublicSuite extends FunSuite {
              import scala.meta._
              implicit val dialect: scala.meta.Dialect = ???
              "".tokenize
-           """
+           """,
     ),
-    ""
+    "",
   ))
 
   test("tokenize with various input types") {
@@ -207,9 +207,9 @@ class PublicSuite extends FunSuite {
              (??? : java.io.File).tokenize
              (??? : Tokens).tokenize
              (??? : Array[Char]).tokenize
-           """
+           """,
       ),
-      ""
+      "",
     )
   }
 
@@ -218,27 +218,27 @@ class PublicSuite extends FunSuite {
     typecheckError(
       """
              scala.meta.dialects.Scala211("").tokenize
-           """
+           """,
     ),
-    ""
+    "",
   ))
 
   test("Dialect.tokenize without input-likeness")(assertEquals(
     typecheckError(
       """
              scala.meta.dialects.Scala211(1).tokenize
-           """
+           """,
     ),
-    "don't know how to convert Int to scala.meta.inputs.Input"
+    "don't know how to convert Int to scala.meta.inputs.Input",
   ))
 
   test("Dialect.tokenize when everything's correct")(assertEquals(
     typecheckError(
       """
              scala.meta.dialects.Scala211("").tokenize
-           """
+           """,
     ),
-    ""
+    "",
   ))
 
   test("Dialect.tokenize with various input types") {
@@ -252,7 +252,7 @@ class PublicSuite extends FunSuite {
              scala.meta.dialects.Scala211(??? : Array[Char]).tokenize
            """
       },
-      ""
+      "",
     )
   }
 
@@ -260,9 +260,9 @@ class PublicSuite extends FunSuite {
     typecheckError(
       """
              (??? : scala.meta.Tree).show[Syntax]
-           """
+           """,
     ),
-    "not found: type Syntax"
+    "not found: type Syntax",
   ))
 
   test("show[Syntax] when everything's correct (static dialect)")(assertEquals(
@@ -272,9 +272,9 @@ class PublicSuite extends FunSuite {
              import scala.meta.dialects.Scala211
              (??? : Tree).show[Syntax]
              (??? : Tree).syntax
-           """
+           """,
     ),
-    ""
+    "",
   ))
 
   test("show[Syntax] when everything's correct (dynamic dialect)")(assertEquals(
@@ -285,18 +285,18 @@ class PublicSuite extends FunSuite {
              (??? : Tree).show[Syntax]
              (??? : Tree).syntax
              dialect(??? : Tree).syntax
-           """
+           """,
     ),
-    ""
+    "",
   ))
 
   test("show[Structure] without import")(assertEquals(
     typecheckError(
       """
              (??? : scala.meta.Tree).show[Structure]
-           """
+           """,
     ),
-    "not found: type Structure"
+    "not found: type Structure",
   ))
 
   test("show[Structure] when everything's correct")(assertEquals(
@@ -305,9 +305,9 @@ class PublicSuite extends FunSuite {
              import scala.meta._
              (??? : Tree).show[Structure]
              (??? : Tree).structure
-           """
+           """,
     ),
-    ""
+    "",
   ))
 
   test("Token.is[T] without import")(assertEquals(
@@ -315,9 +315,9 @@ class PublicSuite extends FunSuite {
       """
              (??? : scala.meta.Token).is[scala.meta.Token]
              (??? : scala.meta.Token).is[scala.meta.Token.Ident]
-           """
+           """,
     ),
-    ""
+    "",
   ))
 
   test("Tree.is[T] without import")(assertEquals(
@@ -325,8 +325,8 @@ class PublicSuite extends FunSuite {
       """
              (??? : scala.meta.Tree).is[scala.meta.Tree]
              (??? : scala.meta.Tree).is[scala.meta.Type]
-           """
+           """,
     ),
-    ""
+    "",
   ))
 }

--- a/tests/jvm/src/test/scala-2/scala/meta/tests/tokens/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2/scala/meta/tests/tokens/ReflectionSuite.scala
@@ -60,7 +60,7 @@ class ReflectionSuite extends TreeSuiteBase {
          |Token.Xml.SpliceEnd
          |Token.Xml.SpliceStart
          |Token.Xml.Start
-         |""".stripMargin.lf2nl
+         |""".stripMargin.lf2nl,
     )
   }
 }

--- a/tests/jvm/src/test/scala/scala/meta/tests/parsers/dotty/CtrlExprJVMSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/parsers/dotty/CtrlExprJVMSuite.scala
@@ -34,8 +34,8 @@ class CtrlExprJVMSuite extends BaseDottySuite {
         Nil,
         List(Nil),
         Some(pname("Unit")),
-        blk(generateIfsTree(nestedNum))
-      ))
+        blk(generateIfsTree(nestedNum)),
+      )),
     )))
 
     runTestAssert[Source](code)(tree)

--- a/tests/jvm/src/test/scala/scala/meta/tests/prettyprinters/RegressionSyntaxSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/prettyprinters/RegressionSyntaxSuite.scala
@@ -11,7 +11,7 @@ class RegressionSyntaxSuite extends ParseSuite {
       testOpts: TestOptions,
       code: String,
       expected: String,
-      newDialect: Dialect = dialects.Scala213
+      newDialect: Dialect = dialects.Scala213,
   )(implicit dialect: Dialect) = test(testOpts) {
     val obtained = code.parse[Stat].get
     val reprintedCode = obtained.reprint(newDialect)

--- a/tests/jvm/src/test/scala/scala/meta/tests/tokenizers/UnicodeEscapeSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/tokenizers/UnicodeEscapeSuite.scala
@@ -13,7 +13,7 @@ class UnicodeEscapeSuite extends BaseTokenizerSuite {
   // as 6 characters instead of one.
   val tests = new String(
     InputStreamIO.readBytes(this.getClass.getClassLoader.getResourceAsStream("unicode.txt")),
-    StandardCharsets.UTF_8
+    StandardCharsets.UTF_8,
   )
 
   // asserts that tokenize(code).syntax == code

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/parsers/dotty/Scala3PositionSuite.scala
@@ -15,14 +15,14 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Type.ParamClause [X@@] =>> (X, X)
        |Type.Bounds [X@@] =>> (X, X)
        |Type.Tuple (X, X)
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Type](
     "[_] =>> Unit",
     """|Type.ParamClause [_]
        |Type.ParamClause [_@@] =>> Unit
        |Type.Bounds [_@@] =>> Unit
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat]("inline def f = 1")
   checkPositions[Stat](
@@ -31,7 +31,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Ctor.Primary open trait a@@
        |Template open trait a@@
        |Template.Body open trait a@@
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -53,7 +53,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Defn.Def def isZero = i == 0
        |Term.ApplyInfix i == 0
        |Type.ArgClause extension [A, B](i: A)(using a: F[A], G[B]) def isZero = i == @@0
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -74,7 +74,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Defn.Def def isOne = i == 1
        |Term.ApplyInfix i == 1
        |Type.ArgClause   def isOne = i == @@1
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // This tests exists to document the symmetry between positions for
@@ -86,7 +86,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Term.ParamClause (implicit a: A, b: B)
        |Term.Param a: A
        |Term.Param b: B
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -99,7 +99,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Template extends A with B { case Monday, Tuesday }
        |Template.Body { case Monday, Tuesday }
        |Defn.RepeatedEnumCase case Monday, Tuesday
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "class Day[T](e: T) extends A with B { val Monday = 42 }",
@@ -111,7 +111,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Template extends A with B { val Monday = 42 }
        |Template.Body { val Monday = 42 }
        |Defn.Val val Monday = 42
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "inline given intOrd: Ord[Int] with Eq[Int] with { def f(): Int = 1 }",
@@ -127,7 +127,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Member.ParamClauseGroup ()
        |Type.ParamClause inline given intOrd: Ord[Int] with Eq[Int] with { def f@@(): Int = 1 }
        |Term.ParamClause ()
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     """|given intOrd: Ord[Int] with Eq[Int] with
@@ -152,7 +152,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |<tparamClause>Type.ParamClause   def f@@(): Int = 1</tparamClause>
        |<paramClauses0>Term.ParamClause ()</paramClauses0>
        |""".stripMargin,
-    showFieldName = true
+    showFieldName = true,
   )
   checkPositions[Stat](
     """|object A{
@@ -167,7 +167,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Decl.Given inline given intOrd: Ord[Int]
        |Type.Apply Ord[Int]
        |Type.ArgClause [Int]
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     """|object A{
@@ -182,7 +182,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Defn.GivenAlias given intOrd: Ord[Int] = intOrd
        |Type.Apply Ord[Int]
        |Type.ArgClause [Int]
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     """|object A {
@@ -196,18 +196,18 @@ class Scala3PositionSuite extends BasePositionSuite {
        |}
        |Export export a.b
        |Importer a.b
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "export A.{ b, c, d, _ }",
     """|Importer A.{ b, c, d, _ }
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "export a.{given Int}",
     """|Importer a.{given Int}
        |Importee.Given given Int
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "import Instances.{ im, given Ordering[?] }",
@@ -217,13 +217,13 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Type.ArgClause [?]
        |Type.Wildcard ?
        |Type.Bounds import Instances.{ im, given Ordering[?@@] }
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "import File.given",
     """|Importer File.given
        |Importee.GivenAll given
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Type]("A & B")
   checkPositions[Type]("A | B")
@@ -246,7 +246,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Type.Apply Array[t]
        |Type.ArgClause [t]
        |Type.Bounds type T @@= A match {
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     """|for case a: TP <- iter if cnd do
@@ -255,14 +255,14 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Enumerator.CaseGenerator case a: TP <- iter
        |Pat.Typed a: TP
        |Enumerator.Guard if cnd
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "infix def a(param: Int) = param",
     """|Member.ParamClauseGroup (param: Int)
        |Type.ParamClause infix def a@@(param: Int) = param
        |Term.ParamClause (param: Int)
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "infix type or[X, Y]",
@@ -272,13 +272,13 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Type.ParamClause infix type or[X, Y@@]
        |Type.Bounds infix type or[X, Y@@]
        |Type.Bounds infix type or[X, Y]@@
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "def fn: Unit = inline if cond then truep",
     """|Term.If inline if cond then truep
        |Lit.Unit def fn: Unit = inline if cond then truep@@
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     """|x match {
@@ -291,7 +291,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Pat.Macro '{ a }
        |Term.QuotedMacroExpr '{ a }
        |Term.Block { a }
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     """|x match {
@@ -304,7 +304,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Pat.Extract List(xs*)
        |Pat.ArgClause (xs*)
        |Pat.Repeated xs*
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "val extractor: (e: Entry, f: Other) => e.Key = extractKey",
@@ -313,7 +313,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Type.TypedParam e: Entry
        |Type.TypedParam f: Other
        |Type.Select e.Key
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "type F0 = [T] => List[T] ?=> Option[T]",
@@ -329,7 +329,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Type.Apply Option[T]
        |Type.ArgClause [T]
        |Type.Bounds type F0 @@= [T] => List[T] ?=> Option[T]
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     """|inline def g: Any = inline x match {
@@ -349,7 +349,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Term.Tuple (x, x)
        |Case case x: Double => x
        |Pat.Typed x: Double
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "class Alpha[T] derives Gamma[T], Beta[T]",
@@ -363,7 +363,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Type.ArgClause [T]
        |Type.Apply Beta[T]
        |Type.ArgClause [T]
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     """|object O {
@@ -413,7 +413,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Importer a.b.C as _
        |Term.Select a.b
        |Importee.Unimport C as _
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -438,7 +438,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Defn.Def def b: String =
        |    "b"
        |Lit.String "b"
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -473,7 +473,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Term.CasesBlock case a =>
        |Case case a =>
        |Term.Block        case a =>@@
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -531,7 +531,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |         st2
        |Term.Block st1
        |         st2
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -555,7 +555,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Term.Block   case bb =>@@
        |Term.Block cc
        |  dd
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -570,7 +570,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |  
        |  private given x: X = ???
        |Defn.GivenAlias private given x: X = ???
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -600,7 +600,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Term.Block {
        |    42
        |  }
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -623,7 +623,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Term.ParamClause (z: String)
        |Term.Block fx
        |      gx
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -650,7 +650,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Term.Apply gx(s)
        |Term.ArgClause (s)
        |Lit.String "yo"
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -681,7 +681,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Term.Apply gx(s)
        |Term.ArgClause (s)
        |Lit.String "yo"
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -706,7 +706,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Pat.Typed _: Enum
        |Case case _: Singleton => xs
        |Pat.Typed _: Singleton
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -725,7 +725,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |}
        |Term.ApplyInfix x * x
        |Type.ArgClause   x * @@x
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -733,7 +733,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |""".stripMargin,
     """|Term.ParamClause (using _: C)
        |Term.Param using _: C
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -756,7 +756,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Term.Block gx
        |    fx
        |Lit.Unit     fx@@
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -802,7 +802,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |      // c1
        |Term.Block gx
        |      // c2
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -851,7 +851,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |      gx
        |Term.Block fx
        |      // c1
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // do not add LF to end of input
@@ -898,7 +898,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |      // c1
        |Term.Block gx
        |      // c2
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // do not add LF to end of input
@@ -948,7 +948,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |      gx
        |Term.Block fx
        |      // c1
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -999,7 +999,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |      gx
        |Term.Block fx
        |      // c1
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -1047,7 +1047,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |      gx
        |Term.Block fx
        |      // c1
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // do not add LF to end of input
@@ -1071,7 +1071,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Template extends ClassificationValue
        |        with ConstantText
        |Template.Body         with ConstantText@@
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -1085,7 +1085,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Case case (false, false) => (baz, qux)
        |Pat.Tuple (false, false)
        |Term.Tuple (baz, qux)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -1100,7 +1100,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Case case (false, false) => (baz, qux)
        |Pat.Tuple (false, false)
        |Term.Tuple (baz, qux)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -1121,7 +1121,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Case case (false, true) => (baz, qux)
        |Pat.Tuple (false, true)
        |Term.Tuple (baz, qux)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -1141,7 +1141,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Case case (false, true) => (baz, qux)
        |Pat.Tuple (false, true)
        |Term.Tuple (baz, qux)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -1157,7 +1157,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Case case (false, true) => (baz, qux)
        |Pat.Tuple (false, true)
        |Term.Tuple (baz, qux)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -1173,7 +1173,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Case case (false, true) => (baz, qux)
        |Pat.Tuple (false, true)
        |Term.Tuple (baz, qux)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -1190,7 +1190,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Case case (false, true) => (baz, qux)
        |Pat.Tuple (false, true)
        |Term.Tuple (baz, qux)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -1207,7 +1207,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Defn.Type type T = String
        |Type.ParamClause val x: (C { type U = T } { type T @@= String }) # U
        |Type.Bounds val x: (C { type U = T } { type T @@= String }) # U
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -1222,7 +1222,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Type.ParamClause   type T@@>: Null
        |Type.Bounds >: Null
        |Type.Bounds type A @@= AnyRef with
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -1238,7 +1238,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Type.ParamClause   type T@@>: Null
        |Type.Bounds >: Null
        |Type.Bounds type A @@= AnyRef:
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Type](
@@ -1247,7 +1247,7 @@ class Scala3PositionSuite extends BasePositionSuite {
     """|Type.FuncParamClause (x: X, y: Y)
        |Type.TypedParam x: X
        |Type.TypedParam y: Y
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Type](
@@ -1257,7 +1257,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Type.Repeated X*
        |Type.ByName => Y*
        |Type.Repeated Y*
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3219
@@ -1265,7 +1265,7 @@ class Scala3PositionSuite extends BasePositionSuite {
     "(10) + 1 toInt",
     """|Term.ApplyInfix (10) + 1
        |Type.ArgClause (10) + @@1 toInt
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     """|if (10) + 1 == 11 then
@@ -1276,7 +1276,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Type.ArgClause if (10) + @@1 == 11 then
        |Type.ArgClause if (10) + 1 == @@11 then
        |Lit.Unit @@
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3319
@@ -1290,7 +1290,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Type.ArgClause   bar foreach@@:
        |Term.Block :
        |    baz
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     """|val foo =
@@ -1308,7 +1308,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Term.Param baz
        |Term.Apply println(baz)
        |Term.ArgClause (baz)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 1
@@ -1318,7 +1318,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |}
        |""".stripMargin,
     """|Defn.Val val a = 1
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 2
@@ -1330,7 +1330,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |""".stripMargin,
     """|Defn.Val val b =
        |    1
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 2.1
@@ -1347,7 +1347,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Term.Block {
        |    1 // comment
        |  }
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 3
@@ -1359,7 +1359,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |""".stripMargin,
     """|Defn.Val val b = // comment1
        |    1
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 3.1
@@ -1376,7 +1376,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Term.Block {
        |    1 // comment2
        |  }
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 4
@@ -1390,7 +1390,7 @@ class Scala3PositionSuite extends BasePositionSuite {
     """|Defn.Val val b =
        |    // comment1
        |    1
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 4.1
@@ -1410,7 +1410,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |    // comment1
        |    1 // comment2
        |  }
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 5
@@ -1422,7 +1422,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |""".stripMargin,
     """|Defn.Val val b = // comment
        |    1
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 5.1
@@ -1439,7 +1439,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Term.Block {
        |    1
        |  }
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 6
@@ -1453,7 +1453,7 @@ class Scala3PositionSuite extends BasePositionSuite {
     """|Defn.Val val b =
        |    // comment
        |    1
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 6.1
@@ -1473,7 +1473,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |    // comment
        |    1
        |  }
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 7
@@ -1489,7 +1489,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |    // comment
        |Term.Block 1
        |    // comment
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 7.1
@@ -1509,7 +1509,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |    1
        |    // comment
        |  }
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 8
@@ -1525,7 +1525,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |    // comment2
        |Term.Block 1
        |    // comment2
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 8.1
@@ -1545,7 +1545,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |    1
        |    // comment2
        |  }
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 9
@@ -1563,7 +1563,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |    // comment2
        |Term.Block 1
        |    // comment2
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 9.1
@@ -1586,7 +1586,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |    1
        |    // comment2
        |  }
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Term](
@@ -1633,7 +1633,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Indentation.Outdent [61..61)
        |EOF [62..62)
        |""".stripMargin,
-    showFieldName = true
+    showFieldName = true,
   )
 
   checkPositions[Term](
@@ -1650,7 +1650,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |<argClause>Term.ArgClause ()</argClause>
        |<elsep>Lit.Unit @@</elsep>
        |""".stripMargin,
-    showFieldName = true
+    showFieldName = true,
   )
 
   checkPositions[Stat](
@@ -1701,7 +1701,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Indentation.Outdent [58..58)
        |EOF [59..59)
        |""".stripMargin,
-    showFieldName = true
+    showFieldName = true,
   )
 
   checkPositions[Term](
@@ -1729,7 +1729,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |RightBrace [46..47)
        |EOF [48..48)
        |""".stripMargin,
-    showFieldName = true
+    showFieldName = true,
   )
 
   checkPositions[Term](
@@ -1761,7 +1761,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |RightBrace [50..51)
        |EOF [52..52)
        |""".stripMargin,
-    showFieldName = true
+    showFieldName = true,
   )
 
   checkPositions[Term](
@@ -1795,7 +1795,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |RightBrace [52..53)
        |EOF [54..54)
        |""".stripMargin,
-    showFieldName = true
+    showFieldName = true,
   )
 
   // comment at end of match but not before case outdent
@@ -1872,7 +1872,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Indentation.Outdent [121..121)
        |EOF [122..122)
        |""".stripMargin,
-    showFieldName = true
+    showFieldName = true,
   )
 
   // comment at end of match and also at end of case
@@ -1952,7 +1952,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Indentation.Outdent [123..123)
        |EOF [124..124)
        |""".stripMargin,
-    showFieldName = true
+    showFieldName = true,
   )
 
   checkPositions[Source](
@@ -1989,7 +1989,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |<templ>Template   // c3@@</templ>
        |<body>Template.Body   // c3@@</body>
        |""".stripMargin,
-    showFieldName = true
+    showFieldName = true,
   )
 
   checkPositions[Source](
@@ -2031,7 +2031,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |<templ>Template   class Baz@@</templ>
        |<body>Template.Body   class Baz@@</body>
        |""".stripMargin,
-    showFieldName = true
+    showFieldName = true,
   )
 
   checkPositions[Source](
@@ -2091,7 +2091,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Indentation.Outdent [82..82)
        |EOF [83..83)
        |""".stripMargin,
-    showFieldName = true
+    showFieldName = true,
   )
 
   checkPositions[Source](
@@ -2165,7 +2165,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |RightBrace [89..90)
        |EOF [91..91)
        |""".stripMargin,
-    showFieldName = true
+    showFieldName = true,
   )
 
   checkPositions[Source](
@@ -2284,7 +2284,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Indentation.Outdent [141..141)
        |EOF [142..142)
        |""".stripMargin,
-    showFieldName = true
+    showFieldName = true,
   )
 
   checkPositions[Source](
@@ -2455,7 +2455,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Indentation.Outdent [177..177)
        |EOF [178..178)
        |""".stripMargin,
-    showFieldName = true
+    showFieldName = true,
   )
 
   checkPositions[Source](
@@ -2645,7 +2645,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |RightBrace [182..183)
        |EOF [184..184)
        |""".stripMargin,
-    showFieldName = true
+    showFieldName = true,
   )
 
   checkPositions[Source](
@@ -2832,7 +2832,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Indentation.Outdent [180..180)
        |EOF [181..181)
        |""".stripMargin,
-    showFieldName = true
+    showFieldName = true,
   )
 
   checkPositions[Stat](
@@ -2873,7 +2873,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Indentation.Outdent [68..68)
        |EOF [69..69)
        |""".stripMargin,
-    showFieldName = true
+    showFieldName = true,
   )
 
   checkPositions[Stat](
@@ -2945,7 +2945,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Indentation.Outdent [137..137)
        |EOF [138..138)
        |""".stripMargin,
-    showFieldName = true
+    showFieldName = true,
   )
 
   checkPositions[Stat](
@@ -3012,7 +3012,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Ident(xyz) [134..137)
        |EOF [138..138)
        |""".stripMargin,
-    showFieldName = true
+    showFieldName = true,
   )
 
   checkPositions[Stat](
@@ -3064,7 +3064,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |EOF [64..64)
        |""".stripMargin,
     showPosition = true,
-    showFieldName = true
+    showFieldName = true,
   )
 
   // given 3.6+
@@ -3080,7 +3080,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Template.Body :
        |  def foo = ???
        |Defn.Def def foo = ???
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -3098,7 +3098,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |  def foo = ???
        |}
        |Defn.Def def foo = ???
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -3106,7 +3106,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |""".stripMargin,
     """|Type.Apply Ord[Int]
        |Type.ArgClause [Int]
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -3121,7 +3121,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Type.ArgClause [List[A]]
        |Type.Apply List[A]
        |Type.ArgClause [A]
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -3136,7 +3136,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Type.ArgClause [List[A]]
        |Type.Apply List[A]
        |Type.ArgClause [A]
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -3153,7 +3153,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Type.ArgClause [List[A]]
        |Type.Apply List[A]
        |Type.ArgClause [A]
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -3170,7 +3170,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Type.ArgClause [List[A]]
        |Type.Apply List[A]
        |Type.ArgClause [A]
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -3190,7 +3190,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Type.ArgClause [List[A]]
        |Type.Apply List[A]
        |Type.ArgClause [A]
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -3216,7 +3216,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Type.ArgClause [List[A]]
        |Type.Apply List[A]
        |Type.ArgClause [A]
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -3234,7 +3234,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Type.ArgClause [List[A]]
        |Type.Apply List[A]
        |Type.ArgClause [A]
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -3251,7 +3251,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Type.ArgClause [List[A]]
        |Type.Apply List[A]
        |Type.ArgClause [A]
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -3277,7 +3277,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |Type.ArgClause [List[B]]
        |Type.Apply List[B]
        |Type.ArgClause [B]
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   locally {
@@ -3297,7 +3297,7 @@ class Scala3PositionSuite extends BasePositionSuite {
          |Term.Apply List(1, 2, 3) [38:List(1, 2, 3):51)
          |Term.ArgClause (1, 2, 3) [42:(1, 2, 3):51)
          |""".stripMargin,
-      showPosition = true
+      showPosition = true,
     )
   }
 
@@ -3322,7 +3322,7 @@ class Scala3PositionSuite extends BasePositionSuite {
          |RightArrow [33..35)
          |Indentation.Outdent [35..35)
          |EOF [36..36)
-         |""".stripMargin
+         |""".stripMargin,
     )
   }
 
@@ -3366,7 +3366,7 @@ class Scala3PositionSuite extends BasePositionSuite {
        |EOF [43..43)
        |""".stripMargin,
     showPosition = true,
-    showFieldName = true
+    showFieldName = true,
   )
 
 }

--- a/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
+++ b/tests/shared/src/test/scala-2.13/scala/meta/tests/tokenizers/TokensPositionSuite.scala
@@ -11,7 +11,7 @@ class TokensPositionSuite extends BasePositionSuite {
     "`a` <- b",
     """|Pat.Var `a`
        |Term.Name `a`
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Enumerator]("a = 1")
   checkPositions[Enumerator]("if x")
@@ -19,7 +19,7 @@ class TokensPositionSuite extends BasePositionSuite {
     "case `a` =>",
     """|Term.Name `a`
        |Term.Block case `a` =>@@
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Case](
     "case `a` :: `b` :: _ =>",
@@ -28,14 +28,14 @@ class TokensPositionSuite extends BasePositionSuite {
        |Pat.ExtractInfix `b` :: _
        |Term.Name `b`
        |Term.Block case `a` :: `b` :: _ =>@@
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Case](
     "case a b `c` =>",
     """|Pat.ExtractInfix a b `c`
        |Term.Name `c`
        |Term.Block case a b `c` =>@@
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Case](
     "case _ op (a | b) =>",
@@ -43,25 +43,25 @@ class TokensPositionSuite extends BasePositionSuite {
        |Pat.ArgClause (a | b)
        |Pat.Alternative a | b
        |Term.Block case _ op (a | b) =>@@
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Case](
     "case x `.y` () =>",
     """|Pat.ExtractInfix x `.y` ()
        |Term.Name `.y`
        |Term.Block case x `.y` () =>@@
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Case](
     "case a if p =>",
     """|Term.Block case a if p =>@@
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Case]("case _ => ()")
   checkPositions[Case](
     "case _ => {}",
     """|Term.Block {}
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Type]("B")
@@ -72,23 +72,23 @@ class TokensPositionSuite extends BasePositionSuite {
   checkPositions[Type](
     "F[T]",
     """|Type.ArgClause [T]
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Type]("K Map V")
   checkPositions[Type](
     "() => B",
     """|Type.FuncParamClause ()
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Type](
     "A => B",
     """|Type.FuncParamClause A
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Type](
     "(A, B) => C",
     """|Type.FuncParamClause (A, B)
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Type]("(A, B)")
   checkPositions[Type]("A with B")
@@ -97,18 +97,18 @@ class TokensPositionSuite extends BasePositionSuite {
     "A { def f: B }",
     """|Stat.Block { def f: B }
        |Decl.Def def f: B
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Type](
     "A{}",
     """|Stat.Block {}
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Type](
     "{ def f: B }",
     """|Stat.Block { def f: B }
        |Decl.Def def f: B
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Type](
     "A forSome { type T }",
@@ -116,32 +116,32 @@ class TokensPositionSuite extends BasePositionSuite {
        |Decl.Type type T
        |Type.ParamClause A forSome { type T @@}
        |Type.Bounds A forSome { type T @@}
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Type](
     "T @A",
     """|Mod.Annot @A
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Type](
     "_",
     """|Type.Bounds _@@
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Type](
     "_ >: A <: B",
     """|Type.Bounds >: A <: B
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Type](
     "_ <: B",
     """|Type.Bounds <: B
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Type](
     "_ >: A",
     """|Type.Bounds >: A
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Type]("=> T")
   checkPositions[Type]("Any*")
@@ -154,7 +154,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |Type.Bounds <% B[A]
        |Type.Apply B[A]
        |Type.ArgClause [A]
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "def f[A: B]: C",
@@ -163,7 +163,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |Type.Param A: B
        |Type.ParamClause def f[A@@: B]: C
        |Type.Bounds : B
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "def f[A : B : C]: D",
@@ -172,30 +172,30 @@ class TokensPositionSuite extends BasePositionSuite {
        |Type.Param A : B : C
        |Type.ParamClause def f[A @@: B : C]: D
        |Type.Bounds : B : C
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
     "(a): @A",
     """|Mod.Annot @A
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "(f)((((a))))",
     """|Term.ArgClause ((((a))))
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "(f)((a))",
     """|Term.ArgClause ((a))
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "(f)({ case a => a })",
     """|Term.ArgClause ({ case a => a })
        |Term.PartialFunction { case a => a }
        |Case case a => a
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "foo { implicit a => { b }: C }",
@@ -205,26 +205,26 @@ class TokensPositionSuite extends BasePositionSuite {
        |Term.Param implicit a
        |Term.Ascribe { b }: C
        |Term.Block { b }
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "(f)({ x })",
     """|Term.ArgClause ({ x })
        |Term.Block { x }
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "(a) op (b)",
     """|Type.ArgClause (a) op @@(b)
        |Term.ArgClause (b)
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "(a, b) op (c, d)",
     """|Term.Tuple (a, b)
        |Type.ArgClause (a, b) op @@(c, d)
        |Term.ArgClause (c, d)
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "(a, b) op ((c, d))",
@@ -232,33 +232,33 @@ class TokensPositionSuite extends BasePositionSuite {
        |Type.ArgClause (a, b) op @@((c, d))
        |Term.ArgClause ((c, d))
        |Term.Tuple (c, d)
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "1 + 1",
     """|Type.ArgClause 1 + @@1
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "a f ()",
     """|Type.ArgClause a f @@()
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "a f (b)",
     """|Type.ArgClause a f @@(b)
        |Term.ArgClause (b)
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "(f) [A,B]",
     """|Type.ArgClause [A,B]
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "(f) [A]",
     """|Type.ArgClause [A]
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat]("- (a)")
   checkPositions[Stat]("(a): (A)")
@@ -267,69 +267,69 @@ class TokensPositionSuite extends BasePositionSuite {
   checkPositions[Stat](
     "do {d} while (p)",
     """|Term.Block {d}
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat]("(f) _")
   checkPositions[Stat](
     "for { x <- xs } (f)",
     """|Term.EnumeratorsBlock { x <- xs }
        |Enumerator.Generator x <- xs
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "for { x <- xs } yield (f)",
     """|Term.EnumeratorsBlock { x <- xs }
        |Enumerator.Generator x <- xs
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "((a), (b)) => (a)",
     """|Term.ParamClause ((a), (b))
        |Term.Param a
        |Term.Param b
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat]("if (p) (t) else (f)")
   checkPositions[Stat](
     "if (p) (t)",
     """|Lit.Unit if (p) (t)@@
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "if (p) if (p2) t",
     """|Term.If if (p2) t
        |Lit.Unit if (p) if (p2) t@@
        |Lit.Unit if (p) if (p2) t@@
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "if (p) {}",
     """|Term.Block {}
        |Lit.Unit if (p) {}@@
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     """ s"start ${(a)} end"""",
     """|Term.Block {(a)}
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "(a) match { case x => x }",
     """|Term.CasesBlock { case x => x }
        |Case case x => x
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "new (A)",
     """|Init (A)
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "new (A){}",
     """|Template (A){}
        |Init (A)
        |Template.Body {}
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "def f(a: A = (da)): A",
@@ -337,26 +337,26 @@ class TokensPositionSuite extends BasePositionSuite {
        |Type.ParamClause def f@@(a: A = (da)): A
        |Term.ParamClause (a: A = (da))
        |Term.Param a: A = (da)
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "{ case x => x; case y => y }",
     """|Case case x => x;
        |Case case y => y
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "f((x): _*)",
     """|Term.ArgClause ((x): _*)
        |Term.Repeated (x): _*
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat]("return (a)")
   checkPositions[Stat]("(a).b")
   checkPositions[Stat](
     "a.super[B].c",
     """|Term.Super a.super[B]
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat]("a.this")
   checkPositions[Stat]("throw (e)")
@@ -366,7 +366,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |Case case x => x;
        |Case case y => y
        |Term.Block { }
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "try (f) catch { case x => (x); case y => y } finally { }",
@@ -374,13 +374,13 @@ class TokensPositionSuite extends BasePositionSuite {
        |Case case x => (x);
        |Case case y => y
        |Term.Block { }
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat]("try ()")
   checkPositions[Stat](
     "try (true, false)",
     """|Term.Tuple (true, false)
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "try {1 + 2}.toString",
@@ -388,42 +388,42 @@ class TokensPositionSuite extends BasePositionSuite {
        |Term.Block {1 + 2}
        |Term.ApplyInfix 1 + 2
        |Type.ArgClause try {1 + @@2}.toString
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "try (a.b).c",
     """|Term.Select (a.b).c
        |Term.Select a.b
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "try (f) catch (h) finally { }",
     """|Term.Block { }
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "try (true, false) catch (h) finally (1, 2)",
     """|Term.Tuple (true, false)
        |Term.Tuple (1, 2)
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "try (a.b).c catch (h) finally (1, 2)",
     """|Term.Select (a.b).c
        |Term.Select a.b
        |Term.Tuple (1, 2)
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat]("((a), (b))")
   checkPositions[Stat](
     "while (p) {d}",
     """|Term.Block {d}
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "<a>b{c}d</a>",
     """|Term.Block {c}
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat]("(x)")
   checkPositions[Stat]("(_)")
@@ -432,48 +432,48 @@ class TokensPositionSuite extends BasePositionSuite {
     "package a",
     """|Pkg package a
        |Pkg.Body package a@@
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Source](
     "package a.b",
     """|Pkg package a.b
        |Term.Select a.b
        |Pkg.Body package a.b@@
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
     "import a.b",
     """|Importer a.b
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "import a.b, c.d",
     """|Importer a.b
        |Importer c.d
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "import a._",
     """|Importer a._
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "import a.{ b, c }",
     """|Importer a.{ b, c }
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "import a.{ b => c }",
     """|Importer a.{ b => c }
        |Importee.Rename b => c
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "import a.{ b => _ }",
     """|Importer a.{ b => _ }
        |Importee.Unimport b => _
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // Decl
@@ -484,7 +484,7 @@ class TokensPositionSuite extends BasePositionSuite {
     "type T",
     """|Type.ParamClause type T@@
        |Type.Bounds type T@@
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -500,7 +500,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |Type.Singleton this
        |Term.This this
        |Term.ArgClause ()
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat]("def f = macro m")
   checkPositions[Stat](
@@ -510,30 +510,30 @@ class TokensPositionSuite extends BasePositionSuite {
        |Term.ParamClause (b: B)
        |Template class A private (b: B)@@
        |Template.Body class A private (b: B)@@
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
     "@tailrec def f = 1",
     """|Mod.Annot @tailrec
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "@tailrec def f = 1",
     """|Mod.Annot @tailrec
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "@a def b = 1",
     """|Mod.Annot @a
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "@a(1) def b = 1",
     """|Mod.Annot @a(1)
        |Init a(1)
        |Term.ArgClause (1)
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "@(a @b) def x = 1",
@@ -541,7 +541,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |Init (a @b)
        |Type.Annotate a @b
        |Mod.Annot @b
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "@(a @b(1, 2)(3)) def x = 1",
@@ -552,17 +552,17 @@ class TokensPositionSuite extends BasePositionSuite {
        |Init b(1, 2)(3)
        |Term.ArgClause (1, 2)
        |Term.ArgClause (3)
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "private[foo] val a = 1",
     """|Mod.Private private[foo]
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "protected[foo] val a = 1",
     """|Mod.Protected protected[foo]
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat]("implicit val a = 1")
   checkPositions[Stat]("final val a = 1")
@@ -572,14 +572,14 @@ class TokensPositionSuite extends BasePositionSuite {
        |Ctor.Primary sealed trait a@@
        |Template sealed trait a@@
        |Template.Body sealed trait a@@
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat]("override def f = 1")
   checkPositions[Stat](
     "case object B",
     """|Template case object B@@
        |Template.Body case object B@@
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "abstract class A",
@@ -587,7 +587,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |Ctor.Primary abstract class A@@
        |Template abstract class A@@
        |Template.Body abstract class A@@
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "class A[+ T]",
@@ -599,7 +599,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |Ctor.Primary class A[+ T]@@
        |Template class A[+ T]@@
        |Template.Body class A[+ T]@@
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "class A[- T]",
@@ -611,7 +611,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |Ctor.Primary class A[- T]@@
        |Template class A[- T]@@
        |Template.Body class A[- T]@@
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat]("lazy val a = 1")
   checkPositions[Stat](
@@ -623,7 +623,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |Mod.ValParam val
        |Template class A(val b: B)@@
        |Template.Body class A(val b: B)@@
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "class A(var b: B)",
@@ -634,7 +634,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |Mod.VarParam var
        |Template class A(var b: B)@@
        |Template.Body class A(var b: B)@@
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -644,7 +644,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |Template { self: B => }
        |Template.Body { self: B => }
        |Self self: B =>
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "trait A { _: B => }",
@@ -653,7 +653,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |Template { _: B => }
        |Template.Body { _: B => }
        |Self _: B =>
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "trait A { self => }",
@@ -662,7 +662,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |Template { self => }
        |Template.Body { self => }
        |Self self =>
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "trait A { this: B => }",
@@ -671,14 +671,14 @@ class TokensPositionSuite extends BasePositionSuite {
        |Template { this: B => }
        |Template.Body { this: B => }
        |Self this: B =>
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
     "new A {}",
     """|Template A {}
        |Template.Body {}
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     "new { val a = 1 } with A {}",
@@ -686,14 +686,14 @@ class TokensPositionSuite extends BasePositionSuite {
        |Stat.Block { val a = 1 }
        |Defn.Val val a = 1
        |Template.Body {}
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Case](
     "case `1` =>",
     """|Term.Name `1`
        |Term.Block case `1` =>@@
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Pat]("a @ A")
   checkPositions[Pat]("_")
@@ -703,7 +703,7 @@ class TokensPositionSuite extends BasePositionSuite {
   checkPositions[Pat](
     "E(a, b)",
     """|Pat.ArgClause (a, b)
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Pat]("a E b")
   checkPositions[Pat]("""s"start ${(a)} end"""", "Pat.Var (a)")
@@ -733,7 +733,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |Type.With X with B with C
        |Type.With X with B
        |Defn.Def def foo: Boolean = true
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -761,7 +761,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |Type.With X with B with C
        |Type.With X with B
        |Defn.Def def foo: Boolean = true
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -778,14 +778,14 @@ class TokensPositionSuite extends BasePositionSuite {
        |Defn.Def private [this] def foo: Int = ???
        |Mod.Private private [this]
        |Term.This this
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
     """|(_: X) => 42
        |""".stripMargin,
     """|Term.ParamClause (_: X)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -793,14 +793,14 @@ class TokensPositionSuite extends BasePositionSuite {
        |""".stripMargin,
     """|Term.ParamClause _
        |Term.Param _
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
     """|q"x $this x"
        |""".stripMargin,
     """|Term.This this
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Term](
@@ -809,7 +809,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |Term.Apply a.b(c)
        |Term.Select a.b
        |Term.ArgClause (c)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Term](
@@ -819,7 +819,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |Term.Match a match { case foo => foo }
        |Term.CasesBlock { case foo => foo }
        |Case case foo => foo
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Term](
@@ -830,7 +830,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |Term.Match a match { case foo => foo }
        |Term.CasesBlock { case foo => foo }
        |Case case foo => foo
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3219
@@ -838,7 +838,7 @@ class TokensPositionSuite extends BasePositionSuite {
     "(10) + 1 toInt",
     """|Term.ApplyInfix (10) + 1
        |Type.ArgClause (10) + @@1 toInt
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 1
@@ -848,7 +848,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |}
        |""".stripMargin,
     """|Defn.Val val a = 1
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 2
@@ -860,7 +860,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |""".stripMargin,
     """|Defn.Val val b =
        |    1
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 2.1
@@ -877,7 +877,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |Term.Block {
        |    1 // comment
        |  }
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 3
@@ -889,7 +889,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |""".stripMargin,
     """|Defn.Val val b = // comment1
        |    1
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 3.1
@@ -906,7 +906,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |Term.Block {
        |    1 // comment2
        |  }
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 4
@@ -920,7 +920,7 @@ class TokensPositionSuite extends BasePositionSuite {
     """|Defn.Val val b =
        |    // comment1
        |    1
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 4.1
@@ -940,7 +940,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |    // comment1
        |    1 // comment2
        |  }
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 5
@@ -952,7 +952,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |""".stripMargin,
     """|Defn.Val val b = // comment
        |    1
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 5.1
@@ -969,7 +969,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |Term.Block {
        |    1
        |  }
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 6
@@ -983,7 +983,7 @@ class TokensPositionSuite extends BasePositionSuite {
     """|Defn.Val val b =
        |    // comment
        |    1
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 6.1
@@ -1003,7 +1003,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |    // comment
        |    1
        |  }
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 7
@@ -1016,7 +1016,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |""".stripMargin,
     """|Defn.Val val b =
        |    1
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 7.1
@@ -1036,7 +1036,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |    1
        |    // comment
        |  }
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 8
@@ -1049,7 +1049,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |""".stripMargin,
     """|Defn.Val val b = // comment1
        |    1
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 8.1
@@ -1069,7 +1069,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |    1
        |    // comment2
        |  }
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 9
@@ -1084,7 +1084,7 @@ class TokensPositionSuite extends BasePositionSuite {
     """|Defn.Val val b =
        |    // comment1
        |    1
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #3689 9.1
@@ -1107,7 +1107,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |    1
        |    // comment2
        |  }
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   // #4208
@@ -1132,7 +1132,7 @@ class TokensPositionSuite extends BasePositionSuite {
        |<body>Term.Block @@}</body> [46::46)
        |""".stripMargin,
     showPosition = true,
-    showFieldName = true
+    showFieldName = true,
   )
 
 }

--- a/tests/shared/src/test/scala-2/scala/meta/tests/classifiers/ClassifierSuite.scala
+++ b/tests/shared/src/test/scala-2/scala/meta/tests/classifiers/ClassifierSuite.scala
@@ -40,9 +40,9 @@ class ClassifierSuite extends FunSuite {
       """
       import scala.meta._
       (??? : Unclassifiable).is[Derived]
-    """
+    """,
     ),
-    "value is is not a member of org.scalameta.tests.classifiers.Unclassifiable"
+    "value is is not a member of org.scalameta.tests.classifiers.Unclassifiable",
   ))
 
   test("unclassifiable typeclass")(assertEquals(
@@ -52,9 +52,9 @@ class ClassifierSuite extends FunSuite {
       (??? : Unclassifiable).is[Manual]
       (??? : Unclassifiable).is[Auto1]
       (??? : Unclassifiable).is[Auto2]
-    """
+    """,
     ),
-    "value is is not a member of org.scalameta.tests.classifiers.Unclassifiable"
+    "value is is not a member of org.scalameta.tests.classifiers.Unclassifiable",
   ))
 
   test("classifiable inheritance") {
@@ -63,9 +63,9 @@ class ClassifierSuite extends FunSuite {
         """
       import scala.meta._
       (??? : MyToken).is[MyIdent]
-    """
+    """,
       ),
-      "don't know how to check whether org.scalameta.tests.classifiers.MyToken is org.scalameta.tests.classifiers.MyIdent"
+      "don't know how to check whether org.scalameta.tests.classifiers.MyToken is org.scalameta.tests.classifiers.MyIdent",
     )
 
     assertEquals(
@@ -73,9 +73,9 @@ class ClassifierSuite extends FunSuite {
         """
       import scala.meta._
       (??? : MyIdent).is[MyIdent]
-    """
+    """,
       ),
-      "don't know how to check whether org.scalameta.tests.classifiers.MyIdent is org.scalameta.tests.classifiers.MyIdent"
+      "don't know how to check whether org.scalameta.tests.classifiers.MyIdent is org.scalameta.tests.classifiers.MyIdent",
     )
   }
 

--- a/tests/shared/src/test/scala-2/scala/meta/tests/contrib/TreeOpsSuite.scala
+++ b/tests/shared/src/test/scala-2/scala/meta/tests/contrib/TreeOpsSuite.scala
@@ -27,8 +27,8 @@ class TreeOpsSuite extends TreeSuiteBase {
            |)""".stripMargin.lf2nl,
         """Pat.Var(Term.Name("x"))""",
         """Term.Name("x")""",
-        """Lit.Int(2)"""
-      )
+        """Lit.Int(2)""",
+      ),
     )
   }
 

--- a/tests/shared/src/test/scala-2/scala/meta/tests/invariants/InvariantSuite.scala
+++ b/tests/shared/src/test/scala-2/scala/meta/tests/invariants/InvariantSuite.scala
@@ -13,11 +13,11 @@ class InvariantSuite extends TreeSuiteBase {
          |when verifying x.>(3)
          |found that x.>(3) is false
          |where x = 2
-         |""".stripMargin.lf2nl
+         |""".stripMargin.lf2nl,
     ) {
       val x = 2
       require(x > 3)
-    }
+    },
   )
 
   test("even more informative error messages") {
@@ -28,7 +28,7 @@ class InvariantSuite extends TreeSuiteBase {
          |where C = C(3)
          |where C.this.x = 3
          |where y = 2
-         |""".stripMargin.lf2nl
+         |""".stripMargin.lf2nl,
     ) {
       val y = 2
       case class C(x: Int) {
@@ -39,7 +39,7 @@ class InvariantSuite extends TreeSuiteBase {
   }
 
   test("unreachable - 1")(
-    interceptMessage[UnreachableError]("this code path should've been unreachable")(unreachable)
+    interceptMessage[UnreachableError]("this code path should've been unreachable")(unreachable),
   )
 
   test("unreachable - 2")(
@@ -47,14 +47,14 @@ class InvariantSuite extends TreeSuiteBase {
       """|this code path should've been unreachable
          |where C.this.x = 3
          |where y = 2
-         |""".stripMargin.lf2nl
+         |""".stripMargin.lf2nl,
     ) {
       val y = 2
       case class C(x: Int) {
         unreachable(debug(x, y))
       }
       C(3)
-    }
+    },
   )
 
   test("don't evaluate debug")(require(true && debug(throw new Exception)))

--- a/tests/shared/src/test/scala-2/scala/meta/tests/prettyprinters/QuasiSyntacticSuite.scala
+++ b/tests/shared/src/test/scala-2/scala/meta/tests/prettyprinters/QuasiSyntacticSuite.scala
@@ -15,7 +15,7 @@ class QuasiSyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
         """.syntax,
       """|class A { class B }
          |          type C = A#B
-         |        """.stripMargin.lf2nl
+         |        """.stripMargin.lf2nl,
     )
     // With lambda trick
     assertNoDiff(
@@ -26,7 +26,7 @@ class QuasiSyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       """|
          |      def foo[F[_]]: Unit = ???
          |      foo[({ type T[A] = Either[Int, A] })#T]
-         |        """.stripMargin.lf2nl
+         |        """.stripMargin.lf2nl,
     )
   }
 
@@ -109,7 +109,7 @@ class QuasiSyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
   test("Term.Apply(_, List(Term.Function(...))) #572, #574")(assertWithOriginalSyntax(
     q"foo { implicit i: Int => () }",
     "foo { implicit i: Int => () }",
-    "foo {\n  implicit i: Int => ()\n}"
+    "foo {\n  implicit i: Int => ()\n}",
   ))
 
   test("macro defs #581") {
@@ -118,7 +118,7 @@ class QuasiSyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
   }
 
   test("Importee.Rename")(
-    assertWithOriginalSyntax(q"import a.{b=>c}", "import a.{b=>c}", "import a.{b => c}")
+    assertWithOriginalSyntax(q"import a.{b=>c}", "import a.{b=>c}", "import a.{b => c}"),
   )
 
   test("backquote importees when needed - scalafix #1337") {
@@ -127,7 +127,7 @@ class QuasiSyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
   }
 
   test("show[Structure] should uppercase long literals suffix: '2l' -> '2L'")(
-    assertTree(q"val x = 1l")(q"val x = 1L")
+    assertTree(q"val x = 1l")(q"val x = 1L"),
   )
 
   test("show[Structure] should lowercase float literals suffix: '0.01F' -> '0.01f'") {
@@ -163,11 +163,11 @@ class QuasiSyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
   }
 
   test("#931 val `a b` = 2")(
-    assertWithOriginalSyntax(q"val `a b` = 2", "val `a b` = 2", "val `a b` = 2")
+    assertWithOriginalSyntax(q"val `a b` = 2", "val `a b` = 2", "val `a b` = 2"),
   )
 
   test("#2097 val `macro` = 42")(
-    assertWithOriginalSyntax(q"val `macro` = 42", "val `macro` = 42", "val `macro` = 42")
+    assertWithOriginalSyntax(q"val `macro` = 42", "val `macro` = 42", "val `macro` = 42"),
   )
 
   test("#1661 Names outside: Must start with either a letter or an operator") {
@@ -215,10 +215,10 @@ class QuasiSyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     checkStat("list map Foo.bar")(q"list map (Foo.bar)")
   }
   test("1826 ApplyInfix parentheses on multiple Select")(
-    checkStat("list map (_.foo.bar)")(q"list map (_.foo.bar)")
+    checkStat("list map (_.foo.bar)")(q"list map (_.foo.bar)"),
   )
   test("#1826 ApplyInfix parentheses on tuple")(
-    checkStat("list map ((_, foo))")(q"list map ((_, foo))")
+    checkStat("list map ((_, foo))")(q"list map ((_, foo))"),
   )
   test("#1826 ApplyInfix parentheses on Apply") {
     checkStat("list map (_.->(foo))")(q"list map (_.->(foo))")
@@ -229,7 +229,7 @@ class QuasiSyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     checkStat("list map a.diff.bar(foo)")(q"list map a.diff.bar(foo)")
   }
   test("#1826 ApplyInfix parentheses on Function")(
-    checkStat("list map (_ => foo)")(q"list map (_ => foo)")
+    checkStat("list map (_ => foo)")(q"list map (_ => foo)"),
   )
   test("#1826 ApplyInfix parentheses on ApplyInfix function") {
     checkStat("list map (_ diff foo)")(q"list map (_ diff foo)")
@@ -242,7 +242,7 @@ class QuasiSyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     checkStat("list map a -> foo")(q"list map (a -> foo)")
   }
   test("1826 ApplyInfix parentheses on Term.Match")(
-    checkStat(s"list map (_ match {$EOL  case 1 => 2$EOL})")(q"list map (_ match { case 1 => 2})")
+    checkStat(s"list map (_ match {$EOL  case 1 => 2$EOL})")(q"list map (_ match { case 1 => 2})"),
   )
 
   test("#1839 ApplyInfix parentheses on Term.Placeholder") {
@@ -259,12 +259,12 @@ class QuasiSyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       "def f: B => B => A" -> q"def f: B => B => A",
       "def f: B => A" -> q"def f: B => A",
       "def f: (B => B) => A => A" -> q"def f: (B => B) => A => A",
-      "def f: (B => B) => (A => A) => A" -> q"def f: (B => B) => (A => A) => A"
+      "def f: (B => B) => (A => A) => A" -> q"def f: (B => B) => (A => A) => A",
     ).foreach { case (code, expected) => checkStat(code, code)(expected) }
   }
 
   test("#1864 Terms with leading numerics are backquoted")(
-    checkStat("""val `123foo` = "hello"""")(q""" val `123foo` = "hello" """)
+    checkStat("""val `123foo` = "hello"""")(q""" val `123foo` = "hello" """),
   )
 
   test("#1868 Term.Eta preserves structure") {
@@ -275,53 +275,53 @@ class QuasiSyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
   test("#2447 Pat.Bind on tname")(checkStat("{\n  case x @ Y => x\n}")(q"{ case x @ Y => x }"))
 
   test("#2447 Pat.Bind on tname backticks")(
-    checkStat("{\n  case x @ `y` => x\n}")(q"{ case x @ `y` => x }")
+    checkStat("{\n  case x @ `y` => x\n}")(q"{ case x @ `y` => x }"),
   )
 
   test("#1843 anonymous functions 1")(checkTree(q"list foo (_ fun (_.bar))")(tinfix(
     tname("list"),
     "foo",
     Term.AnonymousFunction(
-      tinfix(Term.Placeholder(), "fun", Term.AnonymousFunction(tselect(Term.Placeholder(), "bar")))
-    )
+      tinfix(Term.Placeholder(), "fun", Term.AnonymousFunction(tselect(Term.Placeholder(), "bar"))),
+    ),
   )))
 
   test("#1843 anonymous functions 2")(checkTree(q"list foo (_ fun _.bar)")(tinfix(
     tname("list"),
     "foo",
-    Term.AnonymousFunction(tinfix(Term.Placeholder(), "fun", tselect(Term.Placeholder(), "bar")))
+    Term.AnonymousFunction(tinfix(Term.Placeholder(), "fun", tselect(Term.Placeholder(), "bar"))),
   )))
 
   test("#2717 anonymous function with unary")(checkTree(q"xs span { !separates(_) }")(tinfix(
     tname("xs"),
     "span",
     blk(
-      Term.AnonymousFunction(Term.ApplyUnary(tname("!"), tapply(tname("separates"), Term.Placeholder())))
-    )
+      Term.AnonymousFunction(Term.ApplyUnary(tname("!"), tapply(tname("separates"), Term.Placeholder()))),
+    ),
   )))
 
   test("anonymous function with new")(checkTree(q"foo map (new foo(_))")(
-    tinfix(tname("foo"), "map", Term.AnonymousFunction(Term.New(init("foo", List(Term.Placeholder())))))
+    tinfix(tname("foo"), "map", Term.AnonymousFunction(Term.New(init("foo", List(Term.Placeholder()))))),
   ))
 
   test("anonymous function with select")(checkTree(q"foo map (foo(_).bar)")(tinfix(
     tname("foo"),
     "map",
-    Term.AnonymousFunction(tselect(tapply(tname("foo"), Term.Placeholder()), "bar"))
+    Term.AnonymousFunction(tselect(tapply(tname("foo"), Term.Placeholder()), "bar")),
   )))
 
   test("anonymous function with apply type")(checkTree(q"foo map (_.foo[A])")(tinfix(
     tname("foo"),
     "map",
-    Term.AnonymousFunction(tapplytype(tselect(Term.Placeholder(), "foo"), pname("A")))
+    Term.AnonymousFunction(tapplytype(tselect(Term.Placeholder(), "foo"), pname("A"))),
   )))
 
   test("#2317 init block")(
     checkStat(
       """new Foo({
         |  str => str.length
-        |})""".stripMargin
-    )(q"new Foo({str => str.length})")
+        |})""".stripMargin,
+    )(q"new Foo({str => str.length})"),
   )
 
   test("#1917 init lambda")(checkStat("new Foo((a: Int) => a + 1)")(q"new Foo((a: Int) => a + 1)"))
@@ -335,7 +335,7 @@ class QuasiSyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
 
     assertEquals(
       arg1.tokens.structure,
-      "Tokens(LeftBrace [5..6), Ident(b) [6..7), RightBrace [7..8))"
+      "Tokens(LeftBrace [5..6), Ident(b) [6..7), RightBrace [7..8))",
     )
 
     assertEquals(part2.tokens.structure, "Tokens(Xml.Part(</h1>) [8..13))")
@@ -345,10 +345,10 @@ class QuasiSyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     checkStat(
       """def withJsoup(html: Html)(cleaners: HtmlCleaner*): Html = withJsoup(html.body) {
         |  cleaners: _*
-        |}""".stripMargin
+        |}""".stripMargin,
     )(
-      q"def withJsoup(html: Html)(cleaners: HtmlCleaner*): Html = withJsoup(html.body) { cleaners: _* }"
-    )
+      q"def withJsoup(html: Html)(cleaners: HtmlCleaner*): Html = withJsoup(html.body) { cleaners: _* }",
+    ),
   )
 
   test("#2708 term lassoc")(
@@ -358,13 +358,13 @@ class QuasiSyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
             (()) == (())
             () == () == ()
             (()) == (()) == (())
-          }"""
+          }""",
     )(blk(
       tinfix(Lit.Unit(), "=="),
       tinfix(Lit.Unit(), "==", Lit.Unit()),
       tinfix(tinfix(Lit.Unit(), "=="), "=="),
-      tinfix(tinfix(Lit.Unit(), "==", Lit.Unit()), "==", Lit.Unit())
-    ))
+      tinfix(tinfix(Lit.Unit(), "==", Lit.Unit()), "==", Lit.Unit()),
+    )),
   )
 
   test("#2708 term rassoc")(
@@ -374,13 +374,13 @@ class QuasiSyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
             (()) :: (())
             () :: () :: ()
             (()) :: (()) :: (())
-          }"""
+          }""",
     )(blk(
       tinfix(Lit.Unit(), "::"),
       tinfix(Lit.Unit(), "::", Lit.Unit()),
       tinfix(Lit.Unit(), "::", tinfix(Lit.Unit(), "::")),
-      tinfix(Lit.Unit(), "::", tinfix(Lit.Unit(), "::", Lit.Unit()))
-    ))
+      tinfix(Lit.Unit(), "::", tinfix(Lit.Unit(), "::", Lit.Unit())),
+    )),
   )
 
   test("#2708 pat lassoc") {
@@ -390,13 +390,13 @@ class QuasiSyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
             case (()) == (()) =>
             case () == () == () =>
             case (()) == (()) == (()) =>
-          }"""
+          }""",
     )(tmatch(
       tname("foo"),
       Case(patinfix(Lit.Unit(), "=="), None, blk()),
       Case(patinfix(Lit.Unit(), "==", Lit.Unit()), None, blk()),
       Case(patinfix(patinfix(Lit.Unit(), "=="), "=="), None, blk()),
-      Case(patinfix(patinfix(Lit.Unit(), "==", Lit.Unit()), "==", Lit.Unit()), None, blk())
+      Case(patinfix(patinfix(Lit.Unit(), "==", Lit.Unit()), "==", Lit.Unit()), None, blk()),
     ))
   }
 
@@ -407,30 +407,30 @@ class QuasiSyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
             case (()) :: (()) =>
             case () :: () :: () =>
             case (()) :: (()) :: (()) =>
-          }"""
+          }""",
     )(tmatch(
       tname("foo"),
       Case(patinfix(Lit.Unit(), "::"), None, blk()),
       Case(patinfix(Lit.Unit(), "::", Lit.Unit()), None, blk()),
       Case(patinfix(Lit.Unit(), "::", patinfix(Lit.Unit(), "::")), None, blk()),
-      Case(patinfix(Lit.Unit(), "::", patinfix(Lit.Unit(), "::", Lit.Unit())), None, blk())
+      Case(patinfix(Lit.Unit(), "::", patinfix(Lit.Unit(), "::", Lit.Unit())), None, blk()),
     ))
   }
 
   test("pat infix: _ op (a | b)")(checkTree(p"_ op (a | b)", "_ op (a | b)")(
-    patinfix(patwildcard, "op", Pat.Alternative(patvar("a"), patvar("b")))
+    patinfix(patwildcard, "op", Pat.Alternative(patvar("a"), patvar("b"))),
   ))
 
   test("pat infix: _ * (a + b)")(checkTree(p"_ * (a + b)", "_ * (a + b)")(
-    patinfix(patwildcard, "*", patinfix(patvar("a"), "+", patvar("b")))
+    patinfix(patwildcard, "*", patinfix(patvar("a"), "+", patvar("b"))),
   ))
 
   test("term infix: _ * (a + b)")(checkTree(q"_ * (a + b)", "_ * (a + b)")(Term.AnonymousFunction(
-    tinfix(Term.Placeholder(), "*", tinfix(tname("a"), "+", tname("b")))
+    tinfix(Term.Placeholder(), "*", tinfix(tname("a"), "+", tname("b"))),
   )))
 
   test("term infix: 1 + (2 / 3) * 4")(checkTree(q"1 + (2 / 3) * 4", "1 + 2 / 3 * 4")(
-    tinfix(int(1), "+", tinfix(tinfix(int(2), "/", int(3)), "*", int(4)))
+    tinfix(int(1), "+", tinfix(tinfix(int(2), "/", int(3)), "*", int(4))),
   ))
 
   test("term infix: 1 + { 2 / 3 } * 4")(
@@ -438,8 +438,8 @@ class QuasiSyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       q"1 + { 2 / 3 } * 4",
       """|1 + {
          |  2 / 3
-         |} * 4""".stripMargin
-    )(tinfix(int(1), "+", tinfix(blk(tinfix(int(2), "/", int(3))), "*", int(4))))
+         |} * 4""".stripMargin,
+    )(tinfix(int(1), "+", tinfix(blk(tinfix(int(2), "/", int(3))), "*", int(4)))),
   )
 
   test("term infix: { 2 / 3 } + 4")(
@@ -447,8 +447,8 @@ class QuasiSyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       q"{ 2 / 3 } + 4",
       """|{
          |  2 / 3
-         |} + 4""".stripMargin
-    )(tinfix(blk(tinfix(int(2), "/", int(3))), "+", int(4)))
+         |} + 4""".stripMargin,
+    )(tinfix(blk(tinfix(int(2), "/", int(3))), "+", int(4))),
   )
 
   test("term anon func: foo.bar(_: Int, _: String)")(
@@ -456,9 +456,9 @@ class QuasiSyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       tapply(
         tselect("foo", "bar"),
         Term.Ascribe(Term.Placeholder(), pname("Int")),
-        Term.Ascribe(Term.Placeholder(), pname("String"))
-      )
-    ))
+        Term.Ascribe(Term.Placeholder(), pname("String")),
+      ),
+    )),
   )
 
 }

--- a/tests/shared/src/test/scala-2/scala/meta/tests/prettyprinters/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala-2/scala/meta/tests/prettyprinters/SyntacticSuite.scala
@@ -47,7 +47,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
          |  val x = QQQ
          |    x
          |  QQQ
-         |}""".stripMargin.replace("QQQ", "\"\"\"")
+         |}""".stripMargin.replace("QQQ", "\"\"\""),
     )
 
     assertSameLines(
@@ -57,7 +57,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
          |    x
          |  QQQ
          |}
-         |""".stripMargin.replace("QQQ", "\"\"\"")
+         |""".stripMargin.replace("QQQ", "\"\"\""),
     )
   }
 
@@ -68,11 +68,11 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
          |    x
          |  QQQ
          |  val y = "\""
-         |}""".stripMargin.replace("QQQ", "\"\"\"")
+         |}""".stripMargin.replace("QQQ", "\"\"\""),
     )
     assertTree(tree)(blk(
       Defn.Val(Nil, List(patvar("x")), None, str("\n    x\n  ")),
-      Defn.Val(Nil, List(patvar("y")), None, str("\""))
+      Defn.Val(Nil, List(patvar("y")), None, str("\"")),
     ))
     assertSameLines(
       tree.reprint,
@@ -82,7 +82,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
          |  QQQ
          |  val y = "\""
          |}
-         |""".stripMargin.replace("QQQ", "\"\"\"")
+         |""".stripMargin.replace("QQQ", "\"\"\""),
     )
   }
 
@@ -95,7 +95,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
          |    $y
          |    ..$z
          |  QQQ
-         |}""".stripMargin.replace("QQQ", "\"\"\"")
+         |}""".stripMargin.replace("QQQ", "\"\"\""),
     )
     assertTree(tree)(blk(
       Defn.Val(
@@ -105,10 +105,10 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
         Term.Interpolate(
           tname("q"),
           List(str("123 + "), str(" + "), str(" + 456")),
-          List(tname("x"), blk(tapply(tname("foo"), int(123))))
-        )
+          List(tname("x"), blk(tapply(tname("foo"), int(123)))),
+        ),
       ),
-      Defn.Val(Nil, List(patvar("y")), None, str("\n    $x\n    $y\n    ..$z\n  "))
+      Defn.Val(Nil, List(patvar("y")), None, str("\n    $x\n    $y\n    ..$z\n  ")),
     ))
     assertSameLines(
       tree.reprint,
@@ -121,7 +121,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
          |    $y
          |    ..$z
          |  QQQ
-         |}""".stripMargin.replace("QQQ", "\"\"\"")
+         |}""".stripMargin.replace("QQQ", "\"\"\""),
     )
   }
 
@@ -135,7 +135,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     assertEquals(templStat("new { self => val x = 2 }").reprint, "new { self => val x = 2 }")
     assertEquals(
       templStat("new { self: Int => val x = 2 }").reprint,
-      "new { self: Int => val x = 2 }"
+      "new { self: Int => val x = 2 }",
     )
     assertEquals(
       templStat(
@@ -144,12 +144,12 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
            |  val x = 2
            |  val y = 3
            |}
-           |""".stripMargin
+           |""".stripMargin,
       ).reprint,
       """|new {
          |  val x = 2
          |  val y = 3
-         |}""".stripMargin.lf2nl
+         |}""".stripMargin.lf2nl,
     )
     assertEquals(
       templStat(
@@ -158,12 +158,12 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
            |  val x = 2
            |  val y = 3
            |}
-           |""".stripMargin
+           |""".stripMargin,
       ).reprint,
       """|new { self =>
          |  val x = 2
          |  val y = 3
-         |}""".stripMargin.lf2nl
+         |}""".stripMargin.lf2nl,
     )
     assertEquals(
       templStat(
@@ -172,12 +172,12 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
            |  val x = 2
            |  val y = 3
            |}
-           |""".stripMargin
+           |""".stripMargin,
       ).reprint,
       """|new { self: Int =>
          |  val x = 2
          |  val y = 3
-         |}""".stripMargin.lf2nl
+         |}""".stripMargin.lf2nl,
     )
     assertEquals(templStat("class B { x: B => }").reprint, "class B { x: B => }")
   }
@@ -207,14 +207,14 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       tpe("Foo { type T = Int }").reprint,
       """|Foo {
          |  type T = Int
-         |}""".stripMargin.lf2nl
+         |}""".stripMargin.lf2nl,
     )
     assertEquals(
       tpe("Foo { type T = Int; type U <: String }").reprint,
       """|Foo {
          |  type T = Int
          |  type U <: String
-         |}""".stripMargin.lf2nl
+         |}""".stripMargin.lf2nl,
     )
     assertEquals(tpe("Foo with Bar").reprint, "Foo with Bar")
     assertEquals(tpe("Foo with Bar {}").reprint, "Foo with Bar {}")
@@ -222,14 +222,14 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       tpe("Foo with Bar { type T = Int }").reprint,
       """|Foo with Bar {
          |  type T = Int
-         |}""".stripMargin.lf2nl
+         |}""".stripMargin.lf2nl,
     )
     assertEquals(
       tpe("Foo with Bar { type T = Int; type U <: String }").reprint,
       """|Foo with Bar {
          |  type T = Int
          |  type U <: String
-         |}""".stripMargin.lf2nl
+         |}""".stripMargin.lf2nl,
     )
   }
 
@@ -240,19 +240,19 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
   }
 
   test("literalTypes")(
-    intercept[ParseException](dialects.Scala211("val a : 42 = 42").parse[Stat].get.reprint)
+    intercept[ParseException](dialects.Scala211("val a : 42 = 42").parse[Stat].get.reprint),
   )
 
   test("packages") {
     assertEquals(source("package foo.bar; class C").reprint, s"package foo.bar${EOL}class C")
     assertEquals(
       source("package foo.bar; class C; class D").reprint,
-      s"package foo.bar${EOL}class C${EOL}class D"
+      s"package foo.bar${EOL}class C${EOL}class D",
     )
     assertEquals(source("package foo.bar { class C }").reprint, s"package foo.bar${EOL}class C")
     assertEquals(
       source("package foo.bar { class C; class D }").reprint,
-      s"package foo.bar${EOL}class C${EOL}class D"
+      s"package foo.bar${EOL}class C${EOL}class D",
     )
   }
 
@@ -272,7 +272,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     assertEquals(source("class C @foo(x) (x: Int)").reprint, "class C @foo(x) (x: Int)")
     assertEquals(
       source("class C @foo(x) private (x: Int)").reprint,
-      "class C @foo(x) private (x: Int)"
+      "class C @foo(x) private (x: Int)",
     )
   }
 
@@ -280,7 +280,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     templStat("x match { case (xs: List[Int]) :+ x => ??? }").reprint,
     """|x match {
        |  case (xs: List[Int]) :+ x => ???
-       |}""".stripMargin.lf2nl
+       |}""".stripMargin.lf2nl,
   ))
 
   test("List(x, y) :: z") {
@@ -289,13 +289,13 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       templStat("x match { case List(x, y) :: z => ??? }").reprint,
       """|x match {
          |  case List(x, y) :: z => ???
-         |}""".stripMargin.lf2nl
+         |}""".stripMargin.lf2nl,
     )
   }
 
   test("secondary ctor - expr")(assertEquals(
     source("class C(x: Int) { def this() = this(2) }").reprint,
-    "class C(x: Int) { def this() = this(2) }"
+    "class C(x: Int) { def this() = this(2) }",
   ))
 
   test("secondary ctor - block")(assertEquals(
@@ -305,7 +305,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
        |    this(2)
        |    println("OBLIVION!!!")
        |  }
-       |}""".stripMargin.lf2nl
+       |}""".stripMargin.lf2nl,
   ))
 
   test("case semicolons")(assertEquals(
@@ -314,7 +314,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
        |  case y =>
        |    foo1
        |    foo2
-       |}""".stripMargin.lf2nl
+       |}""".stripMargin.lf2nl,
   ))
 
   test("assorted literals") {
@@ -355,7 +355,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
           |when verifying java.lang.Double.isFinite(value)
           |found that java.lang.Double.isFinite(value) is false
           |where value = $what
-          |""".stripMargin.lf2nl
+          |""".stripMargin.lf2nl,
     )(lit(value))
     assertFiniteError(Double.NaN, "NaN")
     assertFiniteError(Double.PositiveInfinity, "Infinity")
@@ -370,7 +370,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
           |when verifying java.lang.Float.isFinite(value)
           |found that java.lang.Float.isFinite(value) is false
           |where value = $what
-          |""".stripMargin.lf2nl
+          |""".stripMargin.lf2nl,
     )(lit(value))
     assertFiniteError(Float.NaN, "NaN")
     assertFiniteError(Float.PositiveInfinity, "Infinity")
@@ -381,7 +381,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     assertEquals(templStat("class C[T: List, U <% Int]").reprint, "class C[T: List, U <% Int]")
     assertEquals(
       templStat("def m[T: List, U <% Int] = ???").reprint,
-      "def m[T: List, U <% Int] = ???"
+      "def m[T: List, U <% Int] = ???",
     )
   }
 
@@ -392,56 +392,56 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     assertEquals(templStat("if (1) if (2) 3 else () else 4").reprint, "if (1) (if (2) 3) else 4")
     assertEquals(
       templStat("if (1) 2 else 3 match { case _ => }").reprint,
-      s"if (1) 2 else 3 match {$EOL  case _ =>$EOL}"
+      s"if (1) 2 else 3 match {$EOL  case _ =>$EOL}",
     )
     assertEquals(
       templStat("(if (1) 2 else 3) match { case _ => }").reprint,
-      s"(if (1) 2 else 3) match {$EOL  case _ =>$EOL}"
+      s"(if (1) 2 else 3) match {$EOL  case _ =>$EOL}",
     )
     assertEquals(templStat("unit.toCheck += (() => body)").reprint, "unit.toCheck += (() => body)")
     assertEquals(
       templStat("({ foo1; foo2 }).orElse(bar)").reprint,
-      s"{$EOL  foo1$EOL  foo2$EOL}.orElse(bar)"
+      s"{$EOL  foo1$EOL  foo2$EOL}.orElse(bar)",
     )
     assertEquals(
       templStat("(foo match { case _ => }).orElse(bar)").reprint,
-      s"(foo match {$EOL  case _ =>$EOL}).orElse(bar)"
+      s"(foo match {$EOL  case _ =>$EOL}).orElse(bar)",
     )
     assertEquals(
       templStat("foo || (if (cond) bar else baz)").reprint,
-      "foo || (if (cond) bar else baz)"
+      "foo || (if (cond) bar else baz)",
     )
     assertEquals(
       templStat("foo && (bar match { case _ => })").reprint,
-      s"foo && (bar match {$EOL  case _ =>$EOL})"
+      s"foo && (bar match {$EOL  case _ =>$EOL})",
     )
     assertEquals(
       templStat("\"foo \" + (if (cond) bar else baz)").reprint,
-      "\"foo \" + (if (cond) bar else baz)"
+      "\"foo \" + (if (cond) bar else baz)",
     )
     assertEquals(
       templStat("foo match { case bar @ (_: T1 | _: T2) => }").reprint,
-      s"foo match {$EOL  case bar @ (_: T1 | _: T2) =>$EOL}"
+      s"foo match {$EOL  case bar @ (_: T1 | _: T2) =>$EOL}",
     )
     assertEquals(
       templStat("foo match { case A + B / C => }").reprint,
-      s"foo match {$EOL  case A + B / C =>$EOL}"
+      s"foo match {$EOL  case A + B / C =>$EOL}",
     )
     assertEquals(
       templStat("foo match { case (A + B) / C => }").reprint,
-      s"foo match {$EOL  case (A + B) / C =>$EOL}"
+      s"foo match {$EOL  case (A + B) / C =>$EOL}",
     )
     assertEquals(
       templStat("foo match { case A + (B / C) => }").reprint,
-      s"foo match {$EOL  case A + B / C =>$EOL}"
+      s"foo match {$EOL  case A + B / C =>$EOL}",
     )
     assertEquals(
       templStat("foo match { case bar :: Nil :: Nil => }").reprint,
-      s"foo match {$EOL  case bar :: Nil :: Nil =>$EOL}"
+      s"foo match {$EOL  case bar :: Nil :: Nil =>$EOL}",
     )
     assertEquals(
       templStat("foo match { case (bar :: Nil) :: Nil => }").reprint,
-      s"foo match {$EOL  case (bar :: Nil) :: Nil =>$EOL}"
+      s"foo match {$EOL  case (bar :: Nil) :: Nil =>$EOL}",
     )
     assertEquals(templStat("@(foo @foo) class Bar").reprint, "@(foo @foo) class Bar")
     assertEquals(templStat("(foo: Foo): @foo").reprint, "(foo: Foo): @foo")
@@ -452,11 +452,11 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     assertEquals(templStat("type T = (A :: B) :: C").reprint, "type T = (A :: B) :: C")
     assertEquals(
       templStat("foo match { case _: A | _: B => }").reprint,
-      s"foo match {$EOL  case _: A | _: B =>$EOL}"
+      s"foo match {$EOL  case _: A | _: B =>$EOL}",
     )
     assertEquals(
       templStat("foo match { case _: A | _: B | _: C => }").reprint,
-      s"foo match {$EOL  case _: A | _: B | _: C =>$EOL}"
+      s"foo match {$EOL  case _: A | _: B | _: C =>$EOL}",
     )
   }
 
@@ -467,60 +467,60 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
   }
 
   test("class C extends (() => Int)")(
-    assertEquals(templStat("class C extends (() => Int)").reprint, "class C extends (() => Int)")
+    assertEquals(templStat("class C extends (() => Int)").reprint, "class C extends (() => Int)"),
   )
 
   test("package object e extends D")(
-    assertEquals(topStat("package object e extends D").reprint, "package object e extends D")
+    assertEquals(topStat("package object e extends D").reprint, "package object e extends D"),
   )
 
   test("trait C extends A with B with D")(assertEquals(
     templStat("trait C extends A with B with D").reprint,
-    "trait C extends A with B with D"
+    "trait C extends A with B with D",
   ))
 
   test("private sealed trait C extends A with B with D")(assertEquals(
     templStat("private sealed trait C extends A with B with D").reprint,
-    "private sealed trait C extends A with B with D"
+    "private sealed trait C extends A with B with D",
   ))
 
   test("object C extends A with B with D")(assertEquals(
     templStat("object C extends A with B with D").reprint,
-    "object C extends A with B with D"
+    "object C extends A with B with D",
   ))
 
   test("private implicit object C extends A with B with D")(assertEquals(
     templStat("private implicit object C extends A with B with D").reprint,
-    "private implicit object C extends A with B with D"
+    "private implicit object C extends A with B with D",
   ))
 
   test("abstract class C extends A with B with D")(assertEquals(
     templStat("abstract class C extends A with B with D").reprint,
-    "abstract class C extends A with B with D"
+    "abstract class C extends A with B with D",
   ))
 
   test("protected abstract class C extends A with B with D")(assertEquals(
     templStat("protected abstract class C extends A with B with D").reprint,
-    "protected abstract class C extends A with B with D"
+    "protected abstract class C extends A with B with D",
   ))
 
   test("new C with A with B with D")(
-    assertEquals(templStat("new C with A with B with D").reprint, "new C with A with B with D")
+    assertEquals(templStat("new C with A with B with D").reprint, "new C with A with B with D"),
   )
 
   test("class C(x: Int)(implicit y: String, z: Boolean)")(assertEquals(
     templStat("class C(x: Int)(implicit y: String, z: Boolean)").reprint,
-    "class C(x: Int)(implicit y: String, z: Boolean)"
+    "class C(x: Int)(implicit y: String, z: Boolean)",
   ))
 
   test("#1837 class C(x: Int, implicit val|var y: String)") {
     assertEquals(
       templStat("class C(x: Int, implicit val y: String)").reprint,
-      "class C(x: Int, implicit val y: String)"
+      "class C(x: Int, implicit val y: String)",
     )
     assertEquals(
       templStat("class C(x: Int, implicit var y: String)").reprint,
-      "class C(x: Int, implicit var y: String)"
+      "class C(x: Int, implicit var y: String)",
     )
   }
 
@@ -536,7 +536,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
   test("class C(implicit override val x: Int, final implicit var y: String)")(
     checkTree(
       templStat("class C(implicit override val x: Int, final implicit var y: String)"),
-      "class C(implicit override val x: Int, final var y: String)"
+      "class C(implicit override val x: Int, final var y: String)",
     )(Defn.Class(
       Nil,
       pname("C"),
@@ -544,10 +544,10 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       ctorp(
         Mod.Implicit(),
         tparam(List(Mod.Implicit(), Mod.Override(), Mod.ValParam()), "x", "Int"),
-        tparam(List(Mod.Final(), Mod.Implicit(), Mod.VarParam()), "y", "String")
+        tparam(List(Mod.Final(), Mod.Implicit(), Mod.VarParam()), "y", "String"),
       ),
-      tplNoBody()
-    ))
+      tplNoBody(),
+    )),
   )
 
   test("#1837 class C(private implicit val x: Int, implicit final val y: String, protected implicit var z: Boolean)") {
@@ -560,9 +560,9 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       ctorp(
         tparam(List(Mod.Private(anon), Mod.Implicit(), Mod.ValParam()), "x", "Int"),
         tparam(List(Mod.Implicit(), Mod.Final(), Mod.ValParam()), "y", "String"),
-        tparam(List(Mod.Protected(anon), Mod.Implicit(), Mod.VarParam()), "z", "Boolean")
+        tparam(List(Mod.Protected(anon), Mod.Implicit(), Mod.VarParam()), "z", "Boolean"),
       ),
-      tplNoBody()
+      tplNoBody(),
     )
     checkTree(templStat(code))(tree)
   }
@@ -570,7 +570,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
   test("#1837 class C(implicit private val x: Int, implicit final val y: String, protected implicit var z: Boolean)") {
     checkTree(
       templStat("class C(implicit private val x: Int, implicit final val y: String, protected implicit var z: Boolean)"),
-      "class C(implicit private val x: Int, final val y: String, protected var z: Boolean)"
+      "class C(implicit private val x: Int, final val y: String, protected var z: Boolean)",
     )(Defn.Class(
       Nil,
       pname("C"),
@@ -579,14 +579,14 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
         Mod.Implicit(),
         tparam(List(Mod.Implicit(), Mod.Private(anon), Mod.ValParam()), "x", "Int"),
         tparam(List(Mod.Implicit(), Mod.Final(), Mod.ValParam()), "y", "String"),
-        tparam(List(Mod.Protected(anon), Mod.Implicit(), Mod.VarParam()), "z", "Boolean")
+        tparam(List(Mod.Protected(anon), Mod.Implicit(), Mod.VarParam()), "z", "Boolean"),
       ),
-      tplNoBody()
+      tplNoBody(),
     ))
   }
 
   test("class C(var x: Int)")(
-    assertEquals(templStat("class C(var x: Int)").reprint, "class C(var x: Int)")
+    assertEquals(templStat("class C(var x: Int)").reprint, "class C(var x: Int)"),
   )
 
   test("private/protected within something") {
@@ -599,21 +599,21 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
            |  protected[this] val z = 3
            |  protected[D] val w = 4
            |}
-           |""".stripMargin
+           |""".stripMargin,
       ).reprint,
       """|class C {
          |  private[this] val x = 1
          |  private[D] val y = 2
          |  protected[this] val z = 3
          |  protected[D] val w = 4
-         |}""".stripMargin.lf2nl
+         |}""".stripMargin.lf2nl,
     )
   }
 
   test("case List(xs @ _*)") {
     val tree = pat("List(xs @ _*)")
     checkTree(tree, "List(xs @ _*)")(
-      Pat.Extract(tname("List"), List(Pat.Bind(patvar("xs"), Pat.SeqWildcard())))
+      Pat.Extract(tname("List"), List(Pat.Bind(patvar("xs"), Pat.SeqWildcard()))),
     )
   }
 
@@ -621,14 +621,14 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     val tree = pat("List[t](xs @ _*)")
     checkTree(tree, "List[t](xs @ _*)")(Pat.Extract(
       tapplytype(tname("List"), Type.Var(pname("t"))),
-      List(Pat.Bind(patvar("xs"), Pat.SeqWildcard()))
+      List(Pat.Bind(patvar("xs"), Pat.SeqWildcard())),
     ))
   }
 
   test("case List[_](xs @ _*)") {
     val tree = pat("List[_](xs @ _*)")
     checkTree(tree, "List[_](xs @ _*)")(
-      Pat.Extract(tapplytype(tname("List"), pwildcard), List(Pat.Bind(patvar("xs"), Pat.SeqWildcard())))
+      Pat.Extract(tapplytype(tname("List"), pwildcard), List(Pat.Bind(patvar("xs"), Pat.SeqWildcard()))),
     )
   }
 
@@ -639,9 +639,9 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
         tname("foo"),
         List(
           Defn.Class(Nil, pname("C"), Nil, ctor, tplNoBody()),
-          Pkg(tname("baz"), List(Defn.Class(Nil, pname("D"), Nil, ctor, tplNoBody())))
-        )
-      ))
+          Pkg(tname("baz"), List(Defn.Class(Nil, pname("D"), Nil, ctor, tplNoBody()))),
+        ),
+      )),
     ))
   }
 
@@ -658,16 +658,16 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
         tname("foo1"),
         List(
           Defn.Class(Nil, pname("C1"), Nil, ctor, tplNoBody()),
-          Pkg(tname("baz1"), List(Defn.Class(Nil, pname("D1"), Nil, ctor, tplNoBody())))
-        )
+          Pkg(tname("baz1"), List(Defn.Class(Nil, pname("D1"), Nil, ctor, tplNoBody()))),
+        ),
       ))),
       Source(List(Pkg(
         tname("foo2"),
         List(
           Defn.Class(Nil, pname("C2"), Nil, ctor, tplNoBody()),
-          Pkg(tname("baz2"), List(Defn.Class(Nil, pname("D2"), Nil, ctor, tplNoBody())))
-        )
-      )))
+          Pkg(tname("baz2"), List(Defn.Class(Nil, pname("D2"), Nil, ctor, tplNoBody()))),
+        ),
+      ))),
     )))
     assertEquals(tree.syntax, code.lf2nl)
     assertEquals(
@@ -684,7 +684,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
          |class C2
          |package baz2 {
          |  class D2
-         |}""".stripMargin.lf2nl
+         |}""".stripMargin.lf2nl,
     )
   }
 
@@ -732,20 +732,20 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       case1.reprint,
       """|case x =>
          |  x
-         |""".stripMargin
+         |""".stripMargin,
     )
     assertEquals(
       case2.reprint,
       """|case List(x, y) =>
          |  println(x)
-         |  println(y)""".stripMargin.lf2nl
+         |  println(y)""".stripMargin.lf2nl,
     )
   }
 
   test("xml literals") {
     val tree = term("<foo>{bar}</foo>")
     checkTree(tree, "<foo>{\n  bar\n}</foo>")(
-      Term.Xml(List(str("<foo>"), str("</foo>")), List(blk(tname("bar"))))
+      Term.Xml(List(str("<foo>"), str("</foo>")), List(blk(tname("bar")))),
     )
   }
 
@@ -763,14 +763,14 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
   test("interpolator unit") {
     val tree = term("""s"Hello${}World"""")
     checkTree(tree, """s"Hello${}World"""")(
-      Term.Interpolate(tname("s"), List(str("Hello"), str("World")), List(blk()))
+      Term.Interpolate(tname("s"), List(str("Hello"), str("World")), List(blk())),
     )
   }
 
   test("interpolator with $ character") {
     val tree = term("""s"$$$foo$$"""")
     checkTree(tree, """s"$$$foo$$"""")(
-      Term.Interpolate(tname("s"), List(str("$"), str("$")), List(tname("foo")))
+      Term.Interpolate(tname("s"), List(str("$"), str("$")), List(tname("foo"))),
     )
   }
 
@@ -786,10 +786,10 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     ("${++}123", "${\n  ++\n}123"),
     ("${++} 123", "${\n  ++\n} 123"),
     ("${++}_123", "${\n  ++\n}_123"),
-    ("${++}+123", "${\n  ++\n}+123")
+    ("${++}+123", "${\n  ++\n}+123"),
   ).foreach { case (codeInterp, termSyntaxInterp) =>
     test(
-      s"term interpolator braces: test syntax/parsing consistency: $codeInterp -> $termSyntaxInterp"
+      s"term interpolator braces: test syntax/parsing consistency: $codeInterp -> $termSyntaxInterp",
     ) {
       def interp(str: String) = s"""s"${str.lf2nl}""""
       val syntax = interp(termSyntaxInterp)
@@ -810,10 +810,10 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     ("${++}123", "${++}123"),
     ("${++} 123", "${++} 123"),
     ("${++}_123", "${++}_123"),
-    ("${++}+123", "${++}+123")
+    ("${++}+123", "${++}+123"),
   ).foreach { case (codeInterp, patSyntaxInterp) =>
     test(
-      s"pat interpolator braces: test syntax/parsing consistency: $codeInterp -> $patSyntaxInterp"
+      s"pat interpolator braces: test syntax/parsing consistency: $codeInterp -> $patSyntaxInterp",
     ) {
       def interp(str: String) = s"""s"${str.lf2nl}""""
       val syntax = interp(patSyntaxInterp)
@@ -826,13 +826,13 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     def interpolate(before: String, after: String): Term.Interpolate = Term.Interpolate(
       prefix = tname("s"),
       parts = List(str(before), str(after)),
-      args = List(tname("_foo"))
+      args = List(tname("_foo")),
     )
     assertWithOriginalSyntax(interpolate("", ""), """s"${_foo}"""", """s"${_foo}"""")
     assertWithOriginalSyntax(
       interpolate("bar", "baz"),
       """s"bar${_foo}baz"""",
-      """s"bar${_foo}baz""""
+      """s"bar${_foo}baz"""",
     )
     assertWithOriginalSyntax(interpolate("[", "]"), """s"[${_foo}]"""", """s"[${_foo}]"""")
   }
@@ -847,7 +847,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     checkTree(tree, "T <: Int")(pparam("T", hiBound("Int")))
 
     assertTree(
-      templStat("def foo[T <: Int] = ???")
+      templStat("def foo[T <: Int] = ???"),
     )(Defn.Def(Nil, tname("foo"), ppc(tree), Nil, None, tname("???")))
   }
 
@@ -874,27 +874,27 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     val interpolate = Pat.Interpolate(
       tname("q"),
       List(str("object "), str(" { .."), str(" }")),
-      List(patvar("name"), patvar("stats"))
+      List(patvar("name"), patvar("stats")),
     )
     assertWithOriginalSyntax(
       interpolate,
       """q"object ${name} { ..${stats} }"""",
-      """q"object ${name} { ..${stats} }""""
+      """q"object ${name} { ..${stats} }"""",
     )
   }
 
   test("show[Structure] should uppercase long literals suffix: '2l' -> '2L'")(
-    assertTree(templStat("foo(1l, 1L)"))(tapply(tname("foo"), lit(1L), lit(1L)))
+    assertTree(templStat("foo(1l, 1L)"))(tapply(tname("foo"), lit(1L), lit(1L))),
   )
 
   test("show[Structure] should lowercase float literals suffix: '0.01F' -> '0.01f'")(
-    assertTree(templStat("foo(0.01f, 0.01F)"))(tapply(tname("foo"), flt("0.01"), flt("0.01")))
+    assertTree(templStat("foo(0.01f, 0.01F)"))(tapply(tname("foo"), flt("0.01"), flt("0.01"))),
   )
 
   test("show[Structure] should lowercase double literals suffix: '0.01D' -> '0.01d'")(
     assertTree(
-      templStat("foo(0.02d, 0.02D, 0.02)")
-    )(tapply(tname("foo"), dbl("0.02"), dbl("0.02"), dbl("0.02")))
+      templStat("foo(0.02d, 0.02D, 0.02)"),
+    )(tapply(tname("foo"), dbl("0.02"), dbl("0.02"), dbl("0.02"))),
   )
 
   test("#1864 Terms with leading numerics are backquoted")(checkStat("`123foo`")(tname("123foo")))
@@ -942,14 +942,14 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
   }
 
   test("#1063 good")(checkTree(term("foo(bar) { baz: _* }"))(
-    tapply(tapply(tname("foo"), tname("bar")), blk(Term.Repeated(tname("baz"))))
+    tapply(tapply(tname("foo"), tname("bar")), blk(Term.Repeated(tname("baz")))),
   ))
 
   test("#1063 bad") {
     val thrown = intercept[ParseException](term("foo(bar) { val baz = qux; baz: _* }"))
     assertEquals(
       thrown.getMessage.substring(0, 52),
-      "<input>:1: error: repeated argument not allowed here"
+      "<input>:1: error: repeated argument not allowed here",
     )
   }
 
@@ -1012,7 +1012,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
           |  {
           |    e
           |  }
-          |}""".stripMargin.lf2nl
+          |}""".stripMargin.lf2nl,
     )
     assertEquals(
       blockStat("{if (a) while (b) for (c <- d) -e; {f}}").reprint,
@@ -1022,7 +1022,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
           |  {
           |    f
           |  }
-          |}""".stripMargin.lf2nl
+          |}""".stripMargin.lf2nl,
     )
   }
 
@@ -1059,7 +1059,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       None,
       tname("bar"),
       begComment = Seq("// c1", "/* c2 */"),
-      endComment = Seq("/* c3 */", "// c4")
+      endComment = Seq("/* c3 */", "// c4"),
     )
     runTestAssert[Stat](code, layout)(tree)
   }

--- a/tests/shared/src/test/scala-2/scala/meta/tests/prettyprinters/dotty/SyntacticSuite.scala
+++ b/tests/shared/src/test/scala-2/scala/meta/tests/prettyprinters/dotty/SyntacticSuite.scala
@@ -9,7 +9,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
   test("literalTypes") {
     assertEquals(
       dialects.Scala3("val a: \"42\" = \"42\"").parse[Stat].get.syntax,
-      "val a: \"42\" = \"42\""
+      "val a: \"42\" = \"42\"",
     )
     assertEquals(pat("_: 42").reprint, "_: 42")
     assertEquals(pat("_: 42f").reprint, "_: 42f")
@@ -24,7 +24,7 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
   test("case List[_](xs @ _*): scala31") {
     implicit val dialect = dialects.Scala31
     checkTree(pat("List[_](xs @ _*)"), "List[_](xs @ _*)")(
-      Pat.Extract(tapplytype(tname("List"), pwildcard), List(Pat.Bind(patvar("xs"), Pat.SeqWildcard())))
+      Pat.Extract(tapplytype(tname("List"), pwildcard), List(Pat.Bind(patvar("xs"), Pat.SeqWildcard()))),
     )
   }
 
@@ -32,50 +32,50 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
     implicit val dialect = dialects.Scala3Future
     checkTree(pat("List[_](xs @ _*)"), "List[_](xs @ _*)")(Pat.Extract(
       tapplytype(tname("List"), Type.AnonymousParam(None)),
-      List(Pat.Bind(patvar("xs"), Pat.SeqWildcard()))
+      List(Pat.Bind(patvar("xs"), Pat.SeqWildcard())),
     ))
   }
 
   test("#2699 method declaration with multiple named 'using' params")(assertEquals(
     templStat("def foo(x: Int)(using y: String, z: Boolean): String").reprint,
-    "def foo(x: Int)(using y: String, z: Boolean): String"
+    "def foo(x: Int)(using y: String, z: Boolean): String",
   ))
 
   test("#2699 method definition with multiple named 'using' params")(assertEquals(
     templStat("def foo(x: Int)(using y: String, z: Boolean) = x").reprint,
-    "def foo(x: Int)(using y: String, z: Boolean) = x"
+    "def foo(x: Int)(using y: String, z: Boolean) = x",
   ))
 
   test("#2699 primary constructor with multiple named 'using' params")(assertEquals(
     templStat("class C(x: Int)(using y: String, z: Boolean)").reprint,
-    "class C(x: Int)(using y: String, z: Boolean)"
+    "class C(x: Int)(using y: String, z: Boolean)",
   ))
 
   test("#2699 secondary constructor with multiple named 'using' params")(assertEquals(
     templStat("class C(x: Int) { def this(x: String)(using y: String, z: Boolean) = this(x.toInt) }")
       .reprint,
-    "class C(x: Int) { def this(x: String)(using y: String, z: Boolean) = this(x.toInt) }"
+    "class C(x: Int) { def this(x: String)(using y: String, z: Boolean) = this(x.toInt) }",
   ))
 
   test("#2699 method declaration with multiple anonymous 'using' params")(assertEquals(
     templStat("def foo(x: Int)(using String, Boolean): String").reprint,
-    "def foo(x: Int)(using String, Boolean): String"
+    "def foo(x: Int)(using String, Boolean): String",
   ))
 
   test("#2699 method definition with multiple anonymous 'using' params")(assertEquals(
     templStat("def foo(x: Int)(using String, Boolean) = x").reprint,
-    "def foo(x: Int)(using String, Boolean) = x"
+    "def foo(x: Int)(using String, Boolean) = x",
   ))
 
   test("#2699 primary constructor with multiple anonymous 'using' params")(assertEquals(
     templStat("class C(x: Int)(using String, Boolean)").reprint,
-    "class C(x: Int)(using String, Boolean)"
+    "class C(x: Int)(using String, Boolean)",
   ))
 
   test("#2699 secondary constructor with multiple anonymous 'using' params")(assertEquals(
     templStat("class C(x: Int) { def this(x: String)(using String, Boolean) = this(x.toInt) }")
       .reprint,
-    "class C(x: Int) { def this(x: String)(using String, Boolean) = this(x.toInt) }"
+    "class C(x: Int) { def this(x: String)(using String, Boolean) = this(x.toInt) }",
   ))
 
   test("#4348 type pattern match with backquotes") {
@@ -95,8 +95,8 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       Term.PartialFunction(List(Case(
         Pat.Tuple(List(Pat.Given(papply("ActorContext", "t")), Pat.Wildcard())),
         None,
-        tselect("Behaviors", "empty")
-      )))
+        tselect("Behaviors", "empty"),
+      ))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -118,8 +118,8 @@ class SyntacticSuite extends scala.meta.tests.parsers.ParseSuite {
       Term.PartialFunction(List(Case(
         Pat.Tuple(List(Pat.Given(papply("ActorContext", Type.Var("t"))), Pat.Wildcard())),
         None,
-        tselect("Behaviors", "empty")
-      )))
+        tselect("Behaviors", "empty"),
+      ))),
     )
     runTestAssert[Stat](layout, layout)(tree)
   }

--- a/tests/shared/src/test/scala-2/scala/meta/tests/quasiquotes/ErrorSuite.scala
+++ b/tests/shared/src/test/scala-2/scala/meta/tests/quasiquotes/ErrorSuite.scala
@@ -26,16 +26,16 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta._
       import scala.meta.dialects.Scala211
       val q"type $name[$X] = $Y" = q"type List[+A] = List[A]"
-    """
+    """,
       )
         // Scala 2.13.7 adds additional message
         .replaceAll(
           "Identifiers that begin with uppercase are not pattern variables but match the value in scope.\r?\n",
-          ""
+          "",
         ),
       """|<macro>:4: not found: value X
          |      val q"type $name[$X] = $Y" = q"type List[+A] = List[A]"
-         |                        ^""".stripMargin
+         |                        ^""".stripMargin,
     )
   }
 
@@ -45,11 +45,11 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta._
       import scala.meta.dialects.Scala211
       q"foo + class"
-    """
+    """,
     ),
     """|<macro>:4: `;` expected but `class` found
        |      q"foo + class"
-       |              ^""".stripMargin
+       |              ^""".stripMargin,
   ))
 
   test("q\"foo(x)\" when x has incompatible type") {
@@ -61,13 +61,13 @@ class ErrorSuite extends TreeSuiteBase {
       class Dummy
       val x = new Dummy
       q"foo($x)"
-    """
+    """,
       ),
       """|<macro>:6: type mismatch when unquoting;
          | found   : Dummy
          | required: scala.meta.Term
          |      q"foo($x)"
-         |            ^""".stripMargin
+         |            ^""".stripMargin,
     )
   }
 
@@ -80,13 +80,13 @@ class ErrorSuite extends TreeSuiteBase {
       class Dummy
       val x = new Dummy
       q"$x"
-    """
+    """,
       ),
       """|<macro>:6: type mismatch when unquoting;
          | found   : Dummy
          | required: scala.meta.Stat
          |      q"$x"
-         |        ^""".stripMargin
+         |        ^""".stripMargin,
     )
   }
 
@@ -99,13 +99,13 @@ class ErrorSuite extends TreeSuiteBase {
       class Dummy
       val xs = List(new Dummy)
       q"foo(..$xs)"
-    """
+    """,
       ),
       """|<macro>:6: type mismatch when unquoting;
          | found   : List[Dummy]
          | required: scala.meta.Term.ArgClause
          |      q"foo(..$xs)"
-         |           ^""".stripMargin
+         |           ^""".stripMargin,
     )
   }
 
@@ -117,13 +117,13 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val xs = List(q"x")
       q"foo($xs)"
-    """
+    """,
       ),
       """|<macro>:5: type mismatch when unquoting;
          | found   : List[scala.meta.Term.Name]
          | required: scala.meta.Term
          |      q"foo($xs)"
-         |            ^""".stripMargin
+         |            ^""".stripMargin,
     )
   }
 
@@ -135,13 +135,13 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val xs = List(q"x")
       q"$xs"
-    """
+    """,
       ),
       """|<macro>:5: type mismatch when unquoting;
          | found   : List[scala.meta.Term.Name]
          | required: scala.meta.Stat
          |      q"$xs"
-         |        ^""".stripMargin
+         |        ^""".stripMargin,
     )
   }
 
@@ -153,13 +153,13 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val xss = List(List(q"x"))
       q"...$xss"
-    """
+    """,
       ),
       """|<macro>:5: rank mismatch when unquoting;
          | found   : ...$
          | required: $ or ..$
          |      q"...$xss"
-         |        ^""".stripMargin
+         |        ^""".stripMargin,
     )
   }
 
@@ -171,13 +171,13 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val xss = List(List(q"x"))
       q"$xss"
-    """
+    """,
       ),
       """|<macro>:5: type mismatch when unquoting;
          | found   : List[List[scala.meta.Term.Name]]
          | required: scala.meta.Stat
          |      q"$xss"
-         |        ^""".stripMargin
+         |        ^""".stripMargin,
     )
   }
 
@@ -189,13 +189,13 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val terms = List(q"T", q"U")
       q"foo[..$terms]"
-    """
+    """,
       ),
       """|<macro>:5: type mismatch when unquoting;
          | found   : List[scala.meta.Term.Name]
          | required: scala.meta.Type.ArgClause
          |      q"foo[..$terms]"
-         |           ^""".stripMargin
+         |           ^""".stripMargin,
     )
   }
 
@@ -212,7 +212,7 @@ class ErrorSuite extends TreeSuiteBase {
           println(ys)
           println(z)
       }
-    """
+    """,
       ),
       """|<macro>:6: rank mismatch when unquoting;
          | found   : ..$
@@ -220,7 +220,7 @@ class ErrorSuite extends TreeSuiteBase {
          |Note that you can extract a list into an unquote when pattern matching,
          |it just cannot follow another list either directly or indirectly.
          |        case q"$_($x, ..$ys, $z, ..$ts)" =>
-         |                                 ^""".stripMargin
+         |                                 ^""".stripMargin,
     )
   }
 
@@ -231,11 +231,11 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val x = "hello"
       qQQQ "$x" QQQ
-    """
+    """,
     ),
     """|<macro>:5: can't unquote into string literals
       |      qQQQ "$x" QQQ
-      |            ^""".replace("QQQ", "\"\"\"").stripMargin
+      |            ^""".replace("QQQ", "\"\"\"").stripMargin,
   ))
 
   test("q\"val name = foo\"")(assertNoDiff(
@@ -245,11 +245,11 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val name = q"x"
       q"val $name = foo"
-    """
+    """,
     ),
     """|<macro>:5: can't unquote a name here, use a pattern instead (e.g. p"x")
        |      q"val $name = foo"
-       |            ^""".stripMargin
+       |            ^""".stripMargin,
   ))
 
   test("q\"var name = foo\"")(assertNoDiff(
@@ -259,11 +259,11 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val name = q"x"
       q"var $name = foo"
-    """
+    """,
     ),
     """|<macro>:5: can't unquote a name here, use a pattern instead (e.g. p"x")
        |      q"var $name = foo"
-       |            ^""".stripMargin
+       |            ^""".stripMargin,
   ))
 
   test("p\"name: T\"")(assertNoDiff(
@@ -273,11 +273,11 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val name = q"x"
       p"$name: T"
-    """
+    """,
     ),
     """|<macro>:5: can't unquote a name here, use a pattern instead (e.g. p"x")
        |      p"$name: T"
-       |        ^""".stripMargin
+       |        ^""".stripMargin,
   ))
 
   test("""q"qname" when qname has incompatible type """) {
@@ -288,13 +288,13 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val name = t"x"
       q"$name"
-    """
+    """,
       ),
       """|<macro>:5: type mismatch when unquoting;
          | found   : scala.meta.Type.Name
          | required: scala.meta.Stat
          |      q"$name"
-         |        ^""".stripMargin
+         |        ^""".stripMargin,
     )
   }
 
@@ -306,13 +306,13 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val tpe = q"T"
       q"expr: $tpe"
-    """
+    """,
       ),
       """|<macro>:5: type mismatch when unquoting;
          | found   : scala.meta.Term.Name
          | required: scala.meta.Type
          |      q"expr: $tpe"
-         |              ^""".stripMargin
+         |              ^""".stripMargin,
     )
   }
 
@@ -324,13 +324,13 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val expr = t"x"
       q"$expr: tpe"
-    """
+    """,
       ),
       """|<macro>:5: type mismatch when unquoting;
          | found   : scala.meta.Type.Name
          | required: scala.meta.Term
          |      q"$expr: tpe"
-         |        ^""".stripMargin
+         |        ^""".stripMargin,
     )
   }
 
@@ -341,11 +341,11 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val tpes = List(q"T")
       q"expr: ..$tpes"
-    """
+    """,
     ),
     """|<macro>:5: `identifier` expected but `ellipsis` found
        |      q"expr: ..$tpes"
-       |              ^""".stripMargin
+       |              ^""".stripMargin,
   ))
 
   test("""q"expr.name" when name has incompatible type """) {
@@ -356,13 +356,13 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val name = t"T"
       q"expr.$name"
-    """
+    """,
       ),
       """|<macro>:5: type mismatch when unquoting;
          | found   : scala.meta.Type.Name
          | required: scala.meta.Term.Name
          |      q"expr.$name"
-         |             ^""".stripMargin
+         |             ^""".stripMargin,
     )
   }
 
@@ -374,13 +374,13 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val expr = t"T"
       q"$expr.name"
-    """
+    """,
       ),
       """|<macro>:5: type mismatch when unquoting;
          | found   : scala.meta.Type.Name
          | required: scala.meta.Term
          |      q"$expr.name"
-         |        ^""".stripMargin
+         |        ^""".stripMargin,
     )
   }
 
@@ -391,11 +391,11 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val names = List(q"T")
       q"expr. ..$names"
-    """
+    """,
     ),
     """|<macro>:5: `identifier` expected but `ellipsis` found
        |      q"expr. ..$names"
-       |              ^""".stripMargin
+       |              ^""".stripMargin,
   ))
 
   test("""p"pat @ pat"""") {
@@ -407,11 +407,11 @@ class ErrorSuite extends TreeSuiteBase {
       val pat1 = p"`x`"
       val pat2 = p"y"
       p"$pat1 @ $pat2"
-    """
+    """,
       ),
       """|<macro>:6: can't unquote a name here, use a pattern instead (e.g. p"x")
          |      p"$pat1 @ $pat2"
-         |        ^""".stripMargin
+         |        ^""".stripMargin,
     )
   }
 
@@ -422,11 +422,11 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta._
       import scala.meta.dialects.Scala211
       val p"$ref[..$tpes](..$pats)" = p"x[A, B]"
-    """
+    """,
       ),
       """|<macro>:4: pattern must be a value or have parens: x[A, B]
          |      val p"$ref[..$tpes](..$pats)" = p"x[A, B]"
-         |                                               ^""".stripMargin
+         |                                               ^""".stripMargin,
     )
   }
 
@@ -439,11 +439,11 @@ class ErrorSuite extends TreeSuiteBase {
       val pat = p"`x`"
       val tpe = t"T"
       p"$pat: $tpe"
-    """
+    """,
       ),
       """|<macro>:6: can't unquote a name here, use a pattern instead (e.g. p"x")
          |      p"$pat: $tpe"
-         |        ^""".stripMargin
+         |        ^""".stripMargin,
     )
   }
 
@@ -454,15 +454,15 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta._
       import scala.meta.dialects.Scala211
       val p"case $X: T => " = p"case x: T =>"
-    """
+    """,
       ) // Scala 2.13.7 adds additional message
         .replaceAll(
           "Identifiers that begin with uppercase are not pattern variables but match the value in scope.\r?\n",
-          ""
+          "",
         ),
       """|<macro>:4: not found: value X
          |      val p"case $X: T => " = p"case x: T =>"
-         |                  ^""".stripMargin
+         |                  ^""".stripMargin,
     )
   }
 
@@ -473,11 +473,11 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta._
       import scala.meta.dialects.Scala211
       q"private final def this(x: X, y: Y) = foo"
-    """
+    """,
       ),
       """|<macro>:4: `this` expected but `identifier` found
          |      q"private final def this(x: X, y: Y) = foo"
-         |                                             ^""".stripMargin
+         |                                             ^""".stripMargin,
     )
   }
 
@@ -489,13 +489,13 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val stats = List(q"def x = 42")
       q"class C { $stats }"
-    """
+    """,
       ),
       """|<macro>:5: type mismatch when unquoting;
          | found   : List[scala.meta.Defn.Def]
          | required: scala.meta.Stat
          |      q"class C { $stats }"
-         |                  ^""".stripMargin
+         |                  ^""".stripMargin,
     )
   }
 
@@ -507,13 +507,13 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val stats = Some(List(q"def x = 42"))
       q"class C { $stats }"
-    """
+    """,
       ),
       """|<macro>:5: type mismatch when unquoting;
          | found   : Some[List[scala.meta.Defn.Def]]
          | required: scala.meta.Stat
          |      q"class C { $stats }"
-         |                  ^""".stripMargin
+         |                  ^""".stripMargin,
     )
   }
 
@@ -524,11 +524,11 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta._
       import scala.meta.dialects.Scala211
       q"package foo {}; package bar {}"
-    """
+    """,
       ),
       """|<macro>:4: these statements can't be mixed together, try source"..." instead
          |      q"package foo {}; package bar {}"
-         |        ^""".stripMargin
+         |        ^""".stripMargin,
     )
   }
 
@@ -539,11 +539,11 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val foo = 'f'
       q"'$foo'"
-    """
+    """,
     ),
     """|<macro>:5: can't unquote into character literals
        |      q"'$foo'"
-       |         ^""".stripMargin
+       |         ^""".stripMargin,
   ))
 
   test("unquote into single-line string literals")(assertNoDiff(
@@ -553,11 +553,11 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val foo = "foo"
       qQQQ "$foo" QQQ
-    """
+    """,
     ),
     """|<macro>:5: can't unquote into string literals
        |      qQQQ "$foo" QQQ
-       |            ^""".stripMargin.replace("QQQ", "\"\"\"")
+       |            ^""".stripMargin.replace("QQQ", "\"\"\""),
   ))
 
   test("unquote into single-line string interpolations")(assertNoDiff(
@@ -567,11 +567,11 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val foo = "foo"
       qQQQ s"$foo" QQQ
-    """
+    """,
     ),
     """|<macro>:5: can't unquote into string interpolations
       |      qQQQ s"$foo" QQQ
-      |             ^""".replace("QQQ", "\"\"\"").stripMargin
+      |             ^""".replace("QQQ", "\"\"\"").stripMargin,
   ))
 
   test("unquote into single-line string interpolations, with braces") {
@@ -582,11 +582,11 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val foo = "foo"
       qQQQ s"${foo}" QQQ
-    """
+    """,
       ),
       """|<macro>:5: can't unquote into string interpolations
          |      qQQQ s"${foo}" QQQ
-         |             ^""".replace("QQQ", "\"\"\"").stripMargin
+         |             ^""".replace("QQQ", "\"\"\"").stripMargin,
     )
   }
 
@@ -598,11 +598,11 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val foo = "foo"
       qQQQ s"${foo + foo}" QQQ
-    """
+    """,
       ),
       """|<macro>:5: can't unquote into string interpolations
          |      qQQQ s"${foo + foo}" QQQ
-         |             ^""".replace("QQQ", "\"\"\"").stripMargin
+         |             ^""".replace("QQQ", "\"\"\"").stripMargin,
     )
   }
 
@@ -614,13 +614,13 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val foo = "foo"
       q"<$foo></foo>"
-    """
+    """,
       ),
       """|<macro>:5: type mismatch when unquoting;
          | found   : String
          | required: scala.meta.Term.Name
          |      q"<$foo></foo>"
-         |         ^""".stripMargin
+         |         ^""".stripMargin,
     )
   }
 
@@ -631,11 +631,11 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val foo = "foo"
       q"`$foo`"
-    """
+    """,
     ),
     """|<macro>:5: can't unquote into quoted identifiers
        |      q"`$foo`"
-       |         ^""".stripMargin
+       |         ^""".stripMargin,
   ))
 
   test("weirdness after dot-dot")(assertNoDiff(
@@ -644,11 +644,11 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta._
       import scala.meta.dialects.Scala211
       q"..x${???}"
-    """
+    """,
     ),
     """|<macro>:4: $, ( or { expected but identifier found
        |      q"..x${???}"
-       |          ^""".stripMargin
+       |          ^""".stripMargin,
   ))
 
   test("weirdness after triple-dor")(assertNoDiff(
@@ -657,11 +657,11 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta._
       import scala.meta.dialects.Scala211
       q"foo(...x${???})"
-    """
+    """,
     ),
     """|<macro>:4: $, ( or { expected but identifier found
        |      q"foo(...x${???})"
-       |               ^""".stripMargin
+       |               ^""".stripMargin,
   ))
 
   test("x before triple-dot") {
@@ -672,13 +672,13 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val xss = List(List(q"x"))
       q"foo(x, ...$xss)"
-    """
+    """,
       ),
       """|<macro>:5: rank mismatch when unquoting;
          | found   : ...$
          | required: $ or ..$
          |      q"foo(x, ...$xss)"
-         |               ^""".stripMargin
+         |               ^""".stripMargin,
     )
   }
 
@@ -691,13 +691,13 @@ class ErrorSuite extends TreeSuiteBase {
       val x = q"x"
       val xss = List(List(q"x"))
       q"foo($x, ...$xss)"
-    """
+    """,
       ),
       """|<macro>:6: rank mismatch when unquoting;
          | found   : ...$
          | required: $ or ..$
          |      q"foo($x, ...$xss)"
-         |                ^""".stripMargin
+         |                ^""".stripMargin,
     )
   }
 
@@ -710,13 +710,13 @@ class ErrorSuite extends TreeSuiteBase {
       val xs = List(q"x")
       val xss = List(List(q"x"))
       q"foo(..$xs, ...$xss)"
-    """
+    """,
       ),
       """|<macro>:6: rank mismatch when unquoting;
          | found   : ...$
          | required: $ or ..$
          |      q"foo(..$xs, ...$xss)"
-         |                   ^""".stripMargin
+         |                   ^""".stripMargin,
     )
   }
 
@@ -727,11 +727,11 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val xss = List(List(q"x"))
       q"foo(...$xss, ...$xss)"
-    """
+    """,
     ),
     """|<macro>:5: `)` expected but `,` found
        |      q"foo(...$xss, ...$xss)"
-       |                   ^""".stripMargin
+       |                   ^""".stripMargin,
   ))
 
   test("triple-dot inside triple-dot (1)") {
@@ -743,7 +743,7 @@ class ErrorSuite extends TreeSuiteBase {
       ??? match {
         case q"$_(...$argss)(...$_)" =>
       }
-    """
+    """,
       ),
       """|<macro>:5: rank mismatch when unquoting;
          | found   : ..$
@@ -751,7 +751,7 @@ class ErrorSuite extends TreeSuiteBase {
          |Note that you can extract a list into an unquote when pattern matching,
          |it just cannot follow another list either directly or indirectly.
          |        case q"$_(...$argss)(...$_)" =>
-         |                            ^""".stripMargin
+         |                            ^""".stripMargin,
     )
   }
 
@@ -764,7 +764,7 @@ class ErrorSuite extends TreeSuiteBase {
       ??? match {
         case q"$_(...$argss)(foo)(...$_)" =>
       }
-    """
+    """,
       ),
       """|<macro>:5: rank mismatch when unquoting;
          | found   : ..$
@@ -772,7 +772,7 @@ class ErrorSuite extends TreeSuiteBase {
          |Note that you can extract a list into an unquote when pattern matching,
          |it just cannot follow another list either directly or indirectly.
          |        case q"$_(...$argss)(foo)(...$_)" =>
-         |                                 ^""".stripMargin
+         |                                 ^""".stripMargin,
     )
   }
 
@@ -784,13 +784,13 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val argss = List(List("y"))
       q"x + (...$argss)"
-    """
+    """,
       ),
       """|<macro>:5: rank mismatch when unquoting;
          | found   : ...$
          | required: $ or ..$
          |      q"x + (...$argss)"
-         |             ^""".stripMargin
+         |             ^""".stripMargin,
     )
   }
 
@@ -802,13 +802,13 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val patss = List(List("x"))
       p"Foo(...$patss)"
-    """
+    """,
       ),
       """|<macro>:5: rank mismatch when unquoting;
          | found   : ...$
          | required: $ or ..$
          |      p"Foo(...$patss)"
-         |            ^""".stripMargin
+         |            ^""".stripMargin,
     )
   }
 
@@ -820,13 +820,13 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta.dialects.Scala211
       val patss = List(List("x"))
       p"x Foo (...$patss)"
-    """
+    """,
       ),
       """|<macro>:5: rank mismatch when unquoting;
          | found   : ...$
          | required: $ or ..$
          |      p"x Foo (...$patss)"
-         |               ^""".stripMargin
+         |               ^""".stripMargin,
     )
   }
 
@@ -837,14 +837,14 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta._
       val notReallyAParent = t"_root_.scala.AnyVal"
       q"class C $notReallyAParent"
-    """
+    """,
       ),
       """|<macro>:4: type mismatch when unquoting;
          | found   : scala.meta.Type.Select
          | required: scala.meta.Template
          |      q"class C $notReallyAParent"
          |                ^
-         |""".stripMargin
+         |""".stripMargin,
     )
   }
 
@@ -855,14 +855,14 @@ class ErrorSuite extends TreeSuiteBase {
       import scala.meta._
       val notReallyAParent = t"_root_.scala.AnyVal"
       q"class C extends $notReallyAParent"
-    """
+    """,
       ),
       """|<macro>:4: type mismatch when unquoting;
          | found   : scala.meta.Type.Select
          | required: scala.meta.Init
          |      q"class C extends $notReallyAParent"
          |                        ^
-         |""".stripMargin
+         |""".stripMargin,
     )
   }
 }

--- a/tests/shared/src/test/scala-2/scala/meta/tests/transversers/TransformerSuite.scala
+++ b/tests/shared/src/test/scala-2/scala/meta/tests/transversers/TransformerSuite.scala
@@ -26,7 +26,7 @@ class TransformerSuite extends TreeSuiteBase {
       """|{
          |  def foo(y: y)(y: Int) = y + y + 1
          |  class C(y: y) { def bar(y: y) = ??? }
-         |}""".stripMargin.lf2nl
+         |}""".stripMargin.lf2nl,
     )
   }
 

--- a/tests/shared/src/test/scala-2/scala/meta/tests/transversers/TraverserSuite.scala
+++ b/tests/shared/src/test/scala-2/scala/meta/tests/transversers/TraverserSuite.scala
@@ -62,7 +62,7 @@ class TraverserSuite extends TreeSuiteBase {
          |x
          |x
          |???
-         |""".stripMargin
+         |""".stripMargin,
     )
   }
 }

--- a/tests/shared/src/test/scala-2/scala/meta/tests/trees/InvariantSuite.scala
+++ b/tests/shared/src/test/scala-2/scala/meta/tests/trees/InvariantSuite.scala
@@ -91,7 +91,7 @@ class InvariantSuite extends TreeSuiteBase {
          |when verifying scala.meta.internal.trees.ParentChecks.MemberTuple(args)
          |found that scala.meta.internal.trees.ParentChecks.MemberTuple(args) is false
          |where args = List((()))
-         |""".stripMargin.lf2nl
+         |""".stripMargin.lf2nl,
     )(tuple)
   }
 
@@ -113,7 +113,7 @@ class InvariantSuite extends TreeSuiteBase {
          |when verifying scala.meta.internal.trees.ParentChecks.MemberTuple(args)
          |found that scala.meta.internal.trees.ParentChecks.MemberTuple(args) is false
          |where args = List((()))
-         |""".stripMargin.lf2nl
+         |""".stripMargin.lf2nl,
     )(tuple)
   }
 
@@ -135,7 +135,7 @@ class InvariantSuite extends TreeSuiteBase {
          |when verifying scala.meta.internal.trees.ParentChecks.MemberTuple(args)
          |found that scala.meta.internal.trees.ParentChecks.MemberTuple(args) is false
          |where args = List((()))
-         |""".stripMargin.lf2nl
+         |""".stripMargin.lf2nl,
     )(tuple)
   }
 

--- a/tests/shared/src/test/scala-2/scala/meta/tests/trees/TokensSuite.scala
+++ b/tests/shared/src/test/scala-2/scala/meta/tests/trees/TokensSuite.scala
@@ -113,7 +113,7 @@ class TokensSuite extends TreeSuiteBase {
               assertEquals((1, 37), (one.start, one.length))
               assertNoDiff(one.syntax, merged3)
             case x => fail(x.mkString(s"Expected one range, got ${x.length}: [\n", "\n], [\n", "\n]"))
-          }
+          },
         )
         getTokens(stats(2), stats(1)).permutations.foreach { x =>
           Tokens.merge(x: _*) match {
@@ -127,7 +127,7 @@ class TokensSuite extends TreeSuiteBase {
                    |
                    |
                    |   import p3.a3 // ct3
-                   |""".stripMargin
+                   |""".stripMargin,
               )
             case x => fail(x.mkString(s"Expected one range, got ${x.length}: [\n", "\n], [\n", "\n]"))
           }
@@ -144,7 +144,7 @@ class TokensSuite extends TreeSuiteBase {
                    |// cl2.1
                    |// cl2.2
                    |import p2.a2 /* ct2.1 */ /* ct2.2 */
-                   |""".stripMargin
+                   |""".stripMargin,
               )
             case x => fail(x.mkString(s"Expected one range, got ${x.length}: [\n", "\n], [\n", "\n]"))
           }
@@ -157,13 +157,13 @@ class TokensSuite extends TreeSuiteBase {
                 one.syntax,
                 """|// cl1
                    |import p1.a1 // ct1
-                   |""".stripMargin
+                   |""".stripMargin,
               )
               assertEquals((31, 7), (two.start, two.length))
               assertNoDiff(
                 two.syntax,
                 """|import p3.a3 // ct3
-                   |""".stripMargin
+                   |""".stripMargin,
               )
             case x =>
               fail(x.mkString(s"Expected two ranges, got ${x.length}: [\n", "\n], [\n", "\n]"))

--- a/tests/shared/src/test/scala-3/scala/meta/tests/quasiquotes/Scala3SpecificSuccessSuite.scala
+++ b/tests/shared/src/test/scala-3/scala/meta/tests/quasiquotes/Scala3SpecificSuccessSuite.scala
@@ -24,7 +24,7 @@ class Scala3SpecificSuccessSuite extends TreeSuiteBase {
          |""".stripMargin,
       showPosition = true,
       showFieldName = true,
-      skipFullTree = false
+      skipFullTree = false,
     )
   }
 
@@ -45,7 +45,7 @@ class Scala3SpecificSuccessSuite extends TreeSuiteBase {
          |""".stripMargin,
       showPosition = true,
       showFieldName = true,
-      skipFullTree = false
+      skipFullTree = false,
     )
   }
 
@@ -57,7 +57,7 @@ class Scala3SpecificSuccessSuite extends TreeSuiteBase {
          |""".stripMargin,
       showPosition = true,
       showFieldName = true,
-      skipFullTree = false
+      skipFullTree = false,
     )
   }
 
@@ -69,7 +69,7 @@ class Scala3SpecificSuccessSuite extends TreeSuiteBase {
          |""".stripMargin,
       showPosition = true,
       showFieldName = true,
-      skipFullTree = false
+      skipFullTree = false,
     )
   }
 
@@ -85,7 +85,7 @@ class Scala3SpecificSuccessSuite extends TreeSuiteBase {
          |Space [17..18)
          |Constant.String(any message) [18..31)
          |EOF [31..31)
-         |""".stripMargin
+         |""".stripMargin,
     )
     val pos = quoted.pos
     assertNoDiff(pos.toString, """[0,31) in str(`${fooTypes(0)}`; "any message")""")
@@ -95,7 +95,7 @@ class Scala3SpecificSuccessSuite extends TreeSuiteBase {
       """|<stats1>Lit.String "any message"</stats1> [18:"any message":31)
          |""".stripMargin,
       showPosition = true,
-      showFieldName = true
+      showFieldName = true,
     )
 
     val syntax =

--- a/tests/shared/src/test/scala/scala/meta/tests/DialectSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/DialectSuite.scala
@@ -43,7 +43,7 @@ class DialectSuite extends FunSuite {
   test("scala3copy toString")(assertEquals(scala3copy.toString, "Scala38"))
 
   test("scala3 without indentation toString")(
-    assertEquals(Scala3.withAllowSignificantIndentation(false).toString, "Dialect()")
+    assertEquals(Scala3.withAllowSignificantIndentation(false).toString, "Dialect()"),
   )
 
   test("scala3.unquoteTerm toString")(assertEquals(Scala3.unquoteTerm(true).toString, "Scala38"))

--- a/tests/shared/src/test/scala/scala/meta/tests/TreeSuiteBase.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/TreeSuiteBase.scala
@@ -18,19 +18,19 @@ abstract class TreeSuiteBase extends FunSuite with CommonTrees {
   def emptyArgClause = Seq.empty[Term.ArgClause]
 
   protected def assertStruct(obtained: Tree, extraClue: String = "")(
-      expected: String
+      expected: String,
   )(implicit loc: Location): Unit = {
     def msg = TestHelpers.getMessageWithExtraClue("tree structure not equal", extraClue)
     assertNoDiff(obtained.structure, expected, msg)
   }
 
   protected def assertTree(obtained: Tree, extraClue: String = "")(expected: Tree)(implicit
-      loc: Location
+      loc: Location,
   ): Unit = assertTreeStruct(obtained, extraClue)(expected, expected.structure)
 
   protected def assertTreeStruct(
       obtained: Tree,
-      extraClue: String = ""
+      extraClue: String = "",
   )(expected: Tree, expectedStruct: String)(implicit loc: Location): Unit = {
     assertStruct(obtained, extraClue)(expectedStruct)
     expected.origin match {
@@ -46,24 +46,24 @@ abstract class TreeSuiteBase extends FunSuite with CommonTrees {
   }
 
   protected def assertTree(
-      obtained: Option[Tree]
+      obtained: Option[Tree],
   )(expected: Option[Tree])(implicit loc: Location): Unit = (obtained, expected) match {
     case (Some(o), Some(e)) => assertTree(o)(e)
     case _ => assertEquals(obtained, expected)
   }
 
   protected def assertSyntax(
-      syntax: String
+      syntax: String,
   )(obtained: Tree)(implicit loc: Location, dialect: Dialect): String =
     assertSyntaxWithClue(obtained)(syntax)(obtained.structure)
 
   protected def assertSyntax(obtained: Tree, syntax: String = null)(
-      expected: Tree
+      expected: Tree,
   )(implicit loc: Location, dialect: Dialect): String =
     assertSyntaxWithClue(obtained, syntax)(expected, expected.structure)
 
   protected def assertSyntaxWithClue(
-      obtained: Tree
+      obtained: Tree,
   )(syntax: String)(clue: => Any)(implicit loc: Location, dialect: Dialect): String = {
     val reprinted = obtained.reprint
     if (syntax.nonEmpty) assertNoDiff(reprinted, syntax, clue)
@@ -72,12 +72,12 @@ abstract class TreeSuiteBase extends FunSuite with CommonTrees {
 
   protected def assertSyntaxWithClue(
       obtained: Tree,
-      syntax: String = null
+      syntax: String = null,
   )(expected: Tree, clue: => Any)(implicit loc: Location, dialect: Dialect): String =
     assertSyntaxWithClue(obtained)(TestHelpers.getSyntax(expected.reprint, syntax))(clue)
 
   protected def checkTree(obtained: Tree, syntax: String = null)(
-      expected: Tree
+      expected: Tree,
   )(implicit loc: Location, dialect: Dialect): Unit = {
     val expectedStruct = expected.structure
     assertTreeStruct(obtained)(expected, expectedStruct)
@@ -85,21 +85,21 @@ abstract class TreeSuiteBase extends FunSuite with CommonTrees {
   }
 
   protected def checkTrees(
-      obtained: Tree*
+      obtained: Tree*,
   )(expected: Tree*)(implicit loc: Location, dialect: Dialect): Unit = {
     assertEquals(obtained.length, expected.length)
     obtained.zip(expected).foreach { case (o, e) => checkTree(o)(e) }
   }
 
   protected def checkTreesWithSyntax(
-      obtained: Tree*
+      obtained: Tree*,
   )(syntax: String*)(expected: Tree*)(implicit loc: Location, dialect: Dialect): Unit = {
     assertEquals(obtained.length, syntax.length)
     checkTreesWithSyntax(obtained.zip(syntax): _*)(expected: _*)
   }
 
   protected def checkTreesWithSyntax(
-      obtained: (Tree, String)*
+      obtained: (Tree, String)*,
   )(expected: Tree*)(implicit loc: Location, dialect: Dialect): Unit = {
     assertEquals(obtained.length, expected.length)
     obtained.zip(expected).foreach { case ((o, s), e) => checkTree(o, s)(e) }
@@ -125,7 +125,7 @@ abstract class TreeSuiteBase extends FunSuite with CommonTrees {
 
   protected def assertWithOriginalSyntax(tree: Tree, original: String, reprinted: String)(implicit
       loc: Location,
-      dialect: Dialect
+      dialect: Dialect,
   ): Unit = {
     val struct = tree.structure
     assertNoDiff(tree.reprint, reprinted, struct)
@@ -133,7 +133,7 @@ abstract class TreeSuiteBase extends FunSuite with CommonTrees {
   }
 
   protected def assertWithOriginalSyntax(
-      trees: Tree*
+      trees: Tree*,
   )(original: String*)(reprinted: String*)(implicit loc: Location, dialect: Dialect): Unit = {
     assertEquals(trees.length, original.length)
     assertEquals(trees.length, reprinted.length)
@@ -143,13 +143,13 @@ abstract class TreeSuiteBase extends FunSuite with CommonTrees {
   }
 
   protected def assertTokensAsStructureLines(tokens: Iterable[Token], expected: String)(implicit
-      loc: Location
+      loc: Location,
   ): Unit = assertNoDiff(TestHelpers.tokensAsStructureLines(tokens.iterator), expected)
 
   protected def assertTokenizedAsStructureLines(
       code: String,
       expected: String,
-      dialect: Dialect
+      dialect: Dialect,
   )(implicit loc: Location, conv: TestHelpers.Tokenize): Unit = {
     implicit val implicitDialect: Dialect = dialect
     assertTokensAsStructureLines(conv(code), expected)
@@ -158,16 +158,16 @@ abstract class TreeSuiteBase extends FunSuite with CommonTrees {
   protected def assertTokenizedAsStructureLines(code: String, expected: String)(implicit
       loc: Location,
       dialect: Dialect,
-      conv: TestHelpers.Tokenize
+      conv: TestHelpers.Tokenize,
   ): Unit = assertTokenizedAsStructureLines(code, expected, dialect)
 
   def assertTokensAsSyntax(tokens: Iterable[Token], expected: String)(implicit
-      loc: Location
+      loc: Location,
   ): Unit = assertNoDiff(TestHelpers.tokensAsSyntax(tokens.iterator), expected)
 
   def assertTokenizedAsSyntax(code: String, expected: String, dialect: Dialect)(implicit
       loc: Location,
-      conv: TestHelpers.Tokenize
+      conv: TestHelpers.Tokenize,
   ): Unit = {
     implicit val implicitDialect: Dialect = dialect
     assertTokensAsSyntax(conv(code), expected)
@@ -176,7 +176,7 @@ abstract class TreeSuiteBase extends FunSuite with CommonTrees {
   def assertTokenizedAsSyntax(code: String, expected: String)(implicit
       loc: Location,
       dialect: Dialect,
-      conv: TestHelpers.Tokenize
+      conv: TestHelpers.Tokenize,
   ): Unit = assertTokenizedAsSyntax(code, expected, dialect)
 
   protected def tokenize(code: String)(implicit dialect: Dialect): Tokens = tokenizerOptions
@@ -221,7 +221,7 @@ abstract class TreeSuiteBase extends FunSuite with CommonTrees {
       expected: String,
       showPosition: Boolean = false,
       showFieldName: Boolean = false,
-      skipFullTree: Boolean = true
+      skipFullTree: Boolean = true,
   )(implicit loc: Location): Unit = {
     val sb = new StringBuilder
     TestHelpers.foreach(tree) {
@@ -258,7 +258,7 @@ abstract class TreeSuiteBase extends FunSuite with CommonTrees {
               case (name, `t`) => name
               case (name, Some(`t`)) => name
               case (name, IterableIndex(idx)) => s"$name$idx"
-            }
+            },
           ).orElse(Some("?"))
           else None
         nameOpt.foreach(x => sb.append('<').append(x).append('>'))

--- a/tests/shared/src/test/scala/scala/meta/tests/inputs/FormatMessageSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/inputs/FormatMessageSuite.scala
@@ -23,7 +23,7 @@ class FormatMessageSuite extends TreeSuiteBase {
        |<input>:1: error: foo
        |
        |^
-       |""".stripMargin.lf2nl
+       |""".stripMargin.lf2nl,
   )
 
   test("\n")(
@@ -34,7 +34,7 @@ class FormatMessageSuite extends TreeSuiteBase {
        |<input>:2: error: foo
        |
        |^
-       |""".stripMargin.lf2nl
+       |""".stripMargin.lf2nl,
   )
 
   test("foo")(
@@ -51,7 +51,7 @@ class FormatMessageSuite extends TreeSuiteBase {
        |<input>:1: error: foo
        |foo
        |   ^
-       |""".stripMargin.lf2nl
+       |""".stripMargin.lf2nl,
   )
 
   test("foo\n")(
@@ -71,7 +71,7 @@ class FormatMessageSuite extends TreeSuiteBase {
        |<input>:2: error: foo
        |
        |^
-       |""".stripMargin.lf2nl
+       |""".stripMargin.lf2nl,
   )
 
   test("foo\nbar") {

--- a/tests/shared/src/test/scala/scala/meta/tests/inputs/OffsetLineColumnSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/inputs/OffsetLineColumnSuite.scala
@@ -12,7 +12,7 @@ class OffsetLineColumnSuite extends FunSuite {
       val content = Input.String(s)
       val len = content.chars.length
       val points = (0 until len).flatMap(i =>
-        Seq(Position.Range.exclusive(content, i, i), Position.Range.inclusive(content, i, i))
+        Seq(Position.Range.exclusive(content, i, i), Position.Range.inclusive(content, i, i)),
       ) :+ Position.Range.exclusive(content, len, len)
       val sb = new StringBuilder
       points.foreach { p =>
@@ -31,14 +31,14 @@ class OffsetLineColumnSuite extends FunSuite {
 
   test("")(
     """|[0, 0) -> [0:0, -1:0] end=(0:0)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   test("\n")(
     """|[0, 0) -> [0:0, -1:0] end=(0:0)
        |[0, 1) -> [0:0, 0:0] end=(1:0)
        |[1, 1) -> [1:0, 0:0] end=(1:0)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   test("foo")(
@@ -49,7 +49,7 @@ class OffsetLineColumnSuite extends FunSuite {
        |[2, 2) -> [0:2, 0:1] end=(0:2)
        |[2, 3) -> [0:2, 0:2] end=(0:3)
        |[3, 3) -> [0:3, 0:2] end=(0:3)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   test("foo\n") {

--- a/tests/shared/src/test/scala/scala/meta/tests/io/NIOPathTest.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/io/NIOPathTest.scala
@@ -79,7 +79,7 @@ class NIOPathTest extends FunSuite {
   }
   test(".relativize(Path)")(assertEquals(abs.relativize(abs.resolve("qux")), Paths.get("qux")))
   test("file.toUri")(
-    assert(file.toUri.getPath.endsWith("build.sbt"))
+    assert(file.toUri.getPath.endsWith("build.sbt")),
     // NOTE: Paths API seems to work inconsistently under Scala Native.
     // [info] - .toUri *** FAILED ***
     // [info]   "/Users/eburmako/Projects/scalameta/project" did not end with "project/" (NIOPathTest.scala:84)
@@ -94,11 +94,11 @@ class NIOPathTest extends FunSuite {
         Files.createDirectories(hello.toNIO)
         assert(hello.toURI.toString.endsWith("hello"))
       }
-    }
+    },
   )
 
   test(".toAbsolutePath")(
-    assert(file.toAbsolutePath.endsWith(file))
+    assert(file.toAbsolutePath.endsWith(file)),
     // NOTE: Paths API seems to work inconsistently under Scala Native.
     // [info] - .toAbsolutePath *** FAILED ***
     // [info]   /bar/foo did not equal //bar/foo (NIOPathTest.scala:88)
@@ -124,14 +124,14 @@ class NIOPathTest extends FunSuite {
       ("c:/foo/bar///baz", "c:\\", 3, Seq("foo", "bar", "baz")),
       ("c:\\foo\\\\bar\\baz", "c:\\", 3, Seq("foo", "bar", "baz")),
       ("foo\\bar\\baz", null, 3, Seq("foo", "bar", "baz")),
-      ("\\\\foo\\bar\\baz", "\\\\foo\\bar\\", 1, Seq("baz"))
+      ("\\\\foo\\bar\\baz", "\\\\foo\\bar\\", 1, Seq("baz")),
     )
     else Seq(
       ("//foo/bar//baz/", "/", 3, Seq("foo", "bar", "baz")),
       ("//foo/bar///baz", "/", 3, Seq("foo", "bar", "baz")),
       ("/foo/bar/baz/", "/", 3, Seq("foo", "bar", "baz")),
       ("/foo/bar/baz", "/", 3, Seq("foo", "bar", "baz")),
-      ("foo/bar////baz", null, 3, Seq("foo", "bar", "baz"))
+      ("foo/bar////baz", null, 3, Seq("foo", "bar", "baz")),
     )
   pathsWithNames.foreach { case (file, root, cnt, names) =>
     test(s".getName: $file -> [${names.mkString(",")}]") {

--- a/tests/shared/src/test/scala/scala/meta/tests/io/PathIOSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/io/PathIOSuite.scala
@@ -6,7 +6,7 @@ import munit.FunSuite
 
 class PathIOSuite extends FunSuite {
   def check(path: String, expectedDir: String, expectedName: String)(implicit
-      loc: munit.Location
+      loc: munit.Location,
   ): Unit = test(path) {
     val obtainedDir = PathIO.dirname(path)
     assertEquals(obtainedDir, expectedDir, "Unexpected dirName")

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/BasePositionSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/BasePositionSuite.scala
@@ -10,7 +10,7 @@ abstract class BasePositionSuite extends ParseSuite {
   import scala.meta.tests.parsers.MoreHelpers._
 
   def checkPositions[T <: Tree: Parse](
-      code: TestOptions
+      code: TestOptions,
   )(implicit loc: Location, dialect: Dialect): Unit = checkPositions[T](code, "")
 
   /**
@@ -51,7 +51,7 @@ abstract class BasePositionSuite extends ParseSuite {
       expected: String,
       expectedTokens: String = "",
       showPosition: Boolean = false,
-      showFieldName: Boolean = false
+      showFieldName: Boolean = false,
   )(implicit loc: Location, dialect: Dialect): Unit = test(code) {
     if (expectedTokens.nonEmpty) assertTokenizedAsStructureLines(code.name, expectedTokens)
     val tree = code.name.asInput.parse[T]

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/BasicPositionSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/BasicPositionSuite.scala
@@ -14,7 +14,7 @@ class BasicPositionSuite extends BasePositionSuite {
        |Term.ApplyInfix 2 / 3
        |Type.ArgClause 1 + (2 / @@3) * 4
        |Type.ArgClause 1 + (2 / 3) * @@4
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Term](
@@ -22,7 +22,7 @@ class BasicPositionSuite extends BasePositionSuite {
     """|Type.ArgClause 1 + @@(()) * 4
        |Term.ApplyInfix (()) * 4
        |Type.ArgClause 1 + (()) * @@4
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Term](
@@ -31,34 +31,34 @@ class BasicPositionSuite extends BasePositionSuite {
        |Term.ApplyInfix ((1, 2, 3)) * 4
        |Term.Tuple (1, 2, 3)
        |Type.ArgClause 1 + ((1, 2, 3)) * @@4
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Term](
     "a f (b)",
     """|Type.ArgClause a f @@(b)
        |Term.ArgClause (b)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Term](
     "a f (123)",
     """|Type.ArgClause a f @@(123)
        |Term.ArgClause (123)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Term](
     "a f ()",
     """|Type.ArgClause a f @@()
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Term](
     "a f (())",
     """|Type.ArgClause a f @@(())
        |Term.ArgClause (())
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Term](
@@ -66,14 +66,14 @@ class BasicPositionSuite extends BasePositionSuite {
     """|Type.ArgClause a f @@((1, 2, 3))
        |Term.ArgClause ((1, 2, 3))
        |Term.Tuple (1, 2, 3)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Term](
     "a f (()).foo",
     """|Type.ArgClause a f @@(()).foo
        |Term.Select (()).foo
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Term](
@@ -81,7 +81,7 @@ class BasicPositionSuite extends BasePositionSuite {
     """|Type.ArgClause a f @@(())(b)
        |Term.Apply (())(b)
        |Term.ArgClause (b)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Term](
@@ -92,7 +92,7 @@ class BasicPositionSuite extends BasePositionSuite {
        |Term.ApplyInfix 2 / 3
        |Type.ArgClause 1 + { 2 / @@3 } * 4
        |Type.ArgClause 1 + { 2 / 3 } * @@4
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Term](
@@ -101,14 +101,14 @@ class BasicPositionSuite extends BasePositionSuite {
        |Term.ApplyInfix 2 / 3
        |Type.ArgClause { 2 / @@3 } + 4
        |Type.ArgClause { 2 / 3 } + @@4
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Term](
     "(1 + 2).foo",
     """|Term.ApplyInfix 1 + 2
        |Type.ArgClause (1 + @@2).foo
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Term](
     "foo == (a + b).c(d)",
@@ -118,13 +118,13 @@ class BasicPositionSuite extends BasePositionSuite {
        |Term.ApplyInfix a + b
        |Type.ArgClause foo == (a + @@b).c(d)
        |Term.ArgClause (d)
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     // Issue #333
     """def shortInfo: String = s"created=$x"""",
     """|Term.Interpolate s"created=$x"
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Case](
     // Issue #331
@@ -132,21 +132,21 @@ class BasicPositionSuite extends BasePositionSuite {
     """|Term.ApplyInfix bar || baz
        |Type.ArgClause case foo if bar || @@baz =>
        |Term.Block case foo if bar || baz =>@@
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkPositions[Stat](
     """a + b + c""",
     """|Term.ApplyInfix a + b
        |Type.ArgClause a + @@b + c
        |Type.ArgClause a + b + @@c
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   test("apply(startLine,startColumn,endLine,endColumn)") {
     val input = Input.String(
       """|  val x = 2 // line 0
          |
-         |            // line 2""".stripMargin
+         |            // line 2""".stripMargin,
     )
     val x = Position.Range(input, 0, 2, 0, 11)
     assertEquals(x.text, "val x = 2")
@@ -165,7 +165,7 @@ class BasicPositionSuite extends BasePositionSuite {
        |Type.ArgClause (((a +: @@b) +: c) +: d)
        |Type.ArgClause (((a +: b) +: @@c) +: d)
        |Type.ArgClause (((a +: b) +: c) +: @@d)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -175,7 +175,7 @@ class BasicPositionSuite extends BasePositionSuite {
        |Type.ArgClause (((a :+ @@b) :+ c) :+ d)
        |Type.ArgClause (((a :+ b) :+ @@c) :+ d)
        |Type.ArgClause (((a :+ b) :+ c) :+ @@d)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -189,7 +189,7 @@ class BasicPositionSuite extends BasePositionSuite {
        |Type.ArgClause (a +: (b +: (c +: @@d) +: b) +: a)
        |Type.ArgClause (a +: (b +: (c +: d) +: @@b) +: a)
        |Type.ArgClause (a +: (b +: (c +: d) +: b) +: @@a)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -201,7 +201,7 @@ class BasicPositionSuite extends BasePositionSuite {
        |Term.ArgClause (c +: d)
        |Term.ApplyInfix c +: d
        |Type.ArgClause (a +: (b +: (c +: @@d)))
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -213,7 +213,7 @@ class BasicPositionSuite extends BasePositionSuite {
        |Term.ArgClause (c :+ d)
        |Term.ApplyInfix c :+ d
        |Type.ArgClause (a :+ (b :+ (c :+ @@d)))
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -229,7 +229,7 @@ class BasicPositionSuite extends BasePositionSuite {
        |Type.ArgClause (a :+ (b :+ (c :+ @@d) :+ b) :+ a)
        |Type.ArgClause (a :+ (b :+ (c :+ d) :+ @@b) :+ a)
        |Type.ArgClause (a :+ (b :+ (c :+ d) :+ b) :+ @@a)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -240,7 +240,7 @@ class BasicPositionSuite extends BasePositionSuite {
        |Term.Apply b (c d)
        |Term.ArgClause (c d)
        |Term.SelectPostfix c d
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -251,7 +251,7 @@ class BasicPositionSuite extends BasePositionSuite {
        |Type.ArgClause (a + (b + @@(c d)))
        |Term.ArgClause (c d)
        |Term.SelectPostfix c d
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -260,21 +260,21 @@ class BasicPositionSuite extends BasePositionSuite {
        |Term.Apply b (c d)
        |Term.ArgClause (c d)
        |Term.SelectPostfix c d
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
     """(((c d) b) a)""",
     """|Term.SelectPostfix (c d) b
        |Term.SelectPostfix c d
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Case](
     """case foo => (a -> b)""",
     """|Term.ApplyInfix a -> b
        |Type.ArgClause case foo => (a -> @@b)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Case](
@@ -283,14 +283,14 @@ class BasicPositionSuite extends BasePositionSuite {
        |Term.ApplyInfix a -> b
        |Type.ArgClause case foo => (a -> @@b) -> c
        |Type.ArgClause case foo => (a -> b) -> @@c
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Case](
     """case foo => (a :+ b)""",
     """|Term.ApplyInfix a :+ b
        |Type.ArgClause case foo => (a :+ @@b)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Case](
@@ -299,14 +299,14 @@ class BasicPositionSuite extends BasePositionSuite {
        |Term.ApplyInfix a :+ b
        |Type.ArgClause case foo => (a :+ @@b) :+ c
        |Type.ArgClause case foo => (a :+ b) :+ @@c
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Case](
     """case foo => (a +: b)""",
     """|Term.ApplyInfix a +: b
        |Type.ArgClause case foo => (a +: @@b)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Case](
@@ -315,20 +315,20 @@ class BasicPositionSuite extends BasePositionSuite {
        |Term.ApplyInfix a +: b
        |Type.ArgClause case foo => (a +: @@b) +: c
        |Type.ArgClause case foo => (a +: b) +: @@c
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Case](
     """case foo => (a, b)""",
     """|Term.Tuple (a, b)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Case](
     """case foo => (a, b).bar""",
     """|Term.Select (a, b).bar
        |Term.Tuple (a, b)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Case](
@@ -336,7 +336,7 @@ class BasicPositionSuite extends BasePositionSuite {
     """|Term.Block {(a -> b)}
        |Term.ApplyInfix a -> b
        |Type.ArgClause case foo => {(a -> @@b)}
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Case](
@@ -344,7 +344,7 @@ class BasicPositionSuite extends BasePositionSuite {
     """|Term.Block {(a :+ b)}
        |Term.ApplyInfix a :+ b
        |Type.ArgClause case foo => {(a :+ @@b)}
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Case](
@@ -352,21 +352,21 @@ class BasicPositionSuite extends BasePositionSuite {
     """|Term.Block {(a +: b)}
        |Term.ApplyInfix a +: b
        |Type.ArgClause case foo => {(a +: @@b)}
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Case](
     """case foo => {(a, b)}""",
     """|Term.Block {(a, b)}
        |Term.Tuple (a, b)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
     """val foo = (a -> b)""",
     """|Term.ApplyInfix a -> b
        |Type.ArgClause val foo = (a -> @@b)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -375,14 +375,14 @@ class BasicPositionSuite extends BasePositionSuite {
        |Term.ApplyInfix a -> b
        |Type.ArgClause val foo = (a -> @@b) -> c
        |Type.ArgClause val foo = (a -> b) -> @@c
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
     """val foo = (a :+ b)""",
     """|Term.ApplyInfix a :+ b
        |Type.ArgClause val foo = (a :+ @@b)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -391,14 +391,14 @@ class BasicPositionSuite extends BasePositionSuite {
        |Term.ApplyInfix a :+ b
        |Type.ArgClause val foo = (a :+ @@b) :+ c
        |Type.ArgClause val foo = (a :+ b) :+ @@c
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
     """val foo = (a +: b)""",
     """|Term.ApplyInfix a +: b
        |Type.ArgClause val foo = (a +: @@b)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -407,20 +407,20 @@ class BasicPositionSuite extends BasePositionSuite {
        |Term.ApplyInfix a +: b
        |Type.ArgClause val foo = (a +: @@b) +: c
        |Type.ArgClause val foo = (a +: b) +: @@c
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
     """val foo = (a, b)""",
     """|Term.Tuple (a, b)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
     """val foo = (a, b).bar""",
     """|Term.Select (a, b).bar
        |Term.Tuple (a, b)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -428,7 +428,7 @@ class BasicPositionSuite extends BasePositionSuite {
     """|Term.Block {(a -> b)}
        |Term.ApplyInfix a -> b
        |Type.ArgClause val foo = {(a -> @@b)}
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -436,7 +436,7 @@ class BasicPositionSuite extends BasePositionSuite {
     """|Term.Block {(a :+ b)}
        |Term.ApplyInfix a :+ b
        |Type.ArgClause val foo = {(a :+ @@b)}
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -444,14 +444,14 @@ class BasicPositionSuite extends BasePositionSuite {
     """|Term.Block {(a +: b)}
        |Term.ApplyInfix a +: b
        |Type.ArgClause val foo = {(a +: @@b)}
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
     """val foo = {(a, b)}""",
     """|Term.Block {(a, b)}
        |Term.Tuple (a, b)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -459,7 +459,7 @@ class BasicPositionSuite extends BasePositionSuite {
     """|Type.ParamClause type foo @@= (a -> b)
        |Type.ApplyInfix a -> b
        |Type.Bounds type foo @@= (a -> b)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -468,7 +468,7 @@ class BasicPositionSuite extends BasePositionSuite {
        |Type.ApplyInfix (a -> b) -> c
        |Type.ApplyInfix a -> b
        |Type.Bounds type foo @@= (a -> b) -> c
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -476,7 +476,7 @@ class BasicPositionSuite extends BasePositionSuite {
     """|Type.ParamClause type foo @@= (a :+ b)
        |Type.ApplyInfix a :+ b
        |Type.Bounds type foo @@= (a :+ b)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -485,7 +485,7 @@ class BasicPositionSuite extends BasePositionSuite {
        |Type.ApplyInfix (a :+ b) :+ c
        |Type.ApplyInfix a :+ b
        |Type.Bounds type foo @@= (a :+ b) :+ c
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -493,7 +493,7 @@ class BasicPositionSuite extends BasePositionSuite {
     """|Type.ParamClause type foo @@= (a +: b)
        |Type.ApplyInfix a +: b
        |Type.Bounds type foo @@= (a +: b)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -502,7 +502,7 @@ class BasicPositionSuite extends BasePositionSuite {
        |Type.ApplyInfix (a +: b) +: c
        |Type.ApplyInfix a +: b
        |Type.Bounds type foo @@= (a +: b) +: c
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -510,52 +510,52 @@ class BasicPositionSuite extends BasePositionSuite {
     """|Type.ParamClause type foo @@= (a, b)
        |Type.Tuple (a, b)
        |Type.Bounds type foo @@= (a, b)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Pat](
     """foo @ (a -> b)""",
     """|Pat.ExtractInfix (a -> b)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Pat](
     """foo @ (a -> b) -> c""",
     """|Pat.ExtractInfix (a -> b) -> c
        |Pat.ExtractInfix (a -> b)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Pat](
     """foo @ (a :+ b)""",
     """|Pat.ExtractInfix (a :+ b)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Pat](
     """foo @ (a :+ b) :+ c""",
     """|Pat.ExtractInfix (a :+ b) :+ c
        |Pat.ExtractInfix (a :+ b)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Pat](
     """foo @ (a +: b)""",
     """|Pat.ExtractInfix (a +: b)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Pat](
     """foo @ (a +: b) +: c""",
     """|Pat.ExtractInfix (a +: b) +: c
        |Pat.ExtractInfix (a +: b)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Pat](
     """foo @ (a, b)""",
     """|Pat.Tuple (a, b)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Pat](
@@ -563,7 +563,7 @@ class BasicPositionSuite extends BasePositionSuite {
     """|Pat.Alternative ((a) | (b))
        |Pat.Var (a)
        |Pat.Var (b)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Pat](
@@ -573,7 +573,7 @@ class BasicPositionSuite extends BasePositionSuite {
        |Pat.Alternative ((b) | (c))
        |Pat.Var (b)
        |Pat.Var (c)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -588,7 +588,7 @@ class BasicPositionSuite extends BasePositionSuite {
        |  (try foo finally bar)
        |}
        |Term.Try try foo finally bar
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -600,7 +600,7 @@ class BasicPositionSuite extends BasePositionSuite {
        |  (try foo finally bar)
        |}
        |Term.Try try foo finally bar
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -615,7 +615,7 @@ class BasicPositionSuite extends BasePositionSuite {
        |}
        |Enumerator.Generator a <- (b)
        |Enumerator.Val c = (d)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   checkPositions[Stat](
@@ -633,7 +633,7 @@ class BasicPositionSuite extends BasePositionSuite {
        |}
        |Case case _ =>
        |Term.Block @@}
-       |""".stripMargin
+       |""".stripMargin,
   )
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
@@ -167,7 +167,7 @@ trait CommonTrees extends CommonTrees.LowPriorityDefinitions {
       mods: List[Mod],
       s: String,
       params: List[Type.Param] = Nil,
-      bounds: Type.Bounds = noBounds
+      bounds: Type.Bounds = noBounds,
   ): Type.Param = {
     val nameTree = nameOr(s, pnameOrCapset)
     Type.Param(mods, nameTree, params, bounds)
@@ -227,7 +227,7 @@ trait CommonTrees extends CommonTrees.LowPriorityDefinitions {
       lo: Type = null,
       hi: Type = null,
       cb: List[Type] = Nil,
-      vb: List[Type] = Nil
+      vb: List[Type] = Nil,
   ): Type.Bounds = Type.Bounds(Option(lo), Option(hi), cb, vb)
 
   final def pwildcard(bounds: Type.Bounds): Type.Wildcard = Type.Wildcard(bounds)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/DeclSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/DeclSuite.scala
@@ -8,11 +8,11 @@ class DeclSuite extends ParseSuite {
   implicit val dialect: Dialect = dialects.Scala211
 
   test("val x: Int")(
-    assertTree(templStat("val x: Int"))(Decl.Val(Nil, List(patvar("x")), pname("Int")))
+    assertTree(templStat("val x: Int"))(Decl.Val(Nil, List(patvar("x")), pname("Int"))),
   )
 
   test("var x: Int")(
-    assertTree(templStat("var x: Int"))(Decl.Var(Nil, List(patvar("x")), pname("Int")))
+    assertTree(templStat("var x: Int"))(Decl.Var(Nil, List(patvar("x")), pname("Int"))),
   )
 
   test("val x, y: Int") {
@@ -21,48 +21,48 @@ class DeclSuite extends ParseSuite {
   }
 
   test("var x, y: Int")(
-    assertTree(templStat("var x, y: Int"))(Decl.Var(Nil, List(patvar("x"), patvar("y")), pname("Int")))
+    assertTree(templStat("var x, y: Int"))(Decl.Var(Nil, List(patvar("x"), patvar("y")), pname("Int"))),
   )
 
   test("type T")(assertTree(templStat("type T"))(Decl.Type(Nil, pname("T"), Nil, noBounds)))
 
   test("type T <: hi")(
-    assertTree(templStat("type T <: hi"))(Decl.Type(Nil, pname("T"), Nil, hiBound("hi")))
+    assertTree(templStat("type T <: hi"))(Decl.Type(Nil, pname("T"), Nil, hiBound("hi"))),
   )
 
   test("type T >: lo")(
-    assertTree(templStat("type T >: lo"))(Decl.Type(Nil, pname("T"), Nil, loBound("lo")))
+    assertTree(templStat("type T >: lo"))(Decl.Type(Nil, pname("T"), Nil, loBound("lo"))),
   )
 
   test("type T >: lo <: hi")(
-    assertTree(templStat("type T >: lo <: hi"))(Decl.Type(Nil, pname("T"), Nil, bounds("lo", "hi")))
+    assertTree(templStat("type T >: lo <: hi"))(Decl.Type(Nil, pname("T"), Nil, bounds("lo", "hi"))),
   )
 
   test("type F[T]")(
-    assertTree(templStat("type F[T]"))(Decl.Type(Nil, pname("F"), pparam("T") :: Nil, noBounds))
+    assertTree(templStat("type F[T]"))(Decl.Type(Nil, pname("F"), pparam("T") :: Nil, noBounds)),
   )
 
   test("type F[_]")(
-    assertTree(templStat("type F[_]"))(Decl.Type(Nil, pname("F"), pparam("_") :: Nil, noBounds))
+    assertTree(templStat("type F[_]"))(Decl.Type(Nil, pname("F"), pparam("_") :: Nil, noBounds)),
   )
 
   test("type F[A <: B]")(assertTree(templStat("type F[T <: B]"))(
-    Decl.Type(Nil, pname("F"), pparam("T", hiBound("B")) :: Nil, noBounds)
+    Decl.Type(Nil, pname("F"), pparam("T", hiBound("B")) :: Nil, noBounds),
   ))
 
   test("type F[+T]") {
     assertTree(
-      templStat("type F[+T]")
+      templStat("type F[+T]"),
     )(Decl.Type(Nil, pname("F"), pparam(Mod.Covariant() :: Nil, "T") :: Nil, noBounds))
     assertTree(
-      templStat("type F[-T]")
+      templStat("type F[-T]"),
     )(Decl.Type(Nil, pname("F"), pparam(Mod.Contravariant() :: Nil, "T") :: Nil, noBounds))
   }
 
   test("def f")(assertTree(templStat("def f"))(Decl.Def(Nil, tname("f"), Nil, Nil, pname("Unit"))))
 
   test("def f(x: Int)")(assertTree(templStat("def f(x: Int)"))(
-    Decl.Def(Nil, tname("f"), Nil, (tparam("x", "Int") :: Nil) :: Nil, pname("Unit"))
+    Decl.Def(Nil, tname("f"), Nil, (tparam("x", "Int") :: Nil) :: Nil, pname("Unit")),
   ))
 
   test("def f(x: Int*)")(assertTree(templStat("def f(x: Int*)"))(Decl.Def(
@@ -70,7 +70,7 @@ class DeclSuite extends ParseSuite {
     tname("f"),
     Nil,
     (tparam("x", Type.Repeated(pname("Int"))) :: Nil) :: Nil,
-    pname("Unit")
+    pname("Unit"),
   )))
 
   test("def f(x: => Int)")(assertTree(templStat("def f(x: => Int)"))(Decl.Def(
@@ -78,7 +78,7 @@ class DeclSuite extends ParseSuite {
     tname("f"),
     Nil,
     (tparam("x", Type.ByName(pname("Int"))) :: Nil) :: Nil,
-    pname("Unit")
+    pname("Unit"),
   )))
 
   test("def f(implicit x: Int)")(assertTree(templStat("def f(implicit x: Int)"))(Decl.Def(
@@ -86,12 +86,12 @@ class DeclSuite extends ParseSuite {
     tname("f"),
     Nil,
     (tparam(Mod.Implicit() :: Nil, "x", "Int") :: Nil) :: Nil,
-    pname("Unit")
+    pname("Unit"),
   )))
 
   test("def f: X")(assertTree(templStat("def f: X"))(Decl.Def(Nil, tname("f"), Nil, Nil, pname("X"))))
 
   test("def f[T]: T")(assertTree(templStat("def f[T]: T"))(
-    Decl.Def(Nil, tname("f"), pparam("T") :: Nil, Nil, pname("T"))
+    Decl.Def(Nil, tname("f"), pparam("T") :: Nil, Nil, pname("T")),
   ))
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
@@ -10,19 +10,19 @@ class DefnSuite extends ParseSuite {
   test("val x = 2")(assertTree(templStat("val x = 2"))(Defn.Val(Nil, patvar("x") :: Nil, None, int(2))))
 
   test("var x = 2")(
-    assertTree(templStat("var x = 2"))(Defn.Var(Nil, patvar("x") :: Nil, None, Some(int(2))))
+    assertTree(templStat("var x = 2"))(Defn.Var(Nil, patvar("x") :: Nil, None, Some(int(2)))),
   )
 
   test("val x, y = 2")(assertTree(templStat("val x, y = 2"))(
-    Defn.Val(Nil, patvar("x") :: patvar("y") :: Nil, None, int(2))
+    Defn.Val(Nil, patvar("x") :: patvar("y") :: Nil, None, int(2)),
   ))
 
   test("val x: Int = 2")(assertTree(templStat("val x: Int = 2"))(
-    Defn.Val(Nil, patvar("x") :: Nil, Some(pname("Int")), int(2))
+    Defn.Val(Nil, patvar("x") :: Nil, Some(pname("Int")), int(2)),
   ))
 
   test("val `x`: Int = 2")(assertTree(templStat("val `x`: Int = 2"))(
-    Defn.Val(Nil, patvar("x") :: Nil, Some(pname("Int")), int(2))
+    Defn.Val(Nil, patvar("x") :: Nil, Some(pname("Int")), int(2)),
   ))
 
   test("val f: Int => String = _.toString")(
@@ -30,8 +30,8 @@ class DefnSuite extends ParseSuite {
       Nil,
       patvar("f") :: Nil,
       Some(pfunc(pname("Int"))(pname("String"))),
-      Term.AnonymousFunction(tselect(Term.Placeholder(), "toString"))
-    ))
+      Term.AnonymousFunction(tselect(Term.Placeholder(), "toString")),
+    )),
   )
 
   test("var f: Int => String = _.toString")(
@@ -39,12 +39,12 @@ class DefnSuite extends ParseSuite {
       Nil,
       patvar("f") :: Nil,
       Some(pfunc(pname("Int"))(pname("String"))),
-      Some(Term.AnonymousFunction(tselect(Term.Placeholder(), "toString")))
-    ))
+      Some(Term.AnonymousFunction(tselect(Term.Placeholder(), "toString"))),
+    )),
   )
 
   test("var x: Int = _")(assertTree(templStat("var x: Int = _"))(
-    Defn.Var(Nil, patvar("x") :: Nil, Some(pname("Int")), None)
+    Defn.Var(Nil, patvar("x") :: Nil, Some(pname("Int")), None),
   ))
 
   test("var x = _ is not allowed")(intercept[parsers.ParseException](templStat("var x = _")))
@@ -52,29 +52,29 @@ class DefnSuite extends ParseSuite {
   test("val x: Int = _ is not allowed")(intercept[parsers.ParseException](templStat("val x: Int = _")))
 
   test("val (x: Int) = 2")(assertTree(templStat("val (x: Int) = 2"))(
-    Defn.Val(Nil, Pat.Typed(patvar("x"), pname("Int")) :: Nil, None, int(2))
+    Defn.Val(Nil, Pat.Typed(patvar("x"), pname("Int")) :: Nil, None, int(2)),
   ))
 
   test("type A = B")(assertTree(templStat("type A = B"))(Defn.Type(Nil, pname("A"), Nil, pname("B"))))
 
   test("type F[T] = List[T]")(assertTree(templStat("type F[T] = List[T]"))(
-    Defn.Type(Nil, pname("F"), pparam("T") :: Nil, papply("List", pname("T")))
+    Defn.Type(Nil, pname("F"), pparam("T") :: Nil, papply("List", pname("T"))),
   ))
 
   test("def x = 2")(
-    assertTree(templStat("def x = 2"))(Defn.Def(Nil, tname("x"), Nil, Nil, None, int(2)))
+    assertTree(templStat("def x = 2"))(Defn.Def(Nil, tname("x"), Nil, Nil, None, int(2))),
   )
 
   test("def x[A <: B] = 2")(assertTree(templStat("def x[A <: B] = 2"))(
-    Defn.Def(Nil, tname("x"), pparam("A", hiBound("B")) :: Nil, Nil, None, int(2))
+    Defn.Def(Nil, tname("x"), pparam("A", hiBound("B")) :: Nil, Nil, None, int(2)),
   ))
 
   test("def x[A <% B] = 2")(assertTree(templStat("def x[A <% B] = 2"))(
-    Defn.Def(Nil, tname("x"), List(pparam("A", bounds(vb = pname("B") :: Nil))), Nil, None, int(2))
+    Defn.Def(Nil, tname("x"), List(pparam("A", bounds(vb = pname("B") :: Nil))), Nil, None, int(2)),
   ))
 
   test("def x[A: B] = 2")(assertTree(templStat("def x[A: B] = 2"))(
-    Defn.Def(Nil, tname("x"), List(pparam("A", bounds(cb = List(pname("B"))))), Nil, None, int(2))
+    Defn.Def(Nil, tname("x"), List(pparam("A", bounds(cb = List(pname("B"))))), Nil, None, int(2)),
   ))
 
   test("def f(a: Int)(implicit b: Int) = a + b")(
@@ -84,16 +84,16 @@ class DefnSuite extends ParseSuite {
       Nil,
       (tparam("a", "Int") :: Nil) :: (tparam(Mod.Implicit() :: Nil, "b", "Int") :: Nil) :: Nil,
       None,
-      tinfix(tname("a"), "+", tname("b"))
-    ))
+      tinfix(tname("a"), "+", tname("b")),
+    )),
   )
 
   test("def proc { return 42 }")(assertTree(templStat("def proc { return 42 }"))(
-    Defn.Def(Nil, tname("proc"), Nil, Nil, Some(pname("Unit")), blk(Term.Return(int(42))))
+    Defn.Def(Nil, tname("proc"), Nil, Nil, Some(pname("Unit")), blk(Term.Return(int(42)))),
   ))
 
   test("def f(x: Int) = macro impl")(assertTree(templStat("def f(x: Int) = macro impl"))(
-    Defn.Macro(Nil, tname("f"), Nil, (tparam("x", "Int") :: Nil) :: Nil, None, tname("impl"))
+    Defn.Macro(Nil, tname("f"), Nil, (tparam("x", "Int") :: Nil) :: Nil, None, tname("impl")),
   ))
 
   test("def f(x: Int): Int = macro impl")(
@@ -103,8 +103,8 @@ class DefnSuite extends ParseSuite {
       Nil,
       (tparam("x", "Int") :: Nil) :: Nil,
       Some(pname("Int")),
-      tname("impl")
-    ))
+      tname("impl"),
+    )),
   )
 
   test("braces-in-functions") {
@@ -115,7 +115,7 @@ class DefnSuite extends ParseSuite {
          |      _ <- scala.util.Success(123)
          |    } yield 42
          |  }.recover(???)
-         |}""".stripMargin
+         |}""".stripMargin,
     )
     assertTree(defn)(Defn.Def(
       Nil,
@@ -128,42 +128,42 @@ class DefnSuite extends ParseSuite {
           blk(Term.ForYield(
             Enumerator
               .Generator(patwildcard, tapply(tselect("scala", "util", "Success"), int(123))) :: Nil,
-            int(42)
+            int(42),
           )),
-          "recover"
+          "recover",
         ),
-        tname("???")
-      )))
+        tname("???"),
+      ))),
     ))
   }
 
   test("braces-in-if-cond") {
     val defn = templStat(
       """|if (cond) { expr }.select else { expr } + { expr }
-         |""".stripMargin
+         |""".stripMargin,
     )
     assertTree(defn)(Term.If(
       tname("cond"),
       tselect(blk(tname("expr")), "select"),
       tinfix(blk(tname("expr")), "+", blk(tname("expr"))),
-      Nil
+      Nil,
     ))
   }
 
   test("braces-in-try-expr") {
     val defn = templStat(
       """|try {expr}.select finally {expr}.select 
-         |""".stripMargin
+         |""".stripMargin,
     )
     assertTree(defn)(
-      Term.Try(tselect(blk(tname("expr")), "select"), Nil, Some(tselect(blk(tname("expr")), "select")))
+      Term.Try(tselect(blk(tname("expr")), "select"), Nil, Some(tselect(blk(tname("expr")), "select"))),
     )
   }
 
   test("braces-in-while-expr") {
     val defn = templStat(
       """|while (cond) {expr}.select
-         |""".stripMargin
+         |""".stripMargin,
     )
     assertTree(defn)(Term.While(tname("cond"), tselect(blk(tname("expr")), "select")))
   }
@@ -171,11 +171,11 @@ class DefnSuite extends ParseSuite {
   test("braces-in-for-expr") {
     val defn = templStat(
       """|for (i <- list) {expr}.select
-         |""".stripMargin
+         |""".stripMargin,
     )
     assertTree(defn)(Term.For(
       List(Enumerator.Generator(patvar("i"), tname("list"))),
-      tselect(blk(tname("expr")), "select")
+      tselect(blk(tname("expr")), "select"),
     ))
   }
 
@@ -206,9 +206,9 @@ class DefnSuite extends ParseSuite {
         None,
         blk(
           Defn.Class(List(Mod.Case()), pname("A6"), Nil, ctorp(tparam("a7", "A8")), tplNoBody()),
-          Defn.Object(Nil, tname("A9"), tplNoBody())
-        )
-      )
+          Defn.Object(Nil, tname("A9"), tplNoBody()),
+        ),
+      ),
     )
     runTestAssert[Stat](code, assertLayout = Some(layout))(tree)
   }
@@ -224,7 +224,7 @@ class DefnSuite extends ParseSuite {
       """|new A { def b: C = ??? }
          |""".stripMargin
     val tree = Term.NewAnonymous(
-      tpl(List(init("A")), List(Defn.Def(Nil, tname("b"), Nil, Some(pname("C")), tname("???"))))
+      tpl(List(init("A")), List(Defn.Def(Nil, tname("b"), Nil, Some(pname("C")), tname("???")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -241,7 +241,7 @@ class DefnSuite extends ParseSuite {
       """|new A { def b: C = ??? }
          |""".stripMargin
     val tree = Term.NewAnonymous(
-      tpl(List(init("A")), List(Defn.Def(Nil, tname("b"), Nil, Some(pname("C")), tname("???"))))
+      tpl(List(init("A")), List(Defn.Def(Nil, tname("b"), Nil, Some(pname("C")), tname("???")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -279,7 +279,7 @@ class DefnSuite extends ParseSuite {
       """|new A { def b: C = ??? }
          |""".stripMargin
     val tree = Term.NewAnonymous(
-      tpl(List(init("A")), List(Defn.Def(Nil, tname("b"), Nil, Some(pname("C")), tname("???"))))
+      tpl(List(init("A")), List(Defn.Def(Nil, tname("b"), Nil, Some(pname("C")), tname("???")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -297,7 +297,7 @@ class DefnSuite extends ParseSuite {
       """|new A { def b: C = ??? }
          |""".stripMargin
     val tree = Term.NewAnonymous(
-      tpl(List(init("A")), List(Defn.Def(Nil, tname("b"), Nil, Some(pname("C")), tname("???"))))
+      tpl(List(init("A")), List(Defn.Def(Nil, tname("b"), Nil, Some(pname("C")), tname("???")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -362,19 +362,19 @@ class DefnSuite extends ParseSuite {
           tselect(
             tapply(
               tselect("object", "allFunctionsByName"),
-              tselect("ScFunction", "CommonNames", "Apply")
+              tselect("ScFunction", "CommonNames", "Apply"),
             ),
-            "nonEmpty"
-          )
+            "nonEmpty",
+          ),
         ),
         Case.createWithComments(
           Pat.Bind(patvar("class"), Pat.Extract(tname("ScClass"), List(tname("type")))),
           None,
           tapply(tname("isCaseOrInScala3File"), tname("class")),
-          endComment = Seq("// SCL-19992, SCL-21187")
+          endComment = Seq("// SCL-19992, SCL-21187"),
         ),
-        Case(patwildcard, None, lit(false))
-      )
+        Case(patwildcard, None, lit(false)),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -402,8 +402,8 @@ class DefnSuite extends ParseSuite {
       Some("Int"),
       tapply(
         "c",
-        blk(tfunc(tparam("D"))(tfunc(tparam("e"))(blk(Defn.Def(Nil, "f", Nil, None, "e"), "f"))))
-      )
+        blk(tfunc(tparam("D"))(tfunc(tparam("e"))(blk(Defn.Def(Nil, "f", Nil, None, "e"), "f")))),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -428,8 +428,8 @@ class DefnSuite extends ParseSuite {
       tapply(
         "test",
         Term.Try(lit(1), Some(Term.CasesBlock(List(Case(patwildcard, None, lit(2))))), None),
-        lit("bar")
-      )
+        lit("bar"),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -442,7 +442,7 @@ class DefnSuite extends ParseSuite {
       Nil,
       List(List(tparam("b", "Boolean"))),
       Some(pfunc("Int")("Int")),
-      Term.If("b", tfunc(tparam("a", "Int"))("a"), "identity", Nil)
+      Term.If("b", tfunc(tparam("a", "Int"))("a"), "identity", Nil),
     )
     runTestAssert[Stat](code)(tree)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ImportSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ImportSuite.scala
@@ -11,75 +11,75 @@ class ImportSuite extends ParseSuite {
   implicit val dialect: Dialect = dialects.Scala211
 
   test("import foo.bar")(assertTree(templStat("import foo.bar"))(Import(
-    Importer(TermName("foo"), Name(Indeterminate("bar")) :: Nil) :: Nil
+    Importer(TermName("foo"), Name(Indeterminate("bar")) :: Nil) :: Nil,
   )))
 
   test("import foo.bar.baz")(assertTree(templStat("import foo.bar.baz"))(Import(
-    Importer(tselect("foo", "bar"), Name(Indeterminate("baz")) :: Nil) :: Nil
+    Importer(tselect("foo", "bar"), Name(Indeterminate("baz")) :: Nil) :: Nil,
   )))
 
   test("import super.foo.bar")(assertTree(templStat("import super.foo.bar"))(Import(
     Importer(
       Select(Super(Anonymous(), Anonymous()), TermName("foo")),
-      Name(Indeterminate("bar")) :: Nil
-    ) :: Nil
+      Name(Indeterminate("bar")) :: Nil,
+    ) :: Nil,
   )))
 
   test("import this.foo.bar")(assertTree(templStat("import this.foo.bar"))(Import(
-    Importer(Select(This(Anonymous()), TermName("foo")), Name(Indeterminate("bar")) :: Nil) :: Nil
+    Importer(Select(This(Anonymous()), TermName("foo")), Name(Indeterminate("bar")) :: Nil) :: Nil,
   )))
 
   test("import foo.bar._")(assertTree(templStat("import foo.bar._"))(Import(
-    Importer(tselect("foo", "bar"), Wildcard() :: Nil) :: Nil
+    Importer(tselect("foo", "bar"), Wildcard() :: Nil) :: Nil,
   )))
 
   test("import super.foo._")(assertTree(templStat("import super.foo._"))(Import(
-    Importer(Select(Super(Anonymous(), Anonymous()), TermName("foo")), Wildcard() :: Nil) :: Nil
+    Importer(Select(Super(Anonymous(), Anonymous()), TermName("foo")), Wildcard() :: Nil) :: Nil,
   )))
 
   test("import this.foo._")(assertTree(templStat("import this.foo._"))(Import(
-    Importer(Select(This(Anonymous()), TermName("foo")), Wildcard() :: Nil) :: Nil
+    Importer(Select(This(Anonymous()), TermName("foo")), Wildcard() :: Nil) :: Nil,
   )))
 
   test("import foo.{bar}")(assertTree(templStat("import foo.{bar}"))(Import(
-    Importer(TermName("foo"), Name(Indeterminate("bar")) :: Nil) :: Nil
+    Importer(TermName("foo"), Name(Indeterminate("bar")) :: Nil) :: Nil,
   )))
 
   test("import foo.{bar, baz}")(assertTree(templStat("import foo.{bar, baz}"))(Import(
     Importer(TermName("foo"), Name(Indeterminate("bar")) :: Name(Indeterminate("baz")) :: Nil) ::
-      Nil
+      Nil,
   )))
 
   test("import foo.{bar => baz}")(assertTree(templStat("import foo.{bar => baz}"))(Import(
-    Importer(TermName("foo"), Rename(Indeterminate("bar"), Indeterminate("baz")) :: Nil) :: Nil
+    Importer(TermName("foo"), Rename(Indeterminate("bar"), Indeterminate("baz")) :: Nil) :: Nil,
   )))
 
   test("import foo.{bar => _}")(assertTree(templStat("import foo.{bar => _}"))(Import(
-    Importer(TermName("foo"), Unimport(Indeterminate("bar")) :: Nil) :: Nil
+    Importer(TermName("foo"), Unimport(Indeterminate("bar")) :: Nil) :: Nil,
   )))
 
   test("import foo.{_ => _}")(assertTree(templStat("import foo.{_ => _}"))(Import(
-    Importer(TermName("foo"), Wildcard() :: Nil) :: Nil
+    Importer(TermName("foo"), Wildcard() :: Nil) :: Nil,
   )))
 
   test("import foo.{bar => _, _}")(assertTree(templStat("import foo.{bar => _, _}"))(Import(
-    Importer(TermName("foo"), Unimport(Indeterminate("bar")) :: Wildcard() :: Nil) :: Nil
+    Importer(TermName("foo"), Unimport(Indeterminate("bar")) :: Wildcard() :: Nil) :: Nil,
   )))
 
   test("import foo.{bar, baz => _, _}")(
     assertTree(templStat("import foo.{bar, baz => _, _}"))(Import(
       Importer(
         TermName("foo"),
-        Name(Indeterminate("bar")) :: Unimport(Indeterminate("baz")) :: Wildcard() :: Nil
-      ) :: Nil
-    ))
+        Name(Indeterminate("bar")) :: Unimport(Indeterminate("baz")) :: Wildcard() :: Nil,
+      ) :: Nil,
+    )),
   )
 
   test("import a.b.{ _, c => _ }")(
     // invalid but we don't check anymore
     assertTree(templStat("import a.b.{ _, c => _ }"))(Import(
-      List(Importer(tselect("a", "b"), List(Wildcard(), Unimport(Indeterminate("c")))))
-    ))
+      List(Importer(tselect("a", "b"), List(Wildcard(), Unimport(Indeterminate("c"))))),
+    )),
   )
 
   test("source3-given-import") {
@@ -126,7 +126,7 @@ class ImportSuite extends ParseSuite {
             val tree = Import.createWithComments(
               List(Importer(tselect("a", "b"), List(Importee.Rename(meta.Name("c"), meta.Name("d"))))),
               begComment = Seq("// c1"),
-              endComment = Seq("// c2")
+              endComment = Seq("// c2"),
             )
             checkTree(head, layout)(tree)
             assertNoDiff(head.original, layout)
@@ -156,7 +156,7 @@ class ImportSuite extends ParseSuite {
                   val tree = Import.createWithComments(
                     List(Importer("y", List(Importee.Name(meta.Name("Y"))))),
                     begComment =
-                      Seq("// This comment is ambiguous and not linked to a specific import")
+                      Seq("// This comment is ambiguous and not linked to a specific import"),
                   )
                   checkTree(one, layout)(tree)
                   assertNoDiff(one.original, layout)
@@ -190,7 +190,7 @@ class ImportSuite extends ParseSuite {
          |""".stripMargin
     val tree = Source(List(Import.createWithComments(
       List(Importer("y", List(Importee.Name(meta.Name("Y"))))),
-      begComment = Seq("// attached comment")
+      begComment = Seq("// attached comment"),
     )))
     parseAndCheckTree[Source](code, layout)(tree)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/LitSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/LitSuite.scala
@@ -26,7 +26,7 @@ class LitSuite extends ParseSuite {
   test("-9223372036854775808L")(assertTree(term("-9223372036854775808L"))(lit(-9223372036854775808L)))
 
   test("42.42")(
-    matchSubStructure[Stat]("42.42", { case t: Lit.Double => assertEquals(t.format, "42.42") })
+    matchSubStructure[Stat]("42.42", { case t: Lit.Double => assertEquals(t.format, "42.42") }),
   )
 
   test("42.0f")(matchSubStructure[Stat]("42.42f", { case Lit(42.42f) => () }))
@@ -65,7 +65,7 @@ class LitSuite extends ParseSuite {
 
     assertTree(term("raw\"\"\"\"\"\"\"\""))(Term.Interpolate(tname("raw"), List(str("\"\"")), Nil))
     assertTree(
-      term("raw\"\"\"\"\"\"\"\"\"\"\"\"\"")
+      term("raw\"\"\"\"\"\"\"\"\"\"\"\"\""),
     )(Term.Interpolate(tname("raw"), List(str("\"\"\"\"\"\"\"")), Nil))
   }
 
@@ -88,12 +88,12 @@ class LitSuite extends ParseSuite {
       pname("Foo"),
       Nil,
       EmptyCtor(),
-      tpl(Defn.Def(Nil, tname("negate"), Nil, Nil, Some(pname("-")), tname("-")))
+      tpl(Defn.Def(Nil, tname("negate"), Nil, Nil, Some(pname("-")), tname("-"))),
     ))
   }
 
   test("simple-expression-parse-error")(
-    intercept[parsers.ParseException](templStat("def neg: Unit = 2 + throw"))
+    intercept[parsers.ParseException](templStat("def neg: Unit = 2 + throw")),
   )
 
   test("binary literals") {
@@ -213,7 +213,7 @@ class LitSuite extends ParseSuite {
     val tree = tinfix(
       tname("behavior"),
       "of",
-      tapply(tname("something"), blk(tinfix(tname("a"), "shouldBe", tname("b"))))
+      tapply(tname("something"), blk(tinfix(tname("a"), "shouldBe", tname("b")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -227,7 +227,7 @@ class LitSuite extends ParseSuite {
     val tree = tinfix(
       tname("behavior"),
       "of",
-      tapply(str("..."), blk(tinfix(tname("a"), "shouldBe", tname("b"))))
+      tapply(str("..."), blk(tinfix(tname("a"), "shouldBe", tname("b")))),
     )
     runTestAssert[Stat](code)(tree)
   }
@@ -250,7 +250,7 @@ class LitSuite extends ParseSuite {
       "0x8000000000000000L",
       lit(-9223372036854775808L),
       -9223372036854775808L,
-      "-9223372036854775808L"
+      "-9223372036854775808L",
     ),
     ("3.4028235e38f", flt("3.4028235E+38"), Float.MaxValue, "3.4028235E+38f"),
     ("-3.4028235e38f", flt("-3.4028235E+38"), Float.MinValue, "-3.4028235E+38f"),
@@ -258,13 +258,13 @@ class LitSuite extends ParseSuite {
       "1.7976931348623157e+308d",
       dbl("1.7976931348623157E+308"),
       Double.MaxValue,
-      "1.7976931348623157E+308d"
+      "1.7976931348623157E+308d",
     ),
     (
       "-1.7976931348623157e+308d",
       dbl("-1.7976931348623157E+308"),
       Double.MinValue,
-      "-1.7976931348623157E+308d"
+      "-1.7976931348623157E+308d",
     ),
     ("1e-500d", dbl("1E-500"), 0d, "1E-500d"),
     ("-1E-500d", dbl("-1E-500"), 0d, "-1E-500d"),
@@ -286,13 +286,13 @@ class LitSuite extends ParseSuite {
       "1.7976931348623158e+308",
       fltXL("1.7976931348623158", "+308"),
       dec("1.7976931348623158", "+308"),
-      "1.7976931348623158e+308"
+      "1.7976931348623158e+308",
     ),
     (
       "-1.7976931348623158e+308",
       lit("-", fltXL("1.7976931348623158", "+308")),
       ("-", dec("1.7976931348623158", "+308")),
-      "-1.7976931348623158e+308"
+      "-1.7976931348623158e+308",
     ),
     ("1e10_0000_000_000", fltXL("1", "100000000000"), dec("1", "100000000000"), "1e100000000000"),
     ("1_000_000_000_000", intXL(1000000000000L), BigInt(1000000000000L), "1000000000000"),
@@ -300,14 +300,14 @@ class LitSuite extends ParseSuite {
       "1_000_000_000_000_000_000",
       intXL("1000000000000000000"),
       BigInt("1000000000000000000"),
-      "1000000000000000000"
+      "1000000000000000000",
     ),
     ("0b111111111111111111111111111111110", intXL(8589934590L), BigInt(8589934590L), "8589934590"),
     (
       "-0b111111111111111111111111111111110",
       intXL(-8589934590L),
       BigInt(-8589934590L),
-      "-8589934590"
+      "-8589934590",
     ),
     ("2147483648", intXL(2147483648L), BigInt(2147483648L), "2147483648"),
     ("-2147483649", intXL(-2147483649L), BigInt(-2147483649L), "-2147483649"),
@@ -315,7 +315,7 @@ class LitSuite extends ParseSuite {
     ("-0xffffffff0", intXL(-68719476720L), BigInt(-68719476720L), "-68719476720"),
     ("0b00101010", lit(42), 42, "42"),
     ("0B_0010_1010", lit(42), 42, "42"),
-    ("0b_0010_1010L", lit(42L), 42L, "42L")
+    ("0b_0010_1010L", lit(42L), 42L, "42L"),
   ).foreach { case (code, tree: Lit, number, syntax) =>
     test(s"numeric literal ok scala213: $code") {
       implicit val dialect: Dialect = dialects.Scala213
@@ -328,7 +328,7 @@ class LitSuite extends ParseSuite {
     ("0.f", tselect(lit(0), "f")),
     ("1.0 + 2.0f", tinfix(lit(1d), "+", lit(2f))),
     ("1d + 2f", tinfix(lit(1d), "+", lit(2f))),
-    ("0b01.toString", tselect(lit(1), "toString"))
+    ("0b01.toString", tselect(lit(1), "toString")),
   ).foreach { case (code, tree: Tree) =>
     test(s"expr with numeric literal ok scala213: $code")(runTestAssert[Stat](code, None)(tree))
   }
@@ -338,104 +338,104 @@ class LitSuite extends ParseSuite {
       "9223372036854775808L",
       """|<input>:1: error: integer number out of range for Long
          |9223372036854775808L
-         |^""".stripMargin
+         |^""".stripMargin,
     ),
     (
       "-9223372036854775809L",
       """|<input>:1: error: integer number out of range for Long
          |-9223372036854775809L
-         | ^""".stripMargin
+         | ^""".stripMargin,
     ),
     (
       "0xffffffffffffffff0L",
       """|<input>:1: error: integer number out of range for Long
          |0xffffffffffffffff0L
-         |^""".stripMargin
+         |^""".stripMargin,
     ),
     (
       "-0xffffffffffffffff0L",
       """|<input>:1: error: integer number out of range for Long
          |-0xffffffffffffffff0L
-         | ^""".stripMargin
+         | ^""".stripMargin,
     ),
     (
       "1_000_000_000_000_000_000_000l",
       """|<input>:1: error: integer number out of range for Long
          |1_000_000_000_000_000_000_000l
-         |^""".stripMargin
+         |^""".stripMargin,
     ),
     (
       "00",
       """|<input>:1: error: Non-zero integral values may not have a leading zero.
          |00
-         |^""".stripMargin
+         |^""".stripMargin,
     ),
     (
       "00l",
       """|<input>:1: error: Non-zero integral values may not have a leading zero.
          |00l
-         |^""".stripMargin
+         |^""".stripMargin,
     ),
     (
       "0b01d",
       """|<input>:1: error: Invalid literal number, followed by identifier character
          |0b01d
-         |    ^""".stripMargin
+         |    ^""".stripMargin,
     ),
     (
       "0b01f",
       """|<input>:1: error: Invalid literal number, followed by identifier character
          |0b01f
-         |    ^""".stripMargin
+         |    ^""".stripMargin,
     ),
     (
       "0b0123",
       """|<input>:1: error: Invalid literal number, followed by identifier character
          |0b0123
-         |    ^""".stripMargin
+         |    ^""".stripMargin,
     ),
     (
       "0b01.2",
       """|<input>:1: error: `;` expected but `double constant` found
          |0b01.2
-         |    ^""".stripMargin
+         |    ^""".stripMargin,
     ),
     (
       "1. + 2.",
       """|<input>:1: error: `;` expected but `integer constant` found
          |1. + 2.
-         |     ^""".stripMargin
+         |     ^""".stripMargin,
     ),
     (
       ".f",
       """|<input>:1: error: illegal start of definition `.`
          |.f
-         |^""".stripMargin
+         |^""".stripMargin,
     ),
     (
       "3.4028236e38f",
       """|<input>:1: error: floating-point value out of range for Float
          |3.4028236e38f
-         |^""".stripMargin
+         |^""".stripMargin,
     ),
     (
       "-3.4028236e38f",
       """|<input>:1: error: floating-point value out of range for Float
          |-3.4028236e38f
-         | ^""".stripMargin
+         | ^""".stripMargin,
     ),
     (
       "1.7976931348623158e+308d",
       """|<input>:1: error: floating-point value out of range for Double
          |1.7976931348623158e+308d
-         |^""".stripMargin
+         |^""".stripMargin,
     ),
     (
       "-1.7976931348623158e+308d",
       """|<input>:1: error: floating-point value out of range for Double
          |-1.7976931348623158e+308d
-         | ^""".stripMargin
-    )
+         | ^""".stripMargin,
+    ),
   ).foreach { case (code, error) =>
     test(s"numeric literal fail scala213: $code")(runTestError[Stat](code, error))
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ModSuite.scala
@@ -6,13 +6,13 @@ import scala.meta._
 class ModSuite extends ParseSuite {
   test("implicit") {
     assertTree(
-      templStat("implicit object A")
+      templStat("implicit object A"),
     )(Defn.Object(List(Mod.Implicit()), tname("A"), tplNoBody()))
     assertTree(
-      templStat("implicit class A")
+      templStat("implicit class A"),
     )(Defn.Class(List(Mod.Implicit()), pname("A"), Nil, ctor, tplNoBody()))
     assertTree(
-      templStat("implicit case object A")
+      templStat("implicit case object A"),
     )(Defn.Object(List(Mod.Implicit(), Mod.Case()), tname("A"), tplNoBody()))
 
     assertTree(templStat("case class A(implicit val a: Int)"))(Defn.Class(
@@ -20,14 +20,14 @@ class ModSuite extends ParseSuite {
       pname("A"),
       Nil,
       ctorp(Mod.Implicit(), tparam(List(Mod.Implicit(), Mod.ValParam()), "a", "Int")),
-      tplNoBody()
+      tplNoBody(),
     ))
     assertTree(templStat("case class A(implicit var a: Int)"))(Defn.Class(
       List(Mod.Case()),
       pname("A"),
       Nil,
       ctorp(Mod.Implicit(), tparam(List(Mod.Implicit(), Mod.VarParam()), "a", "Int")),
-      tplNoBody()
+      tplNoBody(),
     ))
 
     assertTree(templStat("def foo(implicit a: Int): Int = a"))(Defn.Def(
@@ -36,7 +36,7 @@ class ModSuite extends ParseSuite {
       Nil,
       List(List(tparam(List(Mod.Implicit()), "a", "Int"))),
       Some(pname("Int")),
-      tname("a")
+      tname("a"),
     ))
 
     assertTree(templStat("implicit def foo(a: Int): Int = a"))(Defn.Def(
@@ -45,23 +45,23 @@ class ModSuite extends ParseSuite {
       Nil,
       List(List(tparam("a", "Int"))),
       Some(pname("Int")),
-      tname("a")
+      tname("a"),
     ))
 
     assertTree(
-      templStat("implicit val a: Int = 1")
+      templStat("implicit val a: Int = 1"),
     )(Defn.Val(List(Mod.Implicit()), List(patvar("a")), Some(pname("Int")), int(1)))
 
     assertTree(
-      templStat("implicit val a: Int")
+      templStat("implicit val a: Int"),
     )(Decl.Val(List(Mod.Implicit()), List(patvar("a")), pname("Int")))
 
     assertTree(
-      templStat("implicit var a: Int = 1")
+      templStat("implicit var a: Int = 1"),
     )(Defn.Var(List(Mod.Implicit()), List(patvar("a")), Some(pname("Int")), Some(int(1))))
 
     assertTree(
-      templStat("implicit var a: Int")
+      templStat("implicit var a: Int"),
     )(Decl.Var(List(Mod.Implicit()), List(patvar("a")), pname("Int")))
   }
 
@@ -69,15 +69,15 @@ class ModSuite extends ParseSuite {
     matchSubStructure[Stat]("final object A", { case Defn.Object(List(Mod.Final()), _, _) => () })
     matchSubStructure[Stat](
       "final class A",
-      { case Defn.Class(List(Mod.Final()), _, _, _, _) => () }
+      { case Defn.Class(List(Mod.Final()), _, _, _, _) => () },
     )
     matchSubStructure[Stat](
       "final case class A(a: Int)",
-      { case Defn.Class(List(Mod.Final(), Mod.Case()), _, _, _, _) => () }
+      { case Defn.Class(List(Mod.Final(), Mod.Case()), _, _, _, _) => () },
     )
     matchSubStructure[Stat](
       "final case object A",
-      { case Defn.Object(List(Mod.Final(), Mod.Case()), _, _) => () }
+      { case Defn.Object(List(Mod.Final(), Mod.Case()), _, _) => () },
     )
 
     assertTree(templStat("case class A(final val a: Int)"))(Defn.Class(
@@ -85,12 +85,12 @@ class ModSuite extends ParseSuite {
       pname("A"),
       Nil,
       ctorp(tparam(List(Mod.Final(), Mod.ValParam()), "a", "Int")),
-      tplNoBody()
+      tplNoBody(),
     ))
 
     matchSubStructure[Stat](
       "final def foo(a: Int): Int = a",
-      { case Defn.Def(List(Mod.Final()), _, _, _, _, _) => () }
+      { case Defn.Def(List(Mod.Final()), _, _, _, _, _) => () },
     )
 
     matchSubStructure[Stat]("final val a: Int = 1", { case Defn.Val(List(Mod.Final()), _, _, _) => () })
@@ -113,12 +113,12 @@ class ModSuite extends ParseSuite {
 
     matchSubStructure[Stat](
       "sealed abstract class A",
-      { case Defn.Class(List(Mod.Sealed(), Mod.Abstract()), _, _, _, _) => () }
+      { case Defn.Class(List(Mod.Sealed(), Mod.Abstract()), _, _, _, _) => () },
     )
 
     matchSubStructure[Stat](
       "sealed case class A(a: Int)",
-      { case Defn.Class(List(Mod.Sealed(), Mod.Case()), _, _, _, _) => () }
+      { case Defn.Class(List(Mod.Sealed(), Mod.Case()), _, _, _, _) => () },
     )
   }
 
@@ -129,32 +129,32 @@ class ModSuite extends ParseSuite {
 
     matchSubStructure[Stat](
       "override case object A",
-      { case Defn.Object(List(Mod.Override(), Mod.Case()), _, _) => () }
+      { case Defn.Object(List(Mod.Override(), Mod.Case()), _, _) => () },
     )
 
     matchSubStructure[Stat](
       "override def foo(a: Int): Int = a",
-      { case Defn.Def(List(Mod.Override()), _, _, _, _, _) => () }
+      { case Defn.Def(List(Mod.Override()), _, _, _, _, _) => () },
     )
 
     matchSubStructure[Stat](
       "override val a: Int = 1",
-      { case Defn.Val(List(Mod.Override()), _, _, _) => () }
+      { case Defn.Val(List(Mod.Override()), _, _, _) => () },
     )
 
     matchSubStructure[Stat](
       "override var a: Int = 1",
-      { case Defn.Var(List(Mod.Override()), _, _, _) => () }
+      { case Defn.Var(List(Mod.Override()), _, _, _) => () },
     )
 
     matchSubStructure[Stat](
       "override type A = Int",
-      { case Defn.Type(List(Mod.Override()), _, _, _) => () }
+      { case Defn.Type(List(Mod.Override()), _, _, _) => () },
     )
 
     matchSubStructure[Stat](
       "override def foo(a: Int): Int",
-      { case Decl.Def(List(Mod.Override()), _, _, _, _) => () }
+      { case Decl.Def(List(Mod.Override()), _, _, _, _) => () },
     )
 
     matchSubStructure[Stat]("override val a: Int", { case Decl.Val(List(Mod.Override()), _, _) => () })
@@ -165,7 +165,7 @@ class ModSuite extends ParseSuite {
   }
 
   checkOKsWithSyntax(
-    "def foo(override val a: Int): Int = a" -> "def foo(override val a: Int): Int = a"
+    "def foo(override val a: Int): Int = a" -> "def foo(override val a: Int): Int = a",
   )
 
   test("case") {
@@ -173,7 +173,7 @@ class ModSuite extends ParseSuite {
 
     matchSubStructure[Stat](
       "case class A(a: Int)",
-      { case Defn.Class(List(Mod.Case()), _, _, _, _) => () }
+      { case Defn.Class(List(Mod.Case()), _, _, _, _) => () },
     )
   }
 
@@ -196,97 +196,97 @@ class ModSuite extends ParseSuite {
     "case type A = Int",
     "def foo(case val a: Int): Int = a",
     "case def foo(val a: Int): Int = a",
-    "class A(case a: Int)"
+    "class A(case a: Int)",
   )
 
   test("abstract") {
     matchSubStructure[Stat](
       "abstract trait A",
-      { case Defn.Trait(List(Mod.Abstract()), _, _, _, _) => () }
+      { case Defn.Trait(List(Mod.Abstract()), _, _, _, _) => () },
     )
 
     matchSubStructure[Stat](
       "abstract class A",
-      { case Defn.Class(List(Mod.Abstract()), _, _, _, _) => () }
+      { case Defn.Class(List(Mod.Abstract()), _, _, _, _) => () },
     )
 
     matchSubStructure[Stat](
       "abstract case class A(a: Int)",
-      { case Defn.Class(List(Mod.Abstract(), Mod.Case()), _, _, _, _) => () }
+      { case Defn.Class(List(Mod.Abstract(), Mod.Case()), _, _, _, _) => () },
     )
   }
 
   checkOKsWithSyntax(
     "def foo(abstract val a: Int): Int = a" -> "def foo(abstract val a: Int): Int = a",
-    "abstract def foo(val a: Int): Int = a" -> "abstract def foo(val a: Int): Int = a"
+    "abstract def foo(val a: Int): Int = a" -> "abstract def foo(val a: Int): Int = a",
   )
 
   test("lazy")(matchSubStructure[Stat](
     "lazy val a: Int = 1",
-    { case Defn.Val(List(Mod.Lazy()), _, _, _) => () }
+    { case Defn.Val(List(Mod.Lazy()), _, _, _) => () },
   ))
 
   checkOKsWithSyntax(
     "def foo(lazy val a: Int): Int = a" -> "def foo(lazy val a: Int): Int = a",
-    "lazy def foo(val a: Int): Int = a" -> "lazy def foo(val a: Int): Int = a"
+    "lazy def foo(val a: Int): Int = a" -> "lazy def foo(val a: Int): Int = a",
   )
 
   test("abstract override") {
     /* Non-trait members modified by `abstract override` receive a typechecking error */
     matchSubStructure[Stat](
       "abstract override object A",
-      { case Defn.Object(List(Mod.Abstract(), Mod.Override()), _, _) => () }
+      { case Defn.Object(List(Mod.Abstract(), Mod.Override()), _, _) => () },
     )
 
     matchSubStructure[Stat](
       "abstract override case object A",
-      { case Defn.Object(List(Mod.Abstract(), Mod.Override(), Mod.Case()), _, _) => () }
+      { case Defn.Object(List(Mod.Abstract(), Mod.Override(), Mod.Case()), _, _) => () },
     )
 
     matchSubStructure[Stat](
       "abstract override def foo(a: Int): Int = a",
-      { case Defn.Def(List(Mod.Abstract(), Mod.Override()), _, _, _, _, _) => () }
+      { case Defn.Def(List(Mod.Abstract(), Mod.Override()), _, _, _, _, _) => () },
     )
 
     matchSubStructure[Stat](
       "abstract override val a: Int = 1",
-      { case Defn.Val(List(Mod.Abstract(), Mod.Override()), _, _, _) => () }
+      { case Defn.Val(List(Mod.Abstract(), Mod.Override()), _, _, _) => () },
     )
 
     matchSubStructure[Stat](
       "abstract override var a: Int = 1",
-      { case Defn.Var(List(Mod.Abstract(), Mod.Override()), _, _, _) => () }
+      { case Defn.Var(List(Mod.Abstract(), Mod.Override()), _, _, _) => () },
     )
 
     matchSubStructure[Stat](
       "abstract override type A = Int",
-      { case Defn.Type(List(Mod.Abstract(), Mod.Override()), _, _, _) => () }
+      { case Defn.Type(List(Mod.Abstract(), Mod.Override()), _, _, _) => () },
     )
 
     matchSubStructure[Stat](
       "abstract override def foo(a: Int): Int",
-      { case Decl.Def(List(Mod.Abstract(), Mod.Override()), _, _, _, _) => () }
+      { case Decl.Def(List(Mod.Abstract(), Mod.Override()), _, _, _, _) => () },
     )
 
     matchSubStructure[Stat](
       "abstract override val a: Int",
-      { case Decl.Val(List(Mod.Abstract(), Mod.Override()), _, _) => () }
+      { case Decl.Val(List(Mod.Abstract(), Mod.Override()), _, _) => () },
     )
 
     matchSubStructure[Stat](
       "abstract override var a: Int",
-      { case Decl.Var(List(Mod.Abstract(), Mod.Override()), _, _) => () }
+      { case Decl.Var(List(Mod.Abstract(), Mod.Override()), _, _) => () },
     )
 
     matchSubStructure[Stat](
       "abstract override type A",
-      { case Decl.Type(List(Mod.Abstract(), Mod.Override()), _, _, _) => () }
+      { case Decl.Type(List(Mod.Abstract(), Mod.Override()), _, _, _) => () },
     )
   }
 
   checkOKsWithSyntax(
     "def foo(abstract override val a: Int): Int = a" ->
-      "def foo(abstract override val a: Int): Int = a"
+      "def foo(abstract override val a: Int): Int = a",
   )
 
   test("covariant in case class")(assertTree(templStat("case class A[+T](t: T)"))(Defn.Class(
@@ -294,7 +294,7 @@ class ModSuite extends ParseSuite {
     pname("A"),
     pparam(List(Mod.Covariant()), "T") :: Nil,
     ctorp(tparam("t", "T")),
-    tplNoBody()
+    tplNoBody(),
   )))
 
   test("covariant in class")(assertTree(templStat("class A[+T](t: T)"))(Defn.Class(
@@ -302,7 +302,7 @@ class ModSuite extends ParseSuite {
     pname("A"),
     pparam(List(Mod.Covariant()), "T") :: Nil,
     ctorp(tparam("t", "T")),
-    tplNoBody()
+    tplNoBody(),
   )))
 
   test("covariant in type")(assertTree(templStat("type A[+T] = B[T]"))(Defn.Type(
@@ -310,7 +310,7 @@ class ModSuite extends ParseSuite {
     pname("A"),
     pparam(List(Mod.Covariant()), "T") :: Nil,
     papply("B", pname("T")),
-    noBounds
+    noBounds,
   )))
 
   test("covariant-like in type") {
@@ -328,7 +328,7 @@ class ModSuite extends ParseSuite {
     pname("A"),
     pparam(List(Mod.Contravariant()), "T") :: Nil,
     ctorp(tparam("t", "T")),
-    tplNoBody()
+    tplNoBody(),
   )))
 
   test("contravariant in class")(assertTree(templStat("class A[-T](t: T)"))(Defn.Class(
@@ -336,7 +336,7 @@ class ModSuite extends ParseSuite {
     pname("A"),
     pparam(List(Mod.Contravariant()), "T") :: Nil,
     ctorp(tparam("t", "T")),
-    tplNoBody()
+    tplNoBody(),
   )))
 
   test("contravariant-like in class") {
@@ -352,7 +352,7 @@ class ModSuite extends ParseSuite {
     pname("A"),
     pparam(List(Mod.Contravariant()), "T") :: Nil,
     papply("B", "T"),
-    noBounds
+    noBounds,
   )))
 
   checkOKsWithSyntax("def foo[-T](t: T): Int" -> "def foo[-T](t: T): Int")
@@ -362,11 +362,11 @@ class ModSuite extends ParseSuite {
     pname("A"),
     Nil,
     ctorp(tparam(List(Mod.ValParam()), "a", "Int")),
-    tplNoBody()
+    tplNoBody(),
   )))
 
   test("val param in class")(assertTree(templStat("class A(val a: Int)"))(
-    Defn.Class(Nil, pname("A"), Nil, ctorp(tparam(List(Mod.ValParam()), "a", "Int")), tplNoBody())
+    Defn.Class(Nil, pname("A"), Nil, ctorp(tparam(List(Mod.ValParam()), "a", "Int")), tplNoBody()),
   ))
 
   test("implicit val param in case class")(
@@ -375,8 +375,8 @@ class ModSuite extends ParseSuite {
       pname("A"),
       Nil,
       ctorp(Mod.Implicit(), tparam(List(Mod.Implicit(), Mod.ValParam()), "a", "Int")),
-      tplNoBody()
-    ))
+      tplNoBody(),
+    )),
   )
 
   test("implicit val param in class")(
@@ -385,16 +385,16 @@ class ModSuite extends ParseSuite {
       pname("A"),
       Nil,
       ctorp(Mod.Implicit(), tparam(List(Mod.Implicit(), Mod.ValParam()), "a", "Int")),
-      tplNoBody()
-    ))
+      tplNoBody(),
+    )),
   )
 
   test("no val param in def")(
     // No ValParam detected inside parameter list
     assertTree(templStat("def foo(a: Int): Int = a"))(
       Defn
-        .Def(Nil, tname("foo"), Nil, List(tparam("a", "Int")) :: Nil, Some(pname("Int")), tname("a"))
-    )
+        .Def(Nil, tname("foo"), Nil, List(tparam("a", "Int")) :: Nil, Some(pname("Int")), tname("a")),
+    ),
   )
 
   checkOKsWithSyntax("def foo(val a: Int): Int" -> "def foo(val a: Int): Int")
@@ -404,11 +404,11 @@ class ModSuite extends ParseSuite {
     pname("A"),
     Nil,
     ctorp(tparam(List(Mod.VarParam()), "a", "Int")),
-    tplNoBody()
+    tplNoBody(),
   )))
 
   test("var param in class")(assertTree(templStat("class A(var a: Int)"))(
-    Defn.Class(Nil, pname("A"), Nil, ctorp(tparam(List(Mod.VarParam()), "a", "Int")), tplNoBody())
+    Defn.Class(Nil, pname("A"), Nil, ctorp(tparam(List(Mod.VarParam()), "a", "Int")), tplNoBody()),
   ))
 
   test("implicit var param in case class")(
@@ -417,8 +417,8 @@ class ModSuite extends ParseSuite {
       pname("A"),
       Nil,
       ctorp(Mod.Implicit(), tparam(List(Mod.Implicit(), Mod.VarParam()), "a", "Int")),
-      tplNoBody()
-    ))
+      tplNoBody(),
+    )),
   )
 
   test("implicit var param in class")(
@@ -427,26 +427,26 @@ class ModSuite extends ParseSuite {
       pname("A"),
       Nil,
       ctorp(Mod.Implicit(), tparam(List(Mod.Implicit(), Mod.VarParam()), "a", "Int")),
-      tplNoBody()
-    ))
+      tplNoBody(),
+    )),
   )
 
   checkOKsWithSyntax("def foo(var a: Int): Int" -> "def foo(var a: Int): Int")
 
   test("macro")(matchSubStructure[Stat](
     "def foo(a: Int): Int = macro myMacroImpl(a)",
-    { case Defn.Macro(_, _, _, _, _, _) => () }
+    { case Defn.Macro(_, _, _, _, _, _) => () },
   ))
 
   test("final and abstract") {
     // Only check these because abstract cannot only be used for classes
     matchSubStructure[Stat](
       "final abstract class A",
-      { case Defn.Class(List(Mod.Final(), Mod.Abstract()), _, _, _, _) => () }
+      { case Defn.Class(List(Mod.Final(), Mod.Abstract()), _, _, _, _) => () },
     )
     matchSubStructure[Stat](
       "final abstract case class A(a: Int)",
-      { case Defn.Class(List(Mod.Final(), Mod.Abstract(), Mod.Case()), _, _, _, _) => () }
+      { case Defn.Class(List(Mod.Final(), Mod.Abstract(), Mod.Case()), _, _, _, _) => () },
     )
   }
 
@@ -461,9 +461,9 @@ class ModSuite extends ParseSuite {
               _,
               _,
               _,
-              _
+              _,
             ) => ()
-      }
+      },
     )
 
     matchSubStructure[Stat](
@@ -475,9 +475,9 @@ class ModSuite extends ParseSuite {
               _,
               _,
               _,
-              _
+              _,
             ) => ()
-      }
+      },
     )
 
     matchSubStructure[Stat](
@@ -489,9 +489,9 @@ class ModSuite extends ParseSuite {
               _,
               _,
               _,
-              _
+              _,
             ) => ()
-      }
+      },
     )
 
     matchSubStructure[Stat](
@@ -503,9 +503,9 @@ class ModSuite extends ParseSuite {
               _,
               _,
               _,
-              _
+              _,
             ) => ()
-      }
+      },
     )
 
   }
@@ -535,14 +535,14 @@ class ModSuite extends ParseSuite {
       pname("A"),
       Nil,
       ctorp(tparam(List(Mod.ValParam()), "b", Type.ByName("B"))),
-      tplNoBody()
+      tplNoBody(),
     )
     runTestAssert[Stat]("class A(val b: => B)", layout)(tree)
   }
 
   test("by-name parameter: class with private[this] val")(assertNoDiff(
     templStat("class A(private[this] val b: => B)").syntax,
-    "class A(private[this] val b: => B)"
+    "class A(private[this] val b: => B)",
   ))
 
   test("by-name parameter: case class with val") {
@@ -552,7 +552,7 @@ class ModSuite extends ParseSuite {
       pname("A"),
       Nil,
       ctorp(tparam(List(Mod.ValParam()), "b", Type.ByName("B"))),
-      tplNoBody()
+      tplNoBody(),
     )
     runTestAssert[Stat]("case class A(val b: => B)", layout)(tree)
   }
@@ -564,7 +564,7 @@ class ModSuite extends ParseSuite {
       pname("A"),
       Nil,
       ctorp(Mod.Implicit(), tparam(List(Mod.Implicit(), Mod.ValParam()), "b", Type.ByName("B"))),
-      tplNoBody()
+      tplNoBody(),
     )
     runTestAssert[Stat]("class A(implicit val b: => B)", layout)(tree)
   }
@@ -576,7 +576,7 @@ class ModSuite extends ParseSuite {
       pname("Foo"),
       Nil,
       ctorp(tparam(List(Mod.Private(Name("example"))), "field", "String")),
-      tplNoBody()
+      tplNoBody(),
     )
     assertTree(templStat(code))(expected)
   }
@@ -591,11 +591,11 @@ class ModSuite extends ParseSuite {
         List(tparam(
           List(Mod.Protected(Name.Anonymous()), Mod.Implicit(), Mod.ValParam()),
           "viewConfig",
-          "String"
+          "String",
         )),
-        List(tparam(List(Mod.Implicit()), "z", "Double"))
+        List(tparam(List(Mod.Implicit()), "z", "Double")),
       ),
-      tplNoBody()
+      tplNoBody(),
     )
     runTestAssert[Stat](code)(tree)
   }
@@ -610,11 +610,11 @@ class ModSuite extends ParseSuite {
         List(tparam(
           List(Mod.Implicit(), Mod.Protected(Name.Anonymous()), Mod.ValParam()),
           "viewConfig",
-          "String"
+          "String",
         )),
-        List(tparam(List(Mod.Implicit()), "z", "Double"))
+        List(tparam(List(Mod.Implicit()), "z", "Double")),
       ),
-      tplNoBody()
+      tplNoBody(),
     )
     runTestAssert[Stat](code)(tree)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/MoreHelpers.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/MoreHelpers.scala
@@ -19,7 +19,7 @@ object MoreHelpers {
       Nil,
       "Expected all trees to have non-empty `.origin`.\n" +
         "To fix this failure, update ScalametaParser to use `autoPos()` where the trees below got constructed.\n" +
-        "Pro tip: you may also want to add a PositionSuite test for this tree node to verify that the position you set is correct."
+        "Pro tip: you may also want to add a PositionSuite test for this tree node to verify that the position you set is correct.",
     )
     tree
   }
@@ -30,21 +30,21 @@ object MoreHelpers {
     def applyRule[T <: Tree](rule: ScalametaParser => T)(implicit
         dialect: Dialect,
         tokenizerOptions: TokenizerOptions,
-        parserOptions: ParserOptions
+        parserOptions: ParserOptions,
     ): T = asInput.applyRule(rule)
     def parseRule[T <: Tree](rule: ScalametaParser => T)(implicit
         dialect: Dialect,
         tokenizerOptions: TokenizerOptions,
-        parserOptions: ParserOptions
+        parserOptions: ParserOptions,
     ): T = asInput.parseRule(rule)
   }
   implicit class XtensionInput(private val input: Input) extends AnyVal {
     def applyRule[T <: Tree](
-        rule: ScalametaParser => T
+        rule: ScalametaParser => T,
     )(implicit dialect: Dialect, options: ParserOptions): T =
       requireNonEmptyOrigin(rule(new ScalametaParser(input)))
     def parseRule[T <: Tree](
-        rule: ScalametaParser => T
+        rule: ScalametaParser => T,
     )(implicit dialect: Dialect, options: ParserOptions): T = applyRule(_.parseRule(rule))
   }
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/PackageSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/PackageSuite.scala
@@ -9,62 +9,62 @@ class PackageSuite extends ParseSuite {
   implicit val dialect: Dialect = dialects.Scala211
 
   test("class C")(
-    assertTree(source("class C"))(Source(Class(Nil, pname("C"), Nil, ctor, tplNoBody()) :: Nil))
+    assertTree(source("class C"))(Source(Class(Nil, pname("C"), Nil, ctor, tplNoBody()) :: Nil)),
   )
 
   test("package foo; class C")(assertTree(source("package foo; class C"))(Source(
-    Pkg(tname("foo"), Class(Nil, pname("C"), Nil, ctor, tplNoBody()) :: Nil) :: Nil
+    Pkg(tname("foo"), Class(Nil, pname("C"), Nil, ctor, tplNoBody()) :: Nil) :: Nil,
   )))
 
   test("package foo { class C }")(assertTree(source("package foo { class C }"))(Source(
-    Pkg(tname("foo"), Class(Nil, pname("C"), Nil, ctor, tplNoBody()) :: Nil) :: Nil
+    Pkg(tname("foo"), Class(Nil, pname("C"), Nil, ctor, tplNoBody()) :: Nil) :: Nil,
   )))
 
   test("package foo.bar; class C")(assertTree(source("package foo.bar; class C"))(Source(
-    Pkg(tselect("foo", "bar"), Class(Nil, pname("C"), Nil, ctor, tplNoBody()) :: Nil) :: Nil
+    Pkg(tselect("foo", "bar"), Class(Nil, pname("C"), Nil, ctor, tplNoBody()) :: Nil) :: Nil,
   )))
 
   test("package foo.bar { class C }")(assertTree(source("package foo.bar { class C }"))(Source(
-    Pkg(tselect("foo", "bar"), Class(Nil, pname("C"), Nil, ctor, tplNoBody()) :: Nil) :: Nil
+    Pkg(tselect("foo", "bar"), Class(Nil, pname("C"), Nil, ctor, tplNoBody()) :: Nil) :: Nil,
   )))
 
   test("package foo; package bar; class C")(
     assertTree(source("package foo; package bar; class C"))(Source(
       Pkg(
         tname("foo"),
-        Pkg(tname("bar"), Class(Nil, pname("C"), Nil, ctor, tplNoBody()) :: Nil) :: Nil
-      ) :: Nil
-    ))
+        Pkg(tname("bar"), Class(Nil, pname("C"), Nil, ctor, tplNoBody()) :: Nil) :: Nil,
+      ) :: Nil,
+    )),
   )
 
   test("package foo { package bar { class C } }")(
     assertTree(source("package foo { package bar { class C } }"))(Source(
       Pkg(
         tname("foo"),
-        Pkg(tname("bar"), Class(Nil, pname("C"), Nil, ctor, tplNoBody()) :: Nil) :: Nil
-      ) :: Nil
-    ))
+        Pkg(tname("bar"), Class(Nil, pname("C"), Nil, ctor, tplNoBody()) :: Nil) :: Nil,
+      ) :: Nil,
+    )),
   )
 
   test("package foo {}; package bar {}")(assertTree(source("package foo {}; package bar {}"))(Source(
-    Pkg(tname("foo"), Nil) :: Pkg(tname("bar"), Nil) :: Nil
+    Pkg(tname("foo"), Nil) :: Pkg(tname("bar"), Nil) :: Nil,
   )))
 
   test("package object foo")(assertTree(source("package object foo"))(Source(
-    Pkg.Object(Nil, tname("foo"), tplNoBody()) :: Nil
+    Pkg.Object(Nil, tname("foo"), tplNoBody()) :: Nil,
   )))
 
   test("import foo.bar; package object baz")(
     assertTree(source("import foo.bar; package object baz"))(Source(
       Import(Importer(tname("foo"), Importee.Name(Name.Indeterminate("bar")) :: Nil) :: Nil) ::
-        Pkg.Object(Nil, tname("baz"), tplNoBody()) :: Nil
-    ))
+        Pkg.Object(Nil, tname("baz"), tplNoBody()) :: Nil,
+    )),
   )
 
   test("package foo; package bar; package baz")(
     assertTree(source("package foo; package bar; package baz"))(Source(
-      List(Pkg(tname("foo"), List(Pkg(tname("bar"), List(Pkg(tname("baz"), List()))))))
-    ))
+      List(Pkg(tname("foo"), List(Pkg(tname("bar"), List(Pkg(tname("baz"), List())))))),
+    )),
   )
 
   test("package { in newline") {
@@ -80,16 +80,16 @@ class PackageSuite extends ParseSuite {
          |    { }
          |  }
          |}
-         |""".stripMargin
+         |""".stripMargin,
     ))(Source(List(Pkg(
       tnameComments("foo")()("// foo package left brace in newline"),
       Pkg.Body.createWithComments(
         List(Pkg(
           tnameComments("bar")()("/* also in newline */"),
-          Pkg.Body.createWithComments(List(Pkg(tname("baz"), List())), begComment = Seq("// open"))
+          Pkg.Body.createWithComments(List(Pkg(tname("baz"), List())), begComment = Seq("// open")),
         )),
-        begComment = Seq("/* still okay */")
-      )
+        begComment = Seq("/* still okay */"),
+      ),
     ))))
   }
 
@@ -112,8 +112,8 @@ class PackageSuite extends ParseSuite {
       tname("foo"),
       List(
         Import(List(Importer(tname("bar"), List(Importee.Name(Name("baz")))))),
-        Defn.Class(Nil, pname("Qux"), Nil, ctorp(Nil), tplNoBody())
-      )
+        Defn.Class(Nil, pname("Qux"), Nil, ctorp(Nil), tplNoBody()),
+      ),
     )))
     runTestAssert[Source](code, layout)(tree)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
@@ -62,12 +62,12 @@ class ParseSuite extends TreeSuiteBase with CommonTrees {
     stats.foreach(checkError)
   def checkOK(stat: String, syntax: String = "")(implicit
       dialect: Dialect,
-      loc: munit.Location
+      loc: munit.Location,
   ): Unit = test(logger.revealWhitespace(stat).take(50))(assertSyntax(syntax)(templStat(stat)))
   final def checkOKs(stats: String*)(implicit dialect: Dialect, loc: munit.Location): Unit = stats
     .foreach(checkOK(_))
   final def checkOKsWithSyntax(
-      pairs: (String, String)*
+      pairs: (String, String)*,
   )(implicit dialect: Dialect, loc: munit.Location): Unit = pairs.foreach { case (stat, syntax) =>
     checkOK(stat, syntax)
   }
@@ -75,24 +75,24 @@ class ParseSuite extends TreeSuiteBase with CommonTrees {
   protected def checkParsedTree[T <: Tree](
       code: String,
       f: ScalametaParser => T,
-      syntax: String = null
+      syntax: String = null,
   )(tree: Tree)(implicit loc: munit.Location, dialect: Dialect): Unit =
     checkTree(parseRule(code, f), TestHelpers.getSyntax(code, syntax))(tree)
 
   protected def checkStat(code: String, syntax: String = null)(
-      tree: Tree
+      tree: Tree,
   )(implicit loc: munit.Location, dialect: Dialect): Unit =
     checkParsedTree(code, _.entrypointStat(), syntax)(tree)
 
   protected def runTestError[T <: Tree](code: String, expected: String)(implicit
       parser: String => T,
-      loc: munit.Location
+      loc: munit.Location,
   ): Unit = {
     val error = intercept[inputs.InputException] {
       val result = parser(code)
       throw new ParseException(
         Position.None,
-        s"Statement $code should not parse! Got result ${result.structure}"
+        s"Statement $code should not parse! Got result ${result.structure}",
       )
     }
     val obtained = error.getMessage().nl2lf
@@ -101,7 +101,7 @@ class ParseSuite extends TreeSuiteBase with CommonTrees {
 
   protected def matchSubStructure[T <: Tree](
       code: String,
-      expected: PartialFunction[Tree, Unit]
+      expected: PartialFunction[Tree, Unit],
   )(implicit parser: String => T, loc: munit.Location): Unit = {
     val obtained = parser(code)
     expected.lift(obtained).getOrElse(fail(s"Got unexpected tree: ${obtained.structure}"))
@@ -114,7 +114,7 @@ class ParseSuite extends TreeSuiteBase with CommonTrees {
    *   runTestAssert(code, assertLayout)(expected)
    */
   protected def runTestAssert[T <: Tree](code: String, assertLayout: Option[String])(
-      expected: Tree
+      expected: Tree,
   )(implicit loc: munit.Location, parser: String => T, dialect: Dialect): Unit =
     runTestAssert[T](code, assertLayout.getOrElse(""))(expected)
 
@@ -140,7 +140,7 @@ class ParseSuite extends TreeSuiteBase with CommonTrees {
    *   Function used to convert code into structured tree
    */
   protected def runTestAssert[T <: Tree](code: String, assertLayout: String = null)(
-      expected: Tree
+      expected: Tree,
   )(implicit loc: munit.Location, parser: String => T, dialect: Dialect): Unit = {
     val struct = expected.structure
     parseAndCheckTreeWithSyntaxAndStruct[T](code, assertLayout, struct, "Original")
@@ -148,7 +148,7 @@ class ParseSuite extends TreeSuiteBase with CommonTrees {
   }
 
   protected def parseAndCheckTree[T <: Tree](code: String, syntax: String = null)(
-      expected: Tree
+      expected: Tree,
   )(implicit loc: munit.Location, parser: String => T, dialect: Dialect): Unit =
     parseAndCheckTreeWithSyntaxAndStruct[T](code, syntax, expected.structure)
 
@@ -156,11 +156,11 @@ class ParseSuite extends TreeSuiteBase with CommonTrees {
       code: String,
       syntax: String,
       struct: String,
-      extraClue: String = ""
+      extraClue: String = "",
   )(implicit loc: munit.Location, parser: String => T, dialect: Dialect): String = {
     val obtained: T = parser(code)
     val reprinted = assertSyntaxWithClue(obtained)(syntax)(
-      TestHelpers.getMessageWithExtraClue("tree syntax not equal", extraClue) + "\n" + struct
+      TestHelpers.getMessageWithExtraClue("tree syntax not equal", extraClue) + "\n" + struct,
     )
     assertStruct(obtained, extraClue)(struct)
     reprinted
@@ -170,7 +170,7 @@ class ParseSuite extends TreeSuiteBase with CommonTrees {
       code: String,
       syntax: String,
       struct: String,
-      extraClue: String = ""
+      extraClue: String = "",
   )(implicit loc: munit.Location, parser: String => T, dialect: Dialect): Option[String] = {
     val codeLF = code.replaceAll("\\r+\\n", "\n")
     val expectedSyntax = TestHelpers.getSyntax(codeLF, syntax)
@@ -189,7 +189,7 @@ class ParseSuite extends TreeSuiteBase with CommonTrees {
 
   protected def checkWithOriginalSyntax[T <: Tree](tree: T, originalOpt: String = null)(
       reprinted: String,
-      reprintedFails: String = null
+      reprintedFails: String = null,
   )(implicit loc: munit.Location, parser: String => T, dialect: Dialect): Unit = {
     val original = Option(originalOpt).getOrElse(reprinted)
     assertOriginalSyntax(tree, original)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/PatSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/PatSuite.scala
@@ -44,23 +44,23 @@ class PatSuite extends ParseSuite {
   test("patTyp: t Map u")(assertPatTyp("t Map u")(pinfix("t", "Map", pname("u"))))
 
   test("patTyp: t & u | v")(
-    assertPatTyp("t & u | v")(pinfix(pinfix("t", "&", pname("u")), "|", pname("v")))
+    assertPatTyp("t & u | v")(pinfix(pinfix("t", "&", pname("u")), "|", pname("v"))),
   )
 
   test("patTyp: t * u + v")(
-    assertPatTyp("t * u + v")(pinfix(pinfix("t", "*", pname("u")), "+", pname("v")))
+    assertPatTyp("t * u + v")(pinfix(pinfix("t", "*", pname("u")), "+", pname("v"))),
   )
 
   test("patTyp: t * u + v / w")(assertPatTyp("t * u + v / w")(
-    pinfix(pinfix(pinfix("t", "*", pname("u")), "+", pname("v")), "/", pname("w"))
+    pinfix(pinfix(pinfix("t", "*", pname("u")), "+", pname("v")), "/", pname("w")),
   ))
 
   test("patTyp: t + u * v")(
-    assertPatTyp("t + u * v")(pinfix(pinfix("t", "+", pname("u")), "*", pname("v")))
+    assertPatTyp("t + u * v")(pinfix(pinfix("t", "+", pname("u")), "*", pname("v"))),
   )
 
   test("pat: F[t & u | v]()")(assertPat("F[t & u | v]()")(
-    Pat.Extract(tapplytype(tname("F"), pinfix(pinfix("t", "&", pname("u")), "|", pname("v"))), Nil)
+    Pat.Extract(tapplytype(tname("F"), pinfix(pinfix("t", "&", pname("u")), "|", pname("v"))), Nil),
   ))
 
   test("_: (t Map u)")(assertPat("_: (t Map u)")(Typed(patwildcard, pinfix("t", "Map", pname("u")))))
@@ -76,7 +76,7 @@ class PatSuite extends ParseSuite {
   test("foo(_*)")(assertPat("foo(_*)")(Extract(tname("foo"), SeqWildcard() :: Nil)))
 
   test("foo(x @ _*)")(
-    assertPat("foo(x @ _*)")(Extract(tname("foo"), Bind(Var(tname("x")), SeqWildcard()) :: Nil))
+    assertPat("foo(x @ _*)")(Extract(tname("foo"), Bind(Var(tname("x")), SeqWildcard()) :: Nil)),
   )
 
   test("a :: b")(assertPat("a :: b")(patinfix(Var(tname("a")), "::", Var(tname("b")))))
@@ -141,27 +141,27 @@ class PatSuite extends ParseSuite {
   test("foo\"bar\"")(assertPat("foo\"bar\"")(Interpolate(tname("foo"), str("bar") :: Nil, Nil)))
 
   test("foo\"a $b c\"")(assertPat("foo\"a $b c\"")(
-    Interpolate(tname("foo"), str("a ") :: str(" c") :: Nil, Var(tname("b")) :: Nil)
+    Interpolate(tname("foo"), str("a ") :: str(" c") :: Nil, Var(tname("b")) :: Nil),
   ))
 
   test("foo\"${b @ foo()}\"")(assertPat("foo\"${b @ foo()}\"")(Interpolate(
     tname("foo"),
     str("") :: str("") :: Nil,
-    Bind(Var(tname("b")), Extract(tname("foo"), Nil)) :: Nil
+    Bind(Var(tname("b")), Extract(tname("foo"), Nil)) :: Nil,
   )))
 
   test("$_")(assertPat(""" q"x + $_" """)(
-    Pat.Interpolate(tname("q"), List(str("x + "), str("")), List(patwildcard))
+    Pat.Interpolate(tname("q"), List(str("x + "), str("")), List(patwildcard)),
   ))
 
   test("#501")(intercept[ParseException](pat("case List(_: BlockExpr, _: MatchExpr, x:_*)  ⇒ false")))
 
   test("<a>{_*}</a>")(
-    assertPat("<a>{_*}</a>")(Pat.Xml(List(str("<a>"), str("</a>")), List(SeqWildcard())))
+    assertPat("<a>{_*}</a>")(Pat.Xml(List(str("<a>"), str("</a>")), List(SeqWildcard()))),
   )
 
   test("<a>{ns @ _*}</a>")(assertPat("<a>{ns @ _*}</a>")(
-    Pat.Xml(List(str("<a>"), str("</a>")), List(Bind(Var(tname("ns")), SeqWildcard())))
+    Pat.Xml(List(str("<a>"), str("</a>")), List(Bind(Var(tname("ns")), SeqWildcard()))),
   ))
 
   test("(A, B, C)")(assertPat("(A, B, C)")(Pat.Tuple(List(tname("A"), tname("B"), tname("C")))))
@@ -171,13 +171,13 @@ class PatSuite extends ParseSuite {
   test("(A, B, C) :: ((A, B, C))")(assertPat("(A, B, C) :: ((A, B, C))")(patinfix(
     Pat.Tuple(List(tname("A"), tname("B"), tname("C"))),
     "::",
-    Pat.Tuple(List(tname("A"), tname("B"), tname("C")))
+    Pat.Tuple(List(tname("A"), tname("B"), tname("C"))),
   )))
 
   test("((A, B, C)) :: ((A, B, C))")(assertPat("((A, B, C)) :: ((A, B, C))")(patinfix(
     Pat.Tuple(List(tname("A"), tname("B"), tname("C"))),
     "::",
-    Pat.Tuple(List(tname("A"), tname("B"), tname("C")))
+    Pat.Tuple(List(tname("A"), tname("B"), tname("C"))),
   )))
 
   test("((A, B, C)) :: (A, B, C)")(assertPat("((A, B, C)) :: (A, B, C)")(patinfix(
@@ -185,7 +185,7 @@ class PatSuite extends ParseSuite {
     "::",
     tname("A"),
     tname("B"),
-    tname("C")
+    tname("C"),
   )))
 
   test("case: at top level") {
@@ -195,7 +195,7 @@ class PatSuite extends ParseSuite {
          |  List(bar)
          |""".stripMargin
     checkTree(
-      parseCase(code)
+      parseCase(code),
     )(Case(patvar("foo"), Some(bool(true)), tapply(tname("List"), tname("bar"))))
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/QuasiquoteSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/QuasiquoteSuite.scala
@@ -15,32 +15,32 @@ class QuasiquoteSuite extends ParseSuite {
       interceptMessage[ParseException](
         """|<input>:1: error: line breaks are not allowed in single-line quasiquotes
            |foo + 
-           |      ^""".stripMargin.lf2nl
-      )(term("foo + \n bar"))
+           |      ^""".stripMargin.lf2nl,
+      )(term("foo + \n bar")),
     )
 
     test("single-line disallow double quote strings")(
       interceptMessage[ParseException](
         """|<input>:1: error: double quotes are not allowed in single-line quasiquotes
            |"a"
-           |^""".stripMargin.lf2nl
-      )(term("\"a\""))
+           |^""".stripMargin.lf2nl,
+      )(term("\"a\"")),
     )
 
     test("single-line disallow double quote interpolations")(
       interceptMessage[ParseException](
         """|<input>:1: error: double quotes are not allowed in single-line quasiquotes
            |s"a"
-           | ^""".stripMargin.lf2nl
-      )(term("s\"a\""))
+           | ^""".stripMargin.lf2nl,
+      )(term("s\"a\"")),
     )
 
     test("single-line disallow char literal unquote")(
       interceptMessage[ParseException](
         """|<input>:1: error: can't unquote into character literals
            | '$x' 
-           |  ^""".stripMargin.lf2nl
-      )(term(" '$x' "))
+           |  ^""".stripMargin.lf2nl,
+      )(term(" '$x' ")),
     )
   }
 
@@ -52,7 +52,7 @@ class QuasiquoteSuite extends ParseSuite {
     test("multi-line allow unicode escaping")(assertTree(term("\\u0061"))(tname("a")))
 
     test("multi-line allow line breaks")(
-      assertTree(term("foo + \n bar"))(tinfix(tname("foo"), "+", tname("bar")))
+      assertTree(term("foo + \n bar"))(tinfix(tname("foo"), "+", tname("bar"))),
     )
 
     test("multi-line allow double quotes")(assertTree(term("\"a\""))(str("a")))
@@ -61,24 +61,24 @@ class QuasiquoteSuite extends ParseSuite {
       interceptMessage[ParseException](
         """|<input>:2: error: can't unquote into string literals
            |" $x "
-           |  ^""".stripMargin.lf2nl
+           |  ^""".stripMargin.lf2nl,
       )(term(
         """|
            |" $x "
-           |""".stripMargin
-      ))
+           |""".stripMargin,
+      )),
     )
 
     test("multi-line disallow multi-line unquote")(
       interceptMessage[ParseException](
         """|<input>:2: error: can't unquote into multi-line string literals
            |QQQ $x QQQ
-           |    ^""".stripMargin.tq().lf2nl
+           |    ^""".stripMargin.tq().lf2nl,
       )(term(
         """|
            |QQQ $x QQQ
-           |""".stripMargin.tq()
-      ))
+           |""".stripMargin.tq(),
+      )),
     )
   }
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/Scala211Suite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/Scala211Suite.scala
@@ -11,7 +11,7 @@ class Scala211Suite extends ParseSuite {
     def failWithMessage(code: String) = {
       val error = intercept[ParseException](templStat(code))
       assert(error.getMessage.contains(
-        "case classes must have a parameter list; try 'case class A()' or 'case object A'"
+        "case classes must have a parameter list; try 'case class A()' or 'case object A'",
       ))
     }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/Scala213Suite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/Scala213Suite.scala
@@ -5,7 +5,7 @@ import scala.meta._
 
 class Scala213Suite extends ParseSuite {
   private def runAssert(code: String)(
-      expected: Tree
+      expected: Tree,
   )(implicit d: Dialect, loc: munit.Location): Unit = assertTree(templStat(code)(d))(expected)
 
   import dialects.Scala213
@@ -19,11 +19,11 @@ class Scala213Suite extends ParseSuite {
     runAssert("val a: -2 = -2")(Defn.Val(Nil, List(patvar("a")), Some(int(-2)), int(-2)))
 
     runAssert("def foo(a: 3.14159f): .1d")(
-      Decl.Def(Nil, tname("foo"), Nil, List(List(tparam("a", flt("3.14159f")))), dbl("0.1d"))
+      Decl.Def(Nil, tname("foo"), Nil, List(List(tparam("a", flt("3.14159f")))), dbl("0.1d")),
     )
 
     runAssert("def foo(x: 'a'): Option['z']")(
-      Decl.Def(Nil, tname("foo"), Nil, List(List(tparam("x", lit('a')))), papply("Option", lit('z')))
+      Decl.Def(Nil, tname("foo"), Nil, List(List(tparam("x", lit('a')))), papply("Option", lit('z'))),
     )
 
     runAssert("def bar[T <: 1](t: T): T = t")(Defn.Def(
@@ -32,14 +32,14 @@ class Scala213Suite extends ParseSuite {
       List(pparam("T", hiBound(int(1)))),
       List(List(tparam("t", "T"))),
       Some(pname("T")),
-      tname("t")
+      tname("t"),
     ))
   }
 
   test("identifier-types") {
     // "x" is a class with def =>>(x: Int): Int, in dotty ==> is keyword and it will be error here
     runAssert("val c = x =>> 3")(
-      Defn.Val(Nil, List(patvar("c")), None, tinfix(tname("x"), "=>>", int(3)))
+      Defn.Val(Nil, List(patvar("c")), None, tinfix(tname("x"), "=>>", int(3))),
     )
 
     runAssert("val given = 3")(Defn.Val(Nil, List(patvar("given")), None, int(3)))
@@ -51,13 +51,13 @@ class Scala213Suite extends ParseSuite {
 
   test("try with any expr") {
     runAssert("try (1 + 2).toString")(
-      Term.Try(tselect(tinfix(int(1), "+", int(2)), "toString"), Nil, None)
+      Term.Try(tselect(tinfix(int(1), "+", int(2)), "toString"), Nil, None),
     )
     runAssert("try { 1 + 2 }.toString")(
-      Term.Try(tselect(blk(tinfix(int(1), "+", int(2))), "toString"), Nil, None)
+      Term.Try(tselect(blk(tinfix(int(1), "+", int(2))), "toString"), Nil, None),
     )
     runAssert("try (1 :: Nil) map fn")(
-      Term.Try(tinfix(tinfix(int(1), "::", tname("Nil")), "map", tname("fn")), Nil, None)
+      Term.Try(tinfix(tinfix(int(1), "::", tname("Nil")), "map", tname("fn")), Nil, None),
     )
     runAssert("try (true, false)")(Term.Try(Term.Tuple(List(bool(true), bool(false))), Nil, None))
     runAssert("try ()")(Term.Try(Lit.Unit(), Nil, None))
@@ -68,7 +68,7 @@ class Scala213Suite extends ParseSuite {
     runAssert(
       """|val x = "hello"
          |  ++ "world"
-         |""".stripMargin
+         |""".stripMargin,
     )(Defn.Val(Nil, List(patvar("x")), None, tinfix(str("hello"), "++", str("world"))))
   }
 
@@ -80,7 +80,7 @@ class Scala213Suite extends ParseSuite {
          |
          |    input_< ~> filtering ~> removeItems.in0
          |}
-         |""".stripMargin
+         |""".stripMargin,
     )(tapply(
       "Flow",
       blk(
@@ -88,9 +88,9 @@ class Scala213Suite extends ParseSuite {
         tinfix(
           tinfix(tname("input_<"), "~>", tname("filtering")),
           "~>",
-          tselect("removeItems", "in0")
-        )
-      )
+          tselect("removeItems", "in0"),
+        ),
+      ),
     ))
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
@@ -17,14 +17,14 @@ class ScaladocParserSuite extends FunSuite {
 
   private def parseString(comment: String) = ScaladocParser.parse(comment.trim)
   private def assertScaladoc(comment: String, expected: Scaladoc)(implicit
-      loc: munit.Location
+      loc: munit.Location,
   ): Unit = {
     assertEquals(parseString(comment), Option(expected))
     assertEquals(parseString(comment.replace("\n", " \t\r\n")), Option(expected))
   }
 
   private def generateTestString(tagType: TagType, testStringToMerge: String)(implicit
-      sb: StringBuilder
+      sb: StringBuilder,
   ): Unit = {
     val nl = "\n *"
     sb.append(' ').append(tagType.tag)
@@ -43,7 +43,7 @@ class ScaladocParserSuite extends FunSuite {
 
   test("example usage")(assertScaladoc(
     "/** Example scaladoc */",
-    Scaladoc(Seq(Paragraph(Seq(Text(Seq(Word("Example"), Word("scaladoc")))))))
+    Scaladoc(Seq(Paragraph(Seq(Text(Seq(Word("Example"), Word("scaladoc"))))))),
   ))
 
   test("indentation checks") {
@@ -57,14 +57,14 @@ class ScaladocParserSuite extends FunSuite {
          /** $expectedBody
           */
          """,
-      Scaladoc(Seq(Paragraph(Seq(expectedBodyToken))))
+      Scaladoc(Seq(Paragraph(Seq(expectedBodyToken)))),
     )
     assertScaladoc(
       s"""
          /**       $expectedBody
           */
          """,
-      Scaladoc(Seq(Paragraph(Seq(expectedBodyToken))))
+      Scaladoc(Seq(Paragraph(Seq(expectedBodyToken)))),
     )
     assertScaladoc(
       s"""
@@ -72,7 +72,7 @@ class ScaladocParserSuite extends FunSuite {
           *$expectedBody
           */
          """,
-      Scaladoc(Seq(Paragraph(Seq(expectedBodyToken))))
+      Scaladoc(Seq(Paragraph(Seq(expectedBodyToken)))),
     )
   }
 
@@ -89,7 +89,7 @@ class ScaladocParserSuite extends FunSuite {
           *
           */
          """,
-      Scaladoc(Seq(Paragraph(Seq(Text(words))), Paragraph(Seq(Text(words)))))
+      Scaladoc(Seq(Paragraph(Seq(Text(words))), Paragraph(Seq(Text(words))))),
     )
   }
 
@@ -106,7 +106,7 @@ class ScaladocParserSuite extends FunSuite {
           *
           */
          """,
-      Scaladoc(Seq(Paragraph(Seq(Text(words))), Paragraph(Seq(Text(words)))))
+      Scaladoc(Seq(Paragraph(Seq(Text(words))), Paragraph(Seq(Text(words))))),
     )
   }
 
@@ -136,8 +136,8 @@ class ScaladocParserSuite extends FunSuite {
         Paragraph(Seq(Text(words ++ refDots))),
         Paragraph(Seq(Text(words ++ refNone ++ words))),
         Paragraph(Seq(Text(words ++ refNone ++ words))),
-        Paragraph(Seq(Text(refWithSuffix)))
-      ))
+        Paragraph(Seq(Text(refWithSuffix))),
+      )),
     )
   }
 
@@ -159,7 +159,7 @@ class ScaladocParserSuite extends FunSuite {
           * [[$ref]])
           */
          """,
-      Scaladoc(Seq(Paragraph(Seq(Text(text1))), Paragraph(Seq(Text(text2)))))
+      Scaladoc(Seq(Paragraph(Seq(Text(text1))), Paragraph(Seq(Text(text2))))),
     )
   }
 
@@ -200,7 +200,7 @@ class ScaladocParserSuite extends FunSuite {
     val expected = Scaladoc(Seq(
       Paragraph(Seq(Text(textpara1.result()))),
       Paragraph(Seq(Text(words))),
-      Paragraph(Seq(CodeBlock(complexCodeBlock ++ Seq("", " foo")), CodeBlock(complexCodeBlock)))
+      Paragraph(Seq(CodeBlock(complexCodeBlock ++ Seq("", " foo")), CodeBlock(complexCodeBlock))),
     ))
     assertScaladoc(comment, expected)
   }
@@ -278,7 +278,7 @@ class ScaladocParserSuite extends FunSuite {
       MdCodeBlock(Seq("scala"), Nil, "```"),
       MdCodeBlock(Seq("foo", "bar", "baz"), Nil, "```"),
       MdCodeBlock(Seq("bar", "baz"), Seq("     foo"), "~~~"),
-      Text(Seq(Word("``~"), Word("foo"), Word("``~")))
+      Text(Seq(Word("``~"), Word("foo"), Word("``~"))),
     ))))
     assertScaladoc(comment, expected)
   }
@@ -308,7 +308,7 @@ class ScaladocParserSuite extends FunSuite {
 
     val expected = Scaladoc(Seq(
       Paragraph(Seq(Text(Seq(Word("foo"))), MdCodeBlock(Seq("bar", "qux"), codeBlock, fence = "```"))),
-      Paragraph(Seq(MdCodeBlock(Seq("scala"), codeBlock :+ "```", fence = "`````")))
+      Paragraph(Seq(MdCodeBlock(Seq("scala"), codeBlock :+ "```", fence = "`````"))),
     ))
     assertScaladoc(comment, expected)
   }
@@ -340,7 +340,7 @@ class ScaladocParserSuite extends FunSuite {
       Word(",") -> true,
       Word("and"),
       Word("qux"),
-      MdCodeSpan("quux xyzzy", "`")
+      MdCodeSpan("quux xyzzy", "`"),
     ))))))
 
     assertScaladoc(comment, expected)
@@ -358,8 +358,8 @@ class ScaladocParserSuite extends FunSuite {
       ListType.Bullet,
       Seq(
         ListItem("-", Text(Seq(Word("foo"), Word("`bar"))), Nil),
-        ListItem("-", Text(Seq(Word("baz"), Word("qux`"))), Nil)
-      )
+        ListItem("-", Text(Seq(Word("baz"), Word("qux`"))), Nil),
+      ),
     )))))
 
     assertScaladoc(comment, expected)
@@ -375,7 +375,7 @@ class ScaladocParserSuite extends FunSuite {
        """.stripMargin
 
     val expected = Scaladoc(Seq(Paragraph(
-      Seq(Text(Seq(MdCodeSpan(" foo ` ` bar ", "```"))), MdCodeBlock(Seq("foo"), Nil, "```"))
+      Seq(Text(Seq(MdCodeSpan(" foo ` ` bar ", "```"))), MdCodeBlock(Seq("foo"), Nil, "```")),
     )))
     assertScaladoc(comment, expected)
   }
@@ -416,7 +416,7 @@ class ScaladocParserSuite extends FunSuite {
       Heading(6, level6HeadingBody),
       Text(Seq(Word(bad1))),
       Text(Seq(Word(bad2))),
-      Text(Seq(Word(bad3), Word(bad4)))
+      Text(Seq(Word(bad3), Word(bad4))),
     ))))
     assertScaladoc(comment, expected)
   }
@@ -436,7 +436,7 @@ class ScaladocParserSuite extends FunSuite {
     val expected = Scaladoc(Seq(Paragraph(Seq(
       Text(Seq(Word("Some"), Word("text:"))),
       Text(Seq(Word("-"), Word(list11))),
-      Text(Seq(Word("-"), Word(list12)))
+      Text(Seq(Word("-"), Word(list12))),
     ))))
     assertScaladoc(comment, expected)
   }
@@ -470,19 +470,19 @@ class ScaladocParserSuite extends FunSuite {
             Text(Seq(Word(list11))),
             Seq(ListBlock(
               ListType.Decimal,
-              Seq(ListItem("1.", Text(Seq(Word(list21)))), ListItem("2.", Text(Seq(Word(list22)))))
-            ))
+              Seq(ListItem("1.", Text(Seq(Word(list21)))), ListItem("2.", Text(Seq(Word(list22))))),
+            )),
           ),
           ListItem(
             "-",
             Text(Seq(Word(list12))),
             Seq(ListBlock(
               ListType.Alpha,
-              Seq(ListItem("a.", Text(Seq(Word(list21)))), ListItem("b.", Text(Seq(Word(list22)))))
-            ))
-          )
-        )
-      )
+              Seq(ListItem("a.", Text(Seq(Word(list21)))), ListItem("b.", Text(Seq(Word(list22))))),
+            )),
+          ),
+        ),
+      ),
     ))))
     assertScaladoc(comment, expected)
   }
@@ -522,10 +522,10 @@ class ScaladocParserSuite extends FunSuite {
                   Seq(ListItem(
                     "i.",
                     Text(Seq(Word(list21))),
-                    Seq(ListBlock(ListType.Roman, Seq(ListItem("I.", Text(Seq(Word(list31)))))))
-                  ))
-                ))
-              ))
+                    Seq(ListBlock(ListType.Roman, Seq(ListItem("I.", Text(Seq(Word(list31))))))),
+                  )),
+                )),
+              )),
             ),
             ListBlock(
               ListType.Bullet,
@@ -537,11 +537,11 @@ class ScaladocParserSuite extends FunSuite {
                   Seq(ListItem(
                     "I.",
                     Text(Seq(Word(list22))),
-                    Seq(ListBlock(ListType.Roman, Seq(ListItem("I.", Text(Seq(Word(list32)))))))
-                  ))
-                ))
-              ))
-            )
+                    Seq(ListBlock(ListType.Roman, Seq(ListItem("I.", Text(Seq(Word(list32))))))),
+                  )),
+                )),
+              )),
+            ),
           )
         }
       }
@@ -584,9 +584,9 @@ class ScaladocParserSuite extends FunSuite {
                 Text(Seq(Word(list11), Word("i.e."), Word("foo"))),
                 Seq(ListBlock(
                   ListType.Roman,
-                  Seq(ListItem("i.", Text(Seq(Word(list21)))), ListItem("ii.", Text(Seq(Word(list22)))))
-                ))
-              ))
+                  Seq(ListItem("i.", Text(Seq(Word(list21)))), ListItem("ii.", Text(Seq(Word(list22))))),
+                )),
+              )),
             ),
             ListBlock(
               ListType.Bullet,
@@ -602,13 +602,13 @@ class ScaladocParserSuite extends FunSuite {
                       Text(Seq(Word(list22), Word("i.e."), Word("bar"))),
                       Seq(
                         ListBlock(ListType.Roman, Seq(ListItem("i.", Text(Seq(Word(list32)))))),
-                        Text(Seq(Word("baz")))
-                      )
-                    )
-                  )
-                ))
-              ))
-            )
+                        Text(Seq(Word("baz"))),
+                      ),
+                    ),
+                  ),
+                )),
+              )),
+            ),
           )
         }
       }
@@ -639,11 +639,11 @@ class ScaladocParserSuite extends FunSuite {
           ListItem(
             "-",
             Text(Seq(Word(list11), Word(list11))),
-            Seq(ListBlock(ListType.Bullet, Seq(ListItem("-", Text(Seq(Word(list21)))))))
+            Seq(ListBlock(ListType.Bullet, Seq(ListItem("-", Text(Seq(Word(list21))))))),
           ),
-          ListItem("-", Text(Seq(Word(list12))))
-        )
-      )
+          ListItem("-", Text(Seq(Word(list12)))),
+        ),
+      ),
     ))))
     assertScaladoc(comment, expected)
   }
@@ -664,7 +664,7 @@ class ScaladocParserSuite extends FunSuite {
       Tag(TagType.InheritDoc),
       Text(Seq(Word("Some"), Word("text:"))),
       ListBlock(ListType.Decimal, Seq(ListItem("1.", Text(Seq(Word(list11)))))),
-      ListBlock(ListType.Bullet, Seq(ListItem("-", Text(Seq(Word(list12))))))
+      ListBlock(ListType.Bullet, Seq(ListItem("-", Text(Seq(Word(list12)))))),
     ))))
     assertScaladoc(comment, expected)
   }
@@ -693,7 +693,7 @@ class ScaladocParserSuite extends FunSuite {
          """
     val expected = Scaladoc(Seq(Paragraph(Seq(ListBlock(
       ListType.Decimal,
-      Seq(ListItem("1.", Text(Seq(Word("a")))), ListItem("1.", Text(Seq(Word("b")))))
+      Seq(ListItem("1.", Text(Seq(Word("a")))), ListItem("1.", Text(Seq(Word("b"))))),
     )))))
     assertScaladoc(comment, expected)
   }
@@ -733,12 +733,12 @@ class ScaladocParserSuite extends FunSuite {
                 Seq(
                   MdCodeBlock(Seq("scala"), Seq("println(42)"), "```"),
                   Text(Seq(Word("and"), Word("some"), Word("text"))),
-                  ListBlock(ListType.Bullet, Seq(ListItem("-", Text(Seq(Word(list21))))))
-                )
+                  ListBlock(ListType.Bullet, Seq(ListItem("-", Text(Seq(Word(list21)))))),
+                ),
               ),
-              ListItem("-", Text(Seq(Word(list13))))
-            )
-          )
+              ListItem("-", Text(Seq(Word(list13)))),
+            ),
+          ),
         ))
       }
     }
@@ -784,13 +784,13 @@ class ScaladocParserSuite extends FunSuite {
                 Word("```"),
                 Word("and"),
                 Word("some"),
-                Word("text")
+                Word("text"),
               )),
-              Seq(ListBlock(ListType.Bullet, Seq(ListItem("-", Text(Seq(Word(list21)))))))
+              Seq(ListBlock(ListType.Bullet, Seq(ListItem("-", Text(Seq(Word(list21))))))),
             ),
-            ListItem("-", Text(Seq(Word(list13))))
-          )
-        )
+            ListItem("-", Text(Seq(Word(list13)))),
+          ),
+        ),
       )))
     }
     assertScaladoc(comment, expected)
@@ -826,13 +826,13 @@ class ScaladocParserSuite extends FunSuite {
               ListType.Bullet,
               Seq(
                 ListItem("-", Text(Seq(Word(list11)))),
-                ListItem("-", Text(Seq(Word(list12), Word("continue"), Word("text"))))
-              )
+                ListItem("-", Text(Seq(Word(list12), Word("continue"), Word("text")))),
+              ),
             ),
             MdCodeBlock(Seq("scala"), Seq("println(42)"), "```"),
             Text(Seq(Word("and"), Word("some"), Word("text"))),
             ListBlock(ListType.Bullet, Seq(ListItem("-", Text(Seq(Word(list21)))))),
-            ListBlock(ListType.Bullet, Seq(ListItem("-", Text(Seq(Word(list13))))))
+            ListBlock(ListType.Bullet, Seq(ListItem("-", Text(Seq(Word(list13)))))),
           )
         }
       }
@@ -873,12 +873,12 @@ class ScaladocParserSuite extends FunSuite {
             Seq(
               CodeBlock(Seq("     println(42)")),
               Text(Seq(Word("and"), Word("some"), Word("text"))),
-              ListBlock(ListType.Bullet, Seq(ListItem("-", Text(Seq(Word(list21))))))
-            )
+              ListBlock(ListType.Bullet, Seq(ListItem("-", Text(Seq(Word(list21)))))),
+            ),
           ),
-          ListItem("-", Text(Seq(Word(list13))))
-        )
-      )
+          ListItem("-", Text(Seq(Word(list13)))),
+        ),
+      ),
     ))))
     assertScaladoc(comment, expected)
   }
@@ -919,14 +919,14 @@ class ScaladocParserSuite extends FunSuite {
                 Seq(
                   CodeBlock(Seq("     println(42)")),
                   Text(Seq(Word("and"), Word("some"), Word("text"))),
-                  ListBlock(ListType.Bullet, Seq(ListItem("-", Text(Seq(Word(list21))))))
-                )
+                  ListBlock(ListType.Bullet, Seq(ListItem("-", Text(Seq(Word(list21)))))),
+                ),
               ),
-              ListItem("-", Text(Seq(Word(list13))))
-            )
-          )
+              ListItem("-", Text(Seq(Word(list13)))),
+            ),
+          ),
         )),
-        Paragraph(Seq(Text(Seq(Word("next"), Word("para")))))
+        Paragraph(Seq(Text(Seq(Word("next"), Word("para"))))),
       )
     }
     assertScaladoc(comment, expected)
@@ -965,12 +965,12 @@ class ScaladocParserSuite extends FunSuite {
             Seq(
               CodeBlock(Seq(" println(42)")),
               Text(Seq(Word("and"), Word("some"), Word("text"))),
-              ListBlock(ListType.Bullet, Seq(ListItem("-", Text(Seq(Word(list21))))))
-            )
+              ListBlock(ListType.Bullet, Seq(ListItem("-", Text(Seq(Word(list21)))))),
+            ),
           ),
-          ListItem("-", Text(Seq(Word(list13))))
-        )
-      )
+          ListItem("-", Text(Seq(Word(list13)))),
+        ),
+      ),
     ))))
     assertScaladoc(comment, expected)
   }
@@ -1004,13 +1004,13 @@ class ScaladocParserSuite extends FunSuite {
               Table(
                 Table.Row(Seq("one", "two")),
                 Seq(Table.Left, Table.Left),
-                Seq(Table.Row(Seq("1", "2")))
+                Seq(Table.Row(Seq("1", "2"))),
               ),
-              Text(Seq(Word("and"), Word("some"), Word("text")))
-            )
-          )
-        )
-      )
+              Text(Seq(Word("and"), Word("some"), Word("text"))),
+            ),
+          ),
+        ),
+      ),
     ))))
     assertScaladoc(comment, expected)
   }
@@ -1044,13 +1044,13 @@ class ScaladocParserSuite extends FunSuite {
               Table(
                 Table.Row(Seq("one", "two")),
                 Seq(Table.Left, Table.Left),
-                Seq(Table.Row(Seq("1", "2")))
+                Seq(Table.Row(Seq("1", "2"))),
               ),
-              Text(Seq(Word("and"), Word("some"), Word("text")))
-            )
-          )
-        )
-      )
+              Text(Seq(Word("and"), Word("some"), Word("text"))),
+            ),
+          ),
+        ),
+      ),
     ))))
     assertScaladoc(comment, expected)
   }
@@ -1084,13 +1084,13 @@ class ScaladocParserSuite extends FunSuite {
               Table(
                 Table.Row(Seq("one", "two")),
                 Seq(Table.Left, Table.Left),
-                Seq(Table.Row(Seq("1", "2")))
+                Seq(Table.Row(Seq("1", "2"))),
               ),
-              Text(Seq(Word("and"), Word("some"), Word("text")))
-            )
-          )
-        )
-      )
+              Text(Seq(Word("and"), Word("some"), Word("text"))),
+            ),
+          ),
+        ),
+      ),
     ))))
     assertScaladoc(comment, expected)
   }
@@ -1145,7 +1145,7 @@ class ScaladocParserSuite extends FunSuite {
                           Table(
                             Table.Row(Seq("hdr1", "hdr22")),
                             Seq(Table.Left, Table.Right),
-                            Seq(Table.Row(Seq("r1 1", "r1 2")))
+                            Seq(Table.Row(Seq("r1 1", "r1 2"))),
                           ),
                           ListBlock(
                             ListType.Bullet,
@@ -1154,19 +1154,19 @@ class ScaladocParserSuite extends FunSuite {
                               Text(Seq(Word("foo2"))),
                               Seq(
                                 CodeBlock(Seq("         embedded code")),
-                                MdCodeBlock(Nil, Seq("code foo2"), "```")
-                              )
-                            ))
+                                MdCodeBlock(Nil, Seq("code foo2"), "```"),
+                              ),
+                            )),
                           ),
-                          MdCodeBlock(Nil, Seq(" code foo1"), "```")
-                        )
-                      ))
+                          MdCodeBlock(Nil, Seq(" code foo1"), "```"),
+                        ),
+                      )),
                     ),
-                    MdCodeBlock(Nil, Seq("   code foo"), "```")
-                  )
+                    MdCodeBlock(Nil, Seq("   code foo"), "```"),
+                  ),
                 ),
-                ListItem("1.", Text(Seq(Word("bar"))))
-              )
+                ListItem("1.", Text(Seq(Word("bar")))),
+              ),
             )
           }
         }
@@ -1224,7 +1224,7 @@ class ScaladocParserSuite extends FunSuite {
                           Table(
                             Table.Row(Seq("hdr1", "hdr22")),
                             Seq(Table.Left, Table.Right),
-                            Seq(Table.Row(Seq("r1 1", "r1 2")))
+                            Seq(Table.Row(Seq("r1 1", "r1 2"))),
                           ),
                           ListBlock(
                             ListType.Bullet,
@@ -1233,19 +1233,19 @@ class ScaladocParserSuite extends FunSuite {
                               Text(Seq(Word("foo2"))),
                               Seq(
                                 CodeBlock(Seq("         embedded code")),
-                                MdCodeBlock(Nil, Seq("code foo2"), "```")
-                              )
-                            ))
+                                MdCodeBlock(Nil, Seq("code foo2"), "```"),
+                              ),
+                            )),
                           ),
-                          MdCodeBlock(Nil, Seq(" code foo1"), "```")
-                        )
-                      ))
+                          MdCodeBlock(Nil, Seq(" code foo1"), "```"),
+                        ),
+                      )),
                     ),
-                    MdCodeBlock(Nil, Seq("   code foo"), "```")
-                  )
+                    MdCodeBlock(Nil, Seq("   code foo"), "```"),
+                  ),
                 ),
-                ListItem("1.", Text(Seq(Word("bar"))))
-              )
+                ListItem("1.", Text(Seq(Word("bar")))),
+              ),
             )
           }
         }
@@ -1275,7 +1275,7 @@ class ScaladocParserSuite extends FunSuite {
     assertEquals(parsedTags.count(t => t.tag.optDesc && t.desc.nonEmpty), tagsWithDesc)
     assertEquals(
       parsedTags.count(t => !t.tag.optDesc && t.desc.isEmpty),
-      predefinedTagTypes.length - tagsWithDesc
+      predefinedTagTypes.length - tagsWithDesc,
     )
     assertEquals(parsedTags.count(t => !t.tag.optDesc && t.desc.nonEmpty), 0)
 
@@ -1308,7 +1308,7 @@ class ScaladocParserSuite extends FunSuite {
 
     val expected = Scaladoc(Seq(Paragraph(Seq(
       Tag(TagType.Param, Some(Word("foo")), Seq(Text(Seq(Word("-"), Word("bar"), Word("baz"))))),
-      Tag(TagType.Return)
+      Tag(TagType.Return),
     ))))
     assertScaladoc(comment, expected)
   }
@@ -1324,7 +1324,7 @@ class ScaladocParserSuite extends FunSuite {
     val expected = Scaladoc(Seq(Paragraph(Seq(Tag(
       TagType.Param,
       Some(Word("foo")),
-      Seq(ListBlock(ListType.Bullet, Seq(ListItem("-", Text(Seq(Word("bar"), Word("baz")))))))
+      Seq(ListBlock(ListType.Bullet, Seq(ListItem("-", Text(Seq(Word("bar"), Word("baz"))))))),
     )))))
     assertScaladoc(comment, expected)
   }
@@ -1339,7 +1339,7 @@ class ScaladocParserSuite extends FunSuite {
 
     val expected = Scaladoc(Seq(Paragraph(Seq(Tag(
       TagType.UnknownTag("@foo"),
-      desc = Seq(ListBlock(ListType.Bullet, Seq(ListItem("-", Text(Seq(Word("bar"), Word("baz")))))))
+      desc = Seq(ListBlock(ListType.Bullet, Seq(ListItem("-", Text(Seq(Word("bar"), Word("baz"))))))),
     )))))
     assertScaladoc(comment, expected)
   }
@@ -1354,8 +1354,8 @@ class ScaladocParserSuite extends FunSuite {
          """,
     Scaladoc(Seq(Paragraph(Seq(
       Tag(TagType.Throws, Some(Word("e1")), Seq(Text(Seq(Word("foo"), Word("bar"))))),
-      Tag(TagType.Throws, Some(Word("e2")), Seq(Text(Seq(Word("baz"), Word("qux"), Word("bar-baz")))))
-    ))))
+      Tag(TagType.Throws, Some(Word("e2")), Seq(Text(Seq(Word("baz"), Word("qux"), Word("bar-baz"))))),
+    )))),
   ))
 
   test("parse since, version tags")(assertScaladoc(
@@ -1368,8 +1368,8 @@ class ScaladocParserSuite extends FunSuite {
          """,
     Scaladoc(Seq(Paragraph(Seq(
       Tag(TagType.Version, Some(Word("1.0 foo bar"))),
-      Tag(TagType.Since, Some(Word("1.0")), Seq(Text(Seq(Word("baz"), Word("qux"), Word("bar-baz")))))
-    ))))
+      Tag(TagType.Since, Some(Word("1.0")), Seq(Text(Seq(Word("baz"), Word("qux"), Word("bar-baz"))))),
+    )))),
   ))
 
   test("parse define macro tags")(assertScaladoc(
@@ -1382,8 +1382,8 @@ class ScaladocParserSuite extends FunSuite {
     Scaladoc(Seq(Paragraph(Seq(Tag(
       TagType.Define,
       Some(Word("what")),
-      Seq(Text(Seq(Word("for"), Word("what"), Word("reason"), Word("bar-baz"))))
-    )))))
+      Seq(Text(Seq(Word("for"), Word("what"), Word("reason"), Word("bar-baz")))),
+    ))))),
   ))
 
   test("parse usecase tags")(assertScaladoc(
@@ -1396,7 +1396,7 @@ class ScaladocParserSuite extends FunSuite {
       val label = Some(Word("foo bar"))
       val rest = Seq(Text(Seq(Word("baz"), Word("qux"))))
       Scaladoc(Seq(Paragraph(Tag(TagType.UseCase, label = label) +: rest)))
-    }
+    },
   ))
 
   test("parse tag")(assertScaladoc(
@@ -1406,7 +1406,7 @@ class ScaladocParserSuite extends FunSuite {
           * bar-baz
           */
          """,
-    Scaladoc(Seq(Paragraph(Seq(Tag(TagType.Param, Some(Word("foo")), Seq(Text(Seq(Word("bar-baz")))))))))
+    Scaladoc(Seq(Paragraph(Seq(Tag(TagType.Param, Some(Word("foo")), Seq(Text(Seq(Word("bar-baz"))))))))),
   ))
 
   test("failing to parse 1")(assertScaladoc(
@@ -1415,7 +1415,7 @@ class ScaladocParserSuite extends FunSuite {
           * @param
           */
          """,
-    Scaladoc(Seq(Paragraph(Seq(Text(Seq(Word("@param")))))))
+    Scaladoc(Seq(Paragraph(Seq(Text(Seq(Word("@param"))))))),
   ))
 
   test("failing to parse 2")(assertScaladoc(
@@ -1425,7 +1425,7 @@ class ScaladocParserSuite extends FunSuite {
           * @return
           */
          """,
-    Scaladoc(Seq(Paragraph(Seq(Text(Seq(Word("@param"))), Tag(TagType.Return)))))
+    Scaladoc(Seq(Paragraph(Seq(Text(Seq(Word("@param"))), Tag(TagType.Return))))),
   ))
 
   test("using an unrecognized tag")(assertScaladoc(
@@ -1436,8 +1436,8 @@ class ScaladocParserSuite extends FunSuite {
           */
          """,
     Scaladoc(Seq(Paragraph(
-      Seq(Tag(TagType.UnknownTag("@newtag"), desc = Seq(Text(Seq(Word("newtag"), Word("text"))))))
-    )))
+      Seq(Tag(TagType.UnknownTag("@newtag"), desc = Seq(Text(Seq(Word("newtag"), Word("text")))))),
+    ))),
   ))
 
   test("tag description with multiline code blocks") {
@@ -1470,9 +1470,9 @@ class ScaladocParserSuite extends FunSuite {
           CodeBlock(complexCodeBlock),
           Text(Seq(Word("bar"), Word("baz"))),
           CodeBlock(complexCodeBlock),
-          Text(Seq(Word("baz"), Word("qux")))
-        )
-      )
+          Text(Seq(Word("baz"), Word("qux"))),
+        ),
+      ),
     ))))
     assertScaladoc(comment, expected)
   }
@@ -1508,9 +1508,9 @@ class ScaladocParserSuite extends FunSuite {
           MdCodeBlock(Seq("info1", "info2"), complexCodeBlock, "```"),
           Text(Seq(Word("bar"), Word("baz"))),
           MdCodeBlock(Seq("info3", "info4"), complexCodeBlock, "```"),
-          Text(Seq(Word("baz"), Word("qux")))
-        )
-      )
+          Text(Seq(Word("baz"), Word("qux"))),
+        ),
+      ),
     ))))
     assertScaladoc(comment, expected)
   }
@@ -1529,8 +1529,8 @@ class ScaladocParserSuite extends FunSuite {
        """,
       Scaladoc(
         Paragraph(Text(Seq(javaTag1, javaTag2, Word("{@not"), Word("a"), Word("tag}"))) :: Nil) ::
-          Nil
-      )
+          Nil,
+      ),
     )
     assertEquals(javaTag1.syntax, "{@tag1}")
     assertEquals(javaTag2.syntax, "{@tag2 with desc}")
@@ -1553,9 +1553,9 @@ class ScaladocParserSuite extends FunSuite {
       Table(
         Table.Row(Seq("hdr1", "hdr2", "hdr3", "h\\|4")),
         Seq(Table.Left, Table.Left, Table.Right, Table.Center),
-        Seq(Table.Row(Seq("row1", "row2", "row3", "row4")))
+        Seq(Table.Row(Seq("row1", "row2", "row3", "row4"))),
       ),
-      Text(Seq(Word("text3"), Word("text4")))
+      Text(Seq(Word("text3"), Word("text4"))),
     ))))
     assertScaladoc(comment, expected)
   }
@@ -1592,9 +1592,9 @@ class ScaladocParserSuite extends FunSuite {
       Table(
         Table.Row(Seq("hdr1", "hdr2", "hdr3", "hdr4")),
         Seq(Table.Left, Table.Left, Table.Right, Table.Center, Table.Right, Table.Center),
-        Seq(Table.Row(Seq("row1", "row2", "row3", "row4", "row5")))
+        Seq(Table.Row(Seq("row1", "row2", "row3", "row4", "row5"))),
       ),
-      Text(Seq(Word("text3"), Word("text4")))
+      Text(Seq(Word("text3"), Word("text4"))),
     ))))
     assertScaladoc(comment, expected)
   }
@@ -1615,9 +1615,9 @@ class ScaladocParserSuite extends FunSuite {
       Table(
         Table.Row(Seq("hdr1", "hdr2", "hdr3", "hdr4")),
         Seq(Table.Left, Table.Left, Table.Right, Table.Center),
-        Seq(Table.Row(Seq("row1", "row2", "row3", "row4")))
+        Seq(Table.Row(Seq("row1", "row2", "row3", "row4"))),
       ),
-      Text(Seq(Word("text3"), Word("text4")))
+      Text(Seq(Word("text3"), Word("text4"))),
     ))))
     assertScaladoc(comment, expected)
   }
@@ -1641,9 +1641,9 @@ class ScaladocParserSuite extends FunSuite {
       Table(
         Table.Row(Seq("hdr1", "hdr2", "hdr3", "hdr4")),
         Seq(Table.Left, Table.Left, Table.Right, Table.Center),
-        Seq(Table.Row(Seq("row1", "row2", "row3", "row4")))
+        Seq(Table.Row(Seq("row1", "row2", "row3", "row4"))),
       ),
-      Text(Seq(Word("text3"), Word("text4")))
+      Text(Seq(Word("text3"), Word("text4"))),
     ))))
     assertScaladoc(comment, expected)
   }
@@ -1668,10 +1668,10 @@ class ScaladocParserSuite extends FunSuite {
         Seq(Table.Left, Table.Left, Table.Right, Table.Center),
         Seq(
           Table.Row(Seq("----", ":---", "---:", ":--:")),
-          Table.Row(Seq("row1", "row2", "row3", "row4"))
-        )
+          Table.Row(Seq("row1", "row2", "row3", "row4")),
+        ),
       ),
-      Text(Seq(Word("text3"), Word("text4")))
+      Text(Seq(Word("text3"), Word("text4"))),
     ))))
     assertScaladoc(comment, expected)
   }
@@ -1691,7 +1691,7 @@ class ScaladocParserSuite extends FunSuite {
     val expected = Scaladoc(Seq(Paragraph(Seq(
       Text(Seq(Word("text1"), Word("text2"))),
       Table(Table.Row(Seq("")), Seq(Table.Left), Seq(Table.Row(Seq("")))),
-      Text(Seq(Word("text3"), Word("text4")))
+      Text(Seq(Word("text3"), Word("text4"))),
     ))))
     assertScaladoc(comment, expected)
   }
@@ -1710,7 +1710,7 @@ class ScaladocParserSuite extends FunSuite {
     val expected = Scaladoc(Seq(Paragraph(Seq(
       Text(Seq(Word("text1"), Word("text2"))),
       Table(Table.Row(Seq("a")), Seq(Table.Left), Seq(Table.Row(Seq("")))),
-      Text(Seq(Word("text3"), Word("text4")))
+      Text(Seq(Word("text3"), Word("text4"))),
     ))))
     assertScaladoc(comment, expected)
   }
@@ -1737,8 +1737,8 @@ class ScaladocParserSuite extends FunSuite {
         Word("|hdr3|"),
         Word("hdr4||"),
         Word("text3"),
-        Word("text4")
-      ))
+        Word("text4"),
+      )),
     ))))
     assertScaladoc(comment, expected)
   }
@@ -1754,7 +1754,7 @@ class ScaladocParserSuite extends FunSuite {
        """.stripMargin
 
     val expected = Scaladoc(Seq(Paragraph(Seq(
-      Table(Table.Row(Seq("one", "two")), Seq(Table.Left, Table.Left), Seq(Table.Row(Seq("1", "2"))))
+      Table(Table.Row(Seq("one", "two")), Seq(Table.Left, Table.Left), Seq(Table.Row(Seq("1", "2")))),
     ))))
     assertScaladoc(comment, expected)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/StructureSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/StructureSuite.scala
@@ -9,7 +9,7 @@ import munit.Location
 class StructureSuite extends ParseSuite {
 
   def checkStructure[T: Parse: Structure](code: String, expected: Tree)(implicit
-      loc: Location
+      loc: Location,
   ): Unit = test(logger.revealWhitespace(code)) {
     val obtained: String = code.parse[T].get.structure
     assertNoDiff(obtained, expected.structure)
@@ -19,11 +19,11 @@ class StructureSuite extends ParseSuite {
 
   checkStructure[Case](
     "case _ => _ => {false}",
-    Case(patwildcard, None, tfunc(tparam("_"))(blk(bool(false))))
+    Case(patwildcard, None, tfunc(tparam("_"))(blk(bool(false)))),
   )
 
   checkStructure[Case](
     "case _ => _ => false; a",
-    Case(patwildcard, None, tfunc(tparam("_"))(blk(bool(false), tname("a"))))
+    Case(patwildcard, None, tfunc(tparam("_"))(blk(bool(false), tname("a")))),
   )
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TemplateSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TemplateSuite.scala
@@ -22,15 +22,15 @@ class TemplateSuite extends ParseSuite {
   }
 
   test("trait T {}")(
-    assertTree(templStat("trait T {}"))(Trait(Nil, pname("T"), Nil, EmptyCtor(), EmptyTemplate()))
+    assertTree(templStat("trait T {}"))(Trait(Nil, pname("T"), Nil, EmptyCtor(), EmptyTemplate())),
   )
 
   test("trait F[T]")(
-    assertTree(templStat("trait F[T]"))(Trait(Nil, pname("F"), pparam("T") :: Nil, ctor, tplNoBody()))
+    assertTree(templStat("trait F[T]"))(Trait(Nil, pname("F"), pparam("T") :: Nil, ctor, tplNoBody())),
   )
 
   test("trait A extends B")(assertTree(templStat("trait A extends B"))(
-    Trait(Nil, pname("A"), Nil, EmptyCtor(), tplNoBody(init("B")))
+    Trait(Nil, pname("A"), Nil, EmptyCtor(), tplNoBody(init("B"))),
   ))
 
   test("trait Inner <: { val x : Int = 3 }")(
@@ -39,8 +39,8 @@ class TemplateSuite extends ParseSuite {
       pname("Inner"),
       Nil,
       EmptyCtor(),
-      tpl(Defn.Val(Nil, List(patvar("x")), Some(pname("Int")), int(3)))
-    ))
+      tpl(Defn.Val(Nil, List(patvar("x")), Some(pname("Int")), int(3))),
+    )),
   )
 
   test("trait A extends { val x: Int } with B")(
@@ -53,27 +53,27 @@ class TemplateSuite extends ParseSuite {
         Defn.Val(Nil, List(patvar("x")), Some(pname("Int")), int(2)) :: Nil,
         init("B") :: Nil,
         EmptySelf(),
-        Nil
-      )
-    ))
+        Nil,
+      ),
+    )),
   )
 
   test("trait A extends { self: B => }")(assertTree(templStat("trait A { self: B => }"))(
-    Trait(Nil, pname("A"), Nil, EmptyCtor(), tpl(self("self", "B")))
+    Trait(Nil, pname("A"), Nil, EmptyCtor(), tpl(self("self", "B"))),
   ))
 
   test("trait T { def x: Int }")(assertTree(templStat("trait T { def x: Int }"))(
-    Trait(Nil, pname("T"), Nil, EmptyCtor(), tpl(Decl.Def(Nil, tname("x"), Nil, Nil, pname("Int"))))
+    Trait(Nil, pname("T"), Nil, EmptyCtor(), tpl(Decl.Def(Nil, tname("x"), Nil, Nil, pname("Int")))),
   ))
 
   test("class C")(assertTree(templStat("class C"))(Class(Nil, pname("C"), Nil, ctor, tplNoBody())))
 
   test("class C[T]")(
-    assertTree(templStat("class C[T]"))(Class(Nil, pname("C"), pparam("T") :: Nil, ctor, tplNoBody()))
+    assertTree(templStat("class C[T]"))(Class(Nil, pname("C"), pparam("T") :: Nil, ctor, tplNoBody())),
   )
 
   test("class A extends B")(assertTree(templStat("class A extends B"))(
-    Class(Nil, pname("A"), Nil, EmptyCtor(), tplNoBody(init("B")))
+    Class(Nil, pname("A"), Nil, EmptyCtor(), tplNoBody(init("B"))),
   ))
 
   test("class A extends { val x: Int } with B")(
@@ -86,29 +86,29 @@ class TemplateSuite extends ParseSuite {
         Defn.Val(Nil, List(patvar("x")), Some(pname("Int")), int(2)) :: Nil,
         init("B") :: Nil,
         EmptySelf(),
-        Nil
-      )
-    ))
+        Nil,
+      ),
+    )),
   )
 
   test("class A extends { self: B => }")(assertTree(templStat("class A { self: B => }"))(
-    Class(Nil, pname("A"), Nil, EmptyCtor(), tpl(self("self", "B")))
+    Class(Nil, pname("A"), Nil, EmptyCtor(), tpl(self("self", "B"))),
   ))
 
   test("class A { this => }")(assertTree(templStat("class A { this => }"))(
-    Class(Nil, pname("A"), Nil, EmptyCtor(), tpl(self(Name.This())))
+    Class(Nil, pname("A"), Nil, EmptyCtor(), tpl(self(Name.This()))),
   ))
 
   test("class A { _ => }")(assertTree(templStat("class A { this => }"))(
-    Class(Nil, pname("A"), Nil, EmptyCtor(), tpl(self(Name.This())))
+    Class(Nil, pname("A"), Nil, EmptyCtor(), tpl(self(Name.This()))),
   ))
 
   test("class C { def x: Int }")(assertTree(templStat("class C { def x: Int }"))(
-    Class(Nil, pname("C"), Nil, EmptyCtor(), tpl(Decl.Def(Nil, tname("x"), Nil, Nil, pname("Int"))))
+    Class(Nil, pname("C"), Nil, EmptyCtor(), tpl(Decl.Def(Nil, tname("x"), Nil, Nil, pname("Int")))),
   ))
 
   test("class C(x: Int)")(assertTree(templStat("class C(x: Int)"))(
-    Class(Nil, pname("C"), Nil, ctorp(tparam("x", "Int")), tplNoBody())
+    Class(Nil, pname("C"), Nil, ctorp(tparam("x", "Int")), tplNoBody()),
   ))
 
   test("class C private(x: Int)")(assertTree(templStat("class C private(x: Int)"))(Class(
@@ -116,19 +116,19 @@ class TemplateSuite extends ParseSuite {
     pname("C"),
     Nil,
     Ctor.Primary(Mod.Private(anon) :: Nil, anon, (tparam("x", "Int") :: Nil) :: Nil),
-    tplNoBody()
+    tplNoBody(),
   )))
 
   test("class C(val x: Int)")(assertTree(templStat("class C(val x: Int)"))(
-    Class(Nil, pname("C"), Nil, ctorp(tparam(Mod.ValParam() :: Nil, "x", "Int")), tplNoBody())
+    Class(Nil, pname("C"), Nil, ctorp(tparam(Mod.ValParam() :: Nil, "x", "Int")), tplNoBody()),
   ))
 
   test("class C(var x: Int)")(assertTree(templStat("class C(var x: Int)"))(
-    Class(Nil, pname("C"), Nil, ctorp(tparam(Mod.VarParam() :: Nil, "x", "Int")), tplNoBody())
+    Class(Nil, pname("C"), Nil, ctorp(tparam(Mod.VarParam() :: Nil, "x", "Int")), tplNoBody()),
   ))
 
   test("class C(implicit x: Int)")(assertTree(templStat("class C(implicit x: Int)"))(
-    Class(Nil, pname("C"), Nil, ctorp(tparam(Mod.Implicit() :: Nil, "x", "Int")), tplNoBody())
+    Class(Nil, pname("C"), Nil, ctorp(tparam(Mod.Implicit() :: Nil, "x", "Int")), tplNoBody()),
   ))
 
   test("class C(override val x: Int)")(assertTree(templStat("class C(override val x: Int)"))(Class(
@@ -136,7 +136,7 @@ class TemplateSuite extends ParseSuite {
     pname("C"),
     Nil,
     ctorp(tparam(List(Mod.Override(), Mod.ValParam()), "x", "Int")),
-    tplNoBody()
+    tplNoBody(),
   )))
 
   test("case class C(x: Int)(y: => Int)")(
@@ -145,18 +145,18 @@ class TemplateSuite extends ParseSuite {
       pname("C"),
       Nil,
       ctorp(tparam("x", "Int") :: Nil, tparam("y", Type.ByName(pname("Int"))) :: Nil),
-      tplNoBody()
-    ))
+      tplNoBody(),
+    )),
   )
 
   test("object O")(assertTree(templStat("object O"))(Object(Nil, tname("O"), tplNoBody())))
 
   test("case object O")(
-    assertTree(templStat("case object O"))(Object(Mod.Case() :: Nil, tname("O"), tplNoBody()))
+    assertTree(templStat("case object O"))(Object(Mod.Case() :: Nil, tname("O"), tplNoBody())),
   )
 
   test("object A extends B")(
-    assertTree(templStat("object A extends B"))(Object(Nil, tname("A"), tplNoBody(init("B"))))
+    assertTree(templStat("object A extends B"))(Object(Nil, tname("A"), tplNoBody(init("B")))),
   )
 
   test("object A extends { val x: Int } with B")(
@@ -167,13 +167,13 @@ class TemplateSuite extends ParseSuite {
         Defn.Val(Nil, List(patvar("x")), Some(pname("Int")), int(2)) :: Nil,
         init("B") :: Nil,
         EmptySelf(),
-        Nil
-      )
-    ))
+        Nil,
+      ),
+    )),
   )
 
   test("object A extends { self: B => }")(
-    assertTree(templStat("object A { self: B => }"))(Object(Nil, tname("A"), tpl(self("self", "B"))))
+    assertTree(templStat("object A { self: B => }"))(Object(Nil, tname("A"), tpl(self("self", "B")))),
   )
 
   test("trait B extends A.type") {
@@ -215,11 +215,11 @@ class TemplateSuite extends ParseSuite {
         List(Init(
           Type.Apply(Type.Name("F"), Type.ArgClause(List(Type.Name("Int")))),
           Name.Anonymous(),
-          Seq.empty[Term.ArgClause]
+          Seq.empty[Term.ArgClause],
         )),
         Template.Body(None, Nil),
-        Nil
-      )
+        Nil,
+      ),
     )
     checkStat(code, "trait B extends F[Int]")(tree)
     checkStat(code2, "trait B extends F[Int]")(tree)
@@ -260,8 +260,8 @@ class TemplateSuite extends ParseSuite {
       tpl(
         Defn.Class(List(Mod.Case()), pname("Foo"), Nil, ctorp(Nil), tplNoBody()),
         blk(tapplytype(tname("deriveEncoder"), pname("Foo"))),
-        blk(tapplytype(tname("deriveEncoder"), pname("Foo")))
-      )
+        blk(tapplytype(tname("deriveEncoder"), pname("Foo"))),
+      ),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -300,8 +300,8 @@ class TemplateSuite extends ParseSuite {
       tpl(
         Defn.Class(List(Mod.Case()), pname("Foo"), Nil, ctorp(), tplNoBody(init("Bar"))),
         blk(tapplytype(tname("deriveEncoder"), pname("Foo"))),
-        blk(tapplytype(tname("deriveEncoder"), pname("Foo")))
-      )
+        blk(tapplytype(tname("deriveEncoder"), pname("Foo"))),
+      ),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TermSuite.scala
@@ -18,7 +18,7 @@ class TermSuite extends ParseSuite {
     assertTree(term(expr))(tree)
 
   private def checkTerm(expr: String, syntax: String = null)(tree: Tree)(implicit
-      loc: munit.Location
+      loc: munit.Location,
   ): Unit = checkTree(term(expr), syntax)(tree)
 
   test("x")(assertTerm("x")(tname("x")))
@@ -34,7 +34,7 @@ class TermSuite extends ParseSuite {
   test("this")(assertTerm("this")(This(Anonymous())))
 
   test("a.super[b].c")(
-    assertTerm("a.super[b].c")(tselect(Super(Indeterminate("a"), Indeterminate("b")), "c"))
+    assertTerm("a.super[b].c")(tselect(Super(Indeterminate("a"), Indeterminate("b")), "c")),
   )
 
   test("super[b].c")(assertTerm("super[b].c")(tselect(Super(Anonymous(), Indeterminate("b")), "c")))
@@ -44,7 +44,7 @@ class TermSuite extends ParseSuite {
   test("super.c")(assertTerm("super.c")(tselect(Super(Anonymous(), Anonymous()), "c")))
 
   test("s\"a $b c\"")(assertTerm("s\"a $b c\"")(
-    Interpolate(tname("s"), str("a ") :: str(" c") :: Nil, tname("b") :: Nil)
+    Interpolate(tname("s"), str("a ") :: str(" c") :: Nil, tname("b") :: Nil),
   ))
 
   test("f(0)")(assertTerm("f(0)")(Apply(tname("f"), int(0) :: Nil)))
@@ -62,9 +62,9 @@ class TermSuite extends ParseSuite {
       {
         case Term.Apply.After_4_6_0(
               Term.Name("f"),
-              Term.ArgClause(List(Assign(Term.Name("x"), Repeated(Term.Name("xs")))), None)
+              Term.ArgClause(List(Assign(Term.Name("x"), Repeated(Term.Name("xs")))), None),
             ) => ()
-      }
+      },
     )
 
     matchSubStructure(
@@ -72,14 +72,14 @@ class TermSuite extends ParseSuite {
       {
         case Term.Apply.internal.Latest(
               Term.Name("f"),
-              Term.ArgClause(List(Assign(Term.Name("x"), Repeated(Term.Name("xs")))), None)
+              Term.ArgClause(List(Assign(Term.Name("x"), Repeated(Term.Name("xs")))), None),
             ) => ()
-      }
+      },
     )
   }
 
   test("f(x = (xs: _*))")(
-    assertTerm("f(x = (xs: _*))")(tapply(tname("f"), Assign(tname("x"), Repeated(tname("xs")))))
+    assertTerm("f(x = (xs: _*))")(tapply(tname("f"), Assign(tname("x"), Repeated(tname("xs"))))),
   )
 
   test("a + () [scala211]") {
@@ -128,7 +128,7 @@ class TermSuite extends ParseSuite {
     ApplyInfix(tname("a"), tname("+"), Nil, tname("b") :: Nil),
     tname("+"),
     Nil,
-    tname("c") :: Nil
+    tname("c") :: Nil,
   )))
 
   test("a :: b")(assertTerm("a :: b")(ApplyInfix(tname("a"), tname("::"), Nil, tname("b") :: Nil)))
@@ -137,7 +137,7 @@ class TermSuite extends ParseSuite {
     tname("a"),
     tname("::"),
     Nil,
-    ApplyInfix(tname("b"), tname("::"), Nil, tname("c") :: Nil) :: Nil
+    ApplyInfix(tname("b"), tname("::"), Nil, tname("c") :: Nil) :: Nil,
   )))
 
   test("!a")(assertTerm("!a")(ApplyUnary(tname("!"), tname("a"))))
@@ -165,11 +165,11 @@ class TermSuite extends ParseSuite {
   test("{ true }")(assertTerm("{ true }")(blk(bool(true))))
 
   test("if (true) true else false")(
-    assertTerm("if (true) true else false")(If(bool(true), bool(true), bool(false)))
+    assertTerm("if (true) true else false")(If(bool(true), bool(true), bool(false))),
   )
 
   test("if (true) true; else false")(
-    assertTerm("if (true) true; else false")(If(bool(true), bool(true), bool(false)))
+    assertTerm("if (true) true; else false")(If(bool(true), bool(true), bool(false))),
   )
 
   test("if (true) true")(assertTerm("if (true) true")(If(bool(true), bool(true), Lit.Unit())))
@@ -189,10 +189,10 @@ class TermSuite extends ParseSuite {
       tinfix(
         tinfix(bool(true), "&&", tmatch(str(""), Case(patvar("other"), None, bool(true)))),
         "&&",
-        bool(true)
+        bool(true),
       ),
       str(""),
-      Lit.Unit()
+      Lit.Unit(),
     ))
   }
 
@@ -269,27 +269,27 @@ class TermSuite extends ParseSuite {
   test("(x: Int, y: Int) => x") {
     assertTerm("(x: Int, y: Int) => x")(tfunc(tparam("x", "Int"), tparam("y", "Int"))(tname("x")))
     assertTree(
-      blockStat("(x: Int, y: Int) => x")
+      blockStat("(x: Int, y: Int) => x"),
     )(tfunc(tparam("x", "Int"), tparam("y", "Int"))(tname("x")))
     assertTree(
-      templStat("(x: Int, y: Int) => x")
+      templStat("(x: Int, y: Int) => x"),
     )(tfunc(tparam("x", "Int"), tparam("y", "Int"))(tname("x")))
   }
 
   test("{ implicit x => () }")(assertTerm("{ implicit x => () }")(Block(
-    Function(tparam(Mod.Implicit() :: Nil, "x") :: Nil, Lit.Unit()) :: Nil
+    Function(tparam(Mod.Implicit() :: Nil, "x") :: Nil, Lit.Unit()) :: Nil,
   )))
 
   test("1 match { case 1 => true }")(
-    assertTerm("1 match { case 1 => true }")(Match(int(1), Case(int(1), None, bool(true)) :: Nil))
+    assertTerm("1 match { case 1 => true }")(Match(int(1), Case(int(1), None, bool(true)) :: Nil)),
   )
 
   test("1 match { case 1 => }")(
-    assertTerm("1 match { case 1 => }")(Match(int(1), Case(int(1), None, blk()) :: Nil))
+    assertTerm("1 match { case 1 => }")(Match(int(1), Case(int(1), None, blk()) :: Nil)),
   )
 
   test("1 match { case 1 if true => }")(assertTerm("1 match { case 1 if true => }")(
-    Match(int(1), Case(int(1), Some(bool(true)), blk()) :: Nil)
+    Match(int(1), Case(int(1), Some(bool(true)), blk()) :: Nil),
   ))
 
   test("1 match { case case 1 if true => }") {
@@ -304,13 +304,13 @@ class TermSuite extends ParseSuite {
   test("try (2)")(assertTerm("try (2)")(Try(int(2), Nil, None)))
 
   test("try 1 catch { case _ => }")(
-    assertTerm("try 1 catch { case _ => }")(Try(int(1), Case(patwildcard, None, blk()) :: Nil, None))
+    assertTerm("try 1 catch { case _ => }")(Try(int(1), Case(patwildcard, None, blk()) :: Nil, None)),
   )
 
   test("try 1 finally 1")(assertTerm("try 1 finally 1")(Try(int(1), Nil, Some(int(1)))))
 
   test("{ case 1 => () }")(
-    assertTerm("{ case 1 => () }")(PartialFunction(Case(int(1), None, Lit.Unit()) :: Nil))
+    assertTerm("{ case 1 => () }")(PartialFunction(Case(int(1), None, Lit.Unit()) :: Nil)),
   )
 
   test("while (true) false")(assertTerm("while (true) false")(While(bool(true), bool(false))))
@@ -321,28 +321,28 @@ class TermSuite extends ParseSuite {
     List(
       Enumerator.Generator(patvar("a"), tname("b")),
       Enumerator.Guard(tname("c")),
-      Enumerator.Val(patvar("x"), tname("a"))
+      Enumerator.Val(patvar("x"), tname("a")),
     ),
-    tname("x")
+    tname("x"),
   )))
 
   test("for (a <- b; if c; x = a) yield x")(assertTerm("for (a <- b; if c; x = a) yield x")(ForYield(
     List(
       Enumerator.Generator(patvar("a"), tname("b")),
       Enumerator.Guard(tname("c")),
-      Enumerator.Val(patvar("x"), tname("a"))
+      Enumerator.Val(patvar("x"), tname("a")),
     ),
-    tname("x")
+    tname("x"),
   )))
 
   test("f(_)")(assertTerm("f(_)")(AnonymousFunction(Apply(tname("f"), List(Placeholder())))))
 
   test("_ + 1")(
-    assertTerm("_ + 1")(AnonymousFunction(ApplyInfix(Placeholder(), tname("+"), Nil, int(1) :: Nil)))
+    assertTerm("_ + 1")(AnonymousFunction(ApplyInfix(Placeholder(), tname("+"), Nil, int(1) :: Nil))),
   )
 
   test("1 + _")(
-    assertTerm("1 + _")(AnonymousFunction(ApplyInfix(int(1), tname("+"), Nil, Placeholder() :: Nil)))
+    assertTerm("1 + _")(AnonymousFunction(ApplyInfix(int(1), tname("+"), Nil, Placeholder() :: Nil))),
   )
 
   test("f _")(assertTerm("f _")(Eta(tname("f"))))
@@ -364,18 +364,18 @@ class TermSuite extends ParseSuite {
       Defn.Val(Nil, List(patvar("x")), Some(pname("Int")), int(1)) :: Nil,
       init("A") :: Nil,
       EmptySelf(),
-      Nil
-    )))
+      Nil,
+    ))),
   )
 
   test("new { self: T => }")(assertTerm("new { self: T => }")(NewAnonymous(tpl(self("self", "T")))))
 
   test("a + (b = c)")(assertTerm("a + (b = c)")(
-    ApplyInfix(tname("a"), tname("+"), Nil, Assign(tname("b"), tname("c")) :: Nil)
+    ApplyInfix(tname("a"), tname("+"), Nil, Assign(tname("b"), tname("c")) :: Nil),
   ))
 
   test("(a = b) + c")(assertTerm("(a = b) + c")(
-    ApplyInfix(Assign(tname("a"), tname("b")), tname("+"), Nil, tname("c") :: Nil)
+    ApplyInfix(Assign(tname("a"), tname("b")), tname("+"), Nil, tname("c") :: Nil),
   ))
 
   test("a + (b = c).d")(assertTerm("a + (b = c).d")(tinfix("a", "+", tselect(Assign("b", "c"), "d"))))
@@ -385,7 +385,7 @@ class TermSuite extends ParseSuite {
   test("a + ((b: _*))")(assertTerm("a + ((b: _*))")(tinfix("a", "+", Repeated(tname("b")))))
 
   test("local class")(assertTerm("{ case class C(x: Int); }")(blk(
-    Defn.Class(List(Mod.Case()), pname("C"), Nil, ctorp(tparam("x", "Int")), tplNoBody())
+    Defn.Class(List(Mod.Case()), pname("C"), Nil, ctorp(tparam("x", "Int")), tplNoBody()),
   )))
 
   test("xml literal - 1")(
@@ -393,18 +393,18 @@ class TermSuite extends ParseSuite {
       """|{
          |  val x = <p/>
          |  val y = x
-         |}""".stripMargin
+         |}""".stripMargin,
     )(blk(
       Defn.Val(Nil, List(patvar("x")), None, Term.Xml(List(str("<p/>")), Nil)),
-      Defn.Val(Nil, List(patvar("y")), None, tname("x"))
-    ))
+      Defn.Val(Nil, List(patvar("y")), None, tname("x")),
+    )),
   )
 
   test("implicit closure")(
     assertTerm("Action { implicit request: Request[AnyContent] => Ok }")(tapply(
       tname("Action"),
-      blk(tfunc(tparam(List(Mod.Implicit()), "request", papply("Request", "AnyContent")))(tname("Ok")))
-    ))
+      blk(tfunc(tparam(List(Mod.Implicit()), "request", papply("Request", "AnyContent")))(tname("Ok"))),
+    )),
   )
 
   test("#312")(
@@ -412,21 +412,21 @@ class TermSuite extends ParseSuite {
       """|{
          |  val x = yz: (Y, Z)
          |  (x, x)
-         |}""".stripMargin
+         |}""".stripMargin,
     )(blk(
       Defn.Val(
         Nil,
         List(patvar("x")),
         None,
-        Term.Ascribe(tname("yz"), Type.Tuple(List(pname("Y"), pname("Z"))))
+        Term.Ascribe(tname("yz"), Type.Tuple(List(pname("Y"), pname("Z")))),
       ),
-      Term.Tuple(List(tname("x"), tname("x")))
-    ))
+      Term.Tuple(List(tname("x"), tname("x"))),
+    )),
   )
 
   test("spawn { var v: Int = _; ??? }")(assertTerm("spawn { var v: Int = _; ??? }")(tapply(
     tname("spawn"),
-    blk(Defn.Var(Nil, List(patvar("v")), Some(pname("Int")), None), tname("???"))
+    blk(Defn.Var(Nil, List(patvar("v")), Some(pname("Int")), None), tname("???")),
   )))
 
   test("#345")(
@@ -435,12 +435,12 @@ class TermSuite extends ParseSuite {
          |  case x => true
          |  // sobaka
          |  case y => y
-         |}""".stripMargin
+         |}""".stripMargin,
     )(tmatch(
       tname("x"),
       Case(patvar("x"), None, bool(true)),
-      Case.createWithComments(patvar("y"), None, tname("y"), begComment = Seq("// sobaka"))
-    ))
+      Case.createWithComments(patvar("y"), None, tname("y"), begComment = Seq("// sobaka")),
+    )),
   )
 
   test("a + (bs: _*) * c")(intercept[ParseException](term("a + (bs: _*) * c")))
@@ -448,15 +448,15 @@ class TermSuite extends ParseSuite {
   test("a + b: _*")(intercept[ParseException](term("a + b: _*")))
 
   test("foo(a + b: _*)")(assertTerm("foo(a + b: _*)")(
-    tapply(tname("foo"), Term.Repeated(tinfix(tname("a"), "+", tname("b"))))
+    tapply(tname("foo"), Term.Repeated(tinfix(tname("a"), "+", tname("b")))),
   ))
 
   test("a + (c, d) * e")(assertTerm("a + (c, d) * e")(
-    tinfix(tname("a"), "+", tinfix(Term.Tuple(List(tname("c"), tname("d"))), "*", tname("e")))
+    tinfix(tname("a"), "+", tinfix(Term.Tuple(List(tname("c"), tname("d"))), "*", tname("e"))),
   ))
 
   test("a * (c, d) + e")(assertTerm("a * (c, d) + e")(
-    tinfix(tinfix(tname("a"), "*", tname("c"), tname("d")), "+", tname("e"))
+    tinfix(tinfix(tname("a"), "*", tname("c"), tname("d")), "+", tname("e")),
   ))
 
   test("(a + b) c")(assertTerm("(a + b) c")(tpostfix(tinfix("a", "+", "b"), "c")))
@@ -492,37 +492,37 @@ class TermSuite extends ParseSuite {
             tinfix(
               tapplytype(tselect("arr", "cast"), papply("Ptr", "Byte")),
               "+",
-              tapplytype("sizeof", papply("Ptr", pwildcard))
+              tapplytype("sizeof", papply("Ptr", pwildcard)),
             ),
-            "cast"
+            "cast",
           ),
-          papply("Ptr", "Int")
-        )
+          papply("Ptr", "Int"),
+        ),
       ),
-      tname("length")
-    ))
+      tname("length"),
+    )),
   )
 
   test("(x ++ y)[T]")(
-    assertTerm("(x ++ y)[T]")(tapplytype(tinfix(tname("x"), "++", tname("y")), pname("T")))
+    assertTerm("(x ++ y)[T]")(tapplytype(tinfix(tname("x"), "++", tname("y")), pname("T"))),
   )
 
   test(" structHydrators map { _[K]() } ")(assertTerm(" structHydrators map { _[K]() } ")(tinfix(
     tname("structHydrators"),
     "map",
-    blk(AnonymousFunction(tapply(tapplytype(Placeholder(), pname("K")))))
+    blk(AnonymousFunction(tapply(tapplytype(Placeholder(), pname("K"))))),
   )))
 
   test(" new C()[String]() ")(
-    assertTerm(" new C()[String]() ")(tapply(tapplytype(New(init("C", Nil)), pname("String"))))
+    assertTerm(" new C()[String]() ")(tapply(tapplytype(New(init("C", Nil)), pname("String")))),
   )
 
   test("#492 parse Unit in infix operations")(
-    assertTerm("x == () :: Nil")(tinfix(tname("x"), "==", tinfix(Lit.Unit(), "::", tname("Nil"))))
+    assertTerm("x == () :: Nil")(tinfix(tname("x"), "==", tinfix(Lit.Unit(), "::", tname("Nil")))),
   )
 
   test("#492 parse hlist with Unit")(assertTerm(""""foo" :: () :: true :: HNil""")(
-    tinfix(str("foo"), "::", tinfix(Lit.Unit(), "::", tinfix(bool(true), "::", tname("HNil"))))
+    tinfix(str("foo"), "::", tinfix(Lit.Unit(), "::", tinfix(bool(true), "::", tname("HNil")))),
   ))
 
   test("nested-braces-in-paren") {
@@ -537,22 +537,22 @@ class TermSuite extends ParseSuite {
       tname("bar"),
       blk(
         Term.If(tname("foo"), blk(tapply(tname("doFoo"))), Lit.Unit()),
-        Defn.Val(Nil, List(patvar("x")), None, int(2))
+        Defn.Val(Nil, List(patvar("x")), None, int(2)),
       ),
-      Lit.Unit()
+      Lit.Unit(),
     ))
   }
 
   test("fstring-interpolation")(assertTerm("""f"\\u$oct%04x"""")(
-    Term.Interpolate(tname("f"), List(str("\\\\u"), str("%04x")), List(tname("oct")))
+    Term.Interpolate(tname("f"), List(str("\\\\u"), str("%04x")), List(tname("oct"))),
   ))
 
   test("typed-interpolation")(assertTerm("""c"something"[String]""")(
-    tapplytype(Term.Interpolate(tname("c"), List(str("something")), Nil), pname("String"))
+    tapplytype(Term.Interpolate(tname("c"), List(str("something")), Nil), pname("String")),
   ))
 
   test("interpolation-with-escaped-quotes")(assertTerm("""s"\"$t\""""")(
-    Interpolate(tname("s"), List(str("\\\""), str("\\\"")), List(tname("t")))
+    Interpolate(tname("s"), List(str("\\\""), str("\\\"")), List(tname("t"))),
   ))
 
   test("implicit-closure")(
@@ -561,13 +561,13 @@ class TermSuite extends ParseSuite {
          |  {
          |    case bar => foo
          |  }
-         |}""".stripMargin
+         |}""".stripMargin,
     )(tapply(
       tname("function"),
       blk(tfunc(tparam(List(Mod.Implicit()), "c"))(Term.PartialFunction(List(
-        Case(patvar("bar"), None, tname("foo"))
-      ))))
-    ))
+        Case(patvar("bar"), None, tname("foo")),
+      )))),
+    )),
   )
 
   test("type-partial-function") {
@@ -579,7 +579,7 @@ class TermSuite extends ParseSuite {
          |    }: PartialFunction[ThriftStructIface, Unit]
          |  }
          |)
-         |""".stripMargin
+         |""".stripMargin,
     )
 
     val expected = Defn.Val(
@@ -590,11 +590,11 @@ class TermSuite extends ParseSuite {
         tname("resharding"),
         blk(tfunc(tparam("fakePartitionId", "Int"))(Term.Ascribe(
           Term.PartialFunction(List(
-            Case(Pat.Typed(patvar("sendBox"), pselect("SendBox", "Args")), None, blk())
+            Case(Pat.Typed(patvar("sendBox"), pselect("SendBox", "Args")), None, blk()),
           )),
-          papply("PartialFunction", "ThriftStructIface", "Unit")
-        )))
-      )
+          papply("PartialFunction", "ThriftStructIface", "Unit"),
+        ))),
+      ),
     )
     assertTree(res)(expected)
   }
@@ -604,30 +604,30 @@ class TermSuite extends ParseSuite {
       """|{
          |  case true => implicit i => "xxx"
          |  case false => implicit i => i.toString
-         |}""".stripMargin
+         |}""".stripMargin,
     )(Term.PartialFunction(List(
       Case(bool(true), None, tfunc(tparam(List(Mod.Implicit()), "i"))(str("xxx"))),
-      Case(bool(false), None, tfunc(tparam(List(Mod.Implicit()), "i"))(tselect("i", "toString")))
-    )))
+      Case(bool(false), None, tfunc(tparam(List(Mod.Implicit()), "i"))(tselect("i", "toString"))),
+    ))),
   )
 
   // https://github.com/scalameta/scalameta/issues/1843
   test("anonymous-function-#1843-1")(assertTerm("_ fun (_.bar)")(AnonymousFunction(
-    ApplyInfix(Placeholder(), tname("fun"), Nil, List(AnonymousFunction(tselect(Placeholder(), "bar"))))
+    ApplyInfix(Placeholder(), tname("fun"), Nil, List(AnonymousFunction(tselect(Placeholder(), "bar")))),
   )))
   test("anonymous-function-#1843-2")(assertTerm("_ fun _.bar")(AnonymousFunction(
-    ApplyInfix(Placeholder(), tname("fun"), Nil, List(tselect(Placeholder(), "bar")))
+    ApplyInfix(Placeholder(), tname("fun"), Nil, List(tselect(Placeholder(), "bar"))),
   )))
 
   // https://scala-lang.org/files/archive/spec/2.13/06-expressions.html#placeholder-syntax-for-anonymous-functions
   test("anonymous-function-spec-1")(
-    assertTerm("_ + 1")(AnonymousFunction(ApplyInfix(Placeholder(), tname("+"), Nil, List(int(1)))))
+    assertTerm("_ + 1")(AnonymousFunction(ApplyInfix(Placeholder(), tname("+"), Nil, List(int(1))))),
   )
   test("anonymous-function-spec-2")(assertTerm("_ * _")(AnonymousFunction(
-    ApplyInfix(Placeholder(), tname("*"), Nil, List(Placeholder()))
+    ApplyInfix(Placeholder(), tname("*"), Nil, List(Placeholder())),
   )))
   test("anonymous-function-spec-3")(assertTerm("(_: Int) * 2")(AnonymousFunction(
-    ApplyInfix(Ascribe(Placeholder(), pname("Int")), tname("*"), Nil, List(int(2)))
+    ApplyInfix(Ascribe(Placeholder(), pname("Int")), tname("*"), Nil, List(int(2))),
   )))
   test("anonymous-function-spec-3.1")(
     assertTerm("1 + (_: Int) * 2 + 1")(AnonymousFunction(ApplyInfix(
@@ -635,23 +635,23 @@ class TermSuite extends ParseSuite {
         int(1),
         tname("+"),
         Nil,
-        List(ApplyInfix(Ascribe(Placeholder(), pname("Int")), tname("*"), Nil, List(int(2))))
+        List(ApplyInfix(Ascribe(Placeholder(), pname("Int")), tname("*"), Nil, List(int(2)))),
       ),
       tname("+"),
       Nil,
-      List(int(1))
-    )))
+      List(int(1)),
+    ))),
   )
   test("anonymous-function-spec-3.2")(assertTerm("(_: Int)")(Ascribe(Placeholder(), pname("Int"))))
   test("anonymous-function-spec-4")(
-    assertTerm("if (_) x else y")(AnonymousFunction(If(Placeholder(), tname("x"), tname("y"))))
+    assertTerm("if (_) x else y")(AnonymousFunction(If(Placeholder(), tname("x"), tname("y")))),
   )
   test("anonymous-function-spec-5")(
-    assertTerm("_.map(f)")(AnonymousFunction(tapply(tselect(Placeholder(), "map"), "f")))
+    assertTerm("_.map(f)")(AnonymousFunction(tapply(tselect(Placeholder(), "map"), "f"))),
   )
   test("anonymous-function-spec-6")(assertTerm("_.map(_ + 1)")(AnonymousFunction(tapply(
     tselect(Placeholder(), "map"),
-    AnonymousFunction(ApplyInfix(Placeholder(), tname("+"), Nil, List(int(1))))
+    AnonymousFunction(ApplyInfix(Placeholder(), tname("+"), Nil, List(int(1)))),
   ))))
 
   test("anonymous-function-scalafmt-1")(
@@ -663,13 +663,13 @@ class TermSuite extends ParseSuite {
         tselect(
           tapply(
             tselect(tapply(tselect(Placeholder(), "http"), "registry", "port"), "map"),
-            AnonymousFunction(tapply(tselect("Option", "apply"), Placeholder()))
+            AnonymousFunction(tapply(tselect("Option", "apply"), Placeholder())),
           ),
-          "catchSome"
+          "catchSome",
         ),
-        blk(tname("bar"))
-      )))
-    ))
+        blk(tname("bar")),
+      ))),
+    )),
   )
   test("anonymous-function-scalafmt-2")(
     assertTerm("""scalacOptions ~= (_ filterNot (_ startsWith "-Xlint"))""")(ApplyInfix(
@@ -680,15 +680,15 @@ class TermSuite extends ParseSuite {
         Placeholder(),
         tname("filterNot"),
         Nil,
-        List(AnonymousFunction(ApplyInfix(Placeholder(), tname("startsWith"), Nil, List(str("-Xlint")))))
-      )))
-    ))
+        List(AnonymousFunction(ApplyInfix(Placeholder(), tname("startsWith"), Nil, List(str("-Xlint"))))),
+      ))),
+    )),
   )
   test("anonymous-function-scalafmt-3")(assertTerm("`field-names` ~> (`private`(_: _*))")(ApplyInfix(
     tname("field-names"),
     tname("~>"),
     Nil,
-    List(Apply(tname("private"), List(Repeated(AnonymousFunction(Placeholder())))))
+    List(Apply(tname("private"), List(Repeated(AnonymousFunction(Placeholder()))))),
   )))
 
   test("(a, b, c)")(assertTerm("(a, b, c)")(Term.Tuple(List(tname("a"), tname("b"), tname("c")))))
@@ -698,13 +698,13 @@ class TermSuite extends ParseSuite {
   test("(a, b, c) :: ((a, b, c))")(assertTerm("(a, b, c) :: ((a, b, c))")(tinfix(
     Term.Tuple(List(tname("a"), tname("b"), tname("c"))),
     "::",
-    Term.Tuple(List(tname("a"), tname("b"), tname("c")))
+    Term.Tuple(List(tname("a"), tname("b"), tname("c"))),
   )))
 
   test("((a, b, c)) :: ((a, b, c))")(assertTerm("((a, b, c)) :: ((a, b, c))")(tinfix(
     Term.Tuple(List(tname("a"), tname("b"), tname("c"))),
     "::",
-    Term.Tuple(List(tname("a"), tname("b"), tname("c")))
+    Term.Tuple(List(tname("a"), tname("b"), tname("c"))),
   )))
 
   test("((a, b, c)) :: (a, b, c)")(assertTerm("((a, b, c)) :: (a, b, c)")(tinfix(
@@ -712,18 +712,18 @@ class TermSuite extends ParseSuite {
     "::",
     tname("a"),
     tname("b"),
-    tname("c")
+    tname("c"),
   )))
 
   test("#2720 infix with repeated arg last")(
-    assertTerm("a foo (b, c: _*)")(tinfix(tname("a"), "foo", tname("b"), Term.Repeated(tname("c"))))
+    assertTerm("a foo (b, c: _*)")(tinfix(tname("a"), "foo", tname("b"), Term.Repeated(tname("c")))),
   )
   test("#2720-for-comp")(assertTerm("for { `j`: Int <- Seq(4, 5, 6, 7)} yield `j`")(Term.ForYield(
     List(Enumerator.Generator(
       Pat.Typed(patvar("j"), pname("Int")),
-      tapply(tname("Seq"), int(4), int(5), int(6), int(7))
+      tapply(tname("Seq"), int(4), int(5), int(6), int(7)),
     )),
-    tname("j")
+    tname("j"),
   )))
 
   test("#2720 infix with repeated arg not last") {
@@ -744,13 +744,13 @@ class TermSuite extends ParseSuite {
     Nil,
     List(patvar("a")),
     None,
-    tapplyUsing(tapplyUsing(tapply(tname("f")), tname("a")), int(3), bool(true))
+    tapplyUsing(tapplyUsing(tapply(tname("f")), tname("a")), int(3), bool(true)),
   )))
 
   test("scala3-syntax")(runTestError[Term](
     """|() match
        |  case _: Unit => ()""".stripMargin,
-    "error: `{` expected but `case` found"
+    "error: `{` expected but `case` found",
   ))
 
   test("using") {
@@ -762,10 +762,10 @@ class TermSuite extends ParseSuite {
       """|{
          |  val using ="asdsa"; 
          |  foo(using: String) 
-         |}""".stripMargin
+         |}""".stripMargin,
     )(blk(
       Defn.Val(Nil, List(patvar("using")), None, str("asdsa")),
-      tapply(tname("foo"), Term.Ascribe(tname("using"), pname("String")))
+      tapply(tname("foo"), Term.Ascribe(tname("using"), pname("String"))),
     ))
   }
 
@@ -781,8 +781,8 @@ class TermSuite extends ParseSuite {
       tname("foo"),
       blk(tfunc(tparam(List(Mod.Implicit()), "a"))(tfunc(tparam(List(Mod.Implicit()), "b"))(
         Term
-          .Ascribe(Term.PartialFunction(List(Case(patvar("bar"), None, tname("baz")))), pname("qux"))
-      )))
+          .Ascribe(Term.PartialFunction(List(Case(patvar("bar"), None, tname("baz")))), pname("qux")),
+      ))),
     ))
   }
 
@@ -797,8 +797,8 @@ class TermSuite extends ParseSuite {
       tname("foo"),
       blk(tfunc(tparam(List(Mod.Implicit()), "a"))(blk(
         Defn.Val(Nil, List(patvar("bar")), None, tname("baz")),
-        tname("bar")
-      )))
+        tname("bar"),
+      ))),
     ))
   }
 
@@ -809,13 +809,13 @@ class TermSuite extends ParseSuite {
          |else {
          |  (Some(e), Some(f))
          |}
-         |""".stripMargin
+         |""".stripMargin,
     )(Term.If(
       tname("isEmpty"),
       Term.Tuple(List(tname("None"), tname("None"))),
       blk(Term.Tuple(List(tapply(tname("Some"), tname("e")), tapply(tname("Some"), tname("f"))))),
-      Nil
-    ))
+      Nil,
+    )),
   )
 
   test("#3050 function without body") {
@@ -825,7 +825,7 @@ class TermSuite extends ParseSuite {
          |""".stripMargin
     checkTerm(code)(tapply(
       tname("f"),
-      blk(tfunc(tparam("x1", "A"), tparam(Nil, "x2", pfunc(pname("B"))(pname("C"))))(blk()))
+      blk(tfunc(tparam("x1", "A"), tparam(Nil, "x2", pfunc(pname("B"))(pname("C"))))(blk())),
     ))
   }
 
@@ -839,7 +839,7 @@ class TermSuite extends ParseSuite {
     checkTerm(code, code)(Term.TryWithHandler(
       tname("???"),
       blk(Defn.Val(Nil, List(patvar("a")), None, int(10)), tapply(tname("handler"), tname("a"))),
-      None
+      None,
     ))
   }
 
@@ -904,10 +904,10 @@ class TermSuite extends ParseSuite {
         """|{
            |  case foo if true =>
            |    List(bar)
-           |}""".stripMargin
-      )
+           |}""".stripMargin,
+      ),
     )(Term.PartialFunction(
-      Case(patvar("foo"), Some(bool(true)), tapply(tname("List"), tname("bar"))) :: Nil
+      Case(patvar("foo"), Some(bool(true)), tapply(tname("List"), tname("bar"))) :: Nil,
     ))
   }
 
@@ -923,9 +923,9 @@ class TermSuite extends ParseSuite {
     runTestAssert[Term](code, Some(layout))(tmatch(
       Term.Annotate(
         tapply(tname("underlyingStableClassRef"), tselect("mbr", "info", "loBound")),
-        List(Mod.Annot(init("unchecked")))
+        List(Mod.Annot(init("unchecked"))),
       ),
-      Case(Pat.Typed(patvar("ref"), pname("TypeRef")), None, blk())
+      Case(Pat.Typed(patvar("ref"), pname("TypeRef")), None, blk()),
     ))
   }
 
@@ -940,9 +940,9 @@ class TermSuite extends ParseSuite {
     runTestAssert[Term](code, Some(layout))(Term.ForYield(
       List(
         Enumerator.CaseGenerator(Pat.Tuple(List(patvar("a"), patvar("b"))), tname("pairs")),
-        Enumerator.Generator(patvar("x"), tinfix(tname("a"), "to", tname("b")))
+        Enumerator.Generator(patvar("x"), tinfix(tname("a"), "to", tname("b"))),
       ),
-      tname("x")
+      tname("x"),
     ))
   }
 
@@ -968,9 +968,9 @@ class TermSuite extends ParseSuite {
       tapply(
         tselect("x2", "x3"),
         Term.PartialFunction(
-          Case(patvar("x4"), Some(tapply(tselect("x5", "x6", "x7"), "x8")), tname("x9")) :: Nil
-        )
-      )
+          Case(patvar("x4"), Some(tapply(tselect("x5", "x6", "x7"), "x8")), tname("x9")) :: Nil,
+        ),
+      ),
     ))
   }
 
@@ -985,7 +985,7 @@ class TermSuite extends ParseSuite {
          |""".stripMargin
     runTestAssert[Term](code, Some(layout))(tmatch(
       tname("obj"),
-      Case(Pat.Typed(patvar("arr"), papply("Array", papply("Array", pwildcard))), None, blk())
+      Case(Pat.Typed(patvar("arr"), papply("Array", papply("Array", pwildcard))), None, blk()),
     ))
   }
 
@@ -1013,11 +1013,11 @@ class TermSuite extends ParseSuite {
       tapply(tselect("partitions", "getOrElse"), tselect("rdd", "partitions", "indices")),
       Term.Ascribe(
         Term.PartialFunction(List(
-          Case(Pat.Tuple(List(patwildcard, patwildcard)), None, Term.Return(Lit.Unit()))
+          Case(Pat.Tuple(List(patwildcard, patwildcard)), None, Term.Return(Lit.Unit())),
         )),
-        pfunc(pname("Int"), papply("Array", "Int"))(pname("Unit"))
+        pfunc(pname("Int"), papply("Array", "Int"))(pname("Unit")),
       ),
-      blk(Term.Return(Lit.Unit()))
+      blk(Term.Return(Lit.Unit())),
     )
     runTestAssert[Term](code, Some(layout))(tree)
   }
@@ -1050,9 +1050,9 @@ class TermSuite extends ParseSuite {
       List(
         Enumerator.Generator(patvar("a"), tname("fooa")),
         Enumerator.Generator(patvar("b"), tname("foob")),
-        Enumerator.Guard(tinfix(tname("a"), "===", tname("b")))
+        Enumerator.Guard(tinfix(tname("a"), "===", tname("b"))),
       ),
-      tname("a")
+      tname("a"),
     )
     runTestAssert[Term](code, layout)(tree)
   }
@@ -1081,9 +1081,9 @@ class TermSuite extends ParseSuite {
       List(
         Enumerator.Generator(patvar("a"), tname("fooa")),
         Enumerator.Generator(patvar("b"), tname("foob")),
-        Enumerator.Guard(tinfix(tname("a"), "===", tname("b")))
+        Enumerator.Guard(tinfix(tname("a"), "===", tname("b"))),
       ),
-      tname("a")
+      tname("a"),
     )
     runTestAssert[Term](code, layout)(tree)
   }
@@ -1097,9 +1097,9 @@ class TermSuite extends ParseSuite {
     val tree = Term.ForYield(
       List(
         Enumerator.Generator(patvar("a"), tname("fooa")),
-        Enumerator.Guard(tinfix(tname("a"), ">", lit(0)))
+        Enumerator.Guard(tinfix(tname("a"), ">", lit(0))),
       ),
-      tname("a")
+      tname("a"),
     )
     runTestAssert[Term](code, layout)(tree)
   }
@@ -1113,9 +1113,9 @@ class TermSuite extends ParseSuite {
     val tree = Term.ForYield(
       List(
         Enumerator.Generator(patvar("a"), tname("fooa")),
-        Enumerator.Guard(tinfix(tname("a"), ">", lit(0)))
+        Enumerator.Guard(tinfix(tname("a"), ">", lit(0))),
       ),
-      tname("a")
+      tname("a"),
     )
     runTestAssert[Term](code, layout)(tree)
   }
@@ -1133,9 +1133,9 @@ class TermSuite extends ParseSuite {
       List(
         Enumerator.Generator(patvar("m"), tname("decls")),
         Enumerator
-          .Guard(tinfix(tinfix(tname("oneCond"), "&&", tname("cond")), "&&", tname("satisfiable")))
+          .Guard(tinfix(tinfix(tname("oneCond"), "&&", tname("cond")), "&&", tname("satisfiable"))),
       ),
-      blk()
+      blk(),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1145,13 +1145,13 @@ class TermSuite extends ParseSuite {
     ("!=", false),
     ("+=", true),
     ("~=", true),
-    (":=", true)
+    (":=", true),
   ).foreach { case (op, isAssignment) =>
     test(s"isAssignmentOp($op) == $isAssignment") {
       matchSubStructure[Term](op, { case x: Name if x.isAssignmentOp == isAssignment => })
       matchSubStructure[Term](
         s"a $op b",
-        { case x: Member.Infix if x.isAssignment == isAssignment => }
+        { case x: Member.Infix if x.isAssignment == isAssignment => },
       )
     }
   }
@@ -1181,9 +1181,9 @@ class TermSuite extends ParseSuite {
     val tree = Term.ForYield(
       Term.EnumeratorsBlock(List(
         Enumerator.Generator(patwildcard, Term.If(tname("a"), blk(tname("b")), blk(tname("c")), Nil)),
-        Enumerator.Generator(patwildcard, tname("d"))
+        Enumerator.Generator(patwildcard, tname("d")),
       )),
-      tname("e")
+      tname("e"),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1213,9 +1213,9 @@ class TermSuite extends ParseSuite {
     val tree = Term.ForYield(
       Term.EnumeratorsBlock(List(
         Enumerator.Generator(patwildcard, Term.If(tname("a"), blk(tname("b")), blk(tname("c")), Nil)),
-        Enumerator.Generator(patwildcard, tname("d"))
+        Enumerator.Generator(patwildcard, tname("d")),
       )),
-      tname("e")
+      tname("e"),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1403,7 +1403,7 @@ class TermSuite extends ParseSuite {
     val tree = tinfix(
       tinfix("foo", "::", tinfix(tinfix("bar", "==", "baz"), "::", "qux")),
       "==",
-      tinfix(tinfix("xuq", "*:", tinfix("zab", "+:", "rab")), "*", "oof")
+      tinfix(tinfix("xuq", "*:", tinfix("zab", "+:", "rab")), "*", "oof"),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1417,8 +1417,8 @@ class TermSuite extends ParseSuite {
       tinfix(
         tinfix("bar", "==", "baz"),
         "::",
-        tinfix(tinfix(tinfix("qux", "==", "xuq"), "*:", tinfix("zab", "+:", "rab")), "*", "oof")
-      )
+        tinfix(tinfix(tinfix("qux", "==", "xuq"), "*:", tinfix("zab", "+:", "rab")), "*", "oof"),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1429,7 +1429,7 @@ class TermSuite extends ParseSuite {
     val tree = tinfix(
       tinfix(tinfix("foo", "::", "bar"), "==", tinfix("baz", "::", "qux")),
       "==",
-      tinfix(tinfix("xuq", "*:", "zab"), "+:", tinfix("rab", "*", "oof"))
+      tinfix(tinfix("xuq", "*:", "zab"), "+:", tinfix("rab", "*", "oof")),
     )
     runTestAssert[Stat](code, layout)(tree)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ToplevelTermSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ToplevelTermSuite.scala
@@ -17,7 +17,7 @@ class ToplevelTermSuite extends TreeSuiteBase {
     assertEquals(tree.syntax, sourceString.lf2nl)
     val expected = Source(List(
       Defn.Def(Nil, tname("foo"), Nil, List(List(tparam("x", "Int"))), Some(pname("Int")), tname("x")),
-      tapply(tname("foo"), tname("x"))
+      tapply(tname("foo"), tname("x")),
     ))
     assertTree(tree)(expected)
   }
@@ -38,8 +38,8 @@ class ToplevelTermSuite extends TreeSuiteBase {
       List(
         Defn
           .Def(Nil, tname("foo"), Nil, List(List(tparam("x", "Int"))), Some(pname("Int")), tname("x")),
-        tapply(tname("foo"), tname("x"))
-      )
+        tapply(tname("foo"), tname("x")),
+      ),
     )))
     assertTree(tree)(expected)
   }
@@ -55,7 +55,7 @@ class ToplevelTermSuite extends TreeSuiteBase {
     assertEquals(tree.syntax, sourceString.lf2nl)
     val expected = Source(List(
       Defn.Def(Nil, tname("foo"), Nil, List(List(tparam("x", "Int"))), Some(pname("Int")), tname("x")),
-      tapply(tname("foo"), tname("x"))
+      tapply(tname("foo"), tname("x")),
     ))
     assertTree(tree)(expected)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TrailingCommaSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TrailingCommaSuite.scala
@@ -10,7 +10,7 @@ class TrailingCommaSuite extends ParseSuite {
     """trait ValDcl { val foo, bar, = 23 }""",
     """trait VarDcl { var foo, bar, = 23 }""",
     """trait VarDef { var foo, bar, = _ }""",
-    """trait PatDef { val Foo(foo), Bar(bar), = bippy }"""
+    """trait PatDef { val Foo(foo), Bar(bar), = bippy }""",
   )
 
   // Negative tests
@@ -28,7 +28,7 @@ class TrailingCommaSuite extends ParseSuite {
     """trait SimplePattern { val (foo, bar, ) = null: Any }""",
     """trait ImportSelectors { import foo.{ Ev0, Ev1, } }""",
     """trait Import { import foo.Ev0, foo.Ev1, }""",
-    """trait SimpleExpr2 { (23, ) }"""
+    """trait SimpleExpr2 { (23, ) }""",
   )
   checkOKsWithSyntax(
     """trait SimpleType2 { def f: (Int, ) }""" -> "trait SimpleType2 { def f: Int }",
@@ -47,7 +47,7 @@ class TrailingCommaSuite extends ParseSuite {
     """|trait ClassParams2 {
        |  final class C(foo: Int, bar: String)(implicit ev0: Ev0, ev1: Ev1, )
        |}""".stripMargin ->
-      "trait ClassParams2 { final class C(foo: Int, bar: String)(implicit ev0: Ev0, ev1: Ev1) }"
+      "trait ClassParams2 { final class C(foo: Int, bar: String)(implicit ev0: Ev0, ev1: Ev1) }",
   )
   // Positive tests
   checkOKs(
@@ -204,6 +204,6 @@ class TrailingCommaSuite extends ParseSuite {
        |    b: String, // a comment
        |  )
        |}
-       |""".stripMargin
+       |""".stripMargin,
   )
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TypeSuite.scala
@@ -25,7 +25,7 @@ class TypeSuite extends ParseSuite {
   test("A + B * C")(assertTpe("A + B * C")(pinfix(pinfix("A", "+", "B"), "*", "C")))
 
   test("A * B + C / D")(
-    assertTpe("A * B + C / D")(pinfix(pinfix(pinfix("A", "*", "B"), "+", "C"), "/", "D"))
+    assertTpe("A * B + C / D")(pinfix(pinfix(pinfix("A", "*", "B"), "+", "C"), "/", "D")),
   )
 
   test("f.T")(assertTpe("f.T")(pselect("f", "T")))
@@ -53,7 +53,7 @@ class TypeSuite extends ParseSuite {
   test("A { def x: A; val y: B; type C }")(assertTpe("A { def x: Int; val y: B; type C }")(Refine(
     Some(pname("A")),
     Decl.Def(Nil, "x", Nil, Nil, "Int") :: Decl.Val(Nil, List(patvar("y")), "B") ::
-      Decl.Type(Nil, pname("C"), Nil, noBounds) :: Nil
+      Decl.Type(Nil, pname("C"), Nil, noBounds) :: Nil,
   )))
 
   test("F[_ >: lo <: hi]")(assertTpe("F[_ >: lo <: hi]")(papply("F", Wildcard(bounds("lo", "hi")))))
@@ -65,11 +65,11 @@ class TypeSuite extends ParseSuite {
   test("F[_]")(assertTpe("F[_]")(papply("F", Wildcard(noBounds))))
 
   test("F[T] forSome { type T }")(assertTpe("F[T] forSome { type T }")(
-    Existential(papply("F", "T"), Decl.Type(Nil, pname("T"), Nil, noBounds) :: Nil)
+    Existential(papply("F", "T"), Decl.Type(Nil, pname("T"), Nil, noBounds) :: Nil),
   ))
 
   test("a.T forSome { val a: A }")(assertTpe("a.T forSome { val a: A }")(
-    Existential(pselect("a", "T"), Decl.Val(Nil, patvar("a") :: Nil, "A") :: Nil)
+    Existential(pselect("a", "T"), Decl.Val(Nil, patvar("a") :: Nil, "A") :: Nil),
   ))
 
   test("A | B is not a special type")(assertTpe("A | B")(pinfix("A", "|", "B")))
@@ -83,7 +83,7 @@ class TypeSuite extends ParseSuite {
     implicit val dialect = dialects.Scala3
 
     def matchSubStructureTyp3(typ: String, func: PartialFunction[Tree, Unit])(implicit
-        loc: munit.Location
+        loc: munit.Location,
     ) = matchSubStructure[Type](typ, func)(parseType, loc)
 
     assertTpe("42")(int(42))

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/UnclosedTokenSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/UnclosedTokenSuite.scala
@@ -12,80 +12,80 @@ class UnclosedTokenSuite extends ParseSuite {
     interceptMessage[ParseException](
       """|<input>:1: error: unclosed single-line string interpolation
          | s"start   
-         |           ^""".stripMargin.lf2nl
-    )(stat(""" s"start   """))
+         |           ^""".stripMargin.lf2nl,
+    )(stat(""" s"start   """)),
   )
 
   test("unclosed-string-2")(
     interceptMessage[ParseException](
       """|<input>:1: error: unclosed string literal
          | x"${1 + " 
-         |         ^""".stripMargin.lf2nl
-    )(stat(""" x"${1 + " """))
+         |         ^""".stripMargin.lf2nl,
+    )(stat(""" x"${1 + " """)),
   )
 
   test("unclosed-escape")(
     interceptMessage[ParseException](
       """|<input>:1: error: unclosed string literal
          | "start \" 
-         | ^""".stripMargin.lf2nl
-    )(stat(""" "start \" """))
+         | ^""".stripMargin.lf2nl,
+    )(stat(""" "start \" """)),
   )
 
   test("unclosed-interpolation")(
     interceptMessage[ParseException](
       """|<input>:1: error: `}` expected but `end of file` found
          | s"${1+ 
-         |        ^""".stripMargin.lf2nl
-    )(stat(""" s"${1+ """))
+         |        ^""".stripMargin.lf2nl,
+    )(stat(""" s"${1+ """)),
   )
 
   test("unclosed-char")(
     interceptMessage[ParseException](
       """|<input>:1: error: unclosed character literal
          | '.,
-         |  ^""".stripMargin.lf2nl
+         |  ^""".stripMargin.lf2nl,
     )(stat(
       """| '.,
-         |""".stripMargin
-    ))
+         |""".stripMargin,
+    )),
   )
 
   test("unclosed-char-with-NL")(
     interceptMessage[ParseException](
       """|<input>:1: error: can't use unescaped LF in character literals
          | '
-         |  ^""".stripMargin.lf2nl
+         |  ^""".stripMargin.lf2nl,
     )(stat(
       """| '
          |abc
-         |""".stripMargin
-    ))
+         |""".stripMargin,
+    )),
   )
 
   test("unclosed-multi-string-literal")(
     interceptMessage[ParseException](
       s"""|<input>:4: error: unclosed multi-line string literal
           |
-          |^""".stripMargin.lf2nl
+          |^""".stripMargin.lf2nl,
     )(stat(
       s"""|""\"
           |foo
           |""
-          |""".stripMargin
-    ))
+          |""".stripMargin,
+    )),
   )
 
   test("unclosed-comment")(
     interceptMessage[ParseException](
       """|<input>:2: error: unclosed comment
          | * foo
-         |      ^""".stripMargin.lf2nl
+         |      ^""".stripMargin.lf2nl,
     )(stat(
       """|/*
          | * foo
-         |""".stripMargin
-    ))
+         |""".stripMargin,
+    )),
   )
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/VarargParameterSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/VarargParameterSuite.scala
@@ -14,7 +14,7 @@ class VarargParameterSuite extends ParseSuite {
       Nil,
       List(List(tparam("f", Type.Repeated(pname("Int"))))),
       Some(pname("Boolean")),
-      bool(true)
+      bool(true),
     )
     check("def obj(f: Int*): Boolean = true")(obj)
   }
@@ -26,7 +26,7 @@ class VarargParameterSuite extends ParseSuite {
       Nil,
       List(List(tparam("a", "String"), tparam("b", "Boolean"), tparam("f", Type.Repeated(pname("Int"))))),
       Some(pname("Boolean")),
-      bool(true)
+      bool(true),
     )
     check("def obj(a: String, b: Boolean, f: Int*): Boolean = true")(obj)
   }
@@ -38,10 +38,10 @@ class VarargParameterSuite extends ParseSuite {
       Nil,
       List(
         List(tparam("fa", Type.Repeated(pname("Int")))),
-        List(tparam("fb", Type.Repeated(pname("Int"))))
+        List(tparam("fb", Type.Repeated(pname("Int")))),
       ),
       Some(pname("Boolean")),
-      bool(true)
+      bool(true),
     )
     check("def obj(fa: Int*)(fb: Int*): Boolean = true")(obj)
   }
@@ -53,20 +53,20 @@ class VarargParameterSuite extends ParseSuite {
       Nil,
       List(
         List(tparam("fa", Type.Repeated(pname("Int")))),
-        List(tparam(List(Mod.Implicit()), "fb", Type.Repeated(pname("Int"))))
+        List(tparam(List(Mod.Implicit()), "fb", Type.Repeated(pname("Int")))),
       ),
       Some(pname("Boolean")),
-      bool(true)
+      bool(true),
     )
     check("def obj(fa: Int*)(implicit fb: Int*): Boolean = true")(obj)
   }
 
   test("error on return type vararg parameters")(
-    checkError("def obj(f: Int*): Boolean* = true", "error: `=` expected but `identifier` found")
+    checkError("def obj(f: Int*): Boolean* = true", "error: `=` expected but `identifier` found"),
   )
 
   test("error on multiple parameters vararg not last")(
-    checkError("def obj(fa: Int*, fb: String): Boolean = true", "error: *-parameter must come last")
+    checkError("def obj(fa: Int*, fb: String): Boolean = true", "error: *-parameter must come last"),
   )
 
   test("error on repeated byname parameter") {
@@ -75,7 +75,7 @@ class VarargParameterSuite extends ParseSuite {
   }
 
   test("error on multiple vararg parameters")(
-    checkError("def obj(fa: Int*, fb: Int*) = true", "error: *-parameter must come last")
+    checkError("def obj(fa: Int*, fb: Int*) = true", "error: *-parameter must come last"),
   )
 
   test("vararg-like parameters") {
@@ -84,7 +84,7 @@ class VarargParameterSuite extends ParseSuite {
   }
 
   private def check(definition: String)(expected: scala.meta.Stat)(implicit
-      loc: munit.Location
+      loc: munit.Location,
   ): Unit = checkTree(templStat(definition))(expected)
 
   private def checkError(definition: String, expected: String)(implicit loc: munit.Location): Unit = {
@@ -101,7 +101,7 @@ class VarargParameterSuite extends ParseSuite {
       Nil,
       List(List(tparam("x", Type.Repeated(pfunc("Int")(papply("List", "Int")))))),
       Some("Int"),
-      lit(2)
+      lit(2),
     )
     check(code)(tree)
   }
@@ -111,7 +111,7 @@ class VarargParameterSuite extends ParseSuite {
     val code3 = "method1((_: Seq[Int])*)"
     val tree = tapply(
       "method1",
-      Term.Repeated(Term.AnonymousFunction(Term.Ascribe(Term.Placeholder(), papply("Seq", "Int"))))
+      Term.Repeated(Term.AnonymousFunction(Term.Ascribe(Term.Placeholder(), papply("Seq", "Int")))),
     )
     locally {
       implicit val dialect: Dialect = dialects.Scala213
@@ -119,7 +119,7 @@ class VarargParameterSuite extends ParseSuite {
       val layout = "method1((_: Seq[Int]) `*`)"
       val tree3 = tapply(
         "method1",
-        Term.AnonymousFunction(tpostfix(Term.Ascribe(Term.Placeholder(), papply("Seq", "Int")), "*"))
+        Term.AnonymousFunction(tpostfix(Term.Ascribe(Term.Placeholder(), papply("Seq", "Int")), "*")),
       )
       runTestAssert[Stat](code3, layout)(tree3)
     }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/XmlSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/XmlSuite.scala
@@ -34,7 +34,7 @@ class XmlSuite extends ParseSuite {
        |Xml.Part(<foo>bar</foo>) [0..14)
        |Xml.End [14..14)
        |EOF [14..14)
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkToken(
     "<foo>{bar}</foo> ",
@@ -50,7 +50,7 @@ class XmlSuite extends ParseSuite {
        |Xml.End [16..16)
        |Space [16..17)
        |EOF [17..17)
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkToken(
     "<b>{1}{2}</b>",
@@ -71,7 +71,7 @@ class XmlSuite extends ParseSuite {
        |Xml.Part(</b>) [9..13)
        |Xml.End [13..13)
        |EOF [13..13)
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkToken(
     """<foo>{"{" + `{`}</foo>""",
@@ -90,7 +90,7 @@ class XmlSuite extends ParseSuite {
        |Xml.Part(</foo>) [16..22)
        |Xml.End [22..22)
        |EOF [22..22)
-       |""".stripMargin
+       |""".stripMargin,
   )
   checkToken(
     "<foo/>{1}",
@@ -102,7 +102,7 @@ class XmlSuite extends ParseSuite {
        |Constant.Int(1) [7..8)
        |RightBrace [8..9)
        |EOF [9..9)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   private val trickyXml =
@@ -174,7 +174,7 @@ class XmlSuite extends ParseSuite {
        |LF [106..107)
        |RightBrace [107..108)
        |EOF [108..108)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   test("deconstruct")(assertTree(term(trickyXml))(blk(
@@ -184,8 +184,8 @@ class XmlSuite extends ParseSuite {
       None,
       Term.Xml(
         List(str("<div href="), str(">Hello "), str("</div>")),
-        List(blk(tinfix(str("/"), "+", tname("url"))), blk(tname("name")))
-      )
+        List(blk(tinfix(str("/"), "+", tname("url"))), blk(tname("name"))),
+      ),
     ),
     Defn.Val(
       Nil,
@@ -193,10 +193,10 @@ class XmlSuite extends ParseSuite {
       None,
       Term.Xml(
         List(str("<h1>"), str("</h1>")),
-        blk(tinfix(tname("msg"), "infix", tname("upper"))) :: Nil
-      )
+        blk(tinfix(tname("msg"), "infix", tname("upper"))) :: Nil,
+      ),
     ),
-    Defn.Val(Nil, List(patvar("y")), None, int(2))
+    Defn.Val(Nil, List(patvar("y")), None, int(2)),
   )))
 
   checkOKs(
@@ -303,7 +303,7 @@ class XmlSuite extends ParseSuite {
     "<a>&#;</a>",
     "<a>&#x;</a>",
     "<a>]]></a>",
-    "<a/>{0}"
+    "<a/>{0}",
   )
   // checkOK("""<a b="&:;"/>""") // FIXME
   // checkOK("""<a b="&:a;"/>""") //FIXME
@@ -326,7 +326,7 @@ class XmlSuite extends ParseSuite {
     "e match { case <a>{}</a> => ??? }",
     "<a>}</a>",
     "<a>{</a>",
-    "<a>}{</a>"
+    "<a>}{</a>",
 //    "<a></b>", // FIXME: Should not parse
   )
 
@@ -351,8 +351,8 @@ class XmlSuite extends ParseSuite {
       None,
       tmatch(
         tname("e"),
-        Case(Pat.Xml(List(lit("<title>"), lit("</title>")), List(Pat.SeqWildcard())), None, blk())
-      )
+        Case(Pat.Xml(List(lit("<title>"), lit("</title>")), List(Pat.SeqWildcard())), None, blk()),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/AndOrTypesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/AndOrTypesSuite.scala
@@ -8,7 +8,7 @@ class AndOrTypesSuite extends BaseDottySuite {
   test("A with B")(runTestAssert[Type]("A with B", None)(With(pname("A"), pname("B"))))
 
   test("A & B & C")(runTestAssert[Type]("A & B & C")(
-    ApplyInfix(ApplyInfix(pname("A"), pname("&"), pname("B")), pname("&"), pname("C"))
+    ApplyInfix(ApplyInfix(pname("A"), pname("&"), pname("B")), pname("&"), pname("C")),
   ))
 
   test("A & B")(runTestAssert[Type]("A & B")(ApplyInfix(pname("A"), pname("&"), pname("B"))))
@@ -21,25 +21,25 @@ class AndOrTypesSuite extends BaseDottySuite {
       tname("help"),
       Nil,
       List(List(tparam("id", ApplyInfix(pname("UserName"), pname("|"), pname("Password"))))),
-      pname("Unit")
+      pname("Unit"),
     ))
 
     runTestAssert[Stat]("val either: Password | UserName")(
       Decl
-        .Val(Nil, List(patvar("either")), ApplyInfix(pname("Password"), pname("|"), pname("UserName")))
+        .Val(Nil, List(patvar("either")), ApplyInfix(pname("Password"), pname("|"), pname("UserName"))),
     )
   }
 
   test("andtype-example") {
     runTestAssert[Stat]("val x: Reset & Ord[Int]")(
-      Decl.Val(Nil, List(patvar("x")), ApplyInfix(pname("Reset"), pname("&"), papply("Ord", "Int")))
+      Decl.Val(Nil, List(patvar("x")), ApplyInfix(pname("Reset"), pname("&"), papply("Ord", "Int"))),
     )
     runTestAssert[Stat]("def fx(a: List[A & B]): Unit")(Decl.Def(
       Nil,
       tname("fx"),
       Nil,
       List(List(tparam(Nil, "a", papply("List", pinfix("A", "&", "B"))))),
-      pname("Unit")
+      pname("Unit"),
     ))
   }
 
@@ -56,20 +56,20 @@ class AndOrTypesSuite extends BaseDottySuite {
           pinfix(
             pinfix(pinfix("Trait1", "&", pname("Trait2")), "&", pname("Trait3")),
             "&",
-            pname("Trait4")
+            pname("Trait4"),
           ),
           "&",
-          pname("Trait5")
+          pname("Trait5"),
         ),
-        noBounds
-      ))
+        noBounds,
+      )),
     )
     runTestAssert[Stat](
       """|object A:
          |  type AllTraits = Trait1 & Trait2 & Trait3
          |    & Trait4 & Trait5
          |""".stripMargin,
-      Some(layout)
+      Some(layout),
     )(tree)
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -12,7 +12,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
   test("old-if-single1") {
     val code = "if (cond) -a else a"
     runTestAssert[Stat](code)(
-      Term.If(tname("cond"), Term.ApplyUnary(tname("-"), tname("a")), tname("a"))
+      Term.If(tname("cond"), Term.ApplyUnary(tname("-"), tname("a")), tname("a")),
     )
   }
 
@@ -22,7 +22,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |else gx
          |""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some("if (cond) fx else gx"))(
-      Term.If(tname("cond"), tname("fx"), tname("gx"))
+      Term.If(tname("cond"), tname("fx"), tname("gx")),
     )
   }
 
@@ -35,7 +35,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin
     val output = """|if (cond) fx else gx""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.If(tname("cond"), tname("fx"), tname("gx"))
+      Term.If(tname("cond"), tname("fx"), tname("gx")),
     )
   }
 
@@ -50,7 +50,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |}
          |""".stripMargin
     runTestAssert[Stat](code)(
-      Term.If(tname("cond"), blk(tname("fa1"), tname("fa2")), blk(tname("fb1"), tname("fb2")))
+      Term.If(tname("cond"), blk(tname("fa1"), tname("fa2")), blk(tname("fb1"), tname("fb2"))),
     )
   }
 
@@ -61,7 +61,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin
     val output = "if (cond) fx else gx"
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.If(tname("cond"), tname("fx"), tname("gx"))
+      Term.If(tname("cond"), tname("fx"), tname("gx")),
     )
   }
 
@@ -74,7 +74,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin
     val output = "if (cond) fx else gx"
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.If(tname("cond"), tname("fx"), tname("gx"))
+      Term.If(tname("cond"), tname("fx"), tname("gx")),
     )
   }
 
@@ -87,7 +87,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin
     val output = "if (cond1 && cond2) gx"
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.If(tinfix(tname("cond1"), "&&", tname("cond2")), tname("gx"), Lit.Unit())
+      Term.If(tinfix(tname("cond1"), "&&", tname("cond2")), tname("gx"), Lit.Unit()),
     )
   }
 
@@ -98,7 +98,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
     val output = "if (cond1 || cond2(a1)) ok"
     runTestAssert[Stat](code, assertLayout = Some(output))(
       Term
-        .If(tinfix(tname("cond1"), "||", tapply(tname("cond2"), tname("a1"))), tname("ok"), Lit.Unit())
+        .If(tinfix(tname("cond1"), "||", tapply(tname("cond2"), tname("a1"))), tname("ok"), Lit.Unit()),
     )
   }
 
@@ -106,7 +106,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
     val code = "if (cond1).cont then ok"
     val output = "if (cond1.cont) ok"
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.If(tselect("cond1", "cont"), tname("ok"), Lit.Unit())
+      Term.If(tselect("cond1", "cont"), tname("ok"), Lit.Unit()),
     )
   }
 
@@ -128,9 +128,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
         tinfix(tname("x"), ">", int(0)),
         tapply(tname("&&"), tinfix(tname("y"), ">", int(0))),
         Lit.Unit(),
-        Nil
+        Nil,
       ),
-      tinfix(tname("x"), "+=", int(1))
+      tinfix(tname("x"), "+=", int(1)),
     ))
   }
 
@@ -145,7 +145,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
       code,
       """|error: `}` expected but `integer constant` found
          |  if (x > 0) && y > 0
-         |                    ^""".stripMargin
+         |                    ^""".stripMargin,
     )
   }
 
@@ -168,7 +168,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |}
          |""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.If(tname("cond"), blk(tname("fx1"), tname("fx2")), blk(tname("gx1"), tname("gx2")))
+      Term.If(tname("cond"), blk(tname("fx1"), tname("fx2")), blk(tname("gx1"), tname("gx2"))),
     )
   }
 
@@ -182,7 +182,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin
     val output = "fx(if (cond) A else B)"
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      tapply(tname("fx"), Term.If(tname("cond"), tname("A"), tname("B")))
+      tapply(tname("fx"), Term.If(tname("cond"), tname("A"), tname("B"))),
     )
   }
 
@@ -207,7 +207,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(tapply(
       tname("fx"),
-      Term.If(tname("cond"), blk(tname("A1"), tname("A2")), blk(tname("B1"), tname("B2")))
+      Term.If(tname("cond"), blk(tname("A1"), tname("A2")), blk(tname("B1"), tname("B2"))),
     ))
   }
 
@@ -224,7 +224,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |}
          |""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.If(tname("cond"), blk(tname("fx1"), tname("fx2")), Lit.Unit())
+      Term.If(tname("cond"), blk(tname("fx1"), tname("fx2")), Lit.Unit()),
     )
   }
 
@@ -263,7 +263,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
     runTestAssert[Stat](code, assertLayout = Some(output))(tapply(
       tname("fx"),
       Term.If(tname("cond"), blk(tname("A1"), tname("A2")), blk(tname("B1"), tname("B2"))),
-      tname("secondArg")
+      tname("secondArg"),
     ))
   }
 
@@ -284,7 +284,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |}
          |""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.Try(blk(tname("fx")), Nil, Some(blk(tname("ok"))))
+      Term.Try(blk(tname("fx")), Nil, Some(blk(tname("ok")))),
     )
   }
 
@@ -295,7 +295,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin
     val output = "try fx finally ok"
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.Try(tname("fx"), Nil, Some(tname("ok")))
+      Term.Try(tname("fx"), Nil, Some(tname("ok"))),
     )
   }
 
@@ -308,7 +308,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin
     val output = "try fx finally ok"
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.Try(tname("fx"), Nil, Some(tname("ok")))
+      Term.Try(tname("fx"), Nil, Some(tname("ok"))),
     )
   }
 
@@ -331,7 +331,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |}
          |""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.Try(blk(tname("fx"), tname("fy")), Nil, Some(blk(tname("ok1"), tname("ok2"))))
+      Term.Try(blk(tname("fx"), tname("fy")), Nil, Some(blk(tname("ok1"), tname("ok2")))),
     )
   }
 
@@ -345,7 +345,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |  case x => 1
          |}""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.Try(tname("fx"), List(Case(patvar("x"), None, int(1))), None)
+      Term.Try(tname("fx"), List(Case(patvar("x"), None, int(1))), None),
     )
   }
 
@@ -366,7 +366,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
     runTestAssert[Stat](code, assertLayout = Some(output))(Term.Try(
       tname("fx"),
       List(Case(patvar("x"), None, int(1)), Case(patvar("y"), None, int(2))),
-      None
+      None,
     ))
   }
 
@@ -386,7 +386,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |}
          |""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.Try(blk(tname("fx"), tname("fy")), List(Case(patvar("x"), None, tname("ct"))), None)
+      Term.Try(blk(tname("fx"), tname("fy")), List(Case(patvar("x"), None, tname("ct"))), None),
     )
   }
 
@@ -401,7 +401,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |}
          |""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.Try(tname("fx"), List(Case(patvar("x"), None, tname("ct"))), None)
+      Term.Try(tname("fx"), List(Case(patvar("x"), None, tname("ct"))), None),
     )
   }
 
@@ -421,7 +421,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |}
          |""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.Try(tname("fx"), List(Case(patvar("x"), None, blk(tname("fa"), tname("fb")))), None)
+      Term.Try(tname("fx"), List(Case(patvar("x"), None, blk(tname("fa"), tname("fb")))), None),
     )
   }
 
@@ -454,9 +454,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
       List(
         Case(patvar("x"), None, blk(tname("xa"), tname("xb"))),
         Case(patvar("y"), None, tname("yab")),
-        Case(patvar("z"), None, blk(tname("za"), tname("zb")))
+        Case(patvar("z"), None, blk(tname("za"), tname("zb"))),
       ),
-      None
+      None,
     ))
   }
 
@@ -469,7 +469,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin
     val output = "try foo catch bar"
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.TryWithHandler(tname("foo"), tname("bar"), None)
+      Term.TryWithHandler(tname("foo"), tname("bar"), None),
     )
   }
 
@@ -484,7 +484,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin
     val output = "try foo catch bar finally baz"
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.TryWithHandler(tname("foo"), tname("bar"), Some(tname("baz")))
+      Term.TryWithHandler(tname("foo"), tname("bar"), Some(tname("baz"))),
     )
   }
 
@@ -507,7 +507,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
     runTestAssert[Stat](code, assertLayout = Some(output))(Term.Try(
       tname("fx"),
       List(Case(patvar("x"), None, blk(tname("ax"), tname("bx")))),
-      Some(tname("fx"))
+      Some(tname("fx")),
     ))
   }
 
@@ -538,9 +538,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
       List(Case(
         patvar("x"),
         None,
-        Term.Try(tname("fy"), List(Case(patvar("y"), None, Term.Throw(tname("ex")))), None)
+        Term.Try(tname("fy"), List(Case(patvar("y"), None, Term.Throw(tname("ex")))), None),
       )),
-      Some(tname("fxclose"))
+      Some(tname("fxclose")),
     )))
   }
 
@@ -579,11 +579,11 @@ class ControlSyntaxSuite extends BaseDottySuite {
           Term.For(List(Enumerator.Generator(patvar("i"), tname("foo"))), tname("foo")),
           Term.EndMarker(tname("for")),
           tmatch(tname("foo"), Case(patvar("foo"), None, blk())),
-          Term.EndMarker(tname("match"))
+          Term.EndMarker(tname("match")),
         ),
         List(Case(patvar("f"), None, blk())),
-        None
-      ))
+        None,
+      )),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -597,7 +597,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
     val tree = Term.Try(
       Term.Try(tapply(tname("Right"), tapply(tname("f"))), Nil, Some(tapply(tselect("iter", "close")))),
       Nil,
-      Some(tapply(tselect("arena", "close")))
+      Some(tapply(tselect("arena", "close"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -613,7 +613,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
     val tree = Term.Try(
       Term.Try(tapply(tname("Right"), tapply(tname("f"))), Nil, Some(tapply(tselect("iter", "close")))),
       Nil,
-      Some(tapply(tselect("arena", "close")))
+      Some(tapply(tselect("arena", "close"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -638,12 +638,12 @@ class ControlSyntaxSuite extends BaseDottySuite {
         Case(
           Pat.Extract(tname("NonFatal"), List(patvar("ex"))),
           None,
-          tapply(tname("Left"), tname("???"))
+          tapply(tname("Left"), tname("???")),
         ) :: Nil,
-        Some(tapply(tselect("iter", "close")))
+        Some(tapply(tselect("iter", "close"))),
       ),
       Nil,
-      Some(tapply(tselect("arena", "close")))
+      Some(tapply(tselect("arena", "close"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -669,12 +669,12 @@ class ControlSyntaxSuite extends BaseDottySuite {
         Case(
           Pat.Extract(tname("NonFatal"), List(patvar("ex"))),
           None,
-          tapply(tname("Left"), tname("???"))
+          tapply(tname("Left"), tname("???")),
         ) :: Nil,
-        Some(tapply(tselect("iter", "close")))
+        Some(tapply(tselect("iter", "close"))),
       ),
       Nil,
-      Some(tapply(tselect("arena", "close")))
+      Some(tapply(tselect("arena", "close"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -700,12 +700,12 @@ class ControlSyntaxSuite extends BaseDottySuite {
         Case(
           Pat.Extract(tname("NonFatal"), List(patvar("ex"))),
           None,
-          tapply(tname("Left"), tname("???"))
+          tapply(tname("Left"), tname("???")),
         ) :: Nil,
-        Some(tapply(tselect("iter", "close")))
+        Some(tapply(tselect("iter", "close"))),
       ),
       Nil,
-      Some(tapply(tselect("arena", "close")))
+      Some(tapply(tselect("arena", "close"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -732,12 +732,12 @@ class ControlSyntaxSuite extends BaseDottySuite {
         Case(
           Pat.Extract(tname("NonFatal"), List(patvar("ex"))),
           None,
-          tapply(tname("Left"), tname("???"))
+          tapply(tname("Left"), tname("???")),
         ) :: Nil,
-        None
+        None,
       ),
       Nil,
-      Some(tapply(tselect("arena", "close")))
+      Some(tapply(tselect("arena", "close"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -759,10 +759,10 @@ class ControlSyntaxSuite extends BaseDottySuite {
       Term.Try(
         tinfix(blk(tinfix(int(1), "+", int(2))), "+", int(3)),
         Nil,
-        Some(tapply(tselect("iter", "close")))
+        Some(tapply(tselect("iter", "close"))),
       ),
       Nil,
-      Some(tapply(tselect("arena", "close")))
+      Some(tapply(tselect("arena", "close"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -784,10 +784,10 @@ class ControlSyntaxSuite extends BaseDottySuite {
       Term.Try(
         tselect(blk(tinfix(int(1), "+", int(2))), "foo"),
         Nil,
-        Some(tapply(tselect("iter", "close")))
+        Some(tapply(tselect("iter", "close"))),
       ),
       Nil,
-      Some(tapply(tselect("arena", "close")))
+      Some(tapply(tselect("arena", "close"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -842,7 +842,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
     val tree = Term.Try(
       Term.Try(tinfix(int(1), "+", int(2)), Nil, None),
       List(Case(Pat.Extract(tname("NonFatal"), List(patvar("ex"))), None, int(3))),
-      Some(tname("foo"))
+      Some(tname("foo")),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -854,7 +854,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
   test("old-for-single1") {
     val code = "for (i <- 1 to 3) work"
     runTestAssert[Stat](code)(
-      Term.For(List(Enumerator.Generator(patvar("i"), tinfix(int(1), "to", int(3)))), tname("work"))
+      Term.For(List(Enumerator.Generator(patvar("i"), tinfix(int(1), "to", int(3)))), tname("work")),
     )
   }
 
@@ -864,9 +864,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
     runTestAssert[Stat](code, assertLayout = Some(output))(Term.For(
       List(
         Enumerator.Generator(patvar("i"), tinfix(int(1), "to", int(10))),
-        Enumerator.Guard(tinfix(tname("i"), "<", int(4)))
+        Enumerator.Guard(tinfix(tname("i"), "<", int(4))),
       ),
-      tname("work")
+      tname("work"),
     ))
   }
 
@@ -881,16 +881,16 @@ class ControlSyntaxSuite extends BaseDottySuite {
     runTestAssert[Stat](code, assertLayout = Some(output))(Term.For(
       List(
         Enumerator.Generator(patvar("i"), tname("gen")),
-        Enumerator.Guard(tinfix(tname("i"), "<", int(4)))
+        Enumerator.Guard(tinfix(tname("i"), "<", int(4))),
       ),
-      tname("work")
+      tname("work"),
     ))
   }
 
   test("old-for-yield-single1") {
     val code = "for (i <- 1 to 3) yield i"
     runTestAssert[Stat](code)(
-      Term.ForYield(List(Enumerator.Generator(patvar("i"), tinfix(int(1), "to", int(3)))), tname("i"))
+      Term.ForYield(List(Enumerator.Generator(patvar("i"), tinfix(int(1), "to", int(3)))), tname("i")),
     )
   }
 
@@ -898,7 +898,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
     val code = "for { i <- gen } yield i"
     val output = "for (i <- gen) yield i"
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.ForYield(List(Enumerator.Generator(patvar("i"), tname("gen"))), tname("i"))
+      Term.ForYield(List(Enumerator.Generator(patvar("i"), tname("gen"))), tname("i")),
     )
   }
 
@@ -910,7 +910,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |  b
          |}""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.ForYield(List(Enumerator.Generator(patvar("i"), tname("gen"))), blk(tname("a"), tname("b")))
+      Term.ForYield(List(Enumerator.Generator(patvar("i"), tname("gen"))), blk(tname("a"), tname("b"))),
     )
   }
 
@@ -929,9 +929,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
     runTestAssert[Stat](code, assertLayout = Some(output))(Term.ForYield(
       List(
         Enumerator.Generator(patvar("i"), tname("gen")),
-        Enumerator.Guard(tinfix(tname("i"), "<", int(4)))
+        Enumerator.Guard(tinfix(tname("i"), "<", int(4))),
       ),
-      blk(tname("aa"), tname("bb"))
+      blk(tname("aa"), tname("bb")),
     ))
   }
 
@@ -939,7 +939,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
     val code = "for a <- gen do fx"
     val output = "for (a <- gen) fx"
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.For(List(Enumerator.Generator(patvar("a"), tname("gen"))), tname("fx"))
+      Term.For(List(Enumerator.Generator(patvar("a"), tname("gen"))), tname("fx")),
     )
   }
 
@@ -951,7 +951,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin
     val output = "for (a <- gen) fx"
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.For(List(Enumerator.Generator(patvar("a"), tname("gen"))), tname("fx"))
+      Term.For(List(Enumerator.Generator(patvar("a"), tname("gen"))), tname("fx")),
     )
   }
 
@@ -963,7 +963,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
     val output = "for (a <- gen; if cnd) fx"
     runTestAssert[Stat](code, assertLayout = Some(output))(Term.For(
       List(Enumerator.Generator(patvar("a"), tname("gen")), Enumerator.Guard(tname("cnd"))),
-      tname("fx")
+      tname("fx"),
     ))
   }
 
@@ -975,7 +975,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin
     val output = "for (a <- gen) fx"
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.For(List(Enumerator.Generator(patvar("a"), tname("gen"))), tname("fx"))
+      Term.For(List(Enumerator.Generator(patvar("a"), tname("gen"))), tname("fx")),
     )
   }
 
@@ -990,9 +990,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
     runTestAssert[Stat](code, assertLayout = Some(output))(Term.For(
       List(
         Enumerator.Generator(patvar("a"), tname("x")),
-        Enumerator.Generator(patvar("b"), tname("y"))
+        Enumerator.Generator(patvar("b"), tname("y")),
       ),
-      tname("fx")
+      tname("fx"),
     ))
   }
 
@@ -1014,9 +1014,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
     runTestAssert[Stat](code, assertLayout = Some(output))(Term.For(
       List(
         Enumerator.Generator(patvar("a"), tname("x")),
-        Enumerator.Generator(patvar("b"), tname("y"))
+        Enumerator.Generator(patvar("b"), tname("y")),
       ),
-      blk(tname("fx"), tname("fy"))
+      blk(tname("fx"), tname("fy")),
     ))
   }
 
@@ -1033,7 +1033,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |}
          |""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.For(List(Enumerator.Generator(patvar("a"), tname("x"))), blk(tname("fx"), tname("fy")))
+      Term.For(List(Enumerator.Generator(patvar("a"), tname("x"))), blk(tname("fx"), tname("fy"))),
     )
   }
 
@@ -1050,7 +1050,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |}
          |""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.For(List(Enumerator.Generator(patvar("a"), tname("x"))), blk(tname("fx"), tname("fy")))
+      Term.For(List(Enumerator.Generator(patvar("a"), tname("x"))), blk(tname("fx"), tname("fy"))),
     )
   }
 
@@ -1065,9 +1065,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
     runTestAssert[Stat](code, assertLayout = Some(output))(Term.ForYield(
       List(
         Enumerator.Generator(patvar("a"), tname("x")),
-        Enumerator.Generator(patvar("b"), tname("y"))
+        Enumerator.Generator(patvar("b"), tname("y")),
       ),
-      tname("fx")
+      tname("fx"),
     ))
   }
 
@@ -1079,7 +1079,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
     val output = "for (a <- gen; if cnd) yield fx"
     runTestAssert[Stat](code, assertLayout = Some(output))(Term.ForYield(
       List(Enumerator.Generator(patvar("a"), tname("gen")), Enumerator.Guard(tname("cnd"))),
-      tname("fx")
+      tname("fx"),
     ))
   }
 
@@ -1092,7 +1092,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
     val output = "for (a <- gen; if cnd) yield fx"
     runTestAssert[Stat](code, assertLayout = Some(output))(Term.ForYield(
       List(Enumerator.Generator(patvar("a"), tname("gen")), Enumerator.Guard(tname("cnd"))),
-      tname("fx")
+      tname("fx"),
     ))
   }
 
@@ -1114,9 +1114,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
     runTestAssert[Stat](code, assertLayout = Some(output))(Term.ForYield(
       List(
         Enumerator.Generator(patvar("a"), tname("x")),
-        Enumerator.Generator(patvar("b"), tname("y"))
+        Enumerator.Generator(patvar("b"), tname("y")),
       ),
-      blk(tname("fx"), tname("fy"))
+      blk(tname("fx"), tname("fy")),
     ))
   }
 
@@ -1130,7 +1130,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(Term.For(
       List(Enumerator.CaseGenerator(Pat.Typed(patvar("a"), pname("TP")), tname("iter"))),
-      tname("echo")
+      tname("echo"),
     ))
   }
 
@@ -1145,9 +1145,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
     runTestAssert[Stat](code, assertLayout = Some(output))(Term.For(
       List(
         Enumerator.CaseGenerator(Pat.Typed(patvar("a"), pname("TP")), tname("iter")),
-        Enumerator.Guard(tname("cnd"))
+        Enumerator.Guard(tname("cnd")),
       ),
-      tname("echo")
+      tname("echo"),
     ))
   }
 
@@ -1166,9 +1166,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
         Enumerator.Generator(patvar("x"), tname("gen")),
         Enumerator.CaseGenerator(Pat.Typed(patvar("a1"), pname("TP")), tname("iter1")),
         Enumerator.Guard(tname("cnd")),
-        Enumerator.CaseGenerator(Pat.Typed(patvar("a2"), pname("TP")), tname("iter2"))
+        Enumerator.CaseGenerator(Pat.Typed(patvar("a2"), pname("TP")), tname("iter2")),
       ),
-      tname("fn")
+      tname("fn"),
     ))
   }
 
@@ -1184,9 +1184,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
       List(
         Enumerator.Generator(patvar("i"), tname("gen")),
         Enumerator.Val(patvar("x"), int(3)),
-        Enumerator.Guard(tinfix(tname("cnd1"), "&&", tname("cnd2")))
+        Enumerator.Guard(tinfix(tname("cnd1"), "&&", tname("cnd2"))),
       ),
-      tname("work")
+      tname("work"),
     ))
   }
 
@@ -1202,9 +1202,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
       List(
         Enumerator.Generator(Pat.Tuple(List(patvar("a"), patvar("b"))), tname("gen")),
         Enumerator.Guard(tinfix(tname("a"), "<", int(5))),
-        Enumerator.Generator(patvar("c"), tname("otherGen"))
+        Enumerator.Generator(patvar("c"), tname("otherGen")),
       ),
-      tname("c")
+      tname("c"),
     ))
   }
 
@@ -1219,9 +1219,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
     runTestAssert[Stat](code, assertLayout = Some(output))(Term.ForYield(
       List(Enumerator.Generator(
         Pat.Tuple(List(patvar("arg"), patvar("param"))),
-        tapply(tselect("args", "zip"), tname("vparams"))
+        tapply(tselect("args", "zip"), tname("vparams")),
       )),
-      tname("arg")
+      tname("arg"),
     ))
   }
 
@@ -1238,9 +1238,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
       List(
         Enumerator.Generator(patvar("m"), tname("decls")),
         Enumerator
-          .Guard(tinfix(tinfix(tname("oneCond"), "&&", tname("cond")), "&&", tname("satisfiable")))
+          .Guard(tinfix(tinfix(tname("oneCond"), "&&", tname("cond")), "&&", tname("satisfiable"))),
       ),
-      blk()
+      blk(),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1256,9 +1256,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
     val tree = Term.ForYield(
       List(
         Enumerator.Val(patvar("a"), lit(1)),
-        Enumerator.Generator(patvar("b"), tapply(tname("Some"), lit(2)))
+        Enumerator.Generator(patvar("b"), tapply(tname("Some"), lit(2))),
       ),
-      tinfix(tname("a"), "+", tname("b"))
+      tinfix(tname("a"), "+", tname("b")),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1276,9 +1276,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
       List(
         Enumerator.Val(patvar("a"), lit(1)),
         Enumerator.Generator(patvar("b"), tapply(tname("Some"), lit(2))),
-        Enumerator.Val(patvar("c"), lit(3))
+        Enumerator.Val(patvar("c"), lit(3)),
       ),
-      tinfix(tinfix(tname("a"), "+", tname("b")), "+", tname("c"))
+      tinfix(tinfix(tname("a"), "+", tname("b")), "+", tname("c")),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1296,9 +1296,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
       List(
         Enumerator.Val(patvar("a"), lit(1)),
         Enumerator.Val(patvar("b"), lit(3)),
-        Enumerator.Generator(patvar("c"), tapply(tname("Some"), lit(4)))
+        Enumerator.Generator(patvar("c"), tapply(tname("Some"), lit(4))),
       ),
-      tinfix(tinfix(tname("a"), "+", tname("b")), "+", tname("c"))
+      tinfix(tinfix(tname("a"), "+", tname("b")), "+", tname("c")),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1318,9 +1318,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
         Enumerator.Val(patvar("a"), lit(1)),
         Enumerator.Generator(patvar("b"), tapply(tname("Some"), lit(2))),
         Enumerator.Val(patvar("c"), lit(3)),
-        Enumerator.Generator(patvar("d"), tapply(tname("Some"), lit(4)))
+        Enumerator.Generator(patvar("d"), tapply(tname("Some"), lit(4))),
       ),
-      tinfix(tinfix(tinfix(tname("a"), "+", tname("b")), "+", tname("c")), "+", tname("d"))
+      tinfix(tinfix(tinfix(tname("a"), "+", tname("b")), "+", tname("c")), "+", tname("d")),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1342,9 +1342,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
         Enumerator.Generator(patvar("b"), tapply(tname("Some"), lit(2))),
         Enumerator.Guard(tinfix(tname("b"), ">", lit(0))),
         Enumerator.Val(patvar("c"), lit(3)),
-        Enumerator.Generator(patvar("d"), tapply(tname("Some"), lit(4)))
+        Enumerator.Generator(patvar("d"), tapply(tname("Some"), lit(4))),
       ),
-      tinfix(tinfix(tinfix(tname("a"), "+", tname("b")), "+", tname("c")), "+", tname("d"))
+      tinfix(tinfix(tinfix(tname("a"), "+", tname("b")), "+", tname("c")), "+", tname("d")),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1366,9 +1366,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
         Enumerator.Generator(patvar("b"), tapply(tname("Some"), lit(2))),
         Enumerator.Val(patvar("c"), lit(3)),
         Enumerator.Guard(tinfix(tname("b"), ">", lit(0))),
-        Enumerator.Generator(patvar("d"), tapply(tname("Some"), lit(4)))
+        Enumerator.Generator(patvar("d"), tapply(tname("Some"), lit(4))),
       ),
-      tinfix(tinfix(tinfix(tname("a"), "+", tname("b")), "+", tname("c")), "+", tname("d"))
+      tinfix(tinfix(tinfix(tname("a"), "+", tname("b")), "+", tname("c")), "+", tname("d")),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1386,9 +1386,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
       List(
         Enumerator.Val(patvar("a"), lit(1)),
         Enumerator.Guard(tinfix(tname("b"), ">", lit(0))),
-        Enumerator.Generator(patvar("b"), tapply(tname("Some"), lit(2)))
+        Enumerator.Generator(patvar("b"), tapply(tname("Some"), lit(2))),
       ),
-      tinfix(tname("a"), "+", tname("b"))
+      tinfix(tname("a"), "+", tname("b")),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1404,7 +1404,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
       code,
       """|error: illegal start of simple pattern
          |  if a > 0
-         |  ^""".stripMargin
+         |  ^""".stripMargin,
     )
   }
 
@@ -1423,9 +1423,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
         Enumerator.Val(patvar("a"), lit(1)),
         Enumerator.Val(patvar("b"), lit(3)),
         Enumerator.Guard(tinfix(tname("b"), ">", lit(0))),
-        Enumerator.Generator(patvar("c"), tapply(tname("Some"), lit(2)))
+        Enumerator.Generator(patvar("c"), tapply(tname("Some"), lit(2))),
       ),
-      tinfix(tinfix(tname("a"), "+", tname("b")), "+", tname("c"))
+      tinfix(tinfix(tname("a"), "+", tname("b")), "+", tname("c")),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1489,7 +1489,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |  gx
          |}""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.While(tname("cond"), blk(tname("fx"), tname("gx")))
+      Term.While(tname("cond"), blk(tname("fx"), tname("gx"))),
     )
   }
 
@@ -1509,7 +1509,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |}
          |""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.While(tinfix(tname("fx"), "+", tname("fy")), blk(tname("fx"), tname("fy")))
+      Term.While(tinfix(tname("fx"), "+", tname("fy")), blk(tname("fx"), tname("fy"))),
     )
   }
 
@@ -1532,7 +1532,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |}
          |""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.While(blk(tname("s1"), tname("s2")), blk(tname("fx"), tname("fy")))
+      Term.While(blk(tname("s1"), tname("s2")), blk(tname("fx"), tname("fy"))),
     )
   }
 
@@ -1555,7 +1555,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
       Nil,
       List(List()),
       Some(pname("String")),
-      blk(Term.While(tname("cond"), blk()), tapply(tname("other")))
+      blk(Term.While(tname("cond"), blk()), tapply(tname("other"))),
     ))
   }
 
@@ -1568,7 +1568,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
     val output = "while (x > 0 && y > 0) x += 1"
     runTestAssert[Stat](code, assertLayout = Some(output))(Term.While(
       tinfix(tinfix(tname("x"), ">", int(0)), "&&", tinfix(tname("y"), ">", int(0))),
-      tinfix(tname("x"), "+=", int(1))
+      tinfix(tname("x"), "+=", int(1)),
     ))
   }
 
@@ -1582,7 +1582,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
     val output = "while (x > 0 && y > 0) x += 1"
     runTestAssert[Stat](code, assertLayout = Some(output))(Term.While(
       tinfix(tinfix(tname("x"), ">", int(0)), "&&", tinfix(tname("y"), ">", int(0))),
-      tinfix(tname("x"), "+=", int(1))
+      tinfix(tname("x"), "+=", int(1)),
     ))
   }
 
@@ -1590,7 +1590,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
     val output = "while (x > 0 and y > 0) x += 1"
     val expected = Term.While(
       tinfix(tinfix(tname("x"), ">", int(0)), "and", tinfix(tname("y"), ">", int(0))),
-      tinfix(tname("x"), "+=", int(1))
+      tinfix(tname("x"), "+=", int(1)),
     )
 
     val code1 =
@@ -1621,9 +1621,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
         tinfix(tname("sym"), "==", tselect("defn", "ByteClass")),
         tapplytype(tname("classOf"), pname("Byte")),
         Lit.Unit(),
-        Nil
+        Nil,
       ),
-      Nil
+      Nil,
     )
     runTestAssert[Stat](code, Some(layout))(expected)
   }
@@ -1645,9 +1645,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
         tinfix(tname("sym"), "==", tselect("defn", "ByteClass")),
         tapplytype(tname("classOf"), pname("Byte")),
         Lit.Unit(),
-        Nil
+        Nil,
       ),
-      Nil
+      Nil,
     )
     runTestAssert[Stat](code, Some(layout))(expected)
   }
@@ -1667,7 +1667,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin
     runTestAssert[Stat](code, Some(layout))(blk(
       Term.While(tinfix(tname("x"), ">", int(0)), tapply(tname("&&"), tinfix(tname("y"), ">", int(0)))),
-      tinfix(tname("x"), "+=", int(1))
+      tinfix(tname("x"), "+=", int(1)),
     ))
   }
 
@@ -1682,7 +1682,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
       code,
       """|error: `}` expected but `integer constant` found
          |  while (x > 0) && y > 0
-         |                       ^""".stripMargin
+         |                       ^""".stripMargin,
     )
   }
 
@@ -1703,7 +1703,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
       pname("A"),
       Nil,
       EmptyCtor(),
-      tpl(self("slf"), Defn.Val(Nil, List(patvar("x")), None, int(3)))
+      tpl(self("slf"), Defn.Val(Nil, List(patvar("x")), None, int(3))),
     ))
   }
 
@@ -1729,7 +1729,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |}
          |""".stripMargin
     runTestAssert[Stat](code)(
-      tmatch(tname("x"), Case(int(1), None, str("1")), Case(int(2), None, str("2")))
+      tmatch(tname("x"), Case(int(1), None, str("1")), Case(int(2), None, str("2"))),
     )
   }
 
@@ -1747,7 +1747,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
     runTestAssert[Stat](code)(tmatch(
       tname("x"),
       Case(int(1), None, blk(tname("a1"), tname("b1"))),
-      Case(int(2), None, blk(tname("a2"), tname("b2")))
+      Case(int(2), None, blk(tname("a2"), tname("b2"))),
     ))
   }
 
@@ -1766,7 +1766,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
     runTestAssert[Stat](code)(tmatch(
       tname("x"),
       Case(int(1), None, tmatch(tname("y"), Case(int(5), None, str("5")), Case(int(6), None, str("6")))),
-      Case(int(2), None, str("2"))
+      Case(int(2), None, str("2")),
     ))
   }
 
@@ -1783,7 +1783,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |}
          |""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      tmatch(tname("x"), Case(int(1), None, blk()), Case(int(2), None, blk()))
+      tmatch(tname("x"), Case(int(1), None, blk()), Case(int(2), None, blk())),
     )
   }
 
@@ -1800,7 +1800,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |}
          |""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      tmatch(tname("x"), Case(int(1), None, str("1")), Case(int(2), None, str("2")))
+      tmatch(tname("x"), Case(int(1), None, str("1")), Case(int(2), None, str("2"))),
     )
   }
 
@@ -1827,7 +1827,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
     runTestAssert[Stat](code, assertLayout = Some(output))(tmatch(
       tname("x"),
       Case(int(1), None, blk(tname("a1"), tname("b1"))),
-      Case(int(2), None, blk(tname("a2"), tname("b2")))
+      Case(int(2), None, blk(tname("a2"), tname("b2"))),
     ))
   }
 
@@ -1848,7 +1848,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin
 
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      tmatch(tname("cond"), Case(patvar("a"), None, tname("fa")), Case(patvar("b"), None, tname("fb")))
+      tmatch(tname("cond"), Case(patvar("a"), None, tname("fa")), Case(patvar("b"), None, tname("fb"))),
     )
   }
 
@@ -1881,8 +1881,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
       blk(
         Term.Match(tname("x"), List(Case(int(1), None, str("OK")), Case(int(2), None, str("ERROR")))),
         Defn.Val(Nil, List(patvar("c")), None, str("123")),
-        tname("c")
-      )
+        tname("c"),
+      ),
     ))
   }
 
@@ -1909,7 +1909,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
       Nil,
       Nil,
       Some(pname("String")),
-      blk(tmatch(tname("x"), Case(int(2), None, str("ERROR"))), Term.EndMarker(tname("match")))
+      blk(tmatch(tname("x"), Case(int(2), None, str("ERROR"))), Term.EndMarker(tname("match"))),
     ))
   }
 
@@ -1929,7 +1929,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
     runTestAssert[Stat](code, assertLayout = Some(output))(Term.Try(
       tmatch(tname("func"), Case(tname("A"), None, tname("Accept"))),
       List(Case(patvar("ex"), None, tname("Error"))),
-      None
+      None,
     ))
   }
 
@@ -1948,7 +1948,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |   b()
          |}
          |""".stripMargin,
-      assertLayout = Some(expected)
+      assertLayout = Some(expected),
     )(tmatch(tname("x"), Case(patvar("x"), None, blk(tapply(tname("a")), tapply(tname("b"))))))
   }
 
@@ -1967,10 +1967,10 @@ class ControlSyntaxSuite extends BaseDottySuite {
       tmatch(
         tname("xs"),
         Case(tname("Nil"), None, str("empty")),
-        Case(patinfix(patvar("x"), "::", patvar("xs1")), None, str("nonempty"))
+        Case(patinfix(patvar("x"), "::", patvar("xs1")), None, str("nonempty")),
       ),
       Case(str("empty"), None, int(0)),
-      Case(str("nonempty"), None, int(1))
+      Case(str("nonempty"), None, int(1)),
     )
 
     runTestAssert[Stat](
@@ -1982,7 +1982,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |  case "nonempty" => 1
          |}
          |""".stripMargin,
-      layout
+      layout,
     )(tree)
 
     runTestAssert[Stat](
@@ -1993,7 +1993,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |case "empty" => 0
          |case "nonempty" => 1
          |""".stripMargin,
-      layout
+      layout,
     )(tree)
   }
 
@@ -2016,8 +2016,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
       Case(
         patinfix(patvar("x"), "::", patvar("xs1")),
         None,
-        tmatch(str("nonempty"), Case(str("empty"), None, int(0)), Case(str("nonempty"), None, int(1)))
-      )
+        tmatch(str("nonempty"), Case(str("empty"), None, int(0)), Case(str("nonempty"), None, int(1))),
+      ),
     )
 
     runTestAssert[Stat](
@@ -2029,7 +2029,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |  }
          |}
          |""".stripMargin,
-      layout
+      layout,
     )(tree)
 
     runTestAssert[Stat](
@@ -2041,7 +2041,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |    case "nonempty" => 1
          |
          |""".stripMargin,
-      layout
+      layout,
     )(tree)
   }
 
@@ -2063,8 +2063,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
            |  case true => 0
            |  case false => 1
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Val(
       Nil,
       List(patvar("hello")),
@@ -2074,14 +2074,14 @@ class ControlSyntaxSuite extends BaseDottySuite {
           tmatch(
             tname("xs"),
             Case(tname("Nil"), None, str("empty")),
-            Case(patinfix(patvar("x"), "::", patvar("xs1")), None, str("nonempty"))
+            Case(patinfix(patvar("x"), "::", patvar("xs1")), None, str("nonempty")),
           ),
           "startsWith",
-          str("empty")
+          str("empty"),
         ),
         Case(bool(true), None, int(0)),
-        Case(bool(false), None, int(1))
-      )
+        Case(bool(false), None, int(1)),
+      ),
     ))
 
   }
@@ -2103,8 +2103,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
            |  case 1 => true
            |  case 2 => false
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Val(
       Nil,
       List(patvar("hello")),
@@ -2114,14 +2114,14 @@ class ControlSyntaxSuite extends BaseDottySuite {
           tmatch(
             tname("xs"),
             Case(tname("Nil"), None, int(0)),
-            Case(patinfix(patvar("x"), "::", patvar("xs1")), None, int(1))
+            Case(patinfix(patvar("x"), "::", patvar("xs1")), None, int(1)),
           ),
           "+",
-          int(1)
+          int(1),
         ),
         Case(int(1), None, bool(true)),
-        Case(int(2), None, bool(false))
-      )
+        Case(int(2), None, bool(false)),
+      ),
     ))
   }
 
@@ -2142,8 +2142,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
            |  case 1 => true
            |  case 2 => false
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Val(
       Nil,
       List(patvar("hello")),
@@ -2153,14 +2153,14 @@ class ControlSyntaxSuite extends BaseDottySuite {
           tmatch(
             tinfix(int(1), "+", tname("xs")),
             Case(tname("Nil"), None, int(0)),
-            Case(patinfix(patvar("x"), "::", patvar("xs1")), None, int(1))
+            Case(patinfix(patvar("x"), "::", patvar("xs1")), None, int(1)),
           ),
           "+",
-          int(1)
+          int(1),
         ),
         Case(int(1), None, bool(true)),
-        Case(int(2), None, bool(false))
-      )
+        Case(int(2), None, bool(false)),
+      ),
     ))
   }
 
@@ -2182,8 +2182,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
            |  case 1 => true
            |  case 2 => false
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Val(
       Nil,
       List(patvar("hello")),
@@ -2193,14 +2193,14 @@ class ControlSyntaxSuite extends BaseDottySuite {
           tmatch(
             tinfix(int(1), "+", tname("xs")),
             Case(tname("Nil"), None, int(0)),
-            Case(patinfix(patvar("x"), "::", patvar("xs1")), None, int(1))
+            Case(patinfix(patvar("x"), "::", patvar("xs1")), None, int(1)),
           ),
           "+",
-          int(1)
+          int(1),
         ),
         Case(int(1), None, bool(true)),
-        Case(int(2), None, bool(false))
-      )
+        Case(int(2), None, bool(false)),
+      ),
     ))
   }
 
@@ -2221,8 +2221,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
            |}) foo 1 match {
            |  case 1 => true
            |  case 2 => false
-           |}""".stripMargin
-      )
+           |}""".stripMargin,
+      ),
     )(Defn.Val(
       Nil,
       List(patvar("hello")),
@@ -2232,14 +2232,14 @@ class ControlSyntaxSuite extends BaseDottySuite {
           tmatch(
             tinfix(int(1), "foo", tname("xs")),
             Case(tname("Nil"), None, int(0)),
-            Case(patinfix(patvar("x"), "::", patvar("xs1")), None, int(1))
+            Case(patinfix(patvar("x"), "::", patvar("xs1")), None, int(1)),
           ),
           "foo",
-          int(1)
+          int(1),
         ),
         Case(int(1), None, bool(true)),
-        Case(int(2), None, bool(false))
-      )
+        Case(int(2), None, bool(false)),
+      ),
     ))
   }
 
@@ -2260,8 +2260,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
            |}) foo 1 match {
            |  case 1 => true
            |  case 2 => false
-           |}""".stripMargin
-      )
+           |}""".stripMargin,
+      ),
     )(Defn.Val(
       Nil,
       List(patvar("hello")),
@@ -2271,14 +2271,14 @@ class ControlSyntaxSuite extends BaseDottySuite {
           tmatch(
             tinfix(int(1), "foo", tname("xs")),
             Case(tname("Nil"), None, int(0)),
-            Case(patinfix(patvar("x"), "::", patvar("xs1")), None, int(1))
+            Case(patinfix(patvar("x"), "::", patvar("xs1")), None, int(1)),
           ),
           "foo",
-          int(1)
+          int(1),
         ),
         Case(int(1), None, bool(true)),
-        Case(int(2), None, bool(false))
-      )
+        Case(int(2), None, bool(false)),
+      ),
     ))
   }
 
@@ -2305,8 +2305,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
            |    case 1 => true
            |    case 2 => false
            |  }
-           |}""".stripMargin
-      )
+           |}""".stripMargin,
+      ),
     )(blk(
       Defn.Val(
         Nil,
@@ -2315,11 +2315,11 @@ class ControlSyntaxSuite extends BaseDottySuite {
         tmatch(
           tinfix(int(1), "foo", tname("xs")),
           Case(tname("Nil"), None, int(0)),
-          Case(patinfix(patvar("x"), "::", patvar("xs1")), None, int(1))
-        )
+          Case(patinfix(patvar("x"), "::", patvar("xs1")), None, int(1)),
+        ),
       ),
       Term.EndMarker(tname("match")),
-      tmatch(tname("foo"), Case(int(1), None, bool(true)), Case(int(2), None, bool(false)))
+      tmatch(tname("foo"), Case(int(1), None, bool(true)), Case(int(2), None, bool(false))),
     ))
   }
 
@@ -2340,12 +2340,12 @@ class ControlSyntaxSuite extends BaseDottySuite {
            |    }
            |  case b =>
            |    baz
-           |}""".stripMargin
-      )
+           |}""".stripMargin,
+      ),
     )(tmatch(
       tname("foo"),
       Case(patvar("a"), None, tmatch(tname("bar"), Case(patvar("aa"), None, blk()))),
-      Case(patvar("b"), None, tname("baz"))
+      Case(patvar("b"), None, tname("baz")),
     ))
   }
 
@@ -2361,8 +2361,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin,
       Some(
         """|def foo = if ((bar eq baz) && qux != xyz) found else notfound
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Def(
       Nil,
       tname("foo"),
@@ -2372,12 +2372,12 @@ class ControlSyntaxSuite extends BaseDottySuite {
         tinfix(
           tinfix(tname("bar"), "eq", tname("baz")),
           "&&",
-          tinfix(tname("qux"), "!=", tname("xyz"))
+          tinfix(tname("qux"), "!=", tname("xyz")),
         ),
         tname("found"),
         tname("notfound"),
-        Nil
-      )
+        Nil,
+      ),
     ))
   }
 
@@ -2393,8 +2393,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin,
       Some(
         """|def foo = if ((bar eq baz).qux) found else notfound
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Def(
       Nil,
       tname("foo"),
@@ -2404,8 +2404,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
         tselect(tinfix(tname("bar"), "eq", tname("baz")), "qux"),
         tname("found"),
         tname("notfound"),
-        Nil
-      )
+        Nil,
+      ),
     ))
   }
 
@@ -2413,7 +2413,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
     val expected = Term.If(
       tselectmatch("xs", Case("Nil", None, bool(false)), Case(patwildcard, None, bool(true))),
       str("nonempty"),
-      str("empty")
+      str("empty"),
     )
     runTestAssert[Stat](
       """|if xs.match {
@@ -2427,7 +2427,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |  case Nil => false
          |  case _ => true
          |}) "nonempty" else "empty"
-         |""".stripMargin
+         |""".stripMargin,
     )(expected)
   }
 
@@ -2440,8 +2440,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
       Some(pname("String")),
       tapply(tselect(
         tselectmatch("x", Case(int(1), None, str("1")), Case(patwildcard, None, str("ERR"))),
-        "trim"
-      ))
+        "trim",
+      )),
     )
 
     runTestAssert[Stat](
@@ -2455,7 +2455,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |  case 1 => "1"
          |  case _ => "ERR"
          |}.trim()
-         |""".stripMargin
+         |""".stripMargin,
     )(expected)
   }
 
@@ -2473,7 +2473,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
     runTestAssert[Stat](code, assertLayout = Some(expected))(tapply(
       tname("fx"),
       tname("p1"),
-      Term.Try(tapply(tname("func")), List(Case(patvar("x"), None, tapply(tname("ok")))), None)
+      Term.Try(tapply(tname("func")), List(Case(patvar("x"), None, tapply(tname("ok")))), None),
     ))
   }
 
@@ -2495,7 +2495,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
     runTestAssert[Stat](code, assertLayout = Some(expected))(tmatch(
       tname("a"),
       Case(Pat.Extract(tname("A"), Nil), None, tname("succ")),
-      Case(patwildcard, None, tname("fail"))
+      Case(patwildcard, None, tname("fail")),
     ))
   }
 
@@ -2525,10 +2525,10 @@ class ControlSyntaxSuite extends BaseDottySuite {
         tmatch(
           tname("a"),
           Case(Pat.Extract(tname("A"), Nil), None, tname("succ")),
-          Case(patwildcard, None, blk())
+          Case(patwildcard, None, blk()),
         ),
-        Defn.Val(Nil, List(patvar("x")), None, int(0))
-      )
+        Defn.Val(Nil, List(patvar("x")), None, int(0)),
+      ),
     ))
   }
 
@@ -2541,8 +2541,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |else
          |  2
          |""".stripMargin,
-      assertLayout = Some("if (1 max 10 gt 0) 1 else 2")
-    )(Term.If(tinfix(tinfix(int(1), "max", int(10)), "gt", int(0)), int(1), int(2), Nil))
+      assertLayout = Some("if (1 max 10 gt 0) 1 else 2"),
+    )(Term.If(tinfix(tinfix(int(1), "max", int(10)), "gt", int(0)), int(1), int(2), Nil)),
   )
 
   test("no-real-indentation") {
@@ -2572,7 +2572,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
            |  end try
            |}
            |""".stripMargin
-      }
+      },
     ) {
       Defn.Object(
         Nil,
@@ -2584,22 +2584,22 @@ class ControlSyntaxSuite extends BaseDottySuite {
               Case(
                 patinfix(patvar("x"), "::", patvar("xs")),
                 None,
-                tapply(tname("println"), tname("x"))
+                tapply(tname("println"), tname("x")),
               ),
-              Case(tname("Nil"), None, tapply(tname("println"), str("Nil")))
+              Case(tname("Nil"), None, tapply(tname("println"), str("Nil"))),
             ),
             List(
               Case(
                 Pat.Typed(patvar("ex"), Type.Select(tselect("java", "io"), pname("IOException"))),
                 None,
-                tapply(tname("println"), tname("ex"))
+                tapply(tname("println"), tname("ex")),
               ),
-              Case(Pat.Typed(patvar("ex"), pname("Throwable")), None, Term.Throw(tname("ex")))
+              Case(Pat.Typed(patvar("ex"), pname("Throwable")), None, Term.Throw(tname("ex"))),
             ),
-            None
+            None,
           ),
-          Term.EndMarker(tname("try"))
-        )
+          Term.EndMarker(tname("try")),
+        ),
       )
     }
   }
@@ -2618,8 +2618,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin,
       assertLayout = Some(
         """|def f(x: Int) = assert(if (x > 0) true else if (x < 0) true else false, "fail")
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Def(
       Nil,
       tname("f"),
@@ -2632,10 +2632,10 @@ class ControlSyntaxSuite extends BaseDottySuite {
           tinfix(tname("x"), ">", int(0)),
           bool(true),
           Term.If(tinfix(tname("x"), "<", int(0)), bool(true), bool(false), Nil),
-          Nil
+          Nil,
         ),
-        str("fail")
-      )
+        str("fail"),
+      ),
     ))
   }
 
@@ -2653,8 +2653,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
            |    op(c == true)
            |  }) err(context)
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Object(
       Nil,
       tname("foo"),
@@ -2667,9 +2667,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
           tapply(tname("map"), blk(tapply(tname("op"), tinfix(tname("c"), "==", bool(true))))),
           tapply(tname("err"), tname("context")),
           Lit.Unit(),
-          Nil
-        )
-      ))
+          Nil,
+        ),
+      )),
     ))
   }
 
@@ -2685,8 +2685,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
           |    op(c == true)
           |  }) err(context)
           |}
-          |""".stripMargin
-      )
+          |""".stripMargin,
+      ),
     )(Defn.Object(
       Nil,
       tname("foo"),
@@ -2698,13 +2698,13 @@ class ControlSyntaxSuite extends BaseDottySuite {
         Term.If(
           tapply(
             tinfix(tname("a"), "+", tname("b")),
-            blk(tapply(tname("op"), tinfix(tname("c"), "==", bool(true))))
+            blk(tapply(tname("op"), tinfix(tname("c"), "==", bool(true)))),
           ),
           tapply(tname("err"), tname("context")),
           Lit.Unit(),
-          Nil
-        )
-      ))
+          Nil,
+        ),
+      )),
     ))
   }
 
@@ -2716,8 +2716,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin,
       assertLayout = Some(
         """|object foo { def bar = if (a + b op c == true) err(context) }
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Object(
       Nil,
       tname("foo"),
@@ -2730,9 +2730,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
           tinfix(tinfix(tname("a"), "+", tname("b")), "op", tinfix(tname("c"), "==", bool(true))),
           tapply(tname("err"), tname("context")),
           Lit.Unit(),
-          Nil
-        )
-      ))
+          Nil,
+        ),
+      )),
     ))
   }
 
@@ -2744,8 +2744,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin,
       assertLayout = Some(
         """|object foo { def bar = if (a + b) op c err(context) }
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Object(
       Nil,
       tname("foo"),
@@ -2758,9 +2758,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
           tinfix(tname("a"), "+", tname("b")),
           tinfix(tname("op"), "c", tapply(tname("err"), tname("context"))),
           Lit.Unit(),
-          Nil
-        )
-      ))
+          Nil,
+        ),
+      )),
     ))
   }
 
@@ -2772,8 +2772,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin,
       assertLayout = Some(
         """|object foo { def bar = if (a + b) op c err(context) }
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Object(
       Nil,
       tname("foo"),
@@ -2786,9 +2786,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
           tinfix(tname("a"), "+", tname("b")),
           tinfix(tname("op"), "c", tapply(tname("err"), tname("context"))),
           Lit.Unit(),
-          Nil
-        )
-      ))
+          Nil,
+        ),
+      )),
     ))
   }
 
@@ -2823,7 +2823,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
             tinfix(
               tapply(tselect("constraint", "contains"), tname("tl")),
               "||",
-              tapply(tselect("other", "isRemovable"), tname("tl"))
+              tapply(tselect("other", "isRemovable"), tname("tl")),
             ),
             "||",
             blk(
@@ -2836,15 +2836,15 @@ class ControlSyntaxSuite extends BaseDottySuite {
                     tapply(
                       tselect("tl", "paramRefs", "map"),
                       Term.AnonymousFunction(
-                        tapply(tselect("other", "typeVarOfParam"), Term.Placeholder())
-                      )
+                        tapply(tselect("other", "typeVarOfParam"), Term.Placeholder()),
+                      ),
                     ),
-                    "collect"
+                    "collect",
                   ),
                   Term.PartialFunction(
-                    Case(Pat.Typed(patvar("tv"), pname("TypeVar")), None, tname("tv")) :: Nil
-                  )
-                )
+                    Case(Pat.Typed(patvar("tv"), pname("TypeVar")), None, tname("tv")) :: Nil,
+                  ),
+                ),
               ),
               Term.If(
                 tselect(Term.This(anon), "isCommittable"),
@@ -2856,21 +2856,21 @@ class ControlSyntaxSuite extends BaseDottySuite {
                       "&&",
                       Term.ApplyUnary(
                         tname("!"),
-                        tapply(tname("isOwnedAnywhere"), Term.This(anon), tname("tvar"))
-                      )
+                        tapply(tname("isOwnedAnywhere"), Term.This(anon), tname("tvar")),
+                      ),
                     ),
                     tapply(tname("includeVar"), tname("tvar")),
                     Lit.Unit(),
-                    Nil
-                  ))
+                    Nil,
+                  )),
                 ),
                 Lit.Unit(),
-                Nil
+                Nil,
               ),
-              tapply(tselect("typeComparer", "addToConstraint"), tname("tl"), tname("tvars"))
-            )
+              tapply(tselect("typeComparer", "addToConstraint"), tname("tl"), tname("tvars")),
+            ),
           )
-        }
+        },
       )
     }
   }
@@ -2905,7 +2905,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
             Nil,
             List(patvar("hashedDefs")),
             None,
-            tapply(tselect("ir", "Hashers", "hashMemberDefs"), tname("allMemberDefs"))
+            tapply(tselect("ir", "Hashers", "hashMemberDefs"), tname("allMemberDefs")),
           ),
           Defn.Val(
             Nil,
@@ -2918,12 +2918,12 @@ class ControlSyntaxSuite extends BaseDottySuite {
                 tname("isHijacked"),
                 tselect("ClassKind", "HijackedClass"),
                 tselect("ClassKind", "Class"),
-                Nil
+                Nil,
               ),
-              Nil
-            )
-          )
-        )
+              Nil,
+            ),
+          ),
+        ),
       )
     }
   }
@@ -2967,7 +2967,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
            |    String.valueOf(arg)
            |}
            |""".stripMargin
-      }
+      },
     ) {
       tmatch(
         tname("arg"),
@@ -2980,17 +2980,17 @@ class ControlSyntaxSuite extends BaseDottySuite {
               Case(
                 Pat.Typed(patvar("ex"), pname("CyclicReference")),
                 None,
-                str("... (caught cyclic reference) ...")
+                str("... (caught cyclic reference) ..."),
               ),
               Case(
                 Pat.Extract(tname("NonFatal"), List(patvar("ex"))),
                 Some(tinfix(
                   Term.ApplyUnary(
                     tname("!"),
-                    tapply(tselect("ctx", "mode", "is"), tselect("Mode", "PrintShowExceptions"))
+                    tapply(tselect("ctx", "mode", "is"), tselect("Mode", "PrintShowExceptions")),
                   ),
                   "&&",
-                  Term.ApplyUnary(tname("!"), tselect("ctx", "settings", "YshowPrintErrors", "value"))
+                  Term.ApplyUnary(tname("!"), tselect("ctx", "settings", "YshowPrintErrors", "value")),
                 )),
                 blk(
                   Defn.Val(
@@ -3002,23 +3002,23 @@ class ControlSyntaxSuite extends BaseDottySuite {
                       Case(
                         Pat.Typed(patvar("te"), pname("TypeError")),
                         None,
-                        tselect("te", "toMessage")
+                        tselect("te", "toMessage"),
                       ),
-                      Case(patwildcard, None, tselect("ex", "getMessage"))
-                    )
+                      Case(patwildcard, None, tselect("ex", "getMessage")),
+                    ),
                   ),
                   Term.Interpolate(
                     tname("s"),
                     List(str("[cannot display due to "), str(", raw string = "), str("]")),
-                    List(tname("msg"), blk(tselect("arg", "toString")))
-                  )
-                )
-              )
+                    List(tname("msg"), blk(tselect("arg", "toString"))),
+                  ),
+                ),
+              ),
             ),
-            None
-          )
+            None,
+          ),
         ),
-        Case(patwildcard, None, tapply(tselect("String", "valueOf"), tname("arg")))
+        Case(patwildcard, None, tapply(tselect("String", "valueOf"), tname("arg"))),
       )
     }
   }
@@ -3036,8 +3036,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
         """|val tvars = targs.filter(_.isInstanceOf[InferredTypeTree]).tpes.collect {
            |  case tvar: TypeVar if !tvar.isInstantiated && ctx.typerState.ownedVars.contains(tvar) && !locked.contains(tvar) => tvar
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     ) {
       Defn.Val(
         Nil,
@@ -3049,12 +3049,12 @@ class ControlSyntaxSuite extends BaseDottySuite {
               tapply(
                 tselect("targs", "filter"),
                 Term.AnonymousFunction(
-                  tapplytype(tselect(Term.Placeholder(), "isInstanceOf"), pname("InferredTypeTree"))
-                )
+                  tapplytype(tselect(Term.Placeholder(), "isInstanceOf"), pname("InferredTypeTree")),
+                ),
               ),
-              "tpes"
+              "tpes",
             ),
-            "collect"
+            "collect",
           ),
           Term.PartialFunction(
             Case(
@@ -3063,15 +3063,15 @@ class ControlSyntaxSuite extends BaseDottySuite {
                 tinfix(
                   Term.ApplyUnary(tname("!"), tselect("tvar", "isInstantiated")),
                   "&&",
-                  tapply(tselect("ctx", "typerState", "ownedVars", "contains"), tname("tvar"))
+                  tapply(tselect("ctx", "typerState", "ownedVars", "contains"), tname("tvar")),
                 ),
                 "&&",
-                Term.ApplyUnary(tname("!"), tapply(tselect("locked", "contains"), tname("tvar")))
+                Term.ApplyUnary(tname("!"), tapply(tselect("locked", "contains"), tname("tvar"))),
               )),
-              tname("tvar")
-            ) :: Nil
-          )
-        )
+              tname("tvar"),
+            ) :: Nil,
+          ),
+        ),
       )
     }
   }
@@ -3087,8 +3087,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin,
       assertLayout = Some(
         """|if (columnsVar != null) columnsVar.toInt else if (Properties.isWin) if (ansiconVar != null) ansiconVar.toInt else defaultWidth else defaultWidth
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Term.If(
       tinfix(tname("columnsVar"), "!=", Lit.Null()),
       tselect("columnsVar", "toInt"),
@@ -3098,12 +3098,12 @@ class ControlSyntaxSuite extends BaseDottySuite {
           tinfix(tname("ansiconVar"), "!=", Lit.Null()),
           tselect("ansiconVar", "toInt"),
           tname("defaultWidth"),
-          Nil
+          Nil,
         ),
         tname("defaultWidth"),
-        Nil
+        Nil,
       ),
-      Nil
+      Nil,
     ))
   }
 
@@ -3121,8 +3121,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
            |  private def assertBounds(context: String) = if (idx >= query.length) err(context)
            |  private def err(problem: String) = throw new QueryParseException(query, idx, problem)
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     ) {
       Defn.Object(
         Nil,
@@ -3138,8 +3138,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
               tinfix(tname("idx"), ">=", tselect("query", "length")),
               tapply(tname("err"), tname("context")),
               Lit.Unit(),
-              Nil
-            )
+              Nil,
+            ),
           ),
           Defn.Def(
             List(Mod.Private(anon)),
@@ -3148,10 +3148,10 @@ class ControlSyntaxSuite extends BaseDottySuite {
             List(List(tparam("problem", "String"))),
             None,
             Term.Throw(Term.New(
-              init(pname("QueryParseException"), List(tname("query"), tname("idx"), tname("problem")))
-            ))
-          )
-        )
+              init(pname("QueryParseException"), List(tname("query"), tname("idx"), tname("problem"))),
+            )),
+          ),
+        ),
       )
     }
   }
@@ -3166,20 +3166,20 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin,
       assertLayout = Some(
         """|while (idx < str.length) if ((str charAt idx) != '$' || isEscaped) idx += 1 else idx
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Term.While(
       tinfix(tname("idx"), "<", tselect("str", "length")),
       Term.If(
         tinfix(
           tinfix(tinfix(tname("str"), "charAt", tname("idx")), "!=", lit('$')),
           "||",
-          tname("isEscaped")
+          tname("isEscaped"),
         ),
         tinfix(tname("idx"), "+=", int(1)),
         tname("idx"),
-        Nil
-      )
+        Nil,
+      ),
     ))
   }
 
@@ -3195,16 +3195,16 @@ class ControlSyntaxSuite extends BaseDottySuite {
            |} else {
            |  char += 1
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Term.For(
       List(Enumerator.Generator(patvar("c"), tname("str"))),
       Term.If(
         tinfix(tname("c"), "==", lit('\n')),
         blk(tinfix(tname("line"), "+=", int(1)), Term.Assign(tname("char"), int(0))),
         blk(tinfix(tname("char"), "+=", int(1))),
-        Nil
-      )
+        Nil,
+      ),
     ))
   }
 
@@ -3243,12 +3243,12 @@ class ControlSyntaxSuite extends BaseDottySuite {
               tname("typeDef"),
               Term.If(tname("typJava"), blk(), Lit.Unit(), Nil),
               Lit.Unit(),
-              Nil
-            )
-          )
+              Nil,
+            ),
+          ),
         ),
-        Case(patwildcard, None, blk())
-      ))
+        Case(patwildcard, None, blk()),
+      )),
     ))
   }
 
@@ -3278,14 +3278,14 @@ class ControlSyntaxSuite extends BaseDottySuite {
             List(str("ERROR: Multiple index pages for doc found "), str("")),
             blk(tapply(
               tselect("indexes", "map"),
-              Term.AnonymousFunction(tselect(Term.Placeholder(), "file"))
-            )) :: Nil
-          )
+              Term.AnonymousFunction(tselect(Term.Placeholder(), "file")),
+            )) :: Nil,
+          ),
         ),
-        tapply(tselect("report", "error"), tname("msg"))
+        tapply(tselect("report", "error"), tname("msg")),
       ),
       Lit.Unit(),
-      Nil
+      Nil,
     ))
   }
 
@@ -3312,13 +3312,13 @@ class ControlSyntaxSuite extends BaseDottySuite {
             Term.ApplyUnary(tname("!"), tname("tvar")),
             tapply(tname("includeVar"), tname("tvar")),
             Lit.Unit(),
-            Nil
-          ))
+            Nil,
+          )),
         ),
         Lit.Unit(),
-        Nil
+        Nil,
       ),
-      tapply(tselect("typeComparer", "addToConstraint"), tname("tvars"))
+      tapply(tselect("typeComparer", "addToConstraint"), tname("tvars")),
     ))
   }
 
@@ -3349,12 +3349,12 @@ class ControlSyntaxSuite extends BaseDottySuite {
             List(
               Enumerator.Generator(patvar("parent"), tname("parents")),
               Enumerator.Generator(patvar("mbr"), tselect("parent", "abstractTypeMembers")),
-              Enumerator.Guard(tapply(tname("qualifies"), tselect("mbr", "symbol")))
+              Enumerator.Guard(tapply(tname("qualifies"), tselect("mbr", "symbol"))),
             ),
-            tselect("mbr", "name", "asTypeName")
-          )
+            tselect("mbr", "name", "asTypeName"),
+          ),
         ),
-        Term.For(List(Enumerator.Generator(patvar("name"), tname("abstractTypeNames"))), tname("foo"))
+        Term.For(List(Enumerator.Generator(patvar("name"), tname("abstractTypeNames"))), tname("foo")),
       )
     }
   }
@@ -3378,7 +3378,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
       Term.ApplyUnary(tname("!"), tname("other")),
       Term.If(tname("member"), Lit.Unit(), tapply(tname("overrideError")), Nil),
       tapply(tname("checkOverrideDeprecated")),
-      Nil
+      Nil,
     ))
   }
 
@@ -3432,11 +3432,11 @@ class ControlSyntaxSuite extends BaseDottySuite {
           None,
           tmatch(
             tname("that"),
-            Case(patvar("b"), None, blk(tname("bb"), Term.EndMarker(tname("match"))))
-          )
+            Case(patvar("b"), None, blk(tname("bb"), Term.EndMarker(tname("match")))),
+          ),
         ),
-        Case(patvar("b"), None, tmatch(tname("that"), Case(patvar("c"), None, tname("cc"))))
-      )
+        Case(patvar("b"), None, tmatch(tname("that"), Case(patvar("c"), None, tname("cc")))),
+      ),
     ))
   }
 
@@ -3470,12 +3470,12 @@ class ControlSyntaxSuite extends BaseDottySuite {
           blk(
             Term.Try(tname("bar"), Nil, Some(tname("qux"))),
             Term.TryWithHandler(tname("bar"), tname("baz"), Some(tname("qux"))),
-            Term.Try(tname("bar"), List(Case(patwildcard, None, tname("baz"))), Some(tname("qux")))
-          )
+            Term.Try(tname("bar"), List(Case(patwildcard, None, tname("baz"))), Some(tname("qux"))),
+          ),
         ),
-        Case(patvar("xyz"), None, blk())
+        Case(patvar("xyz"), None, blk()),
       ),
-      None
+      None,
     ))
   }
 
@@ -3507,10 +3507,10 @@ class ControlSyntaxSuite extends BaseDottySuite {
         blk(
           Term.Try(tname("bar"), Nil, Some(tname("qux"))),
           Term.TryWithHandler(tname("bar"), tname("baz"), Some(tname("qux"))),
-          Term.Try(tname("bar"), List(Case(patwildcard, None, tname("baz"))), Some(tname("qux")))
-        )
+          Term.Try(tname("bar"), List(Case(patwildcard, None, tname("baz"))), Some(tname("qux"))),
+        ),
       ) :: Nil,
-      Some(tname("xyz"))
+      Some(tname("xyz")),
     ))
   }
 
@@ -3525,9 +3525,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
     runTestAssert[Stat](code, Some(layout))(Term.ForYield(
       List(
         Enumerator.CaseGenerator(Pat.Tuple(List(patvar("a"), patvar("b"))), tname("pairs")),
-        Enumerator.Generator(patvar("x"), tinfix(tname("a"), "to", tname("b")))
+        Enumerator.Generator(patvar("x"), tinfix(tname("a"), "to", tname("b"))),
       ),
-      tname("x")
+      tname("x"),
     ))
   }
 
@@ -3554,9 +3554,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
         tselect("x2", "x3"),
         Term.PartialFunction(
           Case(patvar("x4"), Some(tapply(tselect("x5", "x6", "x7"), tname("x8"))), tname("x9")) ::
-            Nil
-        )
-      )
+            Nil,
+        ),
+      ),
     ))
   }
 
@@ -3633,10 +3633,10 @@ class ControlSyntaxSuite extends BaseDottySuite {
       blk(
         tmatch(
           tname("bar"),
-          Case(int(1), None, blk(tapply(tname("println"), int(2)), Term.Tuple(List(int(3), int(4)))))
+          Case(int(1), None, blk(tapply(tname("println"), int(2)), Term.Tuple(List(int(3), int(4))))),
         ),
-        tname("baz")
-      )
+        tname("baz"),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -3671,10 +3671,10 @@ class ControlSyntaxSuite extends BaseDottySuite {
           blk(
             tapply(tname("println"), int(2)),
             Term.Tuple(List(int(3), int(4))),
-            Defn.Class(List(Mod.Case()), pname("A"), Nil, ctorp(tparam("a", "Int")), tplNoBody())
-          )
-        )
-      )
+            Defn.Class(List(Mod.Case()), pname("A"), Nil, ctorp(tparam("a", "Int")), tplNoBody()),
+          ),
+        ),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -3706,10 +3706,10 @@ class ControlSyntaxSuite extends BaseDottySuite {
       blk(
         tmatch(
           tname("bar"),
-          Case(int(1), None, blk(tapply(tname("println"), int(2)), Term.Tuple(List(int(3), int(4)))))
+          Case(int(1), None, blk(tapply(tname("println"), int(2)), Term.Tuple(List(int(3), int(4))))),
         ),
-        Defn.Class(List(Mod.Case()), pname("A"), Nil, ctorp(tparam("a", "Int")), tplNoBody())
-      )
+        Defn.Class(List(Mod.Case()), pname("A"), Nil, ctorp(tparam("a", "Int")), tplNoBody()),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -3741,9 +3741,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
         Case(
           int(1),
           None,
-          blk(tapply(tname("println"), int(2)), Term.Tuple(List(int(3), int(4))), tname("baz"))
-        )
-      )
+          blk(tapply(tname("println"), int(2)), Term.Tuple(List(int(3), int(4))), tname("baz")),
+        ),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -3771,8 +3771,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
       None,
       blk(
         Term.If(lit(true), tapply(tname("greet")), tapply(tname("sayGoodbye")), Nil),
-        tapply(tname("openDoor"))
-      )
+        tapply(tname("openDoor")),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -3805,10 +3805,10 @@ class ControlSyntaxSuite extends BaseDottySuite {
           tinfix(tinfix(tname("a"), "+", tname("b")), "==", tinfix(tname("c"), "+", tname("d"))),
           tapply(tname("greet")),
           tapply(tname("sayGoodbye")),
-          Nil
+          Nil,
         ),
-        tapply(tname("openDoor"))
-      )
+        tapply(tname("openDoor")),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -3833,7 +3833,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
       Nil,
       List(Nil),
       None,
-      blk(Term.While(lit(true), tapply(tname("sayGoodbye"))), tapply(tname("openDoor")))
+      blk(Term.While(lit(true), tapply(tname("sayGoodbye"))), tapply(tname("openDoor"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -3863,10 +3863,10 @@ class ControlSyntaxSuite extends BaseDottySuite {
       blk(
         Term.While(
           tinfix(tinfix(tname("a"), "+", tname("b")), "==", tinfix(tname("c"), "+", tname("d"))),
-          tapply(tname("sayGoodbye"))
+          tapply(tname("sayGoodbye")),
         ),
-        tapply(tname("openDoor"))
-      )
+        tapply(tname("openDoor")),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -3894,11 +3894,11 @@ class ControlSyntaxSuite extends BaseDottySuite {
           List(
             Enumerator.Generator(patvar("parent"), tname("parents")),
             Enumerator.Generator(patvar("mbr"), tselect("parent", "abstractTypeMembers")),
-            Enumerator.Guard(tapply(tname("qualifies"), tselect("mbr", "symbol")))
+            Enumerator.Guard(tapply(tname("qualifies"), tselect("mbr", "symbol"))),
           ),
-          tselect("mbr", "name", "asTypeName")
-        )
-      ))
+          tselect("mbr", "name", "asTypeName"),
+        ),
+      )),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -3924,8 +3924,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
       tname("a"),
       tpl(
         Term.Try(tname("foo"), List(Case(patvar("ex"), None, Term.New(init("Bar", Nil)))), None),
-        Defn.Def(List(Mod.Private(Name("io"))), tname("baz"), Nil, None, tname("qux"))
-      )
+        Defn.Def(List(Mod.Private(Name("io"))), tname("baz"), Nil, None, tname("qux")),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -3942,7 +3942,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
     val tree = Defn.Object(
       Nil,
       tname("a"),
-      tpl(Term.ForYield(List(Enumerator.Generator(patvar("foo"), tname("bar"))), tname("foo")))
+      tpl(Term.ForYield(List(Enumerator.Generator(patvar("foo"), tname("bar"))), tname("foo"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -3964,8 +3964,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
         tname("foo"),
         Nil,
         None,
-        Term.Try(tinfix(tname("bar"), "&&", tname("baz")), None, Some(tname("qux")))
-      ))
+        Term.Try(tinfix(tname("bar"), "&&", tname("baz")), None, Some(tname("qux"))),
+      )),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -3994,8 +3994,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
         tname("foo"),
         Nil,
         None,
-        blk(Term.Try(tinfix(tname("bar"), "&&", tname("baz")), None, Some(tname("qux"))))
-      ))
+        blk(Term.Try(tinfix(tname("bar"), "&&", tname("baz")), None, Some(tname("qux")))),
+      )),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -4059,9 +4059,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
     val tree = Term.ForYield(
       Term.EnumeratorsBlock(List(
         Enumerator.Generator(patwildcard, Term.If(tname("a"), blk(tname("b")), blk(tname("c")), Nil)),
-        Enumerator.Generator(patwildcard, tname("d"))
+        Enumerator.Generator(patwildcard, tname("d")),
       )),
-      tname("e")
+      tname("e"),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -4125,9 +4125,9 @@ class ControlSyntaxSuite extends BaseDottySuite {
     val tree = Term.ForYield(
       Term.EnumeratorsBlock(List(
         Enumerator.Generator(patwildcard, Term.If(tname("a"), blk(tname("b")), blk(tname("c")), Nil)),
-        Enumerator.Generator(patwildcard, tname("d"))
+        Enumerator.Generator(patwildcard, tname("d")),
       )),
-      tname("e")
+      tname("e"),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -4187,12 +4187,12 @@ class ControlSyntaxSuite extends BaseDottySuite {
           patwildcard,
           tapply(
             tselect(tapply(tname("Option"), lit(42)), "map"),
-            blk(tfunc(tparam("_"))(tname("???")))
-          )
+            blk(tfunc(tparam("_"))(tname("???"))),
+          ),
         ),
-        Enumerator.Generator(patwildcard, tapply(tname("Option"), lit(43)))
+        Enumerator.Generator(patwildcard, tapply(tname("Option"), lit(43))),
       )),
-      Lit.Unit()
+      Lit.Unit(),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -4217,8 +4217,8 @@ class ControlSyntaxSuite extends BaseDottySuite {
       tapply(
         "test",
         Term.Try(lit(1), Some(Term.CasesBlock(List(Case(patwildcard, None, lit(2))))), None),
-        lit("bar")
-      )
+        lit("bar"),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -4247,11 +4247,11 @@ class ControlSyntaxSuite extends BaseDottySuite {
         None,
         Term.ForYield(
           Term.EnumeratorsBlock(List(
-            Enumerator.Generator(patvar("x"), tapply("twice", blk(tselect(lit("4"), "toInt"))))
+            Enumerator.Generator(patvar("x"), tapply("twice", blk(tselect(lit("4"), "toInt")))),
           )),
-          tname("x")
-        )
-      ))
+          tname("x"),
+        ),
+      )),
     )))
     runTestAssert[Source](code, output)(tree)
   }
@@ -4271,7 +4271,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin
     val tree = Term.ForYield(
       Term.EnumeratorsBlock(List(Enumerator.Generator(Pat.Given("Foo"), "frob"))),
-      tapply("identity", blk(Term.Interpolate("sql", List(lit("")), Nil)))
+      tapply("identity", blk(Term.Interpolate("sql", List(lit("")), Nil))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -4291,7 +4291,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin
     val tree = Term.ForYield(
       Term.EnumeratorsBlock(List(Enumerator.Generator(Pat.Given("Foo"), "frob"))),
-      tapply("identity", blk(Term.Interpolate("sql", List(lit("")), Nil)))
+      tapply("identity", blk(Term.Interpolate("sql", List(lit("")), Nil))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -4312,7 +4312,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin
     val tree = Term.ForYield(
       Term.EnumeratorsBlock(List(Enumerator.Generator(Pat.Given("Foo"), "frob"))),
-      tapply("identity", blk(Term.Interpolate("sql", List(lit("")), Nil)))
+      tapply("identity", blk(Term.Interpolate("sql", List(lit("")), Nil))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -4333,7 +4333,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
          |""".stripMargin
     val tree = Term.ForYield(
       Term.EnumeratorsBlock(List(Enumerator.Generator(Pat.Given("Foo"), "frob"))),
-      tapply("identity", blk(Term.Interpolate("sql", List(lit("")), Nil)))
+      tapply("identity", blk(Term.Interpolate("sql", List(lit("")), Nil))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -4346,7 +4346,7 @@ class ControlSyntaxSuite extends BaseDottySuite {
       Nil,
       List(List(tparam("b", "Boolean"))),
       Some(pfunc("Int")("Int")),
-      Term.If("b", tfunc(tparam("a", "Int"))("a"), "identity", Nil)
+      Term.If("b", tfunc(tparam("a", "Int"))("a"), "identity", Nil),
     )
     runTestAssert[Stat](code)(tree)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/DerivesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/DerivesSuite.scala
@@ -23,10 +23,10 @@ class DerivesSuite extends BaseDottySuite {
         slf,
         List(
           Defn.EnumCase(Nil, tname("Branch"), Nil, ctor, Nil),
-          Defn.EnumCase(Nil, tname("Leaf"), Nil, ctor, Nil)
+          Defn.EnumCase(Nil, tname("Leaf"), Nil, ctor, Nil),
         ),
-        List(pname("Eq"), pname("Ordering"), pname("Show"))
-      )
+        List(pname("Eq"), pname("Ordering"), pname("Show")),
+      ),
     ))
 
   }
@@ -37,7 +37,7 @@ class DerivesSuite extends BaseDottySuite {
          |  case Branch
          |  case Leaf
          |}
-         |""".stripMargin
+         |""".stripMargin,
     )(Defn.Enum(
       Nil,
       pname("Tree"),
@@ -49,10 +49,10 @@ class DerivesSuite extends BaseDottySuite {
         slf,
         List(
           Defn.EnumCase(Nil, tname("Branch"), Nil, ctor, Nil),
-          Defn.EnumCase(Nil, tname("Leaf"), Nil, ctor, Nil)
+          Defn.EnumCase(Nil, tname("Leaf"), Nil, ctor, Nil),
         ),
-        List(pname("Eq"), pselect("scala", "derives", "Ordering"), pname("Show"))
-      )
+        List(pname("Eq"), pselect("scala", "derives", "Ordering"), pname("Show")),
+      ),
     ))
 
   }
@@ -69,8 +69,8 @@ class DerivesSuite extends BaseDottySuite {
            |  def hello() = ""
            |  def bye() = ""
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Class(
       List(Mod.Case()),
       pname("Node"),
@@ -82,10 +82,10 @@ class DerivesSuite extends BaseDottySuite {
         slf,
         List(
           Defn.Def(Nil, tname("hello"), Nil, List(List()), None, str("")),
-          Defn.Def(Nil, tname("bye"), Nil, List(List()), None, str(""))
+          Defn.Def(Nil, tname("bye"), Nil, List(List()), None, str("")),
         ),
-        List(pname("Eq"))
-      )
+        List(pname("Eq")),
+      ),
     ))
 
   }
@@ -97,7 +97,7 @@ class DerivesSuite extends BaseDottySuite {
          |      AVeryLongName2,
          |      AVeryLongName3
          |""".stripMargin,
-      assertLayout = Some("class A derives AVeryLongName1, AVeryLongName2, AVeryLongName3")
+      assertLayout = Some("class A derives AVeryLongName1, AVeryLongName2, AVeryLongName3"),
     )(Defn.Class(
       Nil,
       pname("A"),
@@ -108,8 +108,8 @@ class DerivesSuite extends BaseDottySuite {
         Nil,
         slf,
         Nil,
-        List(pname("AVeryLongName1"), pname("AVeryLongName2"), pname("AVeryLongName3"))
-      )
+        List(pname("AVeryLongName1"), pname("AVeryLongName2"), pname("AVeryLongName3")),
+      ),
     ))
   }
 
@@ -125,8 +125,8 @@ class DerivesSuite extends BaseDottySuite {
         Nil,
         slf,
         List(Defn.Def(Nil, tname("a"), Nil, Nil, None, tname("???"))),
-        List(papply("Alpha", "T"), papply("Epsilon", "T"))
-      )
+        List(papply("Alpha", "T"), papply("Epsilon", "T")),
+      ),
     )
     runTestAssert[Stat](
       """|class A[T](a: Int, b: Int)
@@ -135,7 +135,7 @@ class DerivesSuite extends BaseDottySuite {
          |  def a = ???
          |}
          |""".stripMargin,
-      Some(layout)
+      Some(layout),
     )(tree)
     runTestAssert[Stat](
       """|class A[T](a: Int, b: Int)
@@ -146,7 +146,7 @@ class DerivesSuite extends BaseDottySuite {
          |  def a = ???
          |}
          |""".stripMargin,
-      Some(layout)
+      Some(layout),
     )(tree)
   }
 
@@ -162,8 +162,8 @@ class DerivesSuite extends BaseDottySuite {
         Nil,
         slf,
         List(Defn.Def(Nil, tname("a"), Nil, Nil, None, tname("???"))),
-        List(papply("Alpha", "T"), papply("Epsilon", "T"))
-      )
+        List(papply("Alpha", "T"), papply("Epsilon", "T")),
+      ),
     )
     runTestAssert[Stat](
       """|class A[T](a: Int, b: Int)
@@ -171,7 +171,7 @@ class DerivesSuite extends BaseDottySuite {
          |      Epsilon[T]:
          |  def a = ???
          |""".stripMargin,
-      Some(layout)
+      Some(layout),
     )(tree)
     runTestAssert[Stat](
       """|class A[T](a: Int, b: Int)
@@ -180,7 +180,7 @@ class DerivesSuite extends BaseDottySuite {
          |      Epsilon[T]:
          |  def a = ???
          |""".stripMargin,
-      Some(layout)
+      Some(layout),
     )(tree)
     runTestAssert[Stat](
       """|class A[T](a: Int, b: Int)
@@ -189,7 +189,7 @@ class DerivesSuite extends BaseDottySuite {
          |   Epsilon[T]:
          |  def a = ???
          |""".stripMargin,
-      Some(layout)
+      Some(layout),
     )(tree)
   }
 
@@ -205,8 +205,8 @@ class DerivesSuite extends BaseDottySuite {
         List(init(papply("Alpha", "T"))),
         slf,
         List(Defn.Def(Nil, tname("a"), Nil, None, tname("???"))),
-        List(papply("Epsilon", "T"))
-      )
+        List(papply("Epsilon", "T")),
+      ),
     )
     runTestAssert[Stat](
       """|class A[T](a: Int, b: Int)
@@ -214,7 +214,7 @@ class DerivesSuite extends BaseDottySuite {
          |    derives Epsilon[T]:
          |  def a = ???
          |""".stripMargin,
-      Some(layout)
+      Some(layout),
     )(tree)
     runTestAssert[Stat](
       """|class A[T](a: Int, b: Int)
@@ -224,7 +224,7 @@ class DerivesSuite extends BaseDottySuite {
          |      Epsilon[T]:
          |  def a = ???
          |""".stripMargin,
-      Some(layout)
+      Some(layout),
     )(tree)
     runTestAssert[Stat](
       """|class A[T](a: Int, b: Int)
@@ -234,7 +234,7 @@ class DerivesSuite extends BaseDottySuite {
          |   Epsilon[T]:
          |  def a = ???
          |""".stripMargin,
-      Some(layout)
+      Some(layout),
     )(tree)
   }
 
@@ -250,8 +250,8 @@ class DerivesSuite extends BaseDottySuite {
         List(init(papply("Alpha", "T"))),
         slf,
         List(tapply(tname("require"), bool(true))),
-        List(papply("Epsilon", "T"))
-      )
+        List(papply("Epsilon", "T")),
+      ),
     )
     runTestAssert[Stat](
       """|class A[T](a: Int, b: Int)
@@ -259,7 +259,7 @@ class DerivesSuite extends BaseDottySuite {
          |    derives Epsilon[T]:
          |  require(true)
          |""".stripMargin,
-      Some(layout)
+      Some(layout),
     )(tree)
     runTestAssert[Stat](
       """|class A[T](a: Int, b: Int)
@@ -269,7 +269,7 @@ class DerivesSuite extends BaseDottySuite {
          |      Epsilon[T]:
          |  require(true)
          |""".stripMargin,
-      Some(layout)
+      Some(layout),
     )(tree)
     runTestAssert[Stat](
       """|class A[T](a: Int, b: Int)
@@ -279,7 +279,7 @@ class DerivesSuite extends BaseDottySuite {
          |   Epsilon[T]:
          |  require(true)
          |""".stripMargin,
-      Some(layout)
+      Some(layout),
     )(tree)
   }
 
@@ -295,8 +295,8 @@ class DerivesSuite extends BaseDottySuite {
         List(init(papply("Alpha", "T")), init(papply("Epsilon", "T"))),
         slf,
         List(tapply(tname("require"), bool(true))),
-        Nil
-      )
+        Nil,
+      ),
     )
     runTestAssert[Stat](
       """|class A[T](a: Int, b: Int)
@@ -304,7 +304,7 @@ class DerivesSuite extends BaseDottySuite {
          |    with Epsilon[T]:
          |  require(true)
          |""".stripMargin,
-      Some(layout)
+      Some(layout),
     )(tree)
     runTestAssert[Stat](
       """|class A[T](a: Int, b: Int)
@@ -314,7 +314,7 @@ class DerivesSuite extends BaseDottySuite {
          |      Epsilon[T]:
          |  require(true)
          |""".stripMargin,
-      Some(layout)
+      Some(layout),
     )(tree)
     runTestAssert[Stat](
       """|class A[T](a: Int, b: Int)
@@ -324,7 +324,7 @@ class DerivesSuite extends BaseDottySuite {
          |   Epsilon[T]:
          |  require(true)
          |""".stripMargin,
-      Some(layout)
+      Some(layout),
     )(tree)
   }
 
@@ -340,15 +340,15 @@ class DerivesSuite extends BaseDottySuite {
         List(init(papply("Alpha", "T"))),
         slf,
         List(tapply(tname("require"), bool(true))),
-        Nil
-      )
+        Nil,
+      ),
     )
     runTestAssert[Stat](
       """|class A[T](a: Int, b: Int)
          |    extends Alpha[T]:
          |  require(true)
          |""".stripMargin,
-      Some(layout)
+      Some(layout),
     )(tree)
     runTestAssert[Stat](
       """|class A[T](a: Int, b: Int)
@@ -356,7 +356,7 @@ class DerivesSuite extends BaseDottySuite {
          |      Alpha[T]:
          |  require(true)
          |""".stripMargin,
-      Some(layout)
+      Some(layout),
     )(tree)
     runTestAssert[Stat](
       """|class A[T](a: Int, b: Int)
@@ -364,7 +364,7 @@ class DerivesSuite extends BaseDottySuite {
          |   Alpha[T]:
          |  require(true)
          |""".stripMargin,
-      Some(layout)
+      Some(layout),
     )(tree)
   }
 
@@ -386,17 +386,17 @@ class DerivesSuite extends BaseDottySuite {
         slf,
         List(
           Defn.Def(Nil, tname("derives"), Nil, List(Nil), None, tname("???")),
-          tapply(tname("derives"))
+          tapply(tname("derives")),
         ),
-        Nil
-      )
+        Nil,
+      ),
     )
     runTestAssert[Stat]( // no newline
       """|class A:
          |  def derives() = ???
          |  derives()
          |""".stripMargin,
-      Some(layout)
+      Some(layout),
     )(tree)
     runTestAssert[Stat]( // with newline
       """|class A:
@@ -404,7 +404,7 @@ class DerivesSuite extends BaseDottySuite {
          |    derives() = ???
          |  derives()
          |""".stripMargin,
-      Some(layout)
+      Some(layout),
     )(tree)
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EndMarkerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EndMarkerSuite.scala
@@ -26,7 +26,7 @@ class EndMarkerSuite extends BaseDottySuite {
     runTestAssert[Source](code, assertLayout = None)(Source(List(
       Defn.Object(Nil, tname("a"), tpl(tapply(tname("init")))),
       Term.EndMarker(tname("a")),
-      Defn.Type(Nil, pname("K"), Nil, pname("Map"))
+      Defn.Type(Nil, pname("K"), Nil, pname("Map")),
     )))
   }
 
@@ -42,10 +42,10 @@ class EndMarkerSuite extends BaseDottySuite {
       Defn.ExtensionGroup(
         Nil,
         List(List(tparam("a", "Int"))),
-        Defn.Def(Nil, tname("b"), Nil, Nil, None, tinfix(tname("a"), "+", int(1)))
+        Defn.Def(Nil, tname("b"), Nil, Nil, None, tinfix(tname("a"), "+", int(1))),
       ),
       Term.EndMarker(tname("extension")),
-      Defn.Type(Nil, pname("K"), Nil, pname("Map"))
+      Defn.Type(Nil, pname("K"), Nil, pname("Map")),
     )))
   }
 
@@ -68,7 +68,7 @@ class EndMarkerSuite extends BaseDottySuite {
       Nil,
       Nil,
       Some(pname("B")),
-      blk(tinfix(tname("b"), "append", tname("end")), tname("b"))
+      blk(tinfix(tname("b"), "append", tname("end")), tname("b")),
     ))
   }
 
@@ -88,7 +88,7 @@ class EndMarkerSuite extends BaseDottySuite {
       Nil,
       List(List()),
       Some(pname("Unit")),
-      blk(Term.EndMarker(tname("for")), Defn.Val(Nil, List(patvar("x")), None, int(3)))
+      blk(Term.EndMarker(tname("for")), Defn.Val(Nil, List(patvar("x")), None, int(3))),
     ))
   }
 
@@ -105,7 +105,7 @@ class EndMarkerSuite extends BaseDottySuite {
     runTestAssert[Stat](code, assertLayout = Some(output))(Term.If(
       tinfix(tname("limit"), "<", tname("end")),
       blk(Defn.Val(Nil, List(patvar("aa")), None, int(1))),
-      Lit.Unit()
+      Lit.Unit(),
     ))
   }
 
@@ -150,10 +150,10 @@ class EndMarkerSuite extends BaseDottySuite {
             tmatch(
               tname("that"),
               Case(patvar("b"), None, tname("bb")),
-              Case(patvar("c"), None, tname("cc"))
+              Case(patvar("c"), None, tname("cc")),
             ),
-            Term.EndMarker(tname("match"))
-          )
+            Term.EndMarker(tname("match")),
+          ),
         ),
         Case(
           patvar("b"),
@@ -161,10 +161,10 @@ class EndMarkerSuite extends BaseDottySuite {
           tmatch(
             tname("that"),
             Case(patvar("c"), None, tname("cc")),
-            Case(patwildcard, None, tname("dd"))
-          )
-        )
-      )
+            Case(patwildcard, None, tname("dd")),
+          ),
+        ),
+      ),
     ))))
   }
 
@@ -202,17 +202,17 @@ class EndMarkerSuite extends BaseDottySuite {
           Nil,
           List(Pat.Tuple(List(patvar("foo"), patvar("boo")))),
           None,
-          blk(tname("bar"), tname("baz"))
+          blk(tname("bar"), tname("baz")),
         ),
         Term.EndMarker(tname("val")),
         Defn.Val(
           Nil,
           List(Pat.Tuple(List(patvar("foo2"), patvar("boo3")))),
           None,
-          blk(tname("bar"), tname("baz"))
+          blk(tname("bar"), tname("baz")),
         ),
-        Term.EndMarker(tname("val"))
-      )
+        Term.EndMarker(tname("val")),
+      ),
     ))
   }
 
@@ -221,8 +221,8 @@ class EndMarkerSuite extends BaseDottySuite {
       """|object Foo:
          |end Foo
          |""".stripMargin,
-      assertLayout = None
-    )(Source(List(Defn.Object(Nil, tname("Foo"), EmptyTemplate()), Term.EndMarker(tname("Foo")))))
+      assertLayout = None,
+    )(Source(List(Defn.Object(Nil, tname("Foo"), EmptyTemplate()), Term.EndMarker(tname("Foo"))))),
   )
 
   test("class-empty-body-end-marker")(
@@ -230,11 +230,11 @@ class EndMarkerSuite extends BaseDottySuite {
       """|class Foo:
          |end Foo
          |""".stripMargin,
-      assertLayout = None
+      assertLayout = None,
     )(Source(List(
       Defn.Class(Nil, pname("Foo"), Nil, EmptyCtor(), EmptyTemplate()),
-      Term.EndMarker(tname("Foo"))
-    )))
+      Term.EndMarker(tname("Foo")),
+    ))),
   )
 
   test("trait-empty-body-end-marker")(
@@ -242,11 +242,11 @@ class EndMarkerSuite extends BaseDottySuite {
       """|trait Foo:
          |end Foo
          |""".stripMargin,
-      assertLayout = None
+      assertLayout = None,
     )(Source(List(
       Defn.Trait(Nil, pname("Foo"), Nil, EmptyCtor(), EmptyTemplate()),
-      Term.EndMarker(tname("Foo"))
-    )))
+      Term.EndMarker(tname("Foo")),
+    ))),
   )
 
   test("trait-empty-body-no-end-marker")(runTestError[Source](
@@ -258,7 +258,7 @@ class EndMarkerSuite extends BaseDottySuite {
        |""".stripMargin,
     """|<input>:2: error: template body: `indent` expected but `\n` found
        |  trait Baz:
-       |            ^""".stripMargin
+       |            ^""".stripMargin,
   ))
 
   test("trait-empty-body-outer-end-marker")(runTestError[Source](
@@ -268,7 +268,7 @@ class EndMarkerSuite extends BaseDottySuite {
        |""".stripMargin,
     """|<input>:2: error: template body: `indent` expected but `outdent` found
        |  trait Bar:
-       |            ^""".stripMargin
+       |            ^""".stripMargin,
   ))
 
   test("trait-empty-body-no-end-marker")(runTestError[Source](
@@ -276,7 +276,7 @@ class EndMarkerSuite extends BaseDottySuite {
        |""".stripMargin,
     """|<input>:1: error: template body: `indent` expected but `\n` found
        |trait Foo:
-       |          ^""".stripMargin
+       |          ^""".stripMargin,
   ))
 
   test("#3366 not an end marker") {
@@ -290,7 +290,7 @@ class EndMarkerSuite extends BaseDottySuite {
          |}
          |""".stripMargin
     runTestAssert[Stat](code, Some(layout))(
-      tmatch(tselect("x", "end"), Case(patwildcard, None, Lit.Unit()))
+      tmatch(tselect("x", "end"), Case(patwildcard, None, Lit.Unit())),
     )
   }
 
@@ -338,14 +338,14 @@ class EndMarkerSuite extends BaseDottySuite {
             blk(
               tmatch(
                 tname("s"),
-                Case(lit("hello"), None, blk(Defn.Val(Nil, List(patvar("a")), None, lit(1))))
+                Case(lit("hello"), None, blk(Defn.Val(Nil, List(patvar("a")), None, lit(1)))),
               ),
-              Term.EndMarker(tname("match"))
-            )
-          )
-        )
+              Term.EndMarker(tname("match")),
+            ),
+          ),
+        ),
       ),
-      Term.EndMarker(tname("FmtTest"))
+      Term.EndMarker(tname("FmtTest")),
     ))
     runTestAssert[Source](code, layout)(tree)
   }
@@ -365,8 +365,8 @@ class EndMarkerSuite extends BaseDottySuite {
         tname("foo"),
         Nil,
         None,
-        tinfix(tinfix(tname("bar"), "==", tname("end")), "||", tname("baz"))
-      ))
+        tinfix(tinfix(tname("bar"), "==", tname("end")), "||", tname("baz")),
+      )),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -403,10 +403,10 @@ class EndMarkerSuite extends BaseDottySuite {
           "bar",
           blk(tmatch("baz", Case(patvar("qux"), None, "quux")), Term.EndMarker("match")),
           Lit.Unit(),
-          Nil
-        )
+          Nil,
+        ),
       ),
-      Case(patwildcard, None, blk())
+      Case(patwildcard, None, blk()),
     )
     runTestAssert[Stat](code, layout)(tree)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EnumSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/EnumSuite.scala
@@ -16,7 +16,7 @@ class EnumSuite extends BaseDottySuite {
   val RGCase = Defn.RepeatedEnumCase(Nil, List(tname("R"), tname("G")))
 
   test("enum")(runTestAssert[Stat]("enum Color { case R, G }")(
-    Defn.Enum(Nil, pname("Color"), Nil, ctor, tpl(RGCase))
+    Defn.Enum(Nil, pname("Color"), Nil, ctor, tpl(RGCase)),
   ))
 
   test("enum-private-case") {
@@ -27,8 +27,8 @@ class EnumSuite extends BaseDottySuite {
            |  private case R
            |  protected case G
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Enum(
       Nil,
       pname("Color"),
@@ -36,8 +36,8 @@ class EnumSuite extends BaseDottySuite {
       EmptyCtor(),
       tpl(
         Defn.EnumCase(List(Mod.Private(anon)), tname("R"), Nil, EmptyCtor(), Nil),
-        Defn.EnumCase(List(Mod.Protected(anon)), tname("G"), Nil, EmptyCtor(), Nil)
-      )
+        Defn.EnumCase(List(Mod.Protected(anon)), tname("G"), Nil, EmptyCtor(), Nil),
+      ),
     ))
   }
 
@@ -51,33 +51,33 @@ class EnumSuite extends BaseDottySuite {
       pname("Color"),
       Nil,
       ctor,
-      tpl(Defn.RepeatedEnumCase(List(Mod.Open()), List("R", "G")))
+      tpl(Defn.RepeatedEnumCase(List(Mod.Open()), List("R", "G"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
 
   test("enum-parametrized")(runTestAssert[Stat]("enum C(i: Int) { case R, G }")(
-    Defn.Enum(Nil, pname("C"), Nil, ctorp(tparam("i", "Int")), tpl(RGCase))
+    Defn.Enum(Nil, pname("C"), Nil, ctorp(tparam("i", "Int")), tpl(RGCase)),
   ))
 
   test("enum-extends")(runTestAssert[Stat]("enum C extends T with R { case R, G }")(
-    Defn.Enum(Nil, pname("C"), Nil, ctor, tpl(List(init("T"), init("R")), List(RGCase)))
+    Defn.Enum(Nil, pname("C"), Nil, ctor, tpl(List(init("T"), init("R")), List(RGCase))),
   ))
 
   test("enum-generics")(runTestAssert[Stat]("enum C[X, Y] { case R, G }")(
-    Defn.Enum(Nil, pname("C"), List(pparam("X"), pparam("Y")), ctor, tpl(RGCase))
+    Defn.Enum(Nil, pname("C"), List(pparam("X"), pparam("Y")), ctor, tpl(RGCase)),
   ))
 
   test("enum-no-case-allowed") {
     runTestAssert[Stat]("enum Color { }", assertLayout = None)(
-      Defn.Enum(Nil, pname("Color"), Nil, EmptyCtor(), EmptyTemplate())
+      Defn.Enum(Nil, pname("Color"), Nil, EmptyCtor(), EmptyTemplate()),
     )
     runTestAssert[Stat]("enum Color { val PI = 314 }")(Defn.Enum(
       Nil,
       pname("Color"),
       Nil,
       EmptyCtor(),
-      tpl(Defn.Val(Nil, List(patvar("PI")), None, int(314)))
+      tpl(Defn.Val(Nil, List(patvar("PI")), None, int(314))),
     ))
   }
 
@@ -86,7 +86,7 @@ class EnumSuite extends BaseDottySuite {
     pname("Color"),
     Nil,
     ctor,
-    tpl(Defn.EnumCase(Nil, tname("R"), Nil, ctor, List(init("Color"))))
+    tpl(Defn.EnumCase(Nil, tname("R"), Nil, ctor, List(init("Color")))),
   )))
 
   test("enum-other-stat")(
@@ -99,10 +99,10 @@ class EnumSuite extends BaseDottySuite {
         tpl(
           Defn.Val(Nil, List(patvar("PI")), None, int(3)),
           Defn.Def(Nil, tname("r"), Nil, Nil, Some(pname("Int")), int(4)),
-          Defn.EnumCase(Nil, tname("R"), Nil, ctor, Nil)
-        )
-      )
-    )
+          Defn.EnumCase(Nil, tname("R"), Nil, ctor, Nil),
+        ),
+      ),
+    ),
   )
 
   test("enum-parse-option") {
@@ -125,8 +125,8 @@ class EnumSuite extends BaseDottySuite {
         ctor,
         tpl(
           Defn.EnumCase(Nil, tname("Some"), Nil, ctorp(xparam), Nil),
-          Defn.EnumCase(Nil, tname("None"), Nil, ctor, Nil)
-        )
+          Defn.EnumCase(Nil, tname("None"), Nil, ctor, Nil),
+        ),
       ))
     }
 
@@ -144,8 +144,8 @@ class EnumSuite extends BaseDottySuite {
         ctor,
         tpl(
           Defn.EnumCase(Nil, tname("Some"), Nil, ctorp(xparam), List(ext("T"))),
-          Defn.EnumCase(Nil, tname("None"), Nil, ctor, List(ext("Nothing")))
-        )
+          Defn.EnumCase(Nil, tname("None"), Nil, ctor, List(ext("Nothing"))),
+        ),
       ))
     }
   }
@@ -170,8 +170,8 @@ class EnumSuite extends BaseDottySuite {
       tpl(
         Defn.EnumCase(Nil, tname("R"), Nil, ctor, Nil),
         tmatch(tname("v"), unap(1), unap(2)),
-        Defn.EnumCase(Nil, tname("G"), Nil, ctor, Nil)
-      )
+        Defn.EnumCase(Nil, tname("G"), Nil, ctor, Nil),
+      ),
     ))
   }
 
@@ -192,10 +192,10 @@ class EnumSuite extends BaseDottySuite {
         |}""".stripMargin
     val cmatch = tmatch(
       tname("v"),
-      Case(Pat.Alternative(lit('a'), Pat.Alternative(lit('c'), lit('e'))), None, str("OK"))
+      Case(Pat.Alternative(lit('a'), Pat.Alternative(lit('c'), lit('e'))), None, str("OK")),
     )
     runTestAssert[Stat](code, assertLayout = None)(
-      Defn.Enum(Nil, pname("X"), Nil, ctor, tpl(rcase, cmatch, gcase))
+      Defn.Enum(Nil, pname("X"), Nil, ctor, tpl(rcase, cmatch, gcase)),
     )
   }
 
@@ -213,7 +213,7 @@ class EnumSuite extends BaseDottySuite {
     val cmatch = Term
       .Match(tname("v"), List(Case(patvar("x"), Some(tinfix(tname("x"), ">", int(3))), str("OK"))))
     runTestAssert[Stat](code, assertLayout = None)(
-      Defn.Enum(Nil, pname("X"), Nil, ctor, tpl(rcase, cmatch, gcase))
+      Defn.Enum(Nil, pname("X"), Nil, ctor, tpl(rcase, cmatch, gcase)),
     )
   }
 
@@ -234,12 +234,12 @@ class EnumSuite extends BaseDottySuite {
       tapply(tname("a")),
       List(
         Case(Pat.Alternative(lit('a'), lit('e')), None, str("Recovered")),
-        Case(lit('c'), None, str("ERROR"))
+        Case(lit('c'), None, str("ERROR")),
       ),
-      None
+      None,
     )
     runTestAssert[Stat](code, assertLayout = None)(
-      Defn.Enum(Nil, pname("X"), Nil, ctor, tpl(rcase, tryCatch, gcase))
+      Defn.Enum(Nil, pname("X"), Nil, ctor, tpl(rcase, tryCatch, gcase)),
     )
   }
   // ---------------------------------
@@ -247,20 +247,20 @@ class EnumSuite extends BaseDottySuite {
   // ---------------------------------
 
   test("case-repeated")(runTestAssert[Stat]("enum E { case A, B, C }")(
-    enumWithCase("E", Defn.RepeatedEnumCase(Nil, List(tname("A"), tname("B"), tname("C"))))
+    enumWithCase("E", Defn.RepeatedEnumCase(Nil, List(tname("A"), tname("B"), tname("C")))),
   ))
 
   test("case-single") {
     runTestAssert[Stat]("enum E { case A }")(
-      enumWithCase("E", Defn.EnumCase(Nil, tname("A"), Nil, ctor, Nil))
+      enumWithCase("E", Defn.EnumCase(Nil, tname("A"), Nil, ctor, Nil)),
     )
     runTestAssert[Stat]("enum E { case A() }")(
-      enumWithCase("E", Defn.EnumCase(Nil, tname("A"), Nil, ctorp(Nil), Nil))
+      enumWithCase("E", Defn.EnumCase(Nil, tname("A"), Nil, ctorp(Nil), Nil)),
     )
   }
 
   test("case-arguments")(runTestAssert[Stat]("enum Option { case Some(x: Int) }")(
-    enumWithCase("Option", Defn.EnumCase(Nil, tname("Some"), Nil, ctorp(tparam("x", "Int")), Nil))
+    enumWithCase("Option", Defn.EnumCase(Nil, tname("Some"), Nil, ctorp(tparam("x", "Int")), Nil)),
   ))
 
   test("case-annotation")(
@@ -271,33 +271,33 @@ class EnumSuite extends BaseDottySuite {
         tname("Some"),
         Nil,
         ctorp(tparam("x", "Int")),
-        Nil
-      )
-    ))
+        Nil,
+      ),
+    )),
   )
 
   test("case-generic") {
     val generic = pparam("X", bounds(cb = List(pname("Ord"))))
     runTestAssert[Stat]("enum E { case A[X: Ord]() }")(
-      enumWithCase("E", Defn.EnumCase(Nil, tname("A"), List(generic), ctorp(Nil), Nil))
+      enumWithCase("E", Defn.EnumCase(Nil, tname("A"), List(generic), ctorp(Nil), Nil)),
     )
     runTestAssert[Stat]("enum E { case A[X: Ord] }")(
-      enumWithCase("E", Defn.EnumCase(Nil, tname("A"), List(generic), ctor, Nil))
+      enumWithCase("E", Defn.EnumCase(Nil, tname("A"), List(generic), ctor, Nil)),
     )
   }
 
   test("case-extends")(
     runTestAssert[Stat]("enum Option { case None extends Option[Nothing] }")(enumWithCase(
       "Option",
-      Defn.EnumCase(Nil, tname("None"), Nil, ctor, List(init(papply("Option", "Nothing"))))
-    ))
+      Defn.EnumCase(Nil, tname("None"), Nil, ctor, List(init(papply("Option", "Nothing")))),
+    )),
   )
 
   test("case-extends-argument")(
     runTestAssert[Stat]("enum Color { case Red extends Color(65280) }")(enumWithCase(
       "Color",
-      Defn.EnumCase(Nil, tname("Red"), Nil, EmptyCtor(), List(init("Color", List(int(65280)))))
-    ))
+      Defn.EnumCase(Nil, tname("Red"), Nil, EmptyCtor(), List(init("Color", List(int(65280))))),
+    )),
   )
 
   test("case-extends-argument-generic")(
@@ -308,9 +308,9 @@ class EnumSuite extends BaseDottySuite {
         tname("Red"),
         List(pparam("T")),
         ctorp(List(tparam("a", "Int"))),
-        List(init("Color", List(int(65280))))
-      )
-    ))
+        List(init("Color", List(int(65280)))),
+      ),
+    )),
   )
 
   test("enum-case-toplevel") {
@@ -329,8 +329,8 @@ class EnumSuite extends BaseDottySuite {
         tname("Red"),
         List(pparam("T")),
         ctorp(tparam("a", "Int")),
-        List(init("Color", List(lit(65280))))
-      ))
+        List(init("Color", List(lit(65280)))),
+      )),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -342,7 +342,7 @@ class EnumSuite extends BaseDottySuite {
          |""".stripMargin
     val expected = "enum A { case B, C }"
     runTestAssert[Stat](code, assertLayout = Some(expected))(
-      enumWithCase("A", Defn.RepeatedEnumCase(Nil, List(tname("B"), tname("C"))))
+      enumWithCase("A", Defn.RepeatedEnumCase(Nil, List(tname("B"), tname("C")))),
     )
   }
 
@@ -358,7 +358,7 @@ class EnumSuite extends BaseDottySuite {
       pname("A"),
       Nil,
       EmptyCtor(),
-      tpl(Defn.RepeatedEnumCase(Nil, List(tname("B"), tname("C"))))
+      tpl(Defn.RepeatedEnumCase(Nil, List(tname("B"), tname("C")))),
     ))
   }
 
@@ -377,8 +377,8 @@ class EnumSuite extends BaseDottySuite {
       tpl(
         self("self"),
         Defn.EnumCase(Nil, tname("B"), Nil, ctorp(List(tparam("v", "Int"))), Nil),
-        Defn.EnumCase(Nil, tname("C"), Nil, ctorp(List(tparam("v", "String"))), Nil)
-      )
+        Defn.EnumCase(Nil, tname("C"), Nil, ctorp(List(tparam("v", "String"))), Nil),
+      ),
     ))
   }
 
@@ -405,8 +405,8 @@ class EnumSuite extends BaseDottySuite {
         self("self"),
         Defn.EnumCase(Nil, tname("B"), Nil, ctorp(tparam("v", "Int")), Nil),
         Defn.EnumCase(Nil, tname("C"), Nil, ctorp(tparam("v", "String")), Nil),
-        Defn.Def(Nil, tname("fx"), Nil, Nil, Some(pname("Int")), int(4))
-      )
+        Defn.Def(Nil, tname("fx"), Nil, Nil, Some(pname("Int")), int(4)),
+      ),
     ))
   }
 
@@ -430,8 +430,8 @@ class EnumSuite extends BaseDottySuite {
       tname("Main"),
       tpl(
         enumWithCase("A", Defn.RepeatedEnumCase(Nil, List(tname("B"), tname("C")))),
-        Defn.Object(Nil, tname("X"), tpl(Defn.Val(Nil, List(patvar("x")), None, str("x"))))
-      )
+        Defn.Object(Nil, tname("X"), tpl(Defn.Val(Nil, List(patvar("x")), None, str("x")))),
+      ),
     ))
   }
 
@@ -460,10 +460,10 @@ class EnumSuite extends BaseDottySuite {
           pname("A"),
           Nil,
           EmptyCtor(),
-          tpl(self("kind"), Defn.RepeatedEnumCase(Nil, List(tname("B"), tname("C"))))
+          tpl(self("kind"), Defn.RepeatedEnumCase(Nil, List(tname("B"), tname("C")))),
         ),
-        Term.EndMarker(tname("A"))
-      )
+        Term.EndMarker(tname("A")),
+      ),
     ))
   }
 
@@ -491,8 +491,8 @@ class EnumSuite extends BaseDottySuite {
       EmptyCtor(),
       tpl(
         Defn.EnumCase(Nil, tname("Hmm"), Nil, EmptyCtor(), Nil),
-        Defn.Val(Nil, List(patvar("a")), None, tfunc()(blk(tapply(tname("fx")), tapply(tname("gx")))))
-      )
+        Defn.Val(Nil, List(patvar("a")), None, tfunc()(blk(tapply(tname("fx")), tapply(tname("gx"))))),
+      ),
     ))
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ErasedDefsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ErasedDefsSuite.scala
@@ -18,7 +18,7 @@ class ErasedDefsSuite extends BaseDottySuite {
       pname("ClassWithErasedEv"),
       Nil,
       ctorp(tparam(List(Mod.Erased()), "ev", "Ev"), tparam("x", "Int")),
-      tplNoBody()
+      tplNoBody(),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -31,7 +31,7 @@ class ErasedDefsSuite extends BaseDottySuite {
       Nil,
       List(List(tparam(List(Mod.Erased()), "ev", "Ev"), tparam("x", "Int"))),
       Some(pname("Int")),
-      tinfix(tname("x"), "+", int(2))
+      tinfix(tname("x"), "+", int(2)),
     ))
   }
 
@@ -41,14 +41,14 @@ class ErasedDefsSuite extends BaseDottySuite {
       Nil,
       List(patvar("lambdaWithErasedEv")),
       Some(pfunc(Type.FunctionArg(List(Mod.Erased()), pname("Ev")), pname("Int"))(pname("Int"))),
-      tfunc(tparam(List(Mod.Erased()), "ev"), tparam("x"))(tinfix(tname("x"), "+", int(2)))
+      tfunc(tparam(List(Mod.Erased()), "ev"), tparam("x"))(tinfix(tname("x"), "+", int(2))),
     ))
   }
 
   test("erased val") {
     val code = "erased val erasedEvidence: Ev = null"
     runTestAssert[Stat](code)(
-      Defn.Val(List(Mod.Erased()), List(patvar("erasedEvidence")), Some(pname("Ev")), Lit.Null())
+      Defn.Val(List(Mod.Erased()), List(patvar("erasedEvidence")), Some(pname("Ev")), Lit.Null()),
     )
   }
 
@@ -60,7 +60,7 @@ class ErasedDefsSuite extends BaseDottySuite {
       Nil,
       List(List(tparam("x", "Int"), tparam(List(Mod.Erased()), "ev", "Ev"))),
       Some(pname("Int")),
-      tname("???")
+      tname("???"),
     ))
   }
 
@@ -72,7 +72,7 @@ class ErasedDefsSuite extends BaseDottySuite {
       Nil,
       List(tparam(List(Mod.Using(), Mod.Erased()), "ev", papply("IsOff", "S")) :: Nil),
       Some(papply("Machine", "On")),
-      Term.New(init(papply("Machine", "On")))
+      Term.New(init(papply("Machine", "On"))),
     ))
   }
 
@@ -88,7 +88,7 @@ class ErasedDefsSuite extends BaseDottySuite {
       anon,
       None,
       papply("IsEmpty", "Empty"),
-      Term.New(init(papply("IsEmpty", "Empty")))
+      Term.New(init(papply("IsEmpty", "Empty"))),
     ))
   }
 
@@ -99,7 +99,7 @@ class ErasedDefsSuite extends BaseDottySuite {
          |}""".stripMargin
     runTestAssert[Stat](code)(tapply(
       tselect(tapply(tname("List"), int(1), int(2), int(3)), "map"),
-      blk(tfunc(tparam(List(Mod.Using(), Mod.Erased()), "i", "Int"))(tname("i")))
+      blk(tfunc(tparam(List(Mod.Using(), Mod.Erased()), "i", "Int"))(tname("i"))),
     ))
   }
 
@@ -109,7 +109,7 @@ class ErasedDefsSuite extends BaseDottySuite {
       Nil,
       List(patvar("fun")),
       None,
-      tfunc(tparam(List(Mod.Using(), Mod.Erased()), "ctx", "Context"))(tselect("ctx", "open"))
+      tfunc(tparam(List(Mod.Using(), Mod.Erased()), "ctx", "Context"))(tselect("ctx", "open")),
     ))
   }
 
@@ -119,7 +119,7 @@ class ErasedDefsSuite extends BaseDottySuite {
       Nil,
       List(patvar("fun")),
       None,
-      tfunc(tparam(List(Mod.Using(), Mod.Erased()), "ctx"))(tselect("ctx", "open"))
+      tfunc(tparam(List(Mod.Using(), Mod.Erased()), "ctx"))(tselect("ctx", "open")),
     ))
   }
 
@@ -129,7 +129,7 @@ class ErasedDefsSuite extends BaseDottySuite {
       Nil,
       List(patvar("fun")),
       None,
-      tfunc(tparam(List(Mod.Using(), Mod.Erased()), "_", "Context"))(tselect("ctx", "open"))
+      tfunc(tparam(List(Mod.Using(), Mod.Erased()), "_", "Context"))(tselect("ctx", "open")),
     ))
   }
 
@@ -141,7 +141,7 @@ class ErasedDefsSuite extends BaseDottySuite {
          |""".stripMargin
     runTestAssert[Stat](code)(tapply(
       tname("LazyBody"),
-      blk(tfunc(tparam(List(Mod.Using(), Mod.Erased()), "ctx", "Context"))(int(3)))
+      blk(tfunc(tparam(List(Mod.Using(), Mod.Erased()), "ctx", "Context"))(int(3))),
     ))
   }
 
@@ -151,7 +151,7 @@ class ErasedDefsSuite extends BaseDottySuite {
       Nil,
       List(patvar("extractor")),
       Some(pfunc(Type.TypedParam(pname("e"), pname("Entry"), List(Mod.Erased())))(pselect("e", "Key"))),
-      tname("extractKey")
+      tname("extractKey"),
     ))
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExportImportSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExportImportSuite.scala
@@ -5,37 +5,37 @@ import scala.meta._
 class ExportImportSuite extends BaseDottySuite {
 
   test("export-single")(runTestAssert[Stat]("export A.b.c")(Export(
-    List(Importer(tselect("A", "b"), List(Importee.Name(Name("c")))))
+    List(Importer(tselect("A", "b"), List(Importee.Name(Name("c"))))),
   )))
 
   test("export-single-toplevel")(
     runTestAssert[Source](
       """|package a
          |export A.b.c
-         |""".stripMargin
+         |""".stripMargin,
     )(Source(
-      List(Pkg(tname("a"), List(Export(List(Importer(tselect("A", "b"), List(Importee.Name(Name("c")))))))))
-    ))
+      List(Pkg(tname("a"), List(Export(List(Importer(tselect("A", "b"), List(Importee.Name(Name("c"))))))))),
+    )),
   )
 
   test("export-given")(
     runTestAssert[Stat]("export A.{ given Int }", assertLayout = Some("export A.given Int"))(Export(
-      List(Importer(tname("A"), List(Importee.Given(pname("Int")))))
-    ))
+      List(Importer(tname("A"), List(Importee.Given(pname("Int"))))),
+    )),
   )
 
   test("export-given-no-brace")(
     runTestAssert[Stat]("export A.given Int", assertLayout = Some("export A.given Int"))(Export(
-      List(Importer(tname("A"), List(Importee.Given(pname("Int")))))
-    ))
+      List(Importer(tname("A"), List(Importee.Given(pname("Int"))))),
+    )),
   )
 
   test("export-given-all")(
-    runTestAssert[Stat]("export A.given")(Export(List(Importer(tname("A"), List(Importee.GivenAll())))))
+    runTestAssert[Stat]("export A.given")(Export(List(Importer(tname("A"), List(Importee.GivenAll()))))),
   )
 
   test("export-given-all-mixed")(runTestAssert[Stat]("export A.{ given, a }")(Export(
-    List(Importer(tname("A"), List(Importee.GivenAll(), Importee.Name(Name("a")))))
+    List(Importer(tname("A"), List(Importee.GivenAll(), Importee.Name(Name("a"))))),
   )))
 
   test("export-multiple")(runTestAssert[Stat]("export A.{ b, c, d, * }")(Export(List(Importer(
@@ -44,44 +44,44 @@ class ExportImportSuite extends BaseDottySuite {
       Importee.Name(Name("b")),
       Importee.Name(Name("c")),
       Importee.Name(Name("d")),
-      Importee.Wildcard()
-    )
+      Importee.Wildcard(),
+    ),
   )))))
 
   test("export-multiple-rename")(runTestAssert[Stat]("export A.{ b as x, c as _ }")(Export(
-    List(Importer(tname("A"), List(Importee.Rename(Name("b"), Name("x")), Importee.Unimport(Name("c")))))
+    List(Importer(tname("A"), List(Importee.Rename(Name("b"), Name("x")), Importee.Unimport(Name("c"))))),
   )))
 
   test("rename-as")(runTestAssert[Stat]("import a.b.C as D")(Import(
-    List(Importer(tselect("a", "b"), List(Importee.Rename(Name("C"), Name("D")))))
+    List(Importer(tselect("a", "b"), List(Importee.Rename(Name("C"), Name("D"))))),
   )))
 
   test("rename-as-simple")(runTestAssert[Stat]("import c as d")(Import(
-    List(Importer(Term.Anonymous(), List(Importee.Rename(Name("c"), Name("d")))))
+    List(Importer(Term.Anonymous(), List(Importee.Rename(Name("c"), Name("d"))))),
   )))
 
   test("rename-multi")(
     runTestAssert[Stat]("import A.{ min as minimum, `*` as multiply }")(Import(List(Importer(
       tname("A"),
-      List(Importee.Rename(Name("min"), Name("minimum")), Importee.Rename(Name("*"), Name("multiply")))
-    ))))
+      List(Importee.Rename(Name("min"), Name("minimum")), Importee.Rename(Name("*"), Name("multiply"))),
+    )))),
   )
   test("rename-multi-unimport")(
     runTestAssert[Stat]("import Predef.{ augmentString as _, * }")(Import(List(
-      Importer(tname("Predef"), List(Importee.Unimport(Name("augmentString")), Importee.Wildcard()))
-    )))
+      Importer(tname("Predef"), List(Importee.Unimport(Name("augmentString")), Importee.Wildcard())),
+    ))),
   )
 
   test("unimport-as")(runTestAssert[Stat]("import a.b.C as _")(Import(
-    List(Importer(tselect("a", "b"), List(Importee.Unimport(Name("C")))))
+    List(Importer(tselect("a", "b"), List(Importee.Unimport(Name("C"))))),
   )))
 
   test("import-wildcard")(runTestAssert[Stat]("import A.b.*")(Import(
-    List(Importer(tselect("A", "b"), List(Importee.Wildcard())))
+    List(Importer(tselect("A", "b"), List(Importee.Wildcard()))),
   )))
 
   test("import-wildcard-backquoted")(runTestAssert[Stat]("import A.b.`*`")(Import(
-    List(Importer(tselect("A", "b"), List(Importee.Name(Name("*")))))
+    List(Importer(tselect("A", "b"), List(Importee.Name(Name("*"))))),
   )))
 
   test("#3754 export Type.this.field") {
@@ -95,7 +95,7 @@ class ExportImportSuite extends BaseDottySuite {
       pname("A"),
       Nil,
       ctorp(Nil),
-      tpl(Export(List(Importer(Term.This(Name("A")), List(Importee.Name(Name("value")))))))
+      tpl(Export(List(Importer(Term.This(Name("A")), List(Importee.Name(Name("value"))))))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExtensionMethodsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExtensionMethodsSuite.scala
@@ -24,15 +24,15 @@ class ExtensionMethodsSuite extends BaseDottySuite {
 
   test("simple-method")(runTestAssert[Stat]("extension (c: Circle) def crc: Int = 2")(
     Defn
-      .ExtensionGroup(Nil, cparamss, Defn.Def(Nil, tname("crc"), Nil, Nil, Some(pname("Int")), int(2)))
+      .ExtensionGroup(Nil, cparamss, Defn.Def(Nil, tname("crc"), Nil, Nil, Some(pname("Int")), int(2))),
   ))
 
   test("modifier-method")(
     runTestAssert[Stat]("extension (c: Circle) private def crc: Int = 2")(Defn.ExtensionGroup(
       Nil,
       cparamss,
-      Defn.Def(List(Mod.Private(anon)), tname("crc"), Nil, Nil, Some(pname("Int")), int(2))
-    ))
+      Defn.Def(List(Mod.Private(anon)), tname("crc"), Nil, Nil, Some(pname("Int")), int(2)),
+    )),
   )
 
   test("simple-method-indent") {
@@ -44,8 +44,8 @@ class ExtensionMethodsSuite extends BaseDottySuite {
       Defn.ExtensionGroup(
         Nil,
         cparamss,
-        Defn.Def(Nil, tname("crc"), Nil, Nil, Some(pname("Int")), int(2))
-      )
+        Defn.Def(Nil, tname("crc"), Nil, Nil, Some(pname("Int")), int(2)),
+      ),
     )
   }
 
@@ -58,8 +58,8 @@ class ExtensionMethodsSuite extends BaseDottySuite {
       Defn.ExtensionGroup(
         Nil,
         List(List(tparam("c", "Circle"))),
-        Defn.Def(List(Mod.Private(anon)), tname("crc"), Nil, Nil, Some(pname("Int")), int(2))
-      )
+        Defn.Def(List(Mod.Private(anon)), tname("crc"), Nil, Nil, Some(pname("Int")), int(2)),
+      ),
     )
   }
 
@@ -76,8 +76,8 @@ class ExtensionMethodsSuite extends BaseDottySuite {
       blk(
         Defn.Def(Nil, tname("cra"), Nil, Nil, Some(pname("Int")), int(2)),
         Defn.Def(Nil, tname("crb"), Nil, Nil, Some(pname("String")), str("3")),
-        Defn.Def(Nil, tname("crc"), Nil, Nil, Some(pname("Boolean")), int(4))
-      )
+        Defn.Def(Nil, tname("crc"), Nil, Nil, Some(pname("Boolean")), int(4)),
+      ),
     ))
   }
 
@@ -93,12 +93,12 @@ class ExtensionMethodsSuite extends BaseDottySuite {
         """|extension (c: Circle) {
            |  def crc: Int = 2
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.ExtensionGroup(
       Nil,
       List(List(tparam("c", "Circle"))),
-      blk(Defn.Def(Nil, tname("crc"), Nil, Nil, Some(pname("Int")), int(2)))
+      blk(Defn.Def(Nil, tname("crc"), Nil, Nil, Some(pname("Int")), int(2))),
     ))
   }
 
@@ -117,9 +117,9 @@ class ExtensionMethodsSuite extends BaseDottySuite {
       Nil,
       List(
         List(tparam("c", "Circle")),
-        List(tparam(List(Mod.Using()), "", "Context"), tparam(List(Mod.Using()), "x", "Int"))
+        List(tparam(List(Mod.Using()), "", "Context"), tparam(List(Mod.Using()), "x", "Int")),
       ),
-      blk(Defn.Def(Nil, tname("crc"), Nil, Nil, Some(pname("Int")), int(2)))
+      blk(Defn.Def(Nil, tname("crc"), Nil, Nil, Some(pname("Int")), int(2))),
     ))
   }
 
@@ -140,9 +140,9 @@ class ExtensionMethodsSuite extends BaseDottySuite {
       Nil,
       List(
         List(tparam("c", "Circle")),
-        List(tparam(List(Mod.Using()), "", "Context"), tparam(List(Mod.Using()), "x", "Int"))
+        List(tparam(List(Mod.Using()), "", "Context"), tparam(List(Mod.Using()), "x", "Int")),
       ),
-      blk(Defn.Def(Nil, tname("crc"), Nil, Nil, Some(pname("Int")), int(2)))
+      blk(Defn.Def(Nil, tname("crc"), Nil, Nil, Some(pname("Int")), int(2))),
     ))
   }
 
@@ -162,9 +162,9 @@ class ExtensionMethodsSuite extends BaseDottySuite {
       List(
         List(tparam("c", "Circle")),
         List(tparam(List(Mod.Using()), "", "Context"), tparam(List(Mod.Using()), "x", "Int")),
-        List(tparam(List(Mod.Using()), "y", "String"), tparam(List(Mod.Using()), "", "File"))
+        List(tparam(List(Mod.Using()), "y", "String"), tparam(List(Mod.Using()), "", "File")),
       ),
-      blk(Defn.Def(Nil, tname("crc"), Nil, Nil, Some(pname("Int")), int(2)))
+      blk(Defn.Def(Nil, tname("crc"), Nil, Nil, Some(pname("Int")), int(2))),
     ))
   }
 
@@ -182,11 +182,11 @@ class ExtensionMethodsSuite extends BaseDottySuite {
          |""".stripMargin,
       """|extension (a: Int) {
          |  def double = a * 2
-         |}""".stripMargin
+         |}""".stripMargin,
     )(Defn.ExtensionGroup(
       Nil,
       List(List(tparam("a", "Int"))),
-      blk(Defn.Def(Nil, tname("double"), Nil, Nil, None, tinfix(tname("a"), "*", int(2))))
+      blk(Defn.Def(Nil, tname("double"), Nil, Nil, None, tinfix(tname("a"), "*", int(2)))),
     ))
   }
 
@@ -200,14 +200,14 @@ class ExtensionMethodsSuite extends BaseDottySuite {
          |}""".stripMargin,
       s"""|<input>:4: error: Extension without extension method
           |}
-          |^""".stripMargin
+          |^""".stripMargin,
     )
 
     runTestAssert[Stat](
       """|object A {
          |  def extension(a: Int) = a + 2
          |  `extension`(2)
-         |}""".stripMargin
+         |}""".stripMargin,
     )(Defn.Object(
       Nil,
       tname("A"),
@@ -218,10 +218,10 @@ class ExtensionMethodsSuite extends BaseDottySuite {
           Nil,
           List(List(tparam("a", "Int"))),
           None,
-          tinfix(tname("a"), "+", int(2))
+          tinfix(tname("a"), "+", int(2)),
         ),
-        tapply(tname("extension"), int(2))
-      )
+        tapply(tname("extension"), int(2)),
+      ),
     ))
   }
 
@@ -234,7 +234,7 @@ class ExtensionMethodsSuite extends BaseDottySuite {
       Nil,
       List(List(tparam("x", "extension"))),
       Some(pname("extension")),
-      tname("x")
+      tname("x"),
     ))
 
     runTestAssert[Stat]("extension.extension(3)")(tapply(tselect("extension", "extension"), int(3)))
@@ -251,18 +251,18 @@ class ExtensionMethodsSuite extends BaseDottySuite {
           List(pparam("U")),
           List(List(tparam("t", "T"))),
           Some(pname("U")),
-          tname("???")
-        )
-      )
-    )
+          tname("???"),
+        ),
+      ),
+    ),
   )
 
   test("method-using-before")(
     runTestAssert[Stat]("extension (using a: Int)(b: Int) def hello = a + b")(Defn.ExtensionGroup(
       Nil,
       List(List(tparam(List(Mod.Using()), "a", "Int")), List(tparam("b", "Int"))),
-      Defn.Def(Nil, tname("hello"), Nil, Nil, None, tinfix(tname("a"), "+", tname("b")))
-    ))
+      Defn.Def(Nil, tname("hello"), Nil, Nil, None, tinfix(tname("a"), "+", tname("b"))),
+    )),
   )
 
   test("method-multi-using") {
@@ -279,13 +279,13 @@ class ExtensionMethodsSuite extends BaseDottySuite {
          |  ) 
          |    def hello = a + b + c.toInt""".stripMargin,
       assertLayout =
-        Some("extension (using a: Int)(b: Int)(using c: String) def hello = a + b + c.toInt")
+        Some("extension (using a: Int)(b: Int)(using c: String) def hello = a + b + c.toInt"),
     )(Defn.ExtensionGroup(
       Nil,
       List(
         List(tparam(List(Mod.Using()), "a", "Int")),
         List(tparam("b", "Int")),
-        List(tparam(List(Mod.Using()), "c", "String"))
+        List(tparam(List(Mod.Using()), "c", "String")),
       ),
       Defn.Def(
         Nil,
@@ -293,8 +293,8 @@ class ExtensionMethodsSuite extends BaseDottySuite {
         Nil,
         Nil,
         None,
-        tinfix(tinfix(tname("a"), "+", tname("b")), "+", tselect("c", "toInt"))
-      )
+        tinfix(tinfix(tname("a"), "+", tname("b")), "+", tselect("c", "toInt")),
+      ),
     ))
   }
 
@@ -309,8 +309,8 @@ class ExtensionMethodsSuite extends BaseDottySuite {
            |  private def richInt = RichInt(i)
            |  export richInt.*
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.ExtensionGroup(
       Nil,
       List(List(tparam("i", "Int"))),
@@ -321,10 +321,10 @@ class ExtensionMethodsSuite extends BaseDottySuite {
           Nil,
           Nil,
           None,
-          tapply(tname("RichInt"), tname("i"))
+          tapply(tname("RichInt"), tname("i")),
         ),
-        Export(List(Importer(tname("richInt"), List(Importee.Wildcard()))))
-      )
+        Export(List(Importer(tname("richInt"), List(Importee.Wildcard())))),
+      ),
     ))
   }
 
@@ -347,8 +347,8 @@ class ExtensionMethodsSuite extends BaseDottySuite {
            |  def bar: Bar = getBar
            |  end bar
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.ExtensionGroup(
       Nil,
       List(List(tparam("x", "X"))),
@@ -356,8 +356,8 @@ class ExtensionMethodsSuite extends BaseDottySuite {
         Defn.Def(Nil, tname("foo"), Nil, Some(pname("Foo")), tname("getFoo")),
         Term.EndMarker(tname("foo")),
         Defn.Def(Nil, tname("bar"), Nil, Some(pname("Bar")), tname("getBar")),
-        Term.EndMarker(tname("bar"))
-      )
+        Term.EndMarker(tname("bar")),
+      ),
     ))
   }
 
@@ -383,8 +383,8 @@ class ExtensionMethodsSuite extends BaseDottySuite {
            |    end bar
            |  }
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Object(
       Nil,
       tname("MtagsEnrichments"),
@@ -397,10 +397,10 @@ class ExtensionMethodsSuite extends BaseDottySuite {
             Defn.Def(Nil, tname("foo"), Nil, Some(pname("Foo")), tname("getFoo")),
             Term.EndMarker(tname("foo")),
             Defn.Def(Nil, tname("bar"), Nil, Some(pname("Bar")), tname("getBar")),
-            Term.EndMarker(tname("bar"))
-          )
-        ) :: Nil
-      )
+            Term.EndMarker(tname("bar")),
+          ),
+        ) :: Nil,
+      ),
     ))
   }
 
@@ -427,8 +427,8 @@ class ExtensionMethodsSuite extends BaseDottySuite {
            |    end bar
            |  }
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Object(
       Nil,
       tname("MtagsEnrichments"),
@@ -441,10 +441,10 @@ class ExtensionMethodsSuite extends BaseDottySuite {
             Defn.Def(Nil, tname("foo"), Nil, Some(pname("Foo")), tname("getFoo")),
             Term.EndMarker(tname("foo")),
             Defn.Def(Nil, tname("bar"), Nil, Some(pname("Bar")), tname("getBar")),
-            Term.EndMarker(tname("bar"))
-          )
-        ) :: Nil
-      )
+            Term.EndMarker(tname("bar")),
+          ),
+        ) :: Nil,
+      ),
     ))
   }
 
@@ -469,8 +469,8 @@ class ExtensionMethodsSuite extends BaseDottySuite {
            |    @annoBar def bar: Bar = getBar
            |  }
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Object(
       Nil,
       tname("A"),
@@ -485,18 +485,18 @@ class ExtensionMethodsSuite extends BaseDottySuite {
               tname("foo"),
               Nil,
               Some(pname("Foo")),
-              tname("getFoo")
+              tname("getFoo"),
             ),
             Defn.Def(
               List(Mod.Annot(init("annoBar"))),
               tname("bar"),
               Nil,
               Some(pname("Bar")),
-              tname("getBar")
-            )
-          )
-        )
-      )
+              tname("getBar"),
+            ),
+          ),
+        ),
+      ),
     ))
   }
 
@@ -519,8 +519,8 @@ class ExtensionMethodsSuite extends BaseDottySuite {
            |    protected def bar: Bar = getBar
            |  }
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Object(
       Nil,
       tname("A"),
@@ -532,10 +532,10 @@ class ExtensionMethodsSuite extends BaseDottySuite {
           blk(
             Defn.Def(List(Mod.Private(anon)), tname("foo"), Nil, Some(pname("Foo")), tname("getFoo")),
             Defn
-              .Def(List(Mod.Protected(anon)), tname("bar"), Nil, Some(pname("Bar")), tname("getBar"))
-          )
-        )
-      )
+              .Def(List(Mod.Protected(anon)), tname("bar"), Nil, Some(pname("Bar")), tname("getBar")),
+          ),
+        ),
+      ),
     ))
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/FewerBracesSuite.scala
@@ -16,8 +16,8 @@ class FewerBracesSuite extends BaseDottySuite {
            |  val fileNames = files.values
            |  filenames
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Val(
       Nil,
       List(patvar("firstLine")),
@@ -26,9 +26,9 @@ class FewerBracesSuite extends BaseDottySuite {
         tselect(tapply(tselect("files", "get"), tname("fileName")), "fold"),
         blk(
           Defn.Val(Nil, List(patvar("fileNames")), None, tselect("files", "values")),
-          tname("filenames")
-        )
-      )
+          tname("filenames"),
+        ),
+      ),
     ))
   }
   test("simple-comment") {
@@ -45,12 +45,12 @@ class FewerBracesSuite extends BaseDottySuite {
          |    line */
          |  indentedCode
          |}
-         |""".stripMargin
+         |""".stripMargin,
     )(Defn.Val(
       Nil,
       List(patvar("firstLine")),
       None,
-      tapply(tname("map"), blk(tnameComments("indentedCode")("/*\n    line\n    line */")()))
+      tapply(tname("map"), blk(tnameComments("indentedCode")("/*\n    line\n    line */")())),
     ))
   }
 
@@ -63,14 +63,14 @@ class FewerBracesSuite extends BaseDottySuite {
         """|val firstLine = files.map {
            |  a => a
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Val(
       Nil,
       List(patvar("firstLine")),
       None,
-      tapply(tselect("files", "map"), blk(tfunc(tparam("a"))(tname("a"))))
-    ))
+      tapply(tselect("files", "map"), blk(tfunc(tparam("a"))(tname("a")))),
+    )),
   )
 
   test("advanced-same-line") {
@@ -82,13 +82,13 @@ class FewerBracesSuite extends BaseDottySuite {
         """|val firstLine = files.map {
            |  (a, b) => a
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Val(
       Nil,
       List(patvar("firstLine")),
       None,
-      tapply(tselect("files", "map"), blk(tfunc(tparam("a"), tparam("b"))(tname("a"))))
+      tapply(tselect("files", "map"), blk(tfunc(tparam("a"), tparam("b"))(tname("a")))),
     ))
   }
 
@@ -106,7 +106,7 @@ class FewerBracesSuite extends BaseDottySuite {
       Nil,
       List(patvar("firstLine")),
       None,
-      tapply(tselect("files", "map"), blk(tpolyfunc(pparam("a"), pparam("b"))(tname("a"))))
+      tapply(tselect("files", "map"), blk(tpolyfunc(pparam("a"), pparam("b"))(tname("a")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -121,16 +121,16 @@ class FewerBracesSuite extends BaseDottySuite {
         """|val firstLine = files.map {
            |  case (a, b) => a
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Val(
       Nil,
       List(patvar("firstLine")),
       None,
       tapply(
         tselect("files", "map"),
-        Term.PartialFunction(List(Case(Pat.Tuple(List(patvar("a"), patvar("b"))), None, tname("a"))))
-      )
+        Term.PartialFunction(List(Case(Pat.Tuple(List(patvar("a"), patvar("b"))), None, tname("a")))),
+      ),
     ))
   }
 
@@ -152,8 +152,8 @@ class FewerBracesSuite extends BaseDottySuite {
            |  }
            |  def hello = ???
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Def(
       Nil,
       tname("main"),
@@ -169,12 +169,12 @@ class FewerBracesSuite extends BaseDottySuite {
             tselect("files", "map"),
             Term.PartialFunction(List(
               Case(Pat.Extract(tname("A"), List(patvar("a"))), None, tname("a")),
-              Case(Pat.Extract(tname("B"), List(patvar("b"))), None, tname("b"))
-            ))
-          )
+              Case(Pat.Extract(tname("B"), List(patvar("b"))), None, tname("b")),
+            )),
+          ),
         ),
-        Defn.Def(Nil, tname("hello"), Nil, Nil, None, tname("???"))
-      )
+        Defn.Def(Nil, tname("hello"), Nil, Nil, None, tname("???")),
+      ),
     ))
   }
 
@@ -196,8 +196,8 @@ class FewerBracesSuite extends BaseDottySuite {
            |    123
            |  }
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Def(
       Nil,
       tname("O"),
@@ -206,8 +206,8 @@ class FewerBracesSuite extends BaseDottySuite {
       None,
       blk(
         Defn.Val(Nil, List(patvar("firstLine")), None, tapply(tselect("files", "fold"), blk(int(123)))),
-        Defn.Val(Nil, List(patvar("secondLine")), None, tapply(tselect("files", "fold"), blk(int(123))))
-      )
+        Defn.Val(Nil, List(patvar("secondLine")), None, tapply(tselect("files", "fold"), blk(int(123)))),
+      ),
     ))
   }
 
@@ -223,8 +223,8 @@ class FewerBracesSuite extends BaseDottySuite {
            |  val file = Path.userHome / ".credentials"
            |  file
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Def(
       Nil,
       tname("O"),
@@ -238,11 +238,11 @@ class FewerBracesSuite extends BaseDottySuite {
             Nil,
             List(patvar("file")),
             None,
-            tinfix(tselect("Path", "userHome"), "/", str(".credentials"))
+            tinfix(tselect("Path", "userHome"), "/", str(".credentials")),
           ),
-          tname("file")
-        )
-      )
+          tname("file"),
+        ),
+      ),
     ))
   }
 
@@ -264,8 +264,8 @@ class FewerBracesSuite extends BaseDottySuite {
            |    (a, b) => a
            |  }
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Def(
       Nil,
       tname("O"),
@@ -278,9 +278,9 @@ class FewerBracesSuite extends BaseDottySuite {
         None,
         tapply(
           tselect(tapply(tselect("files", "fold"), blk(int(123))), "apply"),
-          blk(tfunc(tparam("a"), tparam("b"))(tname("a")))
-        )
-      ))
+          blk(tfunc(tparam("a"), tparam("b"))(tname("a"))),
+        ),
+      )),
     ))
   }
 
@@ -294,8 +294,8 @@ class FewerBracesSuite extends BaseDottySuite {
         """|def O = List((1, (List(""), 3))).map {
            |  (a: (Int, (List[String], Int))) => a._1 + 1
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Def(
       Nil,
       tname("O"),
@@ -306,18 +306,18 @@ class FewerBracesSuite extends BaseDottySuite {
         tselect(
           tapply(
             tname("List"),
-            Term.Tuple(List(int(1), Term.Tuple(List(tapply(tname("List"), str("")), int(3)))))
+            Term.Tuple(List(int(1), Term.Tuple(List(tapply(tname("List"), str("")), int(3))))),
           ),
-          "map"
+          "map",
         ),
         blk(
           tfunc(tparam(
             Nil,
             "a",
-            Type.Tuple(List(pname("Int"), Type.Tuple(List(papply("List", "String"), pname("Int")))))
-          ))(tinfix(tselect("a", "_1"), "+", int(1)))
-        )
-      )
+            Type.Tuple(List(pname("Int"), Type.Tuple(List(papply("List", "String"), pname("Int"))))),
+          ))(tinfix(tselect("a", "_1"), "+", int(1))),
+        ),
+      ),
     ))
   }
 
@@ -336,8 +336,8 @@ class FewerBracesSuite extends BaseDottySuite {
            |}.filter {
            |  (y: Int) => y > 0
            |}(0)
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Val(
       Nil,
       List(patvar("a")),
@@ -346,12 +346,12 @@ class FewerBracesSuite extends BaseDottySuite {
         tapply(
           tselect(
             tapply(tselect("xs", "map"), blk(tfunc(tparam("x"))(tinfix(tname("x"), "*", tname("x"))))),
-            "filter"
+            "filter",
           ),
-          blk(tfunc(tparam("y", "Int"))(tinfix(tname("y"), ">", int(0))))
+          blk(tfunc(tparam("y", "Int"))(tinfix(tname("y"), ">", int(0)))),
         ),
-        int(0)
-      )
+        int(0),
+      ),
     ))
   }
 
@@ -367,9 +367,9 @@ class FewerBracesSuite extends BaseDottySuite {
            |    22
            |  }
            |}
-           |""".stripMargin
-      )
-    )(Defn.Class(Nil, pname("C"), Nil, EmptyCtor(), tpl(tapply(tname("f"), blk(int(22))))))
+           |""".stripMargin,
+      ),
+    )(Defn.Class(Nil, pname("C"), Nil, EmptyCtor(), tpl(tapply(tname("f"), blk(int(22)))))),
   )
 
   test("no-indent") {
@@ -387,11 +387,11 @@ class FewerBracesSuite extends BaseDottySuite {
            |}.filter {
            |  x => x
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(tapply(
       tselect(tapply(tselect("xs", "map"), blk(tfunc(tparam("x"))(tname("x")))), "filter"),
-      blk(tfunc(tparam("x"))(tname("x")))
+      blk(tfunc(tparam("x"))(tname("x"))),
     ))
   }
 
@@ -409,8 +409,8 @@ class FewerBracesSuite extends BaseDottySuite {
            |  val first = arr(0)
            |  first != 1
            |}) println("invalid arr")
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Term.If(
       tinfix(
         tselect("arr", "isEmpty"),
@@ -419,13 +419,13 @@ class FewerBracesSuite extends BaseDottySuite {
           tname("locally"),
           blk(
             Defn.Val(Nil, List(patvar("first")), None, tapply(tname("arr"), int(0))),
-            tinfix(tname("first"), "!=", int(1))
-          )
-        )
+            tinfix(tname("first"), "!=", int(1)),
+          ),
+        ),
       ),
       tapply(tname("println"), str("invalid arr")),
       Lit.Unit(),
-      Nil
+      Nil,
     ))
   }
   // Cannot chain any braceless lambdas without `.`
@@ -444,8 +444,8 @@ class FewerBracesSuite extends BaseDottySuite {
            |    x == y
            |  }
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Def(
       Nil,
       tname("test24"),
@@ -454,8 +454,8 @@ class FewerBracesSuite extends BaseDottySuite {
       None,
       blk(
         tinfix(tinfix(tname("x"), "<", tname("y")), "or", tinfix(tname("x"), ">", tname("y"))),
-        tapply(tname("or"), blk(tinfix(tname("x"), "==", tname("y"))))
-      )
+        tapply(tname("or"), blk(tinfix(tname("x"), "==", tname("y")))),
+      ),
     ))
   }
 
@@ -469,7 +469,7 @@ class FewerBracesSuite extends BaseDottySuite {
        |""".stripMargin,
     """|<input>:3: error: illegal start of definition `.`
        |    .filter: (y: Int) =>
-       |    ^""".stripMargin
+       |    ^""".stripMargin,
   ))
 
   test("#3164 empty argument 1")(runTestError[Stat](
@@ -478,7 +478,7 @@ class FewerBracesSuite extends BaseDottySuite {
        |""".stripMargin,
     """|<input>:2: error: expected fewer-braces method body
        |  test("foo"):
-       |             ^""".stripMargin
+       |             ^""".stripMargin,
   ))
 
   test("#3164 empty argument 2")(runTestError[Stat](
@@ -488,7 +488,7 @@ class FewerBracesSuite extends BaseDottySuite {
        |""".stripMargin,
     """|<input>:2: error: expected fewer-braces method body
        |  foo :
-       |      ^""".stripMargin
+       |      ^""".stripMargin,
   ))
 
   test("#3164 empty argument 3")(
@@ -502,9 +502,9 @@ class FewerBracesSuite extends BaseDottySuite {
            |  foo {
            |    bar
            |  }
-           |}""".stripMargin
-      )
-    )(Defn.Object(Nil, tname("a"), tpl(tapply(tname("foo"), blk(tname("bar"))))))
+           |}""".stripMargin,
+      ),
+    )(Defn.Object(Nil, tname("a"), tpl(tapply(tname("foo"), blk(tname("bar")))))),
   )
 
   test("#3164 empty argument 4")(
@@ -513,8 +513,8 @@ class FewerBracesSuite extends BaseDottySuite {
          |  foo
          |  : bar
          |""".stripMargin,
-      Some("object a { foo: bar }")
-    )(Defn.Object(Nil, tname("a"), tpl(Term.Ascribe(tname("foo"), pname("bar")))))
+      Some("object a { foo: bar }"),
+    )(Defn.Object(Nil, tname("a"), tpl(Term.Ascribe(tname("foo"), pname("bar"))))),
   )
 
   test("#3296") {
@@ -564,8 +564,8 @@ class FewerBracesSuite extends BaseDottySuite {
       tpl(tinfix(
         tapply(tname("List"), int(1), int(2), int(3)),
         "foreach",
-        blk(tfunc(tparam("x", None))(tapply(tname("println"), tname("x"))))
-      ))
+        blk(tfunc(tparam("x", None))(tapply(tname("println"), tname("x")))),
+      )),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -588,8 +588,8 @@ class FewerBracesSuite extends BaseDottySuite {
       tpl(tinfix(
         tname("ids"),
         "foreach",
-        blk(tfunc(tparam("x", None))(tapply(tname("println"), tname("x"))))
-      ))
+        blk(tfunc(tparam("x", None))(tapply(tname("println"), tname("x")))),
+      )),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -616,8 +616,8 @@ class FewerBracesSuite extends BaseDottySuite {
       tname("MyApp"),
       tpl(
         tinfix(tname("ids"), "map", blk(tfunc(tparam("x", None))(tapply(tname("foo"), tname("x"))))),
-        tapply(tname("map"), blk(tfunc(tparam("x", None))(tapply(tname("bar"), tname("x")))))
-      )
+        tapply(tname("map"), blk(tfunc(tparam("x", None))(tapply(tname("bar"), tname("x"))))),
+      ),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -643,9 +643,9 @@ class FewerBracesSuite extends BaseDottySuite {
         tname("ids"),
         "map",
         blk(tfunc(tparam("x", None))(
-          blk(tapply(tname("foo"), tname("x")), tapply(tname("bar"), tname("x")))
-        ))
-      ))
+          blk(tapply(tname("foo"), tname("x")), tapply(tname("bar"), tname("x"))),
+        )),
+      )),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -665,7 +665,7 @@ class FewerBracesSuite extends BaseDottySuite {
     val tree = Defn.Object(
       Nil,
       tname("MyApp"),
-      tpl(tinfix(tapply(tname("List"), int(1), int(2), int(3)), "foreach", blk(tname("println"))))
+      tpl(tinfix(tapply(tname("List"), int(1), int(2), int(3)), "foreach", blk(tname("println")))),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -707,7 +707,7 @@ class FewerBracesSuite extends BaseDottySuite {
     val tree = Defn.Object(
       Nil,
       tname("MyApp"),
-      tpl(tinfix(tname("ids"), "map", blk(tname("foo"))), tapply(tname("map"), blk(tname("bar"))))
+      tpl(tinfix(tname("ids"), "map", blk(tname("foo"))), tapply(tname("map"), blk(tname("bar")))),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -740,12 +740,12 @@ class FewerBracesSuite extends BaseDottySuite {
           ">>>",
           tapply(
             tselect("b", "map"),
-            blk(tname("foo"), tapply(tname("bar"), tname("baz"), tname("qux")))
-          )
+            blk(tname("foo"), tapply(tname("bar"), tname("baz"), tname("qux"))),
+          ),
         ),
         ">>>",
-        tname("c")
-      ))
+        tname("c"),
+      )),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -770,10 +770,10 @@ class FewerBracesSuite extends BaseDottySuite {
       tinfix(
         tname("a"),
         ">>>",
-        tapply(tselect("b", "map"), blk(tname("foo"), tapply(tname("bar"), tname("baz"), tname("qux"))))
+        tapply(tselect("b", "map"), blk(tname("foo"), tapply(tname("bar"), tname("baz"), tname("qux")))),
       ),
       ">>>",
-      tname("c")
+      tname("c"),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -868,10 +868,10 @@ class FewerBracesSuite extends BaseDottySuite {
       tinfix(
         tapply(tselect("foo", "bar"), blk(tname("arg"))),
         "++",
-        tapply(tname("baz"), blk(tname("arg")))
+        tapply(tname("baz"), blk(tname("arg"))),
       ),
       "++",
-      tname("qux")
+      tname("qux"),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -897,10 +897,10 @@ class FewerBracesSuite extends BaseDottySuite {
       tinfix(
         tapply(tselect("foo", "bar"), blk(tname("arg"))),
         "++",
-        tapply(tname("baz"), blk(tname("arg")))
+        tapply(tname("baz"), blk(tname("arg"))),
       ),
       "++",
-      tname("qux")
+      tname("qux"),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -933,11 +933,11 @@ class FewerBracesSuite extends BaseDottySuite {
         tinfix(
           tapply(tselect("foo", "bar"), blk(tname("arg"))),
           "++",
-          tapply(tname("baz"), blk(tname("arg")))
+          tapply(tname("baz"), blk(tname("arg"))),
         ),
         "++",
-        tname("qux")
-      ))
+        tname("qux"),
+      )),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -969,11 +969,11 @@ class FewerBracesSuite extends BaseDottySuite {
         tinfix(
           tapply(tselect("foo", "bar"), blk(tname("arg"))),
           "++",
-          tapply(tname("baz"), blk(tname("arg")))
+          tapply(tname("baz"), blk(tname("arg"))),
         ),
         "++",
-        tname("qux")
-      ))
+        tname("qux"),
+      )),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -998,10 +998,10 @@ class FewerBracesSuite extends BaseDottySuite {
       tinfix(
         tapply(tselect("foo", "bar"), blk(tname("arg"))),
         "++",
-        tapply(tname("baz"), blk(tname("arg")))
+        tapply(tname("baz"), blk(tname("arg"))),
       ),
       "++",
-      tname("qux")
+      tname("qux"),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -1026,10 +1026,10 @@ class FewerBracesSuite extends BaseDottySuite {
       tinfix(
         tapply(tselect("foo", "bar"), blk(tname("arg"))),
         "++",
-        tapply(tname("baz"), blk(tname("arg")))
+        tapply(tname("baz"), blk(tname("arg"))),
       ),
       "++",
-      tname("qux")
+      tname("qux"),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -1061,11 +1061,11 @@ class FewerBracesSuite extends BaseDottySuite {
         tinfix(
           tapply(tselect("foo", "bar"), blk(tname("arg"))),
           "++",
-          tapply(tname("baz"), blk(tname("arg")))
+          tapply(tname("baz"), blk(tname("arg"))),
         ),
         "++",
-        tname("qux")
-      ))
+        tname("qux"),
+      )),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -1096,11 +1096,11 @@ class FewerBracesSuite extends BaseDottySuite {
         tinfix(
           tapply(tselect("foo", "bar"), blk(tname("arg"))),
           "++",
-          tapply(tname("baz"), blk(tname("arg")))
+          tapply(tname("baz"), blk(tname("arg"))),
         ),
         "++",
-        tname("qux")
-      ))
+        tname("qux"),
+      )),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -1136,9 +1136,9 @@ class FewerBracesSuite extends BaseDottySuite {
         blk(tinfix(
           tname("arg1"),
           "++",
-          tapply(tname("abc"), blk(tinfix(tname("arg2"), "++", tapply(tname("abc"), blk(tname("arg3"))))))
-        ))
-      )
+          tapply(tname("abc"), blk(tinfix(tname("arg2"), "++", tapply(tname("abc"), blk(tname("arg3")))))),
+        )),
+      ),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -1174,9 +1174,9 @@ class FewerBracesSuite extends BaseDottySuite {
         blk(tinfix(
           tname("arg1"),
           "++",
-          tapply(tname("abc"), blk(tinfix(tname("arg2"), "++", tapply(tname("abc"), blk(tname("arg3"))))))
-        ))
-      )
+          tapply(tname("abc"), blk(tinfix(tname("arg2"), "++", tapply(tname("abc"), blk(tname("arg3")))))),
+        )),
+      ),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -1217,9 +1217,9 @@ class FewerBracesSuite extends BaseDottySuite {
         blk(tinfix(
           tname("arg1"),
           "++",
-          tapply(tname("abc"), blk(tinfix(tname("arg2"), "++", tapply(tname("abc"), blk(tname("arg3"))))))
-        ))
-      ))
+          tapply(tname("abc"), blk(tinfix(tname("arg2"), "++", tapply(tname("abc"), blk(tname("arg3")))))),
+        )),
+      )),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -1255,9 +1255,9 @@ class FewerBracesSuite extends BaseDottySuite {
         blk(tinfix(
           tinfix(tname("arg1"), "++", tapply(tname("abc"), blk(tname("arg2")))),
           "++",
-          tapply(tname("abc"), blk(tname("arg3")))
-        ))
-      )
+          tapply(tname("abc"), blk(tname("arg3"))),
+        )),
+      ),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -1294,9 +1294,9 @@ class FewerBracesSuite extends BaseDottySuite {
         blk(tinfix(
           tinfix(tname("arg1"), "++", tapply(tname("abc"), blk(tname("arg2")))),
           "++",
-          tapply(tname("abc"), blk(tname("arg3")))
-        ))
-      )
+          tapply(tname("abc"), blk(tname("arg3"))),
+        )),
+      ),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -1337,9 +1337,9 @@ class FewerBracesSuite extends BaseDottySuite {
         blk(tinfix(
           tinfix(tname("arg1"), "++", tapply(tname("abc"), blk(tname("arg2")))),
           "++",
-          tapply(tname("abc"), blk(tname("arg3")))
-        ))
-      ))
+          tapply(tname("abc"), blk(tname("arg3"))),
+        )),
+      )),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -1380,11 +1380,11 @@ class FewerBracesSuite extends BaseDottySuite {
         tinfix(
           tapply(tname("abc"), blk(tname("arg1"))),
           tnameComments("++")()("/* c1 */", "// c2"),
-          tapply(tname("abc"), blk(tname("arg2")))
+          tapply(tname("abc"), blk(tname("arg2"))),
         ),
         tnameComments("++")()("/*\n        c3\n        */"),
-        tapply(tname("abc"), blk(tname("arg3")))
-      )
+        tapply(tname("abc"), blk(tname("arg3"))),
+      ),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -1418,8 +1418,8 @@ class FewerBracesSuite extends BaseDottySuite {
       tinfix(
         tapply(tname("abc"), blk(tname("arg1"))),
         tnameComments("++")()("/*\n   c2\n    */"),
-        tapply(tname("abc"), blk(tname("arg2")))
-      )
+        tapply(tname("abc"), blk(tname("arg2"))),
+      ),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -1454,8 +1454,8 @@ class FewerBracesSuite extends BaseDottySuite {
       tinfix(
         tapply(tname("abc"), blk(tname("arg1"))),
         tnameComments("++")()("/*\n       c2\n    */"),
-        tapply(tname("abc"), blk(tname("arg2")))
-      )
+        tapply(tname("abc"), blk(tname("arg2"))),
+      ),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -1477,7 +1477,7 @@ class FewerBracesSuite extends BaseDottySuite {
       tname("a"),
       Nil,
       None,
-      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Implicit()), "bar"))(tname("baz"))))
+      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Implicit()), "bar"))(tname("baz")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1499,7 +1499,7 @@ class FewerBracesSuite extends BaseDottySuite {
       tname("a"),
       Nil,
       None,
-      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Implicit()), "bar", "Int"))(tname("baz"))))
+      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Implicit()), "bar", "Int"))(tname("baz")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1521,7 +1521,7 @@ class FewerBracesSuite extends BaseDottySuite {
       tname("a"),
       Nil,
       None,
-      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Implicit()), "bar"))(tname("baz"))))
+      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Implicit()), "bar"))(tname("baz")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1543,7 +1543,7 @@ class FewerBracesSuite extends BaseDottySuite {
       tname("a"),
       Nil,
       None,
-      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Implicit()), "bar", "Int"))(tname("baz"))))
+      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Implicit()), "bar", "Int"))(tname("baz")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1560,7 +1560,7 @@ class FewerBracesSuite extends BaseDottySuite {
       tname("a"),
       Nil,
       None,
-      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Implicit()), "bar"))(tname("baz"))))
+      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Implicit()), "bar"))(tname("baz")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1577,7 +1577,7 @@ class FewerBracesSuite extends BaseDottySuite {
       tname("a"),
       Nil,
       None,
-      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Implicit()), "bar", "Int"))(tname("baz"))))
+      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Implicit()), "bar", "Int"))(tname("baz")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1599,7 +1599,7 @@ class FewerBracesSuite extends BaseDottySuite {
       tname("a"),
       Nil,
       None,
-      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Using()), "bar"))(tname("baz"))))
+      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Using()), "bar"))(tname("baz")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1621,7 +1621,7 @@ class FewerBracesSuite extends BaseDottySuite {
       tname("a"),
       Nil,
       None,
-      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Using()), "bar", "Int"))(tname("baz"))))
+      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Using()), "bar", "Int"))(tname("baz")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1643,7 +1643,7 @@ class FewerBracesSuite extends BaseDottySuite {
       tname("a"),
       Nil,
       None,
-      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Using()), "bar"))(tname("baz"))))
+      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Using()), "bar"))(tname("baz")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1666,7 +1666,7 @@ class FewerBracesSuite extends BaseDottySuite {
       tname("a"),
       Nil,
       None,
-      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Using()), "bar"))(tname("baz"))))
+      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Using()), "bar"))(tname("baz")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1688,7 +1688,7 @@ class FewerBracesSuite extends BaseDottySuite {
       tname("a"),
       Nil,
       None,
-      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Using()), "bar", "Int"))(tname("baz"))))
+      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Using()), "bar", "Int"))(tname("baz")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1711,7 +1711,7 @@ class FewerBracesSuite extends BaseDottySuite {
       tname("a"),
       Nil,
       None,
-      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Using()), "bar", "Int"))(tname("baz"))))
+      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Using()), "bar", "Int"))(tname("baz")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1744,7 +1744,7 @@ class FewerBracesSuite extends BaseDottySuite {
       tname("a"),
       Nil,
       None,
-      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Using()), "bar"))(tname("baz"))))
+      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Using()), "bar"))(tname("baz")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1761,7 +1761,7 @@ class FewerBracesSuite extends BaseDottySuite {
       tname("a"),
       Nil,
       None,
-      tapplyUsing(tname("foo"), Term.Ascribe(tname("bar"), pfunc(pname("Int"))(pname("baz"))))
+      tapplyUsing(tname("foo"), Term.Ascribe(tname("bar"), pfunc(pname("Int"))(pname("baz")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1794,7 +1794,7 @@ class FewerBracesSuite extends BaseDottySuite {
       tname("a"),
       Nil,
       None,
-      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Using()), "bar", "Int"))(tname("baz"))))
+      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Using()), "bar", "Int"))(tname("baz")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1816,7 +1816,7 @@ class FewerBracesSuite extends BaseDottySuite {
       tname("a"),
       Nil,
       None,
-      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Using()), "bar"))(tname("baz"))))
+      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Using()), "bar"))(tname("baz")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1841,9 +1841,9 @@ class FewerBracesSuite extends BaseDottySuite {
       tapply(
         tname("foo"),
         blk(
-          tfunc(tparam(List(Mod.Using()), "bar", pfunc(pname("Int"))(pname("String"))))(tname("baz"))
-        )
-      )
+          tfunc(tparam(List(Mod.Using()), "bar", pfunc(pname("Int"))(pname("String"))))(tname("baz")),
+        ),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1867,8 +1867,8 @@ class FewerBracesSuite extends BaseDottySuite {
       None,
       tapply(
         tname("foo"),
-        blk(tfunc(tparam(Nil, "using", pfunc(pname("Int"))(pname("String"))))(tname("baz")))
-      )
+        blk(tfunc(tparam(Nil, "using", pfunc(pname("Int"))(pname("String"))))(tname("baz"))),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1892,8 +1892,8 @@ class FewerBracesSuite extends BaseDottySuite {
       None,
       tapply(
         tname("foo"),
-        blk(tfunc(tparam(List(Mod.Using()), "bar", "Int"), tparam("baz", "String"))(tname("qux")))
-      )
+        blk(tfunc(tparam(List(Mod.Using()), "bar", "Int"), tparam("baz", "String"))(tname("qux"))),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1917,8 +1917,8 @@ class FewerBracesSuite extends BaseDottySuite {
       None,
       tapply(
         tname("foo"),
-        blk(tfunc(tparam(List(Mod.Using()), "bar", "Int"), tparam("using", "String"))(tname("qux")))
-      )
+        blk(tfunc(tparam(List(Mod.Using()), "bar", "Int"), tparam("using", "String"))(tname("qux"))),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1940,7 +1940,7 @@ class FewerBracesSuite extends BaseDottySuite {
       tname("a"),
       Nil,
       None,
-      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Erased()), "bar"))(tname("baz"))))
+      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Erased()), "bar"))(tname("baz")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1962,7 +1962,7 @@ class FewerBracesSuite extends BaseDottySuite {
       tname("a"),
       Nil,
       None,
-      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Erased()), "bar", "Int"))(tname("baz"))))
+      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Erased()), "bar", "Int"))(tname("baz")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1984,7 +1984,7 @@ class FewerBracesSuite extends BaseDottySuite {
       tname("a"),
       Nil,
       None,
-      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Erased()), "bar"))(tname("baz"))))
+      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Erased()), "bar"))(tname("baz")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2007,7 +2007,7 @@ class FewerBracesSuite extends BaseDottySuite {
       tname("a"),
       Nil,
       None,
-      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Erased()), "bar"))(tname("baz"))))
+      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Erased()), "bar"))(tname("baz")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2029,7 +2029,7 @@ class FewerBracesSuite extends BaseDottySuite {
       tname("a"),
       Nil,
       None,
-      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Erased()), "bar", "Int"))(tname("baz"))))
+      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Erased()), "bar", "Int"))(tname("baz")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2052,7 +2052,7 @@ class FewerBracesSuite extends BaseDottySuite {
       tname("a"),
       Nil,
       None,
-      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Erased()), "bar", "Int"))(tname("baz"))))
+      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Erased()), "bar", "Int"))(tname("baz")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2069,7 +2069,7 @@ class FewerBracesSuite extends BaseDottySuite {
       tname("a"),
       Nil,
       None,
-      tapply(tname("foo"), tfunc(tparam(List(Mod.Erased()), "bar"))(tname("baz")))
+      tapply(tname("foo"), tfunc(tparam(List(Mod.Erased()), "bar"))(tname("baz"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2090,7 +2090,7 @@ class FewerBracesSuite extends BaseDottySuite {
       tname("a"),
       Nil,
       None,
-      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Erased()), "bar"))(tname("baz"))))
+      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Erased()), "bar"))(tname("baz")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2112,7 +2112,7 @@ class FewerBracesSuite extends BaseDottySuite {
       tname("a"),
       Nil,
       None,
-      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Erased()), "bar"))(tname("baz"))))
+      tapply(tname("foo"), blk(tfunc(tparam(List(Mod.Erased()), "bar"))(tname("baz")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2137,9 +2137,9 @@ class FewerBracesSuite extends BaseDottySuite {
       tapply(
         tname("foo"),
         blk(
-          tfunc(tparam(List(Mod.Erased()), "bar", pfunc(pname("Int"))(pname("String"))))(tname("baz"))
-        )
-      )
+          tfunc(tparam(List(Mod.Erased()), "bar", pfunc(pname("Int"))(pname("String"))))(tname("baz")),
+        ),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2165,10 +2165,10 @@ class FewerBracesSuite extends BaseDottySuite {
         tname("foo"),
         blk(
           tfunc(tparam(List(Mod.Erased()), "bar", "Int"), tparam(List(Mod.Erased()), "baz", "String"))(
-            tname("qux")
-          )
-        )
-      )
+            tname("qux"),
+          ),
+        ),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2229,9 +2229,9 @@ class FewerBracesSuite extends BaseDottySuite {
       tapply(
         tapply(tname("bar")),
         blk(tfunc(tparam("loader"))(
-          tapply(tname("baz"), blk(tapply(tname("loader"), blk(tfunc(tparam("_"))(tname("qux"))))))
-        ))
-      )
+          tapply(tname("baz"), blk(tapply(tname("loader"), blk(tfunc(tparam("_"))(tname("qux")))))),
+        )),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2254,7 +2254,7 @@ class FewerBracesSuite extends BaseDottySuite {
          |""".stripMargin
     val tree = tapply(
       tselect(tapply(tselect("arg", "fn1"), blk(tfunc(tparam("_"))(lit("FOO1")))), "fn2"),
-      blk(tfunc(tparam("_"))(lit("FOO2")))
+      blk(tfunc(tparam("_"))(lit("FOO2"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2292,7 +2292,7 @@ class FewerBracesSuite extends BaseDottySuite {
     val tree = Defn.ExtensionGroup(
       List(pparam("B", bounds(cb = List("Seq")))),
       List(List(tparam("b", "Int"))),
-      Defn.Def(Nil, "foo", Nil, None, "b")
+      Defn.Def(Nil, "foo", Nil, None, "b"),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2346,8 +2346,8 @@ class FewerBracesSuite extends BaseDottySuite {
       None,
       tapply(
         tselect(tapply("List", str("")), "map"),
-        Term.PartialFunction(List(Case(patvar("x"), None, tselect("x", "trim"))))
-      )
+        Term.PartialFunction(List(Case(patvar("x"), None, tselect("x", "trim")))),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2404,7 +2404,7 @@ class FewerBracesSuite extends BaseDottySuite {
          |""".stripMargin
     val tree = tapply(
       tselect("xs", "map"),
-      blk(tfunc(tparam(List(Mod.Implicit()), "x"))(tinfix("x", "+", lit(1))))
+      blk(tfunc(tparam(List(Mod.Implicit()), "x"))(tinfix("x", "+", lit(1)))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2420,7 +2420,7 @@ class FewerBracesSuite extends BaseDottySuite {
          |""".stripMargin
     val tree = tapply(
       tselect("xs", "map"),
-      blk(tfunc(tparam(List(Mod.Implicit()), "x", "Int"))(tinfix("x", "+", lit(1))))
+      blk(tfunc(tparam(List(Mod.Implicit()), "x", "Int"))(tinfix("x", "+", lit(1)))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2444,9 +2444,9 @@ class FewerBracesSuite extends BaseDottySuite {
       blk(tfunc(tparam("x"))(tapply(
         "fooY",
         blk(tfunc(tparam("y"))(
-          tapply("fooZ", blk(tfunc(tparam("z"))(tinfix(tinfix("x", "+", "y"), "+", "z"))))
-        ))
-      )))
+          tapply("fooZ", blk(tfunc(tparam("z"))(tinfix(tinfix("x", "+", "y"), "+", "z")))),
+        )),
+      ))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2471,9 +2471,9 @@ class FewerBracesSuite extends BaseDottySuite {
       blk(tfunc(tparam("x"))(tapply(
         "fooY",
         blk(tfunc(tparam("y"))(
-          tapply("fooZ", blk(tfunc(tparam("z"))(tinfix(tinfix("x", "+", "y"), "+", "z"))))
-        ))
-      )))
+          tapply("fooZ", blk(tfunc(tparam("z"))(tinfix(tinfix("x", "+", "y"), "+", "z")))),
+        )),
+      ))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2499,9 +2499,9 @@ class FewerBracesSuite extends BaseDottySuite {
       blk(tfunc(tparam("x"))(tapply(
         "fooY",
         blk(tfunc(tparam("y"))(
-          tapply("fooZ", blk(tfunc(tparam("z"))(tinfix(tinfix("x", "+", "y"), "+", "z"))))
-        ))
-      )))
+          tapply("fooZ", blk(tfunc(tparam("z"))(tinfix(tinfix("x", "+", "y"), "+", "z")))),
+        )),
+      ))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2528,9 +2528,9 @@ class FewerBracesSuite extends BaseDottySuite {
       blk(tfunc(tparam("x"))(tapply(
         "fooY",
         blk(tfunc(tparam("y"))(
-          tapply("fooZ", blk(tfunc(tparam("z"))(tinfix(tinfix("x", "+", "y"), "+", "z"))))
-        ))
-      )))
+          tapply("fooZ", blk(tfunc(tparam("z"))(tinfix(tinfix("x", "+", "y"), "+", "z")))),
+        )),
+      ))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2811,8 +2811,8 @@ class FewerBracesSuite extends BaseDottySuite {
       Case(
         patvar("n"),
         Some(tapply("foo", Term.PartialFunction(List(Case(patvar("b"), None, lit(true)))))),
-        lit(2)
-      )
+        lit(2),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2885,9 +2885,9 @@ class FewerBracesSuite extends BaseDottySuite {
         tselect("a", "flatMap"),
         blk(tfunc(tparam("b"))(blk(
           tapply(tselect("c", "map"), blk(tfunc(tparam("d"))(lit(1)))),
-          Term.If(lit(true), blk(lit(1), lit(2)), lit(3), Nil)
-        )))
-      )
+          Term.If(lit(true), blk(lit(1), lit(2)), lit(3), Nil),
+        ))),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenSyntax36Suite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenSyntax36Suite.scala
@@ -14,7 +14,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       List(pparam("A", bounds(cb = List(Type.BoundsAlias("mm", "Monoid"))))),
       List(List(tparam("xs", "A"))),
       Some("A"),
-      "???"
+      "???",
     ))
   }
 
@@ -33,8 +33,8 @@ class GivenSyntax36Suite extends BaseDottySuite {
         "showMax",
         List(pparam("X", bounds(cb = List("Ordering", "Show")))),
         List(List(tparam("x", "X"), tparam("y", "X"))),
-        "String"
-      ))
+        "String",
+      )),
     )
     runTestAssert[Stat](code)(tree)
   }
@@ -51,11 +51,11 @@ class GivenSyntax36Suite extends BaseDottySuite {
         "showMax",
         List(pparam(
           "X",
-          bounds(cb = List(Type.BoundsAlias("ordering", "Ordering"), Type.BoundsAlias("show", "Show")))
+          bounds(cb = List(Type.BoundsAlias("ordering", "Ordering"), Type.BoundsAlias("show", "Show"))),
         )),
         List(List(tparam("x", "X"), tparam("y", "X"))),
-        "String"
-      ))
+        "String",
+      )),
     )
     runTestAssert[Stat](code)(tree)
   }
@@ -71,8 +71,8 @@ class GivenSyntax36Suite extends BaseDottySuite {
            |  type Element
            |  given Ord[Element] = compiletime.deferred
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Trait(
       Nil,
       pname("Sorted"),
@@ -80,24 +80,24 @@ class GivenSyntax36Suite extends BaseDottySuite {
       ctor,
       tpl(
         Decl.Type(Nil, pname("Element"), Nil, noBounds),
-        Defn.GivenAlias(Nil, anon, None, papply("Ord", "Element"), tselect("compiletime", "deferred"))
-      )
+        Defn.GivenAlias(Nil, anon, None, papply("Ord", "Element"), tselect("compiletime", "deferred")),
+      ),
     ))
   }
 
   test("poly-function")(
     runTestAssert[Stat](
       """|type Comparer = [X: Ord] => (x: X, y: X) => Boolean
-         |""".stripMargin
+         |""".stripMargin,
     )(Defn.Type(
       Nil,
       pname("Comparer"),
       Nil,
       ppolyfunc(
-        pparam("X", bounds(cb = List("Ord")))
+        pparam("X", bounds(cb = List("Ord"))),
       )(pfunc(Type.TypedParam("x", "X", Nil), Type.TypedParam("y", "X", Nil))("Boolean")),
-      noBounds
-    ))
+      noBounds,
+    )),
   )
 
   test("poly-function-val") {
@@ -106,21 +106,21 @@ class GivenSyntax36Suite extends BaseDottySuite {
          |  ord.compare(x, y) < 0
          |""".stripMargin,
       assertLayout =
-        Some("val less: Comparer = [X: Ord as ord] => (x: X, y: X) => ord.compare(x, y) < 0")
+        Some("val less: Comparer = [X: Ord as ord] => (x: X, y: X) => ord.compare(x, y) < 0"),
     )(Defn.Val(
       Nil,
       List(patvar("less")),
       Some("Comparer"),
       tpolyfunc(
-        pparam("X", bounds(cb = List(Type.BoundsAlias("ord", "Ord"))))
+        pparam("X", bounds(cb = List(Type.BoundsAlias("ord", "Ord")))),
       )(tfunc(tparam("x", "X"), tparam("y", "X"))(
-        tinfix(tapply(tselect("ord", "compare"), "x", "y"), "<", lit(0))
-      ))
+        tinfix(tapply(tselect("ord", "compare"), "x", "y"), "<", lit(0)),
+      )),
     ))
   }
 
   val body = tplBody(
-    Defn.Def(Nil, "compare", Nil, List(List(tparam("x", "Int"), tparam("y", "Int"))), None, "???")
+    Defn.Def(Nil, "compare", Nil, List(List(tparam("x", "Int"), tparam("y", "Int"))), None, "???"),
   )
 
   test("given")(
@@ -128,8 +128,8 @@ class GivenSyntax36Suite extends BaseDottySuite {
       """|given Ord[Int] with
          |   def compare(x: Int, y: Int) = ???
          |""".stripMargin,
-      assertLayout = Some("given Ord[Int] with { def compare(x: Int, y: Int) = ??? }")
-    )(Defn.Given(Nil, anon, None, tpl(List(init(papply("Ord", "Int"))), body)))
+      assertLayout = Some("given Ord[Int] with { def compare(x: Int, y: Int) = ??? }"),
+    )(Defn.Given(Nil, anon, None, tpl(List(init(papply("Ord", "Int"))), body))),
   )
 
   val bodyBounds = tpl(
@@ -140,8 +140,8 @@ class GivenSyntax36Suite extends BaseDottySuite {
       Nil,
       List(List(tparam("x", papply("List", "A")), tparam("y", papply("List", "A")))),
       None,
-      "???"
-    ))
+      "???",
+    )),
   )
 
   test("given-context")(
@@ -150,8 +150,8 @@ class GivenSyntax36Suite extends BaseDottySuite {
          |  def compare(x: List[A], y: List[A]) = ???
          |""".stripMargin,
       assertLayout =
-        Some("given [A: Ord]: Ord[List[A]] with { def compare(x: List[A], y: List[A]) = ??? }")
-    )(Defn.Given(Nil, anon, List(pparam("A", bounds(cb = List("Ord")))), Nil, bodyBounds))
+        Some("given [A: Ord]: Ord[List[A]] with { def compare(x: List[A], y: List[A]) = ??? }"),
+    )(Defn.Given(Nil, anon, List(pparam("A", bounds(cb = List("Ord")))), Nil, bodyBounds)),
   )
 
   test("given-context-using") {
@@ -160,14 +160,14 @@ class GivenSyntax36Suite extends BaseDottySuite {
          |  def compare(x: List[A], y: List[A]) = ???
          |""".stripMargin,
       assertLayout = Some(
-        "given [A](using Ord[A]): Ord[List[A]] with { def compare(x: List[A], y: List[A]) = ??? }"
-      )
+        "given [A](using Ord[A]): Ord[List[A]] with { def compare(x: List[A], y: List[A]) = ??? }",
+      ),
     )(Defn.Given(
       Nil,
       anon,
       List(pparam("A")),
       List(List(tparamUsing("", papply("Ord", "A")))),
-      bodyBounds
+      bodyBounds,
     ))
   }
 
@@ -177,17 +177,17 @@ class GivenSyntax36Suite extends BaseDottySuite {
          |  def compare(x: List[A], y: List[A]) = ???
          |""".stripMargin,
       assertLayout =
-        Some("given [A](using ord: Ord[A]): Ord[List[A]] with { def compare(x: List[A], y: List[A]) = ??? }")
+        Some("given [A](using ord: Ord[A]): Ord[List[A]] with { def compare(x: List[A], y: List[A]) = ??? }"),
     )(Defn.Given(
       Nil,
       anon,
       List(pparam("A")),
       List(List(tparamUsing("ord", papply("Ord", "A")))),
-      bodyBounds
+      bodyBounds,
     ))
   }
   test("given-simple-alias")(runTestAssert[Stat]("given Ord[Int] = IntOrd()")(
-    Defn.GivenAlias(Nil, anon, None, papply("Ord", "Int"), tapply("IntOrd"))
+    Defn.GivenAlias(Nil, anon, None, papply("Ord", "Int"), tapply("IntOrd")),
   ))
 
   test("given-alias-context-bound")(
@@ -197,8 +197,8 @@ class GivenSyntax36Suite extends BaseDottySuite {
       List(pparam("A", bounds(cb = List("Ord")))),
       Nil,
       papply("Ord", papply("List", "A")),
-      tapplytype("ListOrd", "A")
-    ))
+      tapplytype("ListOrd", "A"),
+    )),
   )
 
   test("given-alias-context-param")(
@@ -208,12 +208,12 @@ class GivenSyntax36Suite extends BaseDottySuite {
       List(pparam("A")),
       List(List(tparamUsing("", papply("Ord", "A")))),
       papply("Ord", papply("List", "A")),
-      tapplytype("ListOrd", "A")
-    ))
+      tapplytype("ListOrd", "A"),
+    )),
   )
 
   test("given-by-name")(runTestAssert[Stat]("given [DummySoItsByName]: Context = curCtx")(
-    Defn.GivenAlias(Nil, anon, List(pparam("DummySoItsByName")), Nil, "Context", "curCtx")
+    Defn.GivenAlias(Nil, anon, List(pparam("DummySoItsByName")), Nil, "Context", "curCtx"),
   ))
 
   test("given-named")(
@@ -221,8 +221,8 @@ class GivenSyntax36Suite extends BaseDottySuite {
       """|given intOrd: Ord[Int] with
          |   def compare(x: Int, y: Int) = ???
          |""".stripMargin,
-      assertLayout = Some("given intOrd: Ord[Int] with { def compare(x: Int, y: Int) = ??? }")
-    )(Defn.Given(Nil, "intOrd", None, tpl(List(init(papply("Ord", "Int"))), body)))
+      assertLayout = Some("given intOrd: Ord[Int] with { def compare(x: Int, y: Int) = ??? }"),
+    )(Defn.Given(Nil, "intOrd", None, tpl(List(init(papply("Ord", "Int"))), body))),
   )
 
   test("given-context-named") {
@@ -231,8 +231,8 @@ class GivenSyntax36Suite extends BaseDottySuite {
          |  def compare(x: List[A], y: List[A]) = ???
          |""".stripMargin,
       assertLayout = Some(
-        "given listOrd[A: Ord]: Ord[List[A]] with { def compare(x: List[A], y: List[A]) = ??? }"
-      )
+        "given listOrd[A: Ord]: Ord[List[A]] with { def compare(x: List[A], y: List[A]) = ??? }",
+      ),
     )(Defn.Given(Nil, "listOrd", List(pparam("A", bounds(cb = List("Ord")))), Nil, bodyBounds))
   }
 
@@ -242,13 +242,13 @@ class GivenSyntax36Suite extends BaseDottySuite {
          |  def compare(x: List[A], y: List[A]) = ???
          |""".stripMargin,
       assertLayout =
-        Some("given listOrd[A](using Ord[A]): Ord[List[A]] with { def compare(x: List[A], y: List[A]) = ??? }")
+        Some("given listOrd[A](using Ord[A]): Ord[List[A]] with { def compare(x: List[A], y: List[A]) = ??? }"),
     )(Defn.Given(
       Nil,
       "listOrd",
       List(pparam("A")),
       List(List(tparamUsing("", papply("Ord", "A")))),
-      bodyBounds
+      bodyBounds,
     ))
   }
 
@@ -258,18 +258,18 @@ class GivenSyntax36Suite extends BaseDottySuite {
          |  def compare(x: List[A], y: List[A]) = ???
          |""".stripMargin,
       assertLayout =
-        Some("given listOrd[A](using ord: Ord[A]): Ord[List[A]] with { def compare(x: List[A], y: List[A]) = ??? }")
+        Some("given listOrd[A](using ord: Ord[A]): Ord[List[A]] with { def compare(x: List[A], y: List[A]) = ??? }"),
     )(Defn.Given(
       Nil,
       "listOrd",
       List(pparam("A")),
       List(List(tparamUsing("ord", papply("Ord", "A")))),
-      bodyBounds
+      bodyBounds,
     ))
   }
 
   test("given-simple-alias-named")(runTestAssert[Stat]("given intOrd: Ord[Int] = IntOrd()")(
-    Defn.GivenAlias(Nil, "intOrd", None, papply("Ord", "Int"), tapply("IntOrd"))
+    Defn.GivenAlias(Nil, "intOrd", None, papply("Ord", "Int"), tapply("IntOrd")),
   ))
 
   test("given-alias-context-bound-named")(
@@ -279,8 +279,8 @@ class GivenSyntax36Suite extends BaseDottySuite {
       List(pparam("A", bounds(cb = List("Ord")))),
       Nil,
       papply("Ord", papply("List", "A")),
-      tapplytype("ListOrd", "A")
-    ))
+      tapplytype("ListOrd", "A"),
+    )),
   )
 
   test("given-alias-context-param-named")(
@@ -290,17 +290,17 @@ class GivenSyntax36Suite extends BaseDottySuite {
       List(pparam("A")),
       List(List(tparamUsing("", papply("Ord", "A")))),
       papply("Ord", papply("List", "A")),
-      tapplytype("ListOrd", "A")
-    ))
+      tapplytype("ListOrd", "A"),
+    )),
   )
 
   test("given-by-name-named")(
     runTestAssert[Stat]("given context[DummySoItsByName]: Context = curCtx")(
-      Defn.GivenAlias(Nil, "context", List(pparam("DummySoItsByName")), Nil, "Context", "curCtx")
-    )
+      Defn.GivenAlias(Nil, "context", List(pparam("DummySoItsByName")), Nil, "Context", "curCtx"),
+    ),
   )
   test("given-abstract-named")(
-    runTestAssert[Stat]("given context: Context")(Decl.Given(Nil, "context", None, "Context"))
+    runTestAssert[Stat]("given context: Context")(Decl.Given(Nil, "context", None, "Context")),
   )
 
   // https://docs3.scala-lang.org/sips/sips/typeclasses-syntax.html#7-cleanup-of-given-syntax
@@ -316,7 +316,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       Nil,
       anon,
       Nil,
-      tpl(List(init(papply("Ord", "Int"))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", "Int"))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -332,7 +332,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       Nil,
       anon,
       Nil,
-      tpl(List(init(papply("Ord", "Int"))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", "Int"))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -347,7 +347,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       Nil,
       "ord",
       Nil,
-      tpl(List(init(papply("Ord", "Int"))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", "Int"))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -363,7 +363,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       Nil,
       "ord",
       Nil,
-      tpl(List(init(papply("Ord", "Int"))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", "Int"))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -380,7 +380,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       anon,
       List(pparam("A", bounds(cb = List("Ord")))),
       Nil,
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -397,7 +397,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       anon,
       List(pparam("A", bounds(cb = List("Ord")))),
       Nil,
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -413,7 +413,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       tname("ord"),
       List(pparam("A", bounds(cb = List("Ord")))),
       Nil,
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -430,7 +430,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       tname("ord"),
       List(pparam("A", bounds(cb = List("Ord")))),
       Nil,
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -447,7 +447,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       anon,
       List(pparam("A", bounds(cb = List("Ord")))),
       Nil,
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -464,7 +464,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       anon,
       List(pparam("A", bounds(cb = List("Ord")))),
       Nil,
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -480,7 +480,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       tname("ord"),
       List(pparam("A", bounds(cb = List("Ord")))),
       Nil,
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -497,7 +497,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       tname("ord"),
       List(pparam("A", bounds(cb = List("Ord")))),
       Nil,
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -514,7 +514,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       anon,
       List(pparam("A")),
       List(List(tparam("ord", papply("Ord", "A")))),
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -531,7 +531,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       anon,
       List(pparam("A")),
       List(List(tparam("ord", papply("Ord", "A")))),
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -547,7 +547,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       tname("ord"),
       List(pparam("A")),
       List(List(tparam("ord", papply("Ord", "A")))),
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -564,7 +564,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       tname("ord"),
       List(pparam("A")),
       List(List(tparam("ord", papply("Ord", "A")))),
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -581,7 +581,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       anon,
       List(pparam("A")),
       List(List(tparam("", papply("Ord", "A")))),
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -598,7 +598,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       anon,
       List(pparam("A")),
       List(List(tparam("", papply("Ord", "A")))),
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -614,7 +614,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       tname("ord"),
       List(pparam("A")),
       List(List(tparam("", papply("Ord", "A")))),
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -631,7 +631,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       tname("ord"),
       List(pparam("A")),
       List(List(tparam("", papply("Ord", "A")))),
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -649,7 +649,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       "ord",
       Nil,
       List(List(tparam("", Type.Lambda(List(pparam("A")), papply("Ord", "A"))))),
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -666,7 +666,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       "ord",
       Nil,
       List(List(tparam("", Type.Lambda(List(pparam(Nil, "A")), papply("Ord", "A"))))),
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -683,9 +683,9 @@ class GivenSyntax36Suite extends BaseDottySuite {
       Nil,
       List(List(tparam(
         "",
-        ppolyfunc(pparam(Nil, "A"))(pfunc(papply("Ord", "A"))(papply("Ord", papply("List", "A"))))
+        ppolyfunc(pparam(Nil, "A"))(pfunc(papply("Ord", "A"))(papply("Ord", papply("List", "A")))),
       ))),
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -703,9 +703,9 @@ class GivenSyntax36Suite extends BaseDottySuite {
       Nil,
       List(List(tparam(
         "",
-        ppolyfunc(pparam(Nil, "A"))(pfunc(papply("Ord", "A"))(papply("Ord", papply("List", "A"))))
+        ppolyfunc(pparam(Nil, "A"))(pfunc(papply("Ord", "A"))(papply("Ord", papply("List", "A")))),
       ))),
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -723,8 +723,8 @@ class GivenSyntax36Suite extends BaseDottySuite {
       Nil,
       tpl(
         List(init(pfunc(papply("Ord", "A"))(papply("Ord", papply("List", "A"))))),
-        List(Defn.Def(Nil, "foo", Nil, None, "???"))
-      )
+        List(Defn.Def(Nil, "foo", Nil, None, "???")),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -743,8 +743,8 @@ class GivenSyntax36Suite extends BaseDottySuite {
       Nil,
       tpl(
         List(init(pfunc(papply("Ord", "A"))(papply("Ord", papply("List", "A"))))),
-        List(Defn.Def(Nil, "foo", Nil, None, "???"))
-      )
+        List(Defn.Def(Nil, "foo", Nil, None, "???")),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -762,7 +762,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       "ord",
       Nil,
       List(List(tparam("a", "A")), List(tparam("", papply("Ord", "A")))),
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -779,7 +779,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       "ord",
       Nil,
       List(List(tparam("a", "A")), List(tparam("", papply("Ord", "A")))),
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -795,7 +795,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       anon,
       Nil,
       List(List(tparam("a", "A")), List(tparam("", papply("Ord", "A")))),
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -812,7 +812,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       anon,
       Nil,
       List(List(tparam("a", "A")), List(tparam("", papply("Ord", "A")))),
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -830,7 +830,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       "ord",
       Nil,
       List(List(tparam("", "A")), List(tparam("", papply("Ord", "A")))),
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -847,7 +847,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       "ord",
       Nil,
       List(List(tparam("", "A")), List(tparam("", papply("Ord", "A")))),
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -863,7 +863,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       anon,
       Nil,
       List(List(tparam("", "A")), List(tparam("", papply("Ord", "A")))),
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -880,7 +880,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       anon,
       Nil,
       List(List(tparam("", "A")), List(tparam("", papply("Ord", "A")))),
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -898,7 +898,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       anon,
       Nil,
       List(List(tparam("", "A")), List(tparam("", papply("Ord", "A")))),
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -915,7 +915,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       anon,
       Nil,
       List(List(tparam("a", pfunc("A")(papply("Ord", "A"))))),
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -933,7 +933,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       anon,
       Nil,
       List(List(tparam("a", pfunc("A")(papply("Ord", "A"))))),
-      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???")))
+      tpl(List(init(papply("Ord", papply("List", "A")))), List(Defn.Def(Nil, "foo", Nil, None, "???"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -958,9 +958,9 @@ class GivenSyntax36Suite extends BaseDottySuite {
         Import(List(Importer(tselect("scala", "util", "chaining"), List(Importee.GivenAll())))),
         Import(List(Importer(
           tselect("scala", "util", "control"),
-          List(Importee.Name(Name("ControlThrowable")), Importee.Name(Name("NonFatal")))
-        )))
-      )
+          List(Importee.Name(Name("ControlThrowable")), Importee.Name(Name("NonFatal"))),
+        ))),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -982,8 +982,8 @@ class GivenSyntax36Suite extends BaseDottySuite {
       "a",
       tpl(
         Decl.Given(Nil, "TreeMethods", Nil, "TreeMethods"),
-        Defn.Trait(Nil, pname("TreeMethods"), Nil, ctor, tplNoBody())
-      )
+        Defn.Trait(Nil, pname("TreeMethods"), Nil, ctor, tplNoBody()),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -996,7 +996,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       anon,
       Nil,
       List(List(tparam("", papply("List", "Int")))),
-      tpl(List(init("Object")), Nil)
+      tpl(List(init("Object")), Nil),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1031,11 +1031,11 @@ class GivenSyntax36Suite extends BaseDottySuite {
             blk(Term.ForYield(
               Term
                 .EnumeratorsBlock(List(Enumerator.Generator(patvar("i"), tinfix(lit(0), "to", lit(10))))),
-              tname("i")
-            ))
-          )
-        )
-      )
+              tname("i"),
+            )),
+          ),
+        ),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1046,13 +1046,13 @@ class GivenSyntax36Suite extends BaseDottySuite {
       Nil,
       anon,
       List(Member.ParamClauseGroup(List(pparam("T")), List(List(tparamUsing("ord", papply("Ord", "T")))))),
-      papply("Ord", papply("Set", "T"))
+      papply("Ord", papply("Set", "T")),
     ))
     runTestAssert[Stat]("given (using Ord[String]): Ord[Int]")(Decl.GivenAnonymous(
       Nil,
       anon,
       List(Member.ParamClauseGroup(Nil, List(List(tparamUsing("", papply("Ord", "String")))))),
-      papply("Ord", "Int")
+      papply("Ord", "Int"),
     ))
   }
 
@@ -1066,7 +1066,7 @@ class GivenSyntax36Suite extends BaseDottySuite {
       anon,
       Nil,
       pinfix(papply("A", "Int"), "&", papply("B", "Int")),
-      Term.NewAnonymous(tpl(List(init(papply("A", "Int")), init(papply("B", "Int"))), tplBody()))
+      Term.NewAnonymous(tpl(List(init(papply("A", "Int")), init(papply("B", "Int"))), tplBody())),
     )
     runTestAssert[Stat](code, layout)(tree)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/GivenUsingSuite.scala
@@ -28,17 +28,17 @@ class GivenUsingSuite extends BaseDottySuite {
   val defone: Defn.Def = defone(Nil)
 
   test("given-named")(runTestAssert[Stat]("given intOrd: Ord[Int] with { def f(): Int = 1 }")(
-    Defn.Given(Nil, tname("intOrd"), Nil, Nil, tpl(List(init(papply("Ord", "Int"))), List(defone)))
+    Defn.Given(Nil, tname("intOrd"), Nil, Nil, tpl(List(init(papply("Ord", "Int"))), List(defone))),
   ))
 
   test("given-named-newline")(
     runTestAssert[Stat]("given intOrd: Ord[Int] with \n{ def f(): Int = 1 }", assertLayout = None)(
-      Defn.Given(Nil, tname("intOrd"), Nil, Nil, tpl(List(init(papply("Ord", "Int"))), List(defone)))
-    )
+      Defn.Given(Nil, tname("intOrd"), Nil, Nil, tpl(List(init(papply("Ord", "Int"))), List(defone))),
+    ),
   )
 
   test("given-anonymous")(runTestAssert[Stat]("given Ord[Int] with { def f(): Int = 1 }")(
-    Defn.Given(Nil, anon, Nil, Nil, tpl(List(init(papply("Ord", "Int"))), List(defone)))
+    Defn.Given(Nil, anon, Nil, Nil, tpl(List(init(papply("Ord", "Int"))), List(defone))),
   ))
 
   test("given-multiple-inheritance") {
@@ -49,29 +49,29 @@ class GivenUsingSuite extends BaseDottySuite {
       Nil,
       tpl(
         List(init(papply("Ord", "Int")), init(papply("Eq", "Int"))),
-        List(Defn.Def(Nil, tname("fx"), Nil, Nil, None, int(3)))
-      )
+        List(Defn.Def(Nil, tname("fx"), Nil, Nil, None, int(3))),
+      ),
     )
 
     runTestAssert[Stat]("given intM: Ord[Int] with Eq[Int] with { def fx = 3 }")(expectedGiven)
 
     runTestAssert[Stat](
       "given intM: Ord[Int] with\n Eq[Int] with { def fx = 3 }",
-      assertLayout = Some("given intM: Ord[Int] with Eq[Int] with { def fx = 3 }")
+      assertLayout = Some("given intM: Ord[Int] with Eq[Int] with { def fx = 3 }"),
     )(expectedGiven)
   }
 
   test("given-override-def")(
     runTestAssert[Stat](
       "given intOrd: Ord[Int] \n with { override def f(): Int = 1 }",
-      assertLayout = Some("given intOrd: Ord[Int] with { override def f(): Int = 1 }")
+      assertLayout = Some("given intOrd: Ord[Int] with { override def f(): Int = 1 }"),
     )(Defn.Given(
       Nil,
       tname("intOrd"),
       Nil,
       Nil,
-      tpl(List(init(papply("Ord", "Int"))), List(defone(List(Mod.Override()))))
-    ))
+      tpl(List(init(papply("Ord", "Int"))), List(defone(List(Mod.Override())))),
+    )),
   )
   test("given-override-def-colon-newline")(
     runTestAssert[Stat](
@@ -80,14 +80,14 @@ class GivenUsingSuite extends BaseDottySuite {
          |  def fn = ()
          |}
          |""".stripMargin,
-      assertLayout = Some("given intOrd: Ord[Int] with { def fn = () }")
+      assertLayout = Some("given intOrd: Ord[Int] with { def fn = () }"),
     )(Defn.Given(
       Nil,
       tname("intOrd"),
       Nil,
       Nil,
-      tpl(List(init(papply("Ord", "Int"))), List(Defn.Def(Nil, tname("fn"), Nil, Nil, None, Lit.Unit())))
-    ))
+      tpl(List(init(papply("Ord", "Int"))), List(Defn.Def(Nil, tname("fn"), Nil, Nil, None, Lit.Unit()))),
+    )),
   )
 
   test("given-override-def") {
@@ -101,8 +101,8 @@ class GivenUsingSuite extends BaseDottySuite {
            |  override def jnull = ???
            |  override def jtrue = ???
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Given(
       Nil,
       anon,
@@ -112,19 +112,19 @@ class GivenUsingSuite extends BaseDottySuite {
         init(papply(pselect("Facade", "SimpleFacade"), "Json")) :: Nil,
         List(
           Defn.Def(List(Mod.Override()), tname("jnull"), Nil, Nil, None, tname("???")),
-          Defn.Def(List(Mod.Override()), tname("jtrue"), Nil, Nil, None, tname("???"))
-        )
-      )
+          Defn.Def(List(Mod.Override()), tname("jtrue"), Nil, Nil, None, tname("???")),
+        ),
+      ),
     ))
   }
 
   test("given-self")(runTestAssert[Stat]("given intOrd: Ord[Int] with { current => }")(
-    Defn.Given(Nil, tname("intOrd"), Nil, Nil, tpl(List(init(papply("Ord", "Int"))), self("current")))
+    Defn.Given(Nil, tname("intOrd"), Nil, Nil, tpl(List(init(papply("Ord", "Int"))), self("current"))),
   ))
 
   test("given-selftype-error")(runTestError(
     "given intOrd: Ord[Int] with { current: Ord[Int] => }",
-    "given cannot have a self type"
+    "given cannot have a self type",
   ))
 
   test("given-generic-named")(
@@ -133,12 +133,12 @@ class GivenUsingSuite extends BaseDottySuite {
       tname("listOrd"),
       List(pparam("T")),
       Nil,
-      tpl(init(papply("Ord", papply("List", "T"))) :: Nil, List(defone))
-    ))
+      tpl(init(papply("Ord", papply("List", "T"))) :: Nil, List(defone)),
+    )),
   )
 
   test("given-generic-anonymous")(runTestAssert[Stat]("given Ord[List[T]] with { def f(): Int = 1 }")(
-    Defn.Given(Nil, anon, Nil, Nil, tpl(init(papply("Ord", papply("List", "T"))) :: Nil, List(defone)))
+    Defn.Given(Nil, anon, Nil, Nil, tpl(init(papply("Ord", papply("List", "T"))) :: Nil, List(defone))),
   ))
 
   test("given-generic-anonymous") {
@@ -146,7 +146,7 @@ class GivenUsingSuite extends BaseDottySuite {
       """|given noCaller: Caller(???) with
          |  override def computeValue() = ()
          |""".stripMargin,
-      assertLayout = Some("given noCaller: Caller(???) with { override def computeValue() = () }")
+      assertLayout = Some("given noCaller: Caller(???) with { override def computeValue() = () }"),
     )(Defn.Given(
       Nil,
       tname("noCaller"),
@@ -156,8 +156,8 @@ class GivenUsingSuite extends BaseDottySuite {
         List(init("Caller", List(tname("???")))),
         Defn
           .Def(List(Mod.Override()), tname("computeValue"), Nil, List(List()), None, Lit.Unit()) ::
-          Nil
-      )
+          Nil,
+      ),
     ))
   }
 
@@ -165,29 +165,29 @@ class GivenUsingSuite extends BaseDottySuite {
     runTestAssert[Stat](
       """|given C(1) with {}
          |""".stripMargin,
-      assertLayout = Some("given C(1)")
-    )(Defn.Given(Nil, anon, Nil, Nil, tpl(List(init("C", List(int(1)))), Nil)))
+      assertLayout = Some("given C(1)"),
+    )(Defn.Given(Nil, anon, Nil, Nil, tpl(List(init("C", List(int(1)))), Nil))),
   )
 
   test("given-empty-anon-parens")(
     runTestAssert[Stat](
       """|given C(1)
-         |""".stripMargin
-    )(Defn.Given(Nil, anon, Nil, Nil, tplNoBody(init("C", List(int(1))))))
+         |""".stripMargin,
+    )(Defn.Given(Nil, anon, Nil, Nil, tplNoBody(init("C", List(int(1)))))),
   )
 
   test("given-empty-anon-empty-parens")(
     runTestAssert[Stat](
       """|given C()
-         |""".stripMargin
-    )(Defn.Given(Nil, anon, Nil, Nil, tplNoBody(init("C", Nil))))
+         |""".stripMargin,
+    )(Defn.Given(Nil, anon, Nil, Nil, tplNoBody(init("C", Nil)))),
   )
 
   test("given-empty-anon-no-parens")(
     runTestAssert[Stat](
       """|given C with {}
-         |""".stripMargin
-    )(Defn.Given(Nil, anon, Nil, Nil, tpl(List(init("C")), Nil)))
+         |""".stripMargin,
+    )(Defn.Given(Nil, anon, Nil, Nil, tpl(List(init("C")), Nil))),
   )
 
   test("given-empty")(
@@ -196,15 +196,15 @@ class GivenUsingSuite extends BaseDottySuite {
          |""".stripMargin,
       assertLayout = Some(
         """|given t1[T]: E[T]("low")
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Given(
       Nil,
       tname("t1"),
       List(pparam("T")),
       Nil,
-      tpl(init(papply("E", "T"), List(str("low"))) :: Nil, Nil)
-    ))
+      tpl(init(papply("E", "T"), List(str("low"))) :: Nil, Nil),
+    )),
   )
 
   test("given-extension") {
@@ -230,10 +230,10 @@ class GivenUsingSuite extends BaseDottySuite {
             Nil,
             List(List(tparam("y", "Int"))),
             Some(pname("Boolean")),
-            bool(false)
-          )
-        ) :: Nil
-      )
+            bool(false),
+          ),
+        ) :: Nil,
+      ),
     ))
   }
 
@@ -245,9 +245,9 @@ class GivenUsingSuite extends BaseDottySuite {
       Nil,
       tpl(
         List(init(papply("Ord", "Int"))),
-        List(Defn.Def(Nil, tname("f"), Nil, List(List()), Some(pname("Int")), int(1)))
-      )
-    ))
+        List(Defn.Def(Nil, tname("f"), Nil, List(List()), Some(pname("Int")), int(1))),
+      ),
+    )),
   )
 
   test("given-with-import") {
@@ -261,8 +261,8 @@ class GivenUsingSuite extends BaseDottySuite {
         """|given intOrd: Ord[Int] with {
            |  import math.max as maxF
            |  def f(): Int = 1
-           |}""".stripMargin
-      )
+           |}""".stripMargin,
+      ),
     )(Defn.Given(
       Nil,
       tname("intOrd"),
@@ -272,9 +272,9 @@ class GivenUsingSuite extends BaseDottySuite {
         List(init(papply("Ord", "Int"))),
         List(
           Import(List(Importer(tname("math"), List(Importee.Rename(Name("max"), Name("maxF")))))),
-          Defn.Def(Nil, tname("f"), Nil, List(List()), Some(pname("Int")), int(1))
-        )
-      )
+          Defn.Def(Nil, tname("f"), Nil, List(List()), Some(pname("Int")), int(1)),
+        ),
+      ),
     ))
   }
 
@@ -289,8 +289,8 @@ class GivenUsingSuite extends BaseDottySuite {
         """|given intOrd: Ord[Int] with {
            |  export math.max
            |  def f(): Int = 1
-           |}""".stripMargin
-      )
+           |}""".stripMargin,
+      ),
     )(Defn.Given(
       Nil,
       tname("intOrd"),
@@ -300,9 +300,9 @@ class GivenUsingSuite extends BaseDottySuite {
         List(init(papply("Ord", "Int"))),
         List(
           Export(List(Importer(tname("math"), List(Importee.Name(Name("max")))))),
-          Defn.Def(Nil, tname("f"), Nil, List(List()), Some(pname("Int")), int(1))
-        )
-      )
+          Defn.Def(Nil, tname("f"), Nil, List(List()), Some(pname("Int")), int(1)),
+        ),
+      ),
     ))
   }
 
@@ -312,7 +312,7 @@ class GivenUsingSuite extends BaseDottySuite {
         """|given {} with
            |  extension [T](t: T) def hello = ""
            |""".stripMargin,
-      assertLayout = Some("""given {} with { extension [T](t: T) def hello = "" }""")
+      assertLayout = Some("""given {} with { extension [T](t: T) def hello = "" }"""),
     )(Defn.Given(
       Nil,
       anon,
@@ -323,9 +323,9 @@ class GivenUsingSuite extends BaseDottySuite {
         Defn.ExtensionGroup(
           List(pparam("T")),
           List(List(tparam("t", "T"))),
-          Defn.Def(Nil, tname("hello"), Nil, Nil, None, str(""))
-        ) :: Nil
-      )
+          Defn.Def(Nil, tname("hello"), Nil, Nil, None, str("")),
+        ) :: Nil,
+      ),
     ))
   }
 
@@ -340,30 +340,30 @@ class GivenUsingSuite extends BaseDottySuite {
       Nil,
       Nil,
       papply("Option", "Int"),
-      tapply(tname("Some"), int(3))
-    ))
+      tapply(tname("Some"), int(3)),
+    )),
   )
 
   test("given-alias-anonymous")(runTestAssert[Stat]("given Option[Int] = Some(3)")(
-    Defn.GivenAlias(Nil, anon, Nil, Nil, papply("Option", "Int"), tapply(tname("Some"), int(3)))
+    Defn.GivenAlias(Nil, anon, Nil, Nil, papply("Option", "Int"), tapply(tname("Some"), int(3))),
   ))
 
   test("given-alias-anon-or")(runTestAssert[Stat]("given (Cancelable & Movable) = ???")(
-    Defn.GivenAlias(Nil, anon, Nil, Nil, pinfix("Cancelable", "&", pname("Movable")), tname("???"))
+    Defn.GivenAlias(Nil, anon, Nil, Nil, pinfix("Cancelable", "&", pname("Movable")), tname("???")),
   ))
 
   test("given-alias-block")(
     runTestAssert[Stat](
       "given global: Option[Int] = { def f(): Int = 1; Some(3) }",
-      assertLayout = None
+      assertLayout = None,
     )(Defn.GivenAlias(
       Nil,
       tname("global"),
       Nil,
       Nil,
       papply("Option", "Int"),
-      blk(defone, tapply(tname("Some"), int(3)))
-    ))
+      blk(defone, tapply(tname("Some"), int(3))),
+    )),
   )
 
   test("given-alias-using-named")(
@@ -373,8 +373,8 @@ class GivenUsingSuite extends BaseDottySuite {
       Nil,
       List(List(tparam(List(Mod.Using()), "ord", papply("Ord", "Int")))),
       papply("Ord", papply("List", "Int")),
-      tname("???")
-    ))
+      tname("???"),
+    )),
   )
 
   test("given-alias-using-anonymous")(
@@ -384,12 +384,12 @@ class GivenUsingSuite extends BaseDottySuite {
       Nil,
       List(List(tparam(List(Mod.Using()), "ord", papply("Ord", "Int")))),
       papply("Ord", papply("List", "Int")),
-      tname("???")
-    ))
+      tname("???"),
+    )),
   )
 
   test("given-alias-inline")(runTestAssert[Stat]("inline given intOrd: Ord[Int] = ???")(
-    Defn.GivenAlias(List(Mod.Inline()), tname("intOrd"), Nil, Nil, papply("Ord", "Int"), tname("???"))
+    Defn.GivenAlias(List(Mod.Inline()), tname("intOrd"), Nil, Nil, papply("Ord", "Int"), tname("???")),
   ))
   test("given-alias-type-apply") {
     runTestAssert[Stat](
@@ -397,7 +397,7 @@ class GivenUsingSuite extends BaseDottySuite {
          |  given Conversion[AppliedName, Expr.Apply[Id]] = _.toExpr
          |""".stripMargin,
       assertLayout =
-        Some("object AppliedName { given Conversion[AppliedName, Expr.Apply[Id]] = _.toExpr }")
+        Some("object AppliedName { given Conversion[AppliedName, Expr.Apply[Id]] = _.toExpr }"),
     )(Defn.Object(
       Nil,
       tname("AppliedName"),
@@ -407,8 +407,8 @@ class GivenUsingSuite extends BaseDottySuite {
         Nil,
         Nil,
         papply("Conversion", "AppliedName", papply(pselect("Expr", "Apply"), "Id")),
-        Term.AnonymousFunction(tselect(Term.Placeholder(), "toExpr"))
-      ))
+        Term.AnonymousFunction(tselect(Term.Placeholder(), "toExpr")),
+      )),
     ))
   }
 
@@ -417,11 +417,11 @@ class GivenUsingSuite extends BaseDottySuite {
   // ---------------------------------
 
   test("abstract-given")(runTestAssert[Stat]("given intOrd: Ord[Int]")(
-    Decl.Given(Nil, tname("intOrd"), Nil, Nil, papply("Ord", "Int"))
+    Decl.Given(Nil, tname("intOrd"), Nil, Nil, papply("Ord", "Int")),
   ))
 
   test("abstract-given-inline")(runTestAssert[Stat]("inline given intOrd: Ord[Int]")(
-    Decl.Given(List(Mod.Inline()), tname("intOrd"), Nil, Nil, papply("Ord", "Int"))
+    Decl.Given(List(Mod.Inline()), tname("intOrd"), Nil, Nil, papply("Ord", "Int")),
   ))
 
   test("abstract-given-depend")(
@@ -430,8 +430,8 @@ class GivenUsingSuite extends BaseDottySuite {
       tname("setOrd"),
       List(pparam("T")),
       List(List(tparam(List(Mod.Using()), "ord", papply("Ord", "T")))),
-      papply("Ord", papply("Set", "T"))
-    ))
+      papply("Ord", papply("Set", "T")),
+    )),
   )
 
   test("abstract-given-anonymous") {
@@ -458,8 +458,8 @@ class GivenUsingSuite extends BaseDottySuite {
       None,
       tpl(
         List(init(papply("using", "String")), init(papply("Eq", "Int"))),
-        List(Defn.Def(Nil, "foo", Nil, None, "???"))
-      )
+        List(Defn.Def(Nil, "foo", Nil, None, "???")),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -474,7 +474,7 @@ class GivenUsingSuite extends BaseDottySuite {
     Nil,
     List(List(tparam("a", "Int")), List(tparamUsing("ord", "UInt"))),
     Some(pname("Int")),
-    tname("???")
+    tname("???"),
   )))
 
   test("using-anonymous")(runTestAssert[Stat]("def f(a: Int)(using UInt): Int = ???")(Defn.Def(
@@ -483,7 +483,7 @@ class GivenUsingSuite extends BaseDottySuite {
     Nil,
     List(List(tparam("a", "Int")), List(tparamUsing("", "UInt"))),
     Some(pname("Int")),
-    tname("???")
+    tname("???"),
   )))
 
   test("using-multiple-parens") {
@@ -494,10 +494,10 @@ class GivenUsingSuite extends BaseDottySuite {
       List(
         List(tparam("a", "Int")),
         List(tparamUsing("ui", "UInt")),
-        List(tparamUsing("us", "UString"))
+        List(tparamUsing("us", "UString")),
       ),
       Some(pname("Boolean")),
-      tname("???")
+      tname("???"),
     ))
     runTestAssert[Stat]("def f(a: Int)(using UInt)(using UString): Boolean = ???")(Defn.Def(
       Nil,
@@ -505,7 +505,7 @@ class GivenUsingSuite extends BaseDottySuite {
       Nil,
       List(List(tparam("a", "Int")), List(tparamUsing("", "UInt")), List(tparamUsing("", "UString"))),
       Some(pname("Boolean")),
-      tname("???")
+      tname("???"),
     ))
   }
 
@@ -517,7 +517,7 @@ class GivenUsingSuite extends BaseDottySuite {
       Nil,
       List(List(tparam("a", "Int")), List(tparamUsing("ui", "UInt"), paramByName)),
       Some(pname("Boolean")),
-      tname("???")
+      tname("???"),
     ))
     runTestAssert[Stat]("def f(a: Int)(using UInt, UString): Boolean = ???")(Defn.Def(
       Nil,
@@ -525,7 +525,7 @@ class GivenUsingSuite extends BaseDottySuite {
       Nil,
       List(List(tparam("a", "Int")), List(tparamUsing("", "UInt"), tparamUsing("", "UString"))),
       Some(pname("Boolean")),
-      tname("???")
+      tname("???"),
     ))
   }
 
@@ -538,11 +538,11 @@ class GivenUsingSuite extends BaseDottySuite {
         List(tparam("x", "String")),
         List(tparamUsing("", "Int")),
         List(tparam("y", "String")),
-        List(tparamUsing("b", "Int"))
+        List(tparamUsing("b", "Int")),
       ),
       Some(pname("Unit")),
-      tname("???")
-    ))
+      tname("???"),
+    )),
   )
 
   test("using-lambda-method-parameter") {
@@ -552,7 +552,7 @@ class GivenUsingSuite extends BaseDottySuite {
          |}
          |""".stripMargin
     runTestAssert[Stat]("LazyBody { (using ctx: Context) => 3 }", assertLayout = Some(output))(
-      tapply(tname("LazyBody"), blk(tfunc(tparam(List(Mod.Using()), "ctx", "Context"))(int(3))))
+      tapply(tname("LazyBody"), blk(tfunc(tparam(List(Mod.Using()), "ctx", "Context"))(int(3)))),
     )
 
   }
@@ -560,7 +560,7 @@ class GivenUsingSuite extends BaseDottySuite {
   test("using-named-with-by-name-parameter") {
     val usingByName = tparam(List(Mod.Using()), "a", Type.ByName(pname("Int")))
     runTestAssert[Stat]("def f(using a: => Int): Unit = ???")(
-      Defn.Def(Nil, tname("f"), Nil, List(List(usingByName)), Some(pname("Unit")), tname("???"))
+      Defn.Def(Nil, tname("f"), Nil, List(List(usingByName)), Some(pname("Unit")), tname("???")),
     )
   }
 
@@ -568,7 +568,7 @@ class GivenUsingSuite extends BaseDottySuite {
     Nil,
     List(patvar("a")),
     None,
-    tapplyUsing(tapplyUsing(tapply(tname("f")), tname("a")), int(3), bool(true))
+    tapplyUsing(tapplyUsing(tapply(tname("f")), tname("a")), int(3), bool(true)),
   )))
 
   test("using-anonymous-method") {
@@ -576,21 +576,21 @@ class GivenUsingSuite extends BaseDottySuite {
       Nil,
       List(patvar("fun")),
       None,
-      tfunc(tparam(List(Mod.Using()), "ctx", "Context"))(tselect("ctx", "open"))
+      tfunc(tparam(List(Mod.Using()), "ctx", "Context"))(tselect("ctx", "open")),
     ))
 
     runTestAssert[Stat]("val fun = (using ctx) => ctx.open")(Defn.Val(
       Nil,
       List(patvar("fun")),
       None,
-      tfunc(tparam(List(Mod.Using()), "ctx"))(tselect("ctx", "open"))
+      tfunc(tparam(List(Mod.Using()), "ctx"))(tselect("ctx", "open")),
     ))
 
     runTestAssert[Stat]("val fun = (using _: Context) => ctx.open")(Defn.Val(
       Nil,
       List(patvar("fun")),
       None,
-      tfunc(tparam(List(Mod.Using()), "_", "Context"))(tselect("ctx", "open"))
+      tfunc(tparam(List(Mod.Using()), "_", "Context"))(tselect("ctx", "open")),
     ))
   }
 
@@ -599,15 +599,15 @@ class GivenUsingSuite extends BaseDottySuite {
       """|pair match {
          |  case (ctx @ given Context, y) =>
          |}
-         |""".stripMargin
+         |""".stripMargin,
     )(tmatch(
       tname("pair"),
       Case(
         Pat.Tuple(List(Pat.Bind(patvar("ctx"), Pat.Given(pname("Context"))), patvar("y"))),
         None,
-        blk()
-      )
-    ))
+        blk(),
+      ),
+    )),
   )
   test("given-pat-new") {
     runTestAssert[Stat](
@@ -623,16 +623,16 @@ class GivenUsingSuite extends BaseDottySuite {
            |  case ctx @ given (Context => String) =>
            |    new Provider
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(tmatch(
       tname("pair"),
       Case(Pat.Bind(patvar("ctx"), Pat.Given(pname("Context"))), None, Term.New(init("Provider"))),
       Case(
         Pat.Bind(patvar("ctx"), Pat.Given(pfunc(pname("Context"))(pname("String")))),
         None,
-        Term.New(init("Provider"))
-      )
+        Term.New(init("Provider")),
+      ),
     ))
   }
 
@@ -640,11 +640,11 @@ class GivenUsingSuite extends BaseDottySuite {
     runTestAssert[Stat](
       """|for given Context <- applicationContexts do a
          |""".stripMargin,
-      assertLayout = Some("for (given Context <- applicationContexts) a")
+      assertLayout = Some("for (given Context <- applicationContexts) a"),
     )(Term.For(
       List(Enumerator.Generator(Pat.Given(pname("Context")), tname("applicationContexts"))),
-      tname("a")
-    ))
+      tname("a"),
+    )),
   )
 
   // ---------------------------------
@@ -654,29 +654,29 @@ class GivenUsingSuite extends BaseDottySuite {
   test("import-given") {
 
     runTestAssert[Stat]("import File.given")(Import(
-      List(Importer(tname("File"), List(Importee.GivenAll())))
+      List(Importer(tname("File"), List(Importee.GivenAll()))),
     ))
 
     runTestAssert[Stat]("import File.{ *, given }")(Import(
-      List(Importer(tname("File"), List(Importee.Wildcard(), Importee.GivenAll())))
+      List(Importer(tname("File"), List(Importee.Wildcard(), Importee.GivenAll()))),
     ))
 
     runTestAssert[Stat]("import File.{ given, * }")(Import(
-      List(Importer(tname("File"), List(Importee.GivenAll(), Importee.Wildcard())))
+      List(Importer(tname("File"), List(Importee.GivenAll(), Importee.Wildcard()))),
     ))
 
     runTestAssert[Stat]("import File.{ given TC }", assertLayout = Some("import File.given TC"))(
-      Import(List(Importer(tname("File"), List(Importee.Given(pname("TC"))))))
+      Import(List(Importer(tname("File"), List(Importee.Given(pname("TC")))))),
     )
 
     runTestAssert[Stat]("import File.{ given TC, given AC, * }")(Import(List(Importer(
       tname("File"),
-      List(Importee.Given(pname("TC")), Importee.Given(pname("AC")), Importee.Wildcard())
+      List(Importee.Given(pname("TC")), Importee.Given(pname("AC")), Importee.Wildcard()),
     ))))
 
     runTestAssert[Stat]("import Instances.{ im, given Ordering[?] }")(Import(List(Importer(
       tname("Instances"),
-      List(Importee.Name(Name("im")), Importee.Given(papply("Ordering", pwildcard)))
+      List(Importee.Name(Name("im")), Importee.Given(papply("Ordering", pwildcard))),
     ))))
   }
 
@@ -711,10 +711,10 @@ class GivenUsingSuite extends BaseDottySuite {
           "foo",
           Nil,
           None,
-          tapply("bar", Term.PartialFunction(List(Case(Pat.Given("String"), None, blk()))))
+          tapply("bar", Term.PartialFunction(List(Case(Pat.Given("String"), None, blk())))),
         ),
-        Term.EndMarker("foo")
-      )
+        Term.EndMarker("foo"),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InfixSuite.scala
@@ -7,15 +7,15 @@ class InfixSuite extends BaseDottySuite {
   test("simple-modifier")(
     runTestAssert[Stat](
       """|infix def a(param: Int) = param
-         |""".stripMargin
+         |""".stripMargin,
     )(Defn.Def(
       List(Mod.Infix()),
       tname("a"),
       Nil,
       List(List(tparam("param", "Int"))),
       None,
-      tname("param")
-    ))
+      tname("param"),
+    )),
   )
   test("infix-type-complex") {
     runTestAssert[Stat](
@@ -28,8 +28,8 @@ class InfixSuite extends BaseDottySuite {
            |  infix type or[X, Y]
            |  infix def x(a: Int): String or Int = 1
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Class(
       Nil,
       pname("A"),
@@ -43,19 +43,19 @@ class InfixSuite extends BaseDottySuite {
           Nil,
           List(List(tparam("a", "Int"))),
           Some(pinfix("String", "or", pname("Int"))),
-          int(1)
-        )
-      )
+          int(1),
+        ),
+      ),
     ))
 
   }
 
   test("infix-class")(runTestAssert[Stat]("infix class A[B, C]")(
-    Defn.Class(List(Mod.Infix()), pname("A"), List(pparam("B"), pparam("C")), ctor, tplNoBody())
+    Defn.Class(List(Mod.Infix()), pname("A"), List(pparam("B"), pparam("C")), ctor, tplNoBody()),
   ))
 
   test("infix-trait")(runTestAssert[Stat]("infix trait A[B, C]")(
-    Defn.Trait(List(Mod.Infix()), pname("A"), List(pparam("B"), pparam("C")), ctor, tplNoBody())
+    Defn.Trait(List(Mod.Infix()), pname("A"), List(pparam("B"), pparam("C")), ctor, tplNoBody()),
   ))
 
   test("infix-identifier")(
@@ -65,8 +65,8 @@ class InfixSuite extends BaseDottySuite {
       Nil,
       List(List(tparam("infix", "infix"))),
       Some(pname("infix")),
-      Term.NewAnonymous(tpl(List(init("infix")), Nil))
-    ))
+      Term.NewAnonymous(tpl(List(init("infix")), Nil)),
+    )),
   )
 
   test("extension-method")(
@@ -80,10 +80,10 @@ class InfixSuite extends BaseDottySuite {
           Nil,
           List(List(tparam("other", "Int"))),
           Some(pname("Int")),
-          int(0)
-        )
-      )
-    )
+          int(0),
+        ),
+      ),
+    ),
   )
 
   test("issue-2880 1") {
@@ -101,8 +101,8 @@ class InfixSuite extends BaseDottySuite {
            |  b.add()
            |  input_< ~> filtering ~> removeItems.in0 ~> removeItems
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(tapply(
       tname("Flow"),
       blk(
@@ -111,12 +111,12 @@ class InfixSuite extends BaseDottySuite {
           tinfix(
             tinfix(tname("input_<"), "~>", tname("filtering")),
             "~>",
-            tselect("removeItems", "in0")
+            tselect("removeItems", "in0"),
           ),
           "~>",
-          tname("removeItems")
-        )
-      )
+          tname("removeItems"),
+        ),
+      ),
     ))
   }
 
@@ -138,8 +138,8 @@ class InfixSuite extends BaseDottySuite {
            |    input_< ~> filtering ~> removeItems1 ~> removeItems2
            |  }
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(tapply(
       tname("Flow"),
       blk(Defn.Def(
@@ -152,10 +152,10 @@ class InfixSuite extends BaseDottySuite {
           tinfix(
             tinfix(tinfix(tname("input_<"), "~>", tname("filtering")), "~>", tname("removeItems1")),
             "~>",
-            tname("removeItems2")
-          )
-        )
-      ))
+            tname("removeItems2"),
+          ),
+        ),
+      )),
     ))
   }
 
@@ -167,14 +167,14 @@ class InfixSuite extends BaseDottySuite {
          |""".stripMargin,
       Some(
         """|val str = "hello" ++ " world" ++ "!"
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Val(
       Nil,
       List(patvar("str")),
       None,
-      tinfix(tinfix(str("hello"), "++", str(" world")), "++", str("!"))
-    ))
+      tinfix(tinfix(str("hello"), "++", str(" world")), "++", str("!")),
+    )),
   )
 
   test("scala3 infix syntax 2") {
@@ -187,8 +187,8 @@ class InfixSuite extends BaseDottySuite {
          |""".stripMargin,
       Some(
         """|def condition = x > 0 || xs.exists(_ > 0) || xs.isEmpty
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Def(
       Nil,
       tname("condition"),
@@ -200,12 +200,12 @@ class InfixSuite extends BaseDottySuite {
           "||",
           tapply(
             tselect("xs", "exists"),
-            Term.AnonymousFunction(tinfix(Term.Placeholder(), ">", int(0)))
-          )
+            Term.AnonymousFunction(tinfix(Term.Placeholder(), ">", int(0))),
+          ),
         ),
         "||",
-        tselect("xs", "isEmpty")
-      )
+        tselect("xs", "isEmpty"),
+      ),
     ))
   }
 
@@ -220,9 +220,9 @@ class InfixSuite extends BaseDottySuite {
         """|{
            |  freezing | boiling
            |}
-           |""".stripMargin
-      )
-    )(blk(tinfix(tname("freezing"), "|", tname("boiling"))))
+           |""".stripMargin,
+      ),
+    )(blk(tinfix(tname("freezing"), "|", tname("boiling")))),
   )
 
   test("scala3 infix syntax 3.2")(
@@ -237,8 +237,8 @@ class InfixSuite extends BaseDottySuite {
          |  freezing
          |  |boiling
          |}
-         |""".stripMargin
-    )(blk("freezing", tpostfix("|", "boiling")))
+         |""".stripMargin,
+    )(blk("freezing", tpostfix("|", "boiling"))),
   )
 
   test("scala3 infix syntax 3.2.1")(
@@ -253,8 +253,8 @@ class InfixSuite extends BaseDottySuite {
          |  freezing
          |  |boiling
          |}
-         |""".stripMargin
-    )(blk("freezing", tpostfix("|", "boiling")))
+         |""".stripMargin,
+    )(blk("freezing", tpostfix("|", "boiling"))),
   )
 
   test("scala3 infix syntax 3.2.2")(
@@ -269,8 +269,8 @@ class InfixSuite extends BaseDottySuite {
          |  freezing
          |  `|`!
          |}
-         |""".stripMargin
-    )(blk("freezing", tpostfix("|", "!")))
+         |""".stripMargin,
+    )(blk("freezing", tpostfix("|", "!"))),
   )
 
   test("scala3 infix syntax 3.2.3")(
@@ -285,8 +285,8 @@ class InfixSuite extends BaseDottySuite {
          |  freezing
          |  `|`!
          |}
-         |""".stripMargin
-    )(blk("freezing", tpostfix("|", "!")))
+         |""".stripMargin,
+    )(blk("freezing", tpostfix("|", "!"))),
   )
 
   test("scala3 infix syntax 3.2.4")(
@@ -301,8 +301,8 @@ class InfixSuite extends BaseDottySuite {
          |  freezing
          |  `|`|
          |}
-         |""".stripMargin
-    )(blk("freezing", tpostfix("|", "|")))
+         |""".stripMargin,
+    )(blk("freezing", tpostfix("|", "|"))),
   )
 
   test("scala3 infix syntax 3.2.5")(
@@ -317,8 +317,8 @@ class InfixSuite extends BaseDottySuite {
          |  freezing
          |  `|`|
          |}
-         |""".stripMargin
-    )(blk("freezing", tpostfix("|", "|")))
+         |""".stripMargin,
+    )(blk("freezing", tpostfix("|", "|"))),
   )
 
   test("scala3 infix syntax 3.3")(
@@ -333,9 +333,9 @@ class InfixSuite extends BaseDottySuite {
         """|{
            |  freezing | boiling
            |}
-           |""".stripMargin
-      )
-    )(blk(tinfix(tname("freezing"), "|", tname("boiling"))))
+           |""".stripMargin,
+      ),
+    )(blk(tinfix(tname("freezing"), "|", tname("boiling")))),
   )
 
   test("scala3 infix syntax 3.4") {
@@ -364,7 +364,7 @@ class InfixSuite extends BaseDottySuite {
        |""".stripMargin,
     """|error: Invalid indented leading infix operator found
        |    |
-       |    ^""".stripMargin
+       |    ^""".stripMargin,
   ))
 
   test("scala3 infix syntax 3.6 comment") {
@@ -410,7 +410,7 @@ class InfixSuite extends BaseDottySuite {
          |}
          |""".stripMargin
     val tree = blk(
-      tinfix(tname("freezing"), tnameComments("|")("// c1", "/*\n    c2\n  */")(), tname("boiling"))
+      tinfix(tname("freezing"), tnameComments("|")("// c1", "/*\n    c2\n  */")(), tname("boiling")),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -438,7 +438,7 @@ class InfixSuite extends BaseDottySuite {
          |}
          |""".stripMargin
     val tree = blk(
-      tinfix(tname("freezing"), tnameComments("|")("// c1", "/*\n    c2\n  */")(), tname("boiling"))
+      tinfix(tname("freezing"), tnameComments("|")("// c1", "/*\n    c2\n  */")(), tname("boiling")),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -455,9 +455,9 @@ class InfixSuite extends BaseDottySuite {
            |  freezing
            |  !boiling
            |}
-           |""".stripMargin
-      )
-    )(blk(tname("freezing"), Term.ApplyUnary(tname("!"), tname("boiling"))))
+           |""".stripMargin,
+      ),
+    )(blk(tname("freezing"), Term.ApplyUnary(tname("!"), tname("boiling")))),
   )
 
   test("scala3 infix syntax 5.1") {
@@ -478,12 +478,12 @@ class InfixSuite extends BaseDottySuite {
            |    case 0 => 1
            |  }
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(blk(
       tapply(tname("println"), str("hello")),
       tname("???"),
-      tmatch(tname("???"), Case(int(0), None, int(1)))
+      tmatch(tname("???"), Case(int(0), None, int(1))),
     ))
   }
 
@@ -509,7 +509,7 @@ class InfixSuite extends BaseDottySuite {
     val tree = blk(
       tapply(tname("println"), str("hello")),
       tname("???"),
-      tmatch(tname("???"), Case(int(0), None, int(1)))
+      tmatch(tname("???"), Case(int(0), None, int(1))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -538,7 +538,7 @@ class InfixSuite extends BaseDottySuite {
          |  }
          |  end toBeContinued
          |}
-         |""".stripMargin
+         |""".stripMargin,
     ) {
       blk(
         Defn.Def(
@@ -557,31 +557,31 @@ class InfixSuite extends BaseDottySuite {
                 Term.ApplyUnary.createWithComments(
                   tname("!"),
                   tapply(tselect("in", "canStartStatTokens", "contains"), tselect("in", "token")),
-                  endComment = Seq("// not statement, so take as continued expr")
+                  endComment = Seq("// not statement, so take as continued expr"),
                 ),
                 "||",
-                tapply(tname("followedByToken"), tname("altToken"))
+                tapply(tname("followedByToken"), tname("altToken")),
               ),
-              endComment = Seq("// scan ahead to see whether we find a `then` or `do`")
+              endComment = Seq("// scan ahead to see whether we find a `then` or `do`"),
             ),
             tinfix(
               Term.ApplyInfix.createWithComments(
                 Term.ApplyUnary.createWithComments(
                   tname("!"),
                   tselect("in", "isNewLine"),
-                  endComment = Seq("// a newline token means the expression is finished")
+                  endComment = Seq("// a newline token means the expression is finished"),
                 ),
                 "&&",
                 Nil,
                 List(Term.ApplyUnary(tname("!"), tname("migrateTo3"))),
-                endComment = Seq("// old syntax")
+                endComment = Seq("// old syntax"),
               ),
               "&&",
-              tname("canContinue")
-            )
-          )
+              tname("canContinue"),
+            ),
+          ),
         ),
-        Term.EndMarker(tname("toBeContinued"))
+        Term.EndMarker(tname("toBeContinued")),
       )
     }
   }
@@ -595,8 +595,8 @@ class InfixSuite extends BaseDottySuite {
          |""".stripMargin,
       Some(
         """|val httpRoutes2 = (MetricsApp() ++ HomeApp() ++ GreetingApp()) @@ Middleware.cors(corsConfig) @@ Middleware.metrics(MetricsApp.pathLabelMapper) @@ Middleware.debug
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Val(
       Nil,
       List(patvar("httpRoutes2")),
@@ -607,17 +607,17 @@ class InfixSuite extends BaseDottySuite {
             tinfix(
               tinfix(tapply(tname("MetricsApp")), "++", tapply(tname("HomeApp"))),
               "++",
-              tapply(tname("GreetingApp"))
+              tapply(tname("GreetingApp")),
             ),
             "@@",
-            tapply(tselect("Middleware", "cors"), tname("corsConfig"))
+            tapply(tselect("Middleware", "cors"), tname("corsConfig")),
           ),
           "@@",
-          tapply(tselect("Middleware", "metrics"), tselect("MetricsApp", "pathLabelMapper"))
+          tapply(tselect("Middleware", "metrics"), tselect("MetricsApp", "pathLabelMapper")),
         ),
         "@@",
-        tselect("Middleware", "debug")
-      )
+        tselect("Middleware", "debug"),
+      ),
     ))
   }
 
@@ -659,12 +659,12 @@ class InfixSuite extends BaseDottySuite {
           tinfix(
             tinfix(tapply(tname("abc"), tname("arg1")), "++", tapply(tname("abc"), tname("arg2"))),
             "++",
-            tapply(tname("abc"), tname("arg3"))
+            tapply(tname("abc"), tname("arg3")),
           ),
           "++",
-          tapply(tname("abc"), tname("arg4"))
-        )
-      ))
+          tapply(tname("abc"), tname("arg4")),
+        ),
+      )),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -690,8 +690,8 @@ class InfixSuite extends BaseDottySuite {
       tpl(tinfix(
         tapply(tselect("foo", "map"), blk(tfunc(tparam("i"))(tinfix(tname("i"), "+", int(1))))),
         "*>",
-        tname("bar")
-      ))
+        tname("bar"),
+      )),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -732,17 +732,17 @@ class InfixSuite extends BaseDottySuite {
               tapply(
                 tselect("foo", "map"),
                 blk(tfunc(tparam("i"))(
-                  tinfix(tinfix(tinfix(tname("i"), "+", int(1)), "+", int(2)), "+", int(3))
-                ))
+                  tinfix(tinfix(tinfix(tname("i"), "+", int(1)), "+", int(2)), "+", int(3)),
+                )),
               ),
               "*>",
-              tname("bar")
+              tname("bar"),
             ),
-            tname("baz")
-          )
+            tname("baz"),
+          ),
         ),
-        tname("qux")
-      )
+        tname("qux"),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -783,8 +783,8 @@ class InfixSuite extends BaseDottySuite {
       tpl(tinfix(
         tinfix(tname("buffer"), "+=", Term.New(init("Object", Nil))),
         "+=",
-        Term.New(init("Object"))
-      ))
+        Term.New(init("Object")),
+      )),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -842,12 +842,12 @@ class InfixSuite extends BaseDottySuite {
           "+=",
           Term.NewAnonymous(tpl(
             List(init("Object", Nil), init("Foo")),
-            List(Defn.Def(Nil, tname("toString"), Nil, List(Nil), None, lit("foo")))
-          ))
+            List(Defn.Def(Nil, tname("toString"), Nil, List(Nil), None, lit("foo"))),
+          )),
         ),
         "+=",
-        Term.New(init("Object"))
-      ))
+        Term.New(init("Object")),
+      )),
     )
     runTestAssert[Stat](code, layout)(tree)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InlineSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InlineSuite.scala
@@ -13,7 +13,7 @@ class InlineSuite extends BaseDottySuite {
   test("inline-soft-keyword-pos") {
     // as ident
     runTestAssert[Stat]("def f(inline: String): Unit")(
-      Decl.Def(Nil, tname("f"), Nil, List(List(tparam("inline", "String"))), pname("Unit"))
+      Decl.Def(Nil, tname("f"), Nil, List(List(tparam("inline", "String"))), pname("Unit")),
     )
 
     // as ident
@@ -22,7 +22,7 @@ class InlineSuite extends BaseDottySuite {
       tname("inline"),
       Nil,
       List(List(tparam("inline", "inline"))),
-      pname("inline")
+      pname("inline"),
     ))
 
     // as modifier
@@ -31,7 +31,7 @@ class InlineSuite extends BaseDottySuite {
       tname("inline"),
       Nil,
       List(List(tparamInline("param", "inline"))),
-      pname("inline")
+      pname("inline"),
     ))
 
     // as ident and modifier
@@ -40,17 +40,17 @@ class InlineSuite extends BaseDottySuite {
       tname("inline"),
       Nil,
       List(List(tparamInline("inline", "inline"))),
-      pname("inline")
+      pname("inline"),
     ))
 
     // as ident and modifier
     runTestAssert[Stat]("inline val inline = false")(
-      Defn.Val(List(Mod.Inline()), List(patvar("inline")), None, bool(false))
+      Defn.Val(List(Mod.Inline()), List(patvar("inline")), None, bool(false)),
     )
 
     // inline for class as ident
     runTestAssert[Stat]("case class A(inline: Int)")(
-      Defn.Class(List(Mod.Case()), pname("A"), Nil, ctorp(tparam("inline", "Int")), tplNoBody())
+      Defn.Class(List(Mod.Case()), pname("A"), Nil, ctorp(tparam("inline", "Int")), tplNoBody()),
     )
   }
 
@@ -65,13 +65,13 @@ class InlineSuite extends BaseDottySuite {
           Nil,
           List(
             List(tparamInline("sc", "Str")),
-            List(tparam(List(Mod.Inline()), "args", Type.Repeated(pname("Any"))))
+            List(tparam(List(Mod.Inline()), "args", Type.Repeated(pname("Any")))),
           ),
           Some(pname("String")),
-          tname("???")
-        ))
-      )
-    )
+          tname("???"),
+        )),
+      ),
+    ),
   )
   test("inline-mods-combination") {
     runTestAssert[Stat]("object X { inline override protected def f(): Unit = ??? }")(Defn.Object(
@@ -83,8 +83,8 @@ class InlineSuite extends BaseDottySuite {
         Nil,
         List(List()),
         Some(pname("Unit")),
-        tname("???")
-      ))
+        tname("???"),
+      )),
     ))
 
     runTestAssert[Stat]("object X { final override inline protected def f(): Unit = ??? }")(
@@ -97,9 +97,9 @@ class InlineSuite extends BaseDottySuite {
           Nil,
           List(List()),
           Some(pname("Unit")),
-          tname("???")
-        ))
-      )
+          tname("???"),
+        )),
+      ),
     )
 
     runTestAssert[Stat]("case class Y(val inline: String, inline: Int)")(Defn.Class(
@@ -107,7 +107,7 @@ class InlineSuite extends BaseDottySuite {
       pname("Y"),
       Nil,
       ctorp(tparam(List(Mod.ValParam()), "inline", "String"), tparam("inline", "Int")),
-      tplNoBody()
+      tplNoBody(),
     ))
   }
 
@@ -121,11 +121,11 @@ class InlineSuite extends BaseDottySuite {
 
     runTestError[Stat](
       "object X { inline + 3 }",
-      "`inline` must be followed by an `if` or a `match`"
+      "`inline` must be followed by an `if` or a `match`",
     )
 
     runTestAssert[Stat]("object X { `inline` + 3 }")(
-      Defn.Object(Nil, tname("X"), tpl(tinfix(tname("inline"), "+", int(3))))
+      Defn.Object(Nil, tname("X"), tpl(tinfix(tname("inline"), "+", int(3)))),
     )
   }
 
@@ -135,7 +135,7 @@ class InlineSuite extends BaseDottySuite {
          |  case x: String => (x, x) 
          |  case x: Double => x
          |}""".stripMargin,
-      assertLayout = None
+      assertLayout = None,
     )(Defn.Def(
       List(Mod.Inline()),
       tname("g"),
@@ -145,8 +145,8 @@ class InlineSuite extends BaseDottySuite {
       tmatch(Mod.Inline())(
         tname("x"),
         Case(Pat.Typed(patvar("x"), pname("String")), None, Term.Tuple(List(tname("x"), tname("x")))),
-        Case(Pat.Typed(patvar("x"), pname("Double")), None, tname("x"))
-      )
+        Case(Pat.Typed(patvar("x"), pname("Double")), None, tname("x")),
+      ),
     ))
   }
 
@@ -155,15 +155,15 @@ class InlineSuite extends BaseDottySuite {
       """|inline def g = inline (x) match {
          |  case x => x
          |}""".stripMargin,
-      assertLayout = None
+      assertLayout = None,
     )(Defn.Def(
       List(Mod.Inline()),
       tname("g"),
       Nil,
       Nil,
       None,
-      tmatch(Mod.Inline())(tname("x"), Case(patvar("x"), None, tname("x")))
-    ))
+      tmatch(Mod.Inline())(tname("x"), Case(patvar("x"), None, tname("x"))),
+    )),
   )
 
   test("inline-match-brace")(
@@ -171,15 +171,15 @@ class InlineSuite extends BaseDottySuite {
       """|inline def g = inline {x} match {
          |  case x => x
          |}""".stripMargin,
-      assertLayout = None
+      assertLayout = None,
     )(Defn.Def(
       List(Mod.Inline()),
       tname("g"),
       Nil,
       Nil,
       None,
-      tmatch(Mod.Inline())(blk(tname("x")), Case(patvar("x"), None, tname("x")))
-    ))
+      tmatch(Mod.Inline())(blk(tname("x")), Case(patvar("x"), None, tname("x"))),
+    )),
   )
 
   test("inline-match-block")(
@@ -189,15 +189,15 @@ class InlineSuite extends BaseDottySuite {
          |    case x => x
          |  }
          |}""".stripMargin,
-      assertLayout = None
+      assertLayout = None,
     )(Defn.Def(
       List(Mod.Inline()),
       tname("g"),
       Nil,
       Nil,
       None,
-      blk(tmatch(Mod.Inline())(tname("x"), Case(patvar("x"), None, tname("x"))))
-    ))
+      blk(tmatch(Mod.Inline())(tname("x"), Case(patvar("x"), None, tname("x")))),
+    )),
   )
 
   test("inline-match-block-paren")(
@@ -207,15 +207,15 @@ class InlineSuite extends BaseDottySuite {
          |    case x => x
          |  }
          |}""".stripMargin,
-      assertLayout = None
+      assertLayout = None,
     )(Defn.Def(
       List(Mod.Inline()),
       tname("g"),
       Nil,
       Nil,
       None,
-      blk(tmatch(Mod.Inline())(tname("x"), Case(patvar("x"), None, tname("x"))))
-    ))
+      blk(tmatch(Mod.Inline())(tname("x"), Case(patvar("x"), None, tname("x")))),
+    )),
   )
 
   test("inline-match-block-brace")(
@@ -225,15 +225,15 @@ class InlineSuite extends BaseDottySuite {
          |    case x => x
          |  }
          |}""".stripMargin,
-      assertLayout = None
+      assertLayout = None,
     )(Defn.Def(
       List(Mod.Inline()),
       tname("g"),
       Nil,
       Nil,
       None,
-      blk(tmatch(Mod.Inline())(blk(tname("x")), Case(patvar("x"), None, tname("x"))))
-    ))
+      blk(tmatch(Mod.Inline())(blk(tname("x")), Case(patvar("x"), None, tname("x")))),
+    )),
   )
 
   test("inline-match-new")(
@@ -243,15 +243,15 @@ class InlineSuite extends BaseDottySuite {
          |    case x => x
          |  }
          |}""".stripMargin,
-      assertLayout = None
+      assertLayout = None,
     )(Defn.Def(
       List(Mod.Inline()),
       tname("g"),
       Nil,
       Nil,
       None,
-      blk(tmatch(Mod.Inline())(Term.New(init("X")), Case(patvar("x"), None, tname("x"))))
-    ))
+      blk(tmatch(Mod.Inline())(Term.New(init("X")), Case(patvar("x"), None, tname("x")))),
+    )),
   )
 
   test("inline-if-method")(
@@ -260,30 +260,30 @@ class InlineSuite extends BaseDottySuite {
          |    inline if cond then
          |  truep
          |""".stripMargin,
-      assertLayout = Some("def fn: Unit = inline if (cond) truep")
+      assertLayout = Some("def fn: Unit = inline if (cond) truep"),
     )(Defn.Def(
       Nil,
       tname("fn"),
       Nil,
       Nil,
       Some(pname("Unit")),
-      Term.If(tname("cond"), tname("truep"), Lit.Unit(), List(Mod.Inline()))
-    ))
+      Term.If(tname("cond"), tname("truep"), Lit.Unit(), List(Mod.Inline())),
+    )),
   )
 
   test("inline-if-method-oneline")(
     runTestAssert[Stat](
       """|def fn: Unit = inline if cond then truep
          |""".stripMargin,
-      assertLayout = Some("def fn: Unit = inline if (cond) truep")
+      assertLayout = Some("def fn: Unit = inline if (cond) truep"),
     )(Defn.Def(
       Nil,
       tname("fn"),
       Nil,
       Nil,
       Some(pname("Unit")),
-      Term.If(tname("cond"), tname("truep"), Lit.Unit(), List(Mod.Inline()))
-    ))
+      Term.If(tname("cond"), tname("truep"), Lit.Unit(), List(Mod.Inline())),
+    )),
   )
 
   test("transparent-inline") {
@@ -291,23 +291,23 @@ class InlineSuite extends BaseDottySuite {
       """|transparent inline def choose(b: Boolean): A =
          |   if b then new A else new B
          |""".stripMargin,
-      assertLayout = Some("transparent inline def choose(b: Boolean): A = if (b) new A else new B")
+      assertLayout = Some("transparent inline def choose(b: Boolean): A = if (b) new A else new B"),
     )(Defn.Def(
       List(Mod.Transparent(), Mod.Inline()),
       tname("choose"),
       Nil,
       List(List(tparam("b", "Boolean"))),
       Some(pname("A")),
-      Term.If(tname("b"), Term.New(init("A")), Term.New(init("B")), Nil)
+      Term.If(tname("b"), Term.New(init("A")), Term.New(init("B")), Nil),
     ))
   }
 
   test("transparent-trait")(runTestAssert[Stat]("transparent trait S")(
-    Defn.Trait(List(Mod.Transparent()), pname("S"), Nil, ctor, tplNoBody())
+    Defn.Trait(List(Mod.Transparent()), pname("S"), Nil, ctor, tplNoBody()),
   ))
 
   test("transparent-class")(runTestAssert[Stat]("transparent class S")(
-    Defn.Class(List(Mod.Transparent()), pname("S"), Nil, ctor, tplNoBody())
+    Defn.Class(List(Mod.Transparent()), pname("S"), Nil, ctor, tplNoBody()),
   ))
 
   test("transparent-trait-newlines")(
@@ -315,8 +315,8 @@ class InlineSuite extends BaseDottySuite {
       """|transparent 
          |
          |trait S""".stripMargin,
-      assertLayout = Some("transparent trait S")
-    )(Defn.Trait(List(Mod.Transparent()), pname("S"), Nil, ctor, tplNoBody()))
+      assertLayout = Some("transparent trait S"),
+    )(Defn.Trait(List(Mod.Transparent()), pname("S"), Nil, ctor, tplNoBody())),
   )
 
   test("transparent-inline-with-constant") {
@@ -334,8 +334,8 @@ class InlineSuite extends BaseDottySuite {
            |      case x: String => x
            |    }
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Def(
       List(Mod.Transparent(), Mod.Inline()),
       tname("f"),
@@ -349,10 +349,10 @@ class InlineSuite extends BaseDottySuite {
           None,
           tmatch(Mod.Inline())(
             str("foo"),
-            Case(Pat.Typed(patvar("x"), pname("String")), None, tname("x"))
-          )
-        )
-      )
+            Case(Pat.Typed(patvar("x"), pname("String")), None, tname("x")),
+          ),
+        ),
+      ),
     ))
   }
 
@@ -369,8 +369,8 @@ class InlineSuite extends BaseDottySuite {
            |  case Zero => ()
            |  case Succ(p) => ()
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Def(
       List(Mod.Transparent(), Mod.Inline()),
       tname("nat"),
@@ -380,8 +380,8 @@ class InlineSuite extends BaseDottySuite {
       tmatch(Mod.Inline())(
         Term.This(anon),
         Case(tname("Zero"), None, Lit.Unit()),
-        Case(Pat.Extract(tname("Succ"), List(patvar("p"))), None, Lit.Unit())
-      )
+        Case(Pat.Extract(tname("Succ"), List(patvar("p"))), None, Lit.Unit()),
+      ),
     ))
   }
 
@@ -395,12 +395,12 @@ class InlineSuite extends BaseDottySuite {
         """|"static meta" - {
            |  implicit inline def qm = ???
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(tinfix(
       str("static meta"),
       "-",
-      blk(Defn.Def(List(Mod.Implicit(), Mod.Inline()), tname("qm"), Nil, Nil, None, tname("???")))
+      blk(Defn.Def(List(Mod.Implicit(), Mod.Inline()), tname("qm"), Nil, Nil, None, tname("???"))),
     ))
   }
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InterleavedDeclSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InterleavedDeclSuite.scala
@@ -9,20 +9,20 @@ class InterleavedDeclSuite extends BaseDottySuite {
   override protected val dialect: Dialect = Scala3Future
 
   test("def f: Unit")(
-    checkTree(templStat("def f: Unit"))(Decl.Def(Nil, tname("f"), Nil, pname("Unit")))
+    checkTree(templStat("def f: Unit"))(Decl.Def(Nil, tname("f"), Nil, pname("Unit"))),
   )
 
   test("def f(x: Int): Unit")(checkTree(templStat("def f(x: Int): Unit"))(
-    Decl.Def(Nil, tname("f"), Nil, List(tparam("x", "Int") :: Nil), pname("Unit"))
+    Decl.Def(Nil, tname("f"), Nil, List(tparam("x", "Int") :: Nil), pname("Unit")),
   ))
 
   test("def f(x: Int*): Unit")(checkTree(templStat("def f(x: Int*): Unit"))(
     Decl
-      .Def(Nil, tname("f"), Nil, List(tparam("x", Type.Repeated(pname("Int"))) :: Nil), pname("Unit"))
+      .Def(Nil, tname("f"), Nil, List(tparam("x", Type.Repeated(pname("Int"))) :: Nil), pname("Unit")),
   ))
 
   test("def f(x: => Int): Unit")(checkTree(templStat("def f(x: => Int): Unit"))(
-    Decl.Def(Nil, tname("f"), Nil, List(tparam("x", Type.ByName(pname("Int"))) :: Nil), pname("Unit"))
+    Decl.Def(Nil, tname("f"), Nil, List(tparam("x", Type.ByName(pname("Int"))) :: Nil), pname("Unit")),
   ))
 
   test("def f(implicit x: Int): Unit")(checkTree(templStat("def f(implicit x: Int): Unit"))(Decl.Def(
@@ -30,20 +30,20 @@ class InterleavedDeclSuite extends BaseDottySuite {
     tname("f"),
     Nil,
     List(tparam(Mod.Implicit() :: Nil, "x", "Int") :: Nil),
-    pname("Unit")
+    pname("Unit"),
   )))
 
   test("def f: X")(checkTree(templStat("def f: X"))(Decl.Def(Nil, tname("f"), Nil, pname("X"))))
 
   test("def f[T]: T")(
-    checkTree(templStat("def f[T]: T"))(Decl.Def(Nil, tname("f"), pparam("T") :: Nil, Nil, pname("T")))
+    checkTree(templStat("def f[T]: T"))(Decl.Def(Nil, tname("f"), pparam("T") :: Nil, Nil, pname("T"))),
   )
 
   test("def f[A][B]: A")(runTestError[Stat](
     "def f[A][B]: A",
     """|error: `=` expected but `[` found
        |def f[A][B]: A
-       |        ^""".stripMargin
+       |        ^""".stripMargin,
   ))
 
   test("def f[A](a: A, as: A*)[B]: B")(runTestAssert[Stat]("def f[A](a: A, as: A*)[B]: B")(Decl.Def(
@@ -51,14 +51,14 @@ class InterleavedDeclSuite extends BaseDottySuite {
     tname("f"),
     pcg(List(pparam("A")), List(tparam("a", "A"), tparam("as", Type.Repeated(pname("A"))))) ::
       pcg(List(pparam("B"))) :: Nil,
-    pname("B")
+    pname("B"),
   )))
 
   test("def f[A](implicit a: A)[B](implicit b: B): B")(runTestError[Stat](
     "def f[A](implicit a: A)[B](implicit b: B): B",
     """|error: `=` expected but `[` found
        |def f[A](implicit a: A)[B](implicit b: B): B
-       |                       ^""".stripMargin
+       |                       ^""".stripMargin,
   ))
 
   test("def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B")(
@@ -68,8 +68,8 @@ class InterleavedDeclSuite extends BaseDottySuite {
       pcg(List(pparam("A")), List(tparam("a", "A"), tparam("as", Type.Repeated(pname("A"))))) ::
         pcg(List(pparam("B")), List(tparam("b", "B"), tparam("bs", Type.Repeated(pname("B"))))) ::
         pcg(List(pparam("C")), List(tparam(List(Mod.Implicit()), "c", "C"))) :: Nil,
-      pname("B")
-    ))
+      pname("B"),
+    )),
   )
 
   test("f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B [def with breaks]") {
@@ -90,7 +90,7 @@ class InterleavedDeclSuite extends BaseDottySuite {
       pcg(List(pparam("A")), List(tparam("a", "A"), tparam("as", Type.Repeated(pname("A"))))) ::
         pcg(List(pparam("B")), List(tparam("b", "B"), tparam("bs", Type.Repeated(pname("B"))))) ::
         pcg(List(pparam("C")), List(tparam(List(Mod.Implicit()), "c", "C"))) :: Nil,
-      pname("B")
+      pname("B"),
     ))
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InterleavedDefnSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/InterleavedDefnSuite.scala
@@ -11,11 +11,11 @@ class InterleavedDefnSuite extends BaseDottySuite {
   test("def x = 2")(checkTree(templStat("def x = 2"))(Defn.Def(Nil, tname("x"), Nil, None, int(2))))
 
   test("def x[A <: B] = 2")(checkTree(templStat("def x[A <: B] = 2"))(
-    Defn.Def(Nil, tname("x"), pparam("A", hiBound("B")) :: Nil, Nil, None, int(2))
+    Defn.Def(Nil, tname("x"), pparam("A", hiBound("B")) :: Nil, Nil, None, int(2)),
   ))
 
   test("def x[A: B] = 2")(checkTree(templStat("def x[A: B] = 2"))(
-    Defn.Def(Nil, tname("x"), List(pparam("A", bounds(cb = List(pname("B"))))), Nil, None, int(2))
+    Defn.Def(Nil, tname("x"), List(pparam("A", bounds(cb = List(pname("B"))))), Nil, None, int(2)),
   ))
 
   test("def f(a: Int)(implicit b: Int) = a + b")(
@@ -25,12 +25,12 @@ class InterleavedDefnSuite extends BaseDottySuite {
       Nil,
       List(tparam("a", "Int") :: Nil, tparam(Mod.Implicit() :: Nil, "b", "Int") :: Nil),
       None,
-      tinfix(tname("a"), "+", tname("b"))
-    ))
+      tinfix(tname("a"), "+", tname("b")),
+    )),
   )
 
   test("def f(x: Int) = macro impl")(checkTree(templStat("def f(x: Int) = macro impl"))(
-    Defn.Macro(Nil, tname("f"), Nil, List(tparam(List(), "x", "Int") :: Nil), None, tname("impl"))
+    Defn.Macro(Nil, tname("f"), Nil, List(tparam(List(), "x", "Int") :: Nil), None, tname("impl")),
   ))
 
   test("def f(x: Int): Int = macro impl")(
@@ -40,8 +40,8 @@ class InterleavedDefnSuite extends BaseDottySuite {
       Nil,
       List(tparam(List(), "x", "Int") :: Nil),
       Some(pname("Int")),
-      tname("impl")
-    ))
+      tname("impl"),
+    )),
   )
 
   test("braces-in-functions") {
@@ -52,7 +52,7 @@ class InterleavedDefnSuite extends BaseDottySuite {
          |      _ <- scala.util.Success(123)
          |    } yield 42
          |  }.recover(???)
-         |}""".stripMargin
+         |}""".stripMargin,
     )
     checkTree(defn)(Defn.Def(
       Nil,
@@ -63,14 +63,14 @@ class InterleavedDefnSuite extends BaseDottySuite {
         tselect(
           blk(Term.ForYield(
             List(
-              Enumerator.Generator(patwildcard, tapply(tselect("scala", "util", "Success"), int(123)))
+              Enumerator.Generator(patwildcard, tapply(tselect("scala", "util", "Success"), int(123))),
             ),
-            int(42)
+            int(42),
           )),
-          "recover"
+          "recover",
         ),
-        tname("???")
-      )))
+        tname("???"),
+      ))),
     ))
   }
 
@@ -78,7 +78,7 @@ class InterleavedDefnSuite extends BaseDottySuite {
     "def f[A][B]: A = ???",
     """|error: `=` expected but `[` found
        |def f[A][B]: A = ???
-       |        ^""".stripMargin
+       |        ^""".stripMargin,
   ))
 
   test("def f[A](a: A, as: A*)[B]: B = ???")(
@@ -87,18 +87,18 @@ class InterleavedDefnSuite extends BaseDottySuite {
       tname("f"),
       List(
         pcg(List(pparam("A")), List(tparam("a", "A"), tparam("as", Type.Repeated(pname("A"))))),
-        pcg(List(pparam("B")))
+        pcg(List(pparam("B"))),
       ),
       Some(pname("B")),
-      tname("???")
-    ))
+      tname("???"),
+    )),
   )
 
   test("def f[A](implicit a: A)[B](implicit b: B): B = ???")(runTestError[Stat](
     "def f[A](implicit a: A)[B](implicit b: B): B = ???",
     """|error: `=` expected but `[` found
        |def f[A](implicit a: A)[B](implicit b: B): B = ???
-       |                       ^""".stripMargin
+       |                       ^""".stripMargin,
   ))
 
   test("def f[A](a: A, as: A*)[B](b: B, bs: B*)[C](implicit c: C): B = ???") {
@@ -110,8 +110,8 @@ class InterleavedDefnSuite extends BaseDottySuite {
           pcg(List(pparam("B")), List(tparam("b", "B"), tparam("bs", Type.Repeated(pname("B"))))) ::
           pcg(List(pparam("C")), List(tparam(List(Mod.Implicit()), "c", "C"))) :: Nil,
         Some(pname("B")),
-        tname("???")
-      )
+        tname("???"),
+      ),
     )
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/LanguageExtensionsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/LanguageExtensionsSuite.scala
@@ -16,9 +16,9 @@ class LanguageExtensionsSuite extends BaseDottySuite {
         List(Mod.Tracked(), Mod.ValParam()),
         Term.Name("size"),
         Some(Type.Name("Int")),
-        None
+        None,
       )),
-      tplNoBody()
+      tplNoBody(),
     )
     runTestAssert[Stat](code)(tree)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MacroSuite.scala
@@ -20,64 +20,64 @@ class MacroSuite extends BaseDottySuite {
    *   - `SplicedMacroExpr`: `${ ... }` OR `$ident`
    */
   test("parse-single-quote-character")(
-    runTestAssert[Stat]("val a = 'c'")(Defn.Val(Nil, List(patvar("a")), None, lit('c')))
+    runTestAssert[Stat]("val a = 'c'")(Defn.Val(Nil, List(patvar("a")), None, lit('c'))),
   )
 
   test("parse-single-quote-space")(runTestAssert[Stat]("' { 'ax }", assertLayout = Some("'{ 'ax }"))(
-    Term.QuotedMacroExpr(blk(Term.QuotedMacroExpr(tname("ax"))))
+    Term.QuotedMacroExpr(blk(Term.QuotedMacroExpr(tname("ax")))),
   ))
 
   test("macro-quote-expr: '{ 'ax }")(
-    runTestAssert[Stat]("'{ 'ax }")(Term.QuotedMacroExpr(blk(Term.QuotedMacroExpr(tname("ax")))))
+    runTestAssert[Stat]("'{ 'ax }")(Term.QuotedMacroExpr(blk(Term.QuotedMacroExpr(tname("ax"))))),
   )
 
   test("macro-quote-expr: '{ 'a + 'b }")(runTestAssert[Stat]("'{ 'a + 'b }")(Term.QuotedMacroExpr(
-    blk(tinfix(Term.QuotedMacroExpr(tname("a")), "+", Term.QuotedMacroExpr(tname("b"))))
+    blk(tinfix(Term.QuotedMacroExpr(tname("a")), "+", Term.QuotedMacroExpr(tname("b")))),
   )))
 
   test("macro-quote-expr: '{ 'a + 'b + 'c }")(
     runTestAssert[Stat]("'{ 'a + 'b + 'c }")(Term.QuotedMacroExpr(blk(tinfix(
       tinfix(Term.QuotedMacroExpr(tname("a")), "+", Term.QuotedMacroExpr(tname("b"))),
       "+",
-      Term.QuotedMacroExpr(tname("c"))
-    ))))
+      Term.QuotedMacroExpr(tname("c")),
+    )))),
   )
 
   test("macro-quote-expr: '{ Int.MinValue }")(
-    runTestAssert[Stat]("'{ Int.MinValue }")(Term.QuotedMacroExpr(blk(tselect("Int", "MinValue"))))
+    runTestAssert[Stat]("'{ Int.MinValue }")(Term.QuotedMacroExpr(blk(tselect("Int", "MinValue")))),
   )
 
   test("macro-quote-expr: '{ (x: T) => 'x }")(runTestAssert[Stat]("'{ (x: T) => 'x }")(
-    Term.QuotedMacroExpr(blk(tfunc(tparam("x", "T"))(Term.QuotedMacroExpr(tname("x")))))
+    Term.QuotedMacroExpr(blk(tfunc(tparam("x", "T"))(Term.QuotedMacroExpr(tname("x"))))),
   ))
 
   test("macro-quote-expr: f('{ 2 })")(
-    runTestAssert[Stat]("f('{ 2 })")(tapply(tname("f"), Term.QuotedMacroExpr(blk(int(2)))))
+    runTestAssert[Stat]("f('{ 2 })")(tapply(tname("f"), Term.QuotedMacroExpr(blk(int(2))))),
   )
 
   test("macro-quote-expr: if (b) '{ true } else '{ false }")(
     runTestAssert[Stat]("if (b) '{ true } else '{ false }")(
-      Term.If(tname("b"), Term.QuotedMacroExpr(blk(bool(true))), Term.QuotedMacroExpr(blk(bool(false))))
-    )
+      Term.If(tname("b"), Term.QuotedMacroExpr(blk(bool(true))), Term.QuotedMacroExpr(blk(bool(false)))),
+    ),
   )
 
   test("macro-quote-expr: '{ val y = a; ${ env } }")(
     runTestAssert[Stat]("'{ val y = a; ${ env } }", assertLayout = None)(Term.QuotedMacroExpr(
-      blk(Defn.Val(Nil, List(patvar("y")), None, tname("a")), Term.SplicedMacroExpr(blk(tname("env"))))
-    ))
+      blk(Defn.Val(Nil, List(patvar("y")), None, tname("a")), Term.SplicedMacroExpr(blk(tname("env")))),
+    )),
   )
 
   test("macro-quote-expr: x match { case 'c => 1 }") {
     val layoutMatchSimple = "x match {\n  case 'c => 1\n}"
     runTestAssert[Stat]("x match { case 'c => 1 }", assertLayout = Some(layoutMatchSimple))(
-      tmatch(tname("x"), Case(Pat.Macro(Term.QuotedMacroExpr(tname("c"))), None, int(1)))
+      tmatch(tname("x"), Case(Pat.Macro(Term.QuotedMacroExpr(tname("c"))), None, int(1))),
     )
   }
 
   test("macro-quote-expr: x match { case '{ a } => 1 }") {
     val layoutMatchComplex = "x match {\n  case '{ a } => 1\n}"
     runTestAssert[Stat]("x match { case '{ a } => 1 }", assertLayout = Some(layoutMatchComplex))(
-      Term.Match(tname("x"), List(Case(Pat.Macro(Term.QuotedMacroExpr(blk(tname("a")))), None, int(1))))
+      Term.Match(tname("x"), List(Case(Pat.Macro(Term.QuotedMacroExpr(blk(tname("a")))), None, int(1)))),
     )
   }
 
@@ -85,16 +85,16 @@ class MacroSuite extends BaseDottySuite {
     val layoutMatchWithSplice = s"x match {\n  case '{ $${ bind @ '{ a } } } => 1\n}"
     runTestAssert[Stat](
       s"x match { case '{ $${bind@'{a}} } => 1 }",
-      assertLayout = Some(layoutMatchWithSplice)
+      assertLayout = Some(layoutMatchWithSplice),
     )(tmatch(
       tname("x"),
       Case(
         Pat.Macro(Term.QuotedMacroExpr(blk(
-          Term.SplicedMacroPat(Pat.Bind(patvar("bind"), Pat.Macro(Term.QuotedMacroExpr(blk(tname("a"))))))
+          Term.SplicedMacroPat(Pat.Bind(patvar("bind"), Pat.Macro(Term.QuotedMacroExpr(blk(tname("a")))))),
         ))),
         None,
-        int(1)
-      )
+        int(1),
+      ),
     ))
   }
 
@@ -103,15 +103,15 @@ class MacroSuite extends BaseDottySuite {
       """|tpr.asType match {
          |  case '[ t ] =>
          |    getTypeTree[t]
-         |}""".stripMargin
+         |}""".stripMargin,
     )(tmatch(
       tselect("tpr", "asType"),
       Case(
         Pat.Macro(Term.QuotedMacroType(pname("t"))),
         None,
-        tapplytype(tname("getTypeTree"), pname("t"))
-      )
-    ))
+        tapplytype(tname("getTypeTree"), pname("t")),
+      ),
+    )),
   )
 
   test("macro-quote-multiline") {
@@ -124,22 +124,22 @@ class MacroSuite extends BaseDottySuite {
     runTestAssert[Stat](code)(Term.QuotedMacroExpr(blk(
       tinfix(int(1), "+", int(3)),
       tinfix(Term.QuotedMacroExpr(tname("x")), "+", int(3)),
-      tname("zzz")
+      tname("zzz"),
     )))
   }
 
   test("macro-quote-type: '[ Map[Int, String] ]")(
-    runTestAssert[Stat]("'[ Map[Int, String] ]")(Term.QuotedMacroType(papply("Map", "Int", "String")))
+    runTestAssert[Stat]("'[ Map[Int, String] ]")(Term.QuotedMacroType(papply("Map", "Int", "String"))),
   )
 
   test("macro-quote-type: '[ List[${ summon[Type[T]] }] ]")(
     runTestAssert[Stat]("'[ List[${ summon[Type[T]] }] ]")(Term.QuotedMacroType(
-      papply("List", Type.Macro(Term.SplicedMacroExpr(blk(tapplytype("summon", papply("Type", "T"))))))
-    ))
+      papply("List", Type.Macro(Term.SplicedMacroExpr(blk(tapplytype("summon", papply("Type", "T")))))),
+    )),
   )
 
   test("macro-quote-type: '[ Show[$tp] ]")(runTestAssert[Stat]("'[ Show[$tp] ]")(
-    Term.QuotedMacroType(papply("Show", Type.Macro(Term.SplicedMacroExpr(tname("tp")))))
+    Term.QuotedMacroType(papply("Show", Type.Macro(Term.SplicedMacroExpr(tname("tp"))))),
   ))
 
   test("macro-quote-id-by-itself: 'x") {
@@ -218,7 +218,7 @@ class MacroSuite extends BaseDottySuite {
   }
 
   test("macro-splice: ${ powerCode('x) }")(runTestAssert[Stat]("${ powerCode('x) }")(
-    Term.SplicedMacroExpr(blk(tapply(tname("powerCode"), Term.QuotedMacroExpr(tname("x")))))
+    Term.SplicedMacroExpr(blk(tapply(tname("powerCode"), Term.QuotedMacroExpr(tname("x"))))),
   ))
 
   test("macro-splice: ${ val x = 'y; println(d); 1 }") {
@@ -227,16 +227,16 @@ class MacroSuite extends BaseDottySuite {
       Term.SplicedMacroExpr(blk(
         Defn.Val(Nil, List(patvar("x")), None, Term.QuotedMacroExpr(tname("y"))),
         tapply(tname("println"), tname("d")),
-        int(1)
-      ))
+        int(1),
+      )),
     )
   }
 
   test("macro-splice: ${ assertImpl('{ x != $y }) }")(
     runTestAssert[Stat]("${ assertImpl('{ x != $y }) }")(Term.SplicedMacroExpr(blk(tapply(
       tname("assertImpl"),
-      Term.QuotedMacroExpr(blk(tinfix(tname("x"), "!=", Term.SplicedMacroExpr(tname("y")))))
-    ))))
+      Term.QuotedMacroExpr(blk(tinfix(tname("x"), "!=", Term.SplicedMacroExpr(tname("y"))))),
+    )))),
   )
 
   test("macro-splice-multiline") {
@@ -249,7 +249,7 @@ class MacroSuite extends BaseDottySuite {
     runTestAssert[Stat](code)(Term.SplicedMacroExpr(blk(
       Defn.Val(Nil, List(patvar("x")), None, Term.QuotedMacroExpr(tname("y"))),
       tapply(tname("println"), tname("d")),
-      int(1)
+      int(1),
     )))
   }
 
@@ -265,7 +265,7 @@ class MacroSuite extends BaseDottySuite {
       pname("$F2"),
       Nil,
       ppolyfunc(pparam("$T"))(pfunc(pname("$T"))(papply("Option", "$T"))),
-      noBounds
+      noBounds,
     ))
   }
 
@@ -275,44 +275,44 @@ class MacroSuite extends BaseDottySuite {
         tapplytype(tname("ClassTag"), pname("T")),
         Term.SplicedMacroExpr(blk(tapply(
           tname("Expr"),
-          tapplytype(tselect("ct", "runtimeClass", "asInstanceOf"), papply("Class", "T"))
-        )))
-      )))
-    )
+          tapplytype(tselect("ct", "runtimeClass", "asInstanceOf"), papply("Class", "T")),
+        ))),
+      ))),
+    ),
   )
 
   test("macro-quote-complex: 2") {
     runTestAssert[Stat]("'{ ${ summon[H].toExpr(tup.head) } *: ${ summon[T].toExpr(tup.tail) } }")(
       Term.QuotedMacroExpr(blk(tinfix(
         Term.SplicedMacroExpr(blk(
-          tapply(tselect(tapplytype(tname("summon"), pname("H")), "toExpr"), tselect("tup", "head"))
+          tapply(tselect(tapplytype(tname("summon"), pname("H")), "toExpr"), tselect("tup", "head")),
         )),
         "*:",
         Term.SplicedMacroExpr(blk(
-          tapply(tselect(tapplytype(tname("summon"), pname("T")), "toExpr"), tselect("tup", "tail"))
-        ))
-      )))
+          tapply(tselect(tapplytype(tname("summon"), pname("T")), "toExpr"), tselect("tup", "tail")),
+        )),
+      ))),
     )
   }
 
   test("simpler")(
     runTestAssert[Stat](
       "'{ val x: Int = ${ (q2) ?=> a } }",
-      assertLayout = Some("'{ val x: Int = ${ q2 ?=> a } }")
+      assertLayout = Some("'{ val x: Int = ${ q2 ?=> a } }"),
     )(Term.QuotedMacroExpr(blk(Defn.Val(
       Nil,
       List(patvar("x")),
       Some(pname("Int")),
-      Term.SplicedMacroExpr(blk(tctxfunc(tparam("q2"))(tname("a"))))
-    ))))
+      Term.SplicedMacroExpr(blk(tctxfunc(tparam("q2"))(tname("a")))),
+    )))),
   )
 
   test("no-name") {
     runTestAssert[Stat]("'{ val x: Int = $ }")(Term.QuotedMacroExpr(blk(
-      Defn.Val(Nil, List(patvar("x")), Some(pname("Int")), tname("$"))
+      Defn.Val(Nil, List(patvar("x")), Some(pname("Int")), tname("$")),
     )))
     runTestAssert[Stat]("${ val x: Int = $ }")(Term.SplicedMacroExpr(blk(
-      Defn.Val(Nil, List(patvar("x")), Some(pname("Int")), tname("$"))
+      Defn.Val(Nil, List(patvar("x")), Some(pname("Int")), tname("$")),
     )))
   }
 
@@ -325,7 +325,7 @@ class MacroSuite extends BaseDottySuite {
   test("#3610 2") {
     val code = "'[ type t = Int; List[t] ]"
     val tree = Term.QuotedMacroType(
-      Type.Block(List(Defn.Type(Nil, pname("t"), Nil, pname("Int"), noBounds)), papply("List", "t"))
+      Type.Block(List(Defn.Type(Nil, pname("t"), Nil, pname("Int"), noBounds)), papply("List", "t")),
     )
     runTestAssert[Stat](code)(tree)
   }
@@ -334,7 +334,7 @@ class MacroSuite extends BaseDottySuite {
     val code = "'[ type tail <: Tuple; *:[Int, tail] ]"
     val tree = Term.QuotedMacroType(Type.Block(
       List(Decl.Type(Nil, pname("tail"), Nil, bounds(hi = "Tuple"))),
-      papply("*:", "Int", "tail")
+      papply("*:", "Int", "tail"),
     ))
     runTestAssert[Stat](code)(tree)
   }
@@ -361,11 +361,11 @@ class MacroSuite extends BaseDottySuite {
     val tree = tapply(
       tapplytype(
         tpolyfunc(
-          pparam("B")
+          pparam("B"),
         )(tfunc(tparam("c", "B"))(tapply(tapplytype(tname("fn"), pname("B")), tname("c")))),
-        pname("Int")
+        pname("Int"),
       ),
-      lit(0)
+      lit(0),
     )
     runTestAssert[Stat](code)(tree)
   }
@@ -379,11 +379,11 @@ class MacroSuite extends BaseDottySuite {
     val tree = tapply(
       tapplytype(
         blk(tpolyfunc(pparam("B"))(
-          tfunc(tparam("c", "B"))(tapply(tapplytype(tname("fn"), pname("B")), tname("c")))
+          tfunc(tparam("c", "B"))(tapply(tapplytype(tname("fn"), pname("B")), tname("c"))),
         )),
-        pname("Int")
+        pname("Int"),
       ),
-      lit(0)
+      lit(0),
     )
     runTestAssert[Stat](code)(tree)
   }
@@ -413,7 +413,7 @@ class MacroSuite extends BaseDottySuite {
       runTestAssert[Stat](code)(treeWithQuote)
     }
     locally(intercept[IllegalArgumentException](
-      dialects.Scala3.withAllowSymbolLiterals(true).withAllowSpliceAndQuote(true)
+      dialects.Scala3.withAllowSymbolLiterals(true).withAllowSpliceAndQuote(true),
     ))
 
     // default scala3
@@ -445,7 +445,7 @@ class MacroSuite extends BaseDottySuite {
       runTestAssert[Stat](code)(treeWithQuote)
     }
     locally(intercept[IllegalArgumentException](
-      dialects.Scala3.withAllowSymbolLiterals(true).withAllowSpliceAndQuote(true)
+      dialects.Scala3.withAllowSymbolLiterals(true).withAllowSpliceAndQuote(true),
     ))
 
     // default scala3

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MatchTypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MatchTypeSuite.scala
@@ -12,15 +12,15 @@ class MatchTypeSuite extends BaseDottySuite {
          |  case String => Char
          |  case Array[t] => t
          |}
-         |""".stripMargin
+         |""".stripMargin,
     )(Defn.Type(
       Nil,
       pname("Elem"),
       List(pparam("X")),
       Type.Match(
         pname("X"),
-        List(TypeCase(pname("String"), pname("Char")), TypeCase(papply("Array", "t"), pname("t")))
-      )
+        List(TypeCase(pname("String"), pname("Char")), TypeCase(papply("Array", "t"), pname("t"))),
+      ),
     ))
   }
 
@@ -37,16 +37,16 @@ class MatchTypeSuite extends BaseDottySuite {
            |  case String => Char
            |  case Array[t] => t
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Type(
       Nil,
       pname("Elem"),
       List(pparam("X")),
       Type.Match(
         pname("X"),
-        List(TypeCase(pname("String"), pname("Char")), TypeCase(papply("Array", "t"), pname("t")))
-      )
+        List(TypeCase(pname("String"), pname("Char")), TypeCase(papply("Array", "t"), pname("t"))),
+      ),
     ))
   }
 
@@ -55,13 +55,13 @@ class MatchTypeSuite extends BaseDottySuite {
       """|type Head[X <: Tuple] = X match {
          |  case (x1, ?) => x1
          |}
-         |""".stripMargin
+         |""".stripMargin,
     )(Defn.Type(
       Nil,
       pname("Head"),
       List(pparam("X", hiBound("Tuple"))),
-      Type.Match(pname("X"), List(TypeCase(Type.Tuple(List(pname("x1"), pwildcard)), pname("x1"))))
-    ))
+      Type.Match(pname("X"), List(TypeCase(Type.Tuple(List(pname("x1"), pwildcard)), pname("x1")))),
+    )),
   )
 
   test("recursive")(
@@ -70,7 +70,7 @@ class MatchTypeSuite extends BaseDottySuite {
          |  case Unit => 0
          |  case x *: xs => S[Len[xs]]
          |}
-         |""".stripMargin
+         |""".stripMargin,
     )(Defn.Type(
       Nil,
       pname("Len"),
@@ -79,11 +79,11 @@ class MatchTypeSuite extends BaseDottySuite {
         pname("X"),
         List(
           TypeCase(pname("Unit"), int(0)),
-          TypeCase(pinfix("x", "*:", pname("xs")), papply("S", papply("Len", "xs")))
-        )
+          TypeCase(pinfix("x", "*:", pname("xs")), papply("S", papply("Len", "xs"))),
+        ),
       ),
-      hiBound("Int")
-    ))
+      hiBound("Int"),
+    )),
   )
 
   test("concat") {
@@ -92,7 +92,7 @@ class MatchTypeSuite extends BaseDottySuite {
          |  case Unit => Y
          |  case x1 *: xs1 => x1 *: Concat[xs1, Y]
          |}
-         |""".stripMargin
+         |""".stripMargin,
     )(Defn.Type(
       Nil,
       pname("Concat"),
@@ -101,10 +101,10 @@ class MatchTypeSuite extends BaseDottySuite {
         pname("X"),
         List(
           TypeCase(pname("Unit"), pname("Y")),
-          TypeCase(pinfix("x1", "*:", pname("xs1")), pinfix("x1", "*:", papply("Concat", "xs1", "Y")))
-        )
+          TypeCase(pinfix("x1", "*:", pname("xs1")), pinfix("x1", "*:", papply("Concat", "xs1", "Y"))),
+        ),
       ),
-      hiBound("Tuple")
+      hiBound("Tuple"),
     ))
   }
 
@@ -120,16 +120,16 @@ class MatchTypeSuite extends BaseDottySuite {
            |  case String => Char
            |  case Array[t] => t
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Type(
       Nil,
       pname("Elem"),
       List(pparam("X")),
       Type.Match(
         pname("X"),
-        List(TypeCase(pname("String"), pname("Char")), TypeCase(papply("Array", "t"), pname("t")))
-      )
+        List(TypeCase(pname("String"), pname("Char")), TypeCase(papply("Array", "t"), pname("t"))),
+      ),
     ))
   }
   test("double-newline") {
@@ -148,8 +148,8 @@ class MatchTypeSuite extends BaseDottySuite {
            |    case ? => Left
            |  }
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Object(
       Nil,
       tname("match_types"),
@@ -159,10 +159,10 @@ class MatchTypeSuite extends BaseDottySuite {
         List(pparam("Left"), pparam("Right")),
         Type.Match(
           pname("Left"),
-          List(TypeCase(pname("Unit"), pname("Right")), TypeCase(pname("?"), pname("Left")))
+          List(TypeCase(pname("Unit"), pname("Right")), TypeCase(pname("?"), pname("Left"))),
         ),
-        noBounds
-      ))
+        noBounds,
+      )),
     ))
   }
 
@@ -185,8 +185,8 @@ class MatchTypeSuite extends BaseDottySuite {
            |    case ? => L
            |  }
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Object(
       Nil,
       tname("match_types"),
@@ -200,11 +200,11 @@ class MatchTypeSuite extends BaseDottySuite {
             TypeCase(Type.AnonymousLambda(papply("Foo", Type.AnonymousParam(None))), pname("L")),
             TypeCase(papply("Bar", pwildcard), pname("L")),
             TypeCase(Type.PatWildcard(), pname("R")),
-            TypeCase(pname("?"), pname("L"))
-          )
+            TypeCase(pname("?"), pname("L")),
+          ),
         ),
-        noBounds
-      ))
+        noBounds,
+      )),
     ))
   }
 
@@ -225,9 +225,9 @@ class MatchTypeSuite extends BaseDottySuite {
       papply(
         "A",
         Type
-          .Lambda(List(pparam("T")), Type.Match(pname("T"), List(TypeCase(Type.PatWildcard(), "Int"))))
+          .Lambda(List(pparam("T")), Type.Match(pname("T"), List(TypeCase(Type.PatWildcard(), "Int")))),
       ),
-      noBounds
+      noBounds,
     )
 
     runTestAssert[Stat](code, layout)(tree)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/MinorDottySuite.scala
@@ -14,21 +14,21 @@ class MinorDottySuite extends BaseDottySuite {
   test("open-class") {
     matchSubStructure[Stat](
       "open class A {}",
-      { case Defn.Class(List(Mod.Open()), Type.Name("A"), _, _, _) => () }
+      { case Defn.Class(List(Mod.Open()), Type.Name("A"), _, _, _) => () },
     )
     matchSubStructure[Stat](
       "open trait C {}",
-      { case Defn.Trait(List(Mod.Open()), Type.Name("C"), _, _, _) => () }
+      { case Defn.Trait(List(Mod.Open()), Type.Name("C"), _, _, _) => () },
     )
 
     matchSubStructure[Stat](
       "open private trait C {}",
-      { case Defn.Trait(List(Mod.Open(), Mod.Private(anon)), Type.Name("C"), _, _, _) => () }
+      { case Defn.Trait(List(Mod.Open(), Mod.Private(anon)), Type.Name("C"), _, _, _) => () },
     )
 
     matchSubStructure[Stat](
       "open object X {}",
-      { case Defn.Object(List(Mod.Open()), Term.Name("X"), _) => () }
+      { case Defn.Object(List(Mod.Open()), Term.Name("X"), _) => () },
     )
 
   }
@@ -52,8 +52,8 @@ class MinorDottySuite extends BaseDottySuite {
            |  val price1 = price.open
            |  val price2 = 1
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Source(List(Defn.Class(
       List(Mod.Case()),
       pname("OHLCPrice"),
@@ -62,8 +62,8 @@ class MinorDottySuite extends BaseDottySuite {
       tpl(
         Defn.Val(Nil, List(patvar("price")), None, tapply(tname("OHLCPrice"), int(1))),
         Defn.Val(Nil, List(patvar("price1")), None, tselect("price", "open")),
-        Defn.Val(Nil, List(patvar("price2")), None, int(1))
-      )
+        Defn.Val(Nil, List(patvar("price2")), None, int(1)),
+      ),
     ))))
   }
 
@@ -74,8 +74,8 @@ class MinorDottySuite extends BaseDottySuite {
       Nil,
       List(List()),
       Some(pname("Unit")),
-      blk(tname("start"), tapply(tname("open"), tname("p")), tname("end"))
-    ))
+      blk(tname("start"), tapply(tname("open"), tname("p")), tname("end")),
+    )),
   )
 
   test("case-classes-empty-plist") {
@@ -87,19 +87,19 @@ class MinorDottySuite extends BaseDottySuite {
   test("xml-literals")(term("<foo>{bar}</foo>")(dialects.Scala3))
 
   test("opaque-type-alias")(runTestAssert[Stat]("opaque type F = X")(
-    Defn.Type(List(Mod.Opaque()), pname("F"), Nil, pname("X"), noBounds)
+    Defn.Type(List(Mod.Opaque()), pname("F"), Nil, pname("X"), noBounds),
   ))
 
   test("opaque-type-bounded-alias")(runTestAssert[Stat]("opaque type F <: A & B = AB")(
     Defn
-      .Type(List(Mod.Opaque()), pname("F"), Nil, pname("AB"), bounds(hi = pinfix("A", "&", pname("B"))))
+      .Type(List(Mod.Opaque()), pname("F"), Nil, pname("AB"), bounds(hi = pinfix("A", "&", pname("B")))),
   ))
 
   test("opaque-type-bounded-alias-with-quasiquotes") {
     val dialect: Dialect = null // overrides implicit
     import dialects.Scala3
     runTestAssert[Stat]("opaque type Foo <: String = String")(
-      Defn.Type(List(Mod.Opaque()), pname("Foo"), Nil, pname("String"), hiBound("String"))
+      Defn.Type(List(Mod.Opaque()), pname("Foo"), Nil, pname("String"), hiBound("String")),
     )
   }
 
@@ -111,21 +111,21 @@ class MinorDottySuite extends BaseDottySuite {
         List(Mod.Opaque()),
         pname("IArray"),
         List(pparam(List(Mod.Covariant()), "T")),
-        pname("Array")
-      ))
-    ))))
+        pname("Array"),
+      )),
+    )))),
   )
 
   test("opaque-type-mix-mods") {
     runTestAssert[Stat]("object X { private opaque type T = List[Int] }")(Defn.Object(
       Nil,
       tname("X"),
-      tpl(Defn.Type(List(Mod.Private(anon), Mod.Opaque()), pname("T"), Nil, papply("List", "Int")))
+      tpl(Defn.Type(List(Mod.Private(anon), Mod.Opaque()), pname("T"), Nil, papply("List", "Int"))),
     ))
     runTestAssert[Stat]("object X { opaque private type T = List[Int] }")(Defn.Object(
       Nil,
       tname("X"),
-      tpl(Defn.Type(List(Mod.Opaque(), Mod.Private(anon)), pname("T"), Nil, papply("List", "Int")))
+      tpl(Defn.Type(List(Mod.Opaque(), Mod.Private(anon)), pname("T"), Nil, papply("List", "Int"))),
     ))
   }
 
@@ -134,39 +134,39 @@ class MinorDottySuite extends BaseDottySuite {
     pname("Foo"),
     Nil,
     ctorp(List(tparamval("foo", "Int")), List(tparam("bar", "Int"))),
-    tplNoBody()
+    tplNoBody(),
   )))
 
   test("secondary-trait-constructors")(
-    runTestError[Stat]("trait Foo{ def this(i: Int) = this() }", "Illegal secondary constructor")
+    runTestError[Stat]("trait Foo{ def this(i: Int) = this() }", "Illegal secondary constructor"),
   )
 
   test("secondary-object-constructors")(
-    runTestError[Stat]("object Foo{ def this(i: Int) = this() }", "Illegal secondary constructor")
+    runTestError[Stat]("object Foo{ def this(i: Int) = this() }", "Illegal secondary constructor"),
   )
 
   test("no-params")(runTestError[Stat](
     """|class A
        |class B extends A:
        |  def this = this.f()""".stripMargin,
-    "secondary constructor needs explicit parameter list"
+    "secondary constructor needs explicit parameter list",
   ))
 
   test("trait-parameters-generic")(runTestAssert[Stat]("trait Foo[T](bar: T)")(
-    Defn.Trait(Nil, pname("Foo"), List(pparam("T")), ctorp(tparam("bar", "T")), tplNoBody())
+    Defn.Trait(Nil, pname("Foo"), List(pparam("T")), ctorp(tparam("bar", "T")), tplNoBody()),
   ))
 
   test("trait-parameters-context-bounds")(runTestAssert[Stat]("trait Foo[T: Eq]")(
-    Defn.Trait(Nil, pname("Foo"), List(pparam("T", bounds(cb = List(pname("Eq"))))), ctor, tplNoBody())
+    Defn.Trait(Nil, pname("Foo"), List(pparam("T", bounds(cb = List(pname("Eq"))))), ctor, tplNoBody()),
   ))
 
   test("class-parameters-using") {
     runTestAssert[Stat]("trait A(using String)")(
-      Defn.Trait(Nil, pname("A"), Nil, ctorp(tparamUsing("", "String")), tplNoBody())
+      Defn.Trait(Nil, pname("A"), Nil, ctorp(tparamUsing("", "String")), tplNoBody()),
     )
 
     runTestAssert[Stat]("class A(using String)")(
-      Defn.Class(Nil, pname("A"), Nil, ctorp(tparamUsing("", "String")), tplNoBody())
+      Defn.Class(Nil, pname("A"), Nil, ctorp(tparamUsing("", "String")), tplNoBody()),
     )
 
     runTestAssert[Stat]("case class A(a: Int)(using b: String)")(Defn.Class(
@@ -174,19 +174,19 @@ class MinorDottySuite extends BaseDottySuite {
       pname("A"),
       Nil,
       ctorp(List(tparam("a", "Int")), List(tparamUsing("b", "String"))),
-      tplNoBody()
+      tplNoBody(),
     ))
   }
 
   test("trait-extends-coma-separated")(
     runTestAssert[Stat](
       "trait Foo extends A, B, C",
-      assertLayout = Some("trait Foo extends A with B with C")
-    )(Defn.Trait(Nil, pname("Foo"), Nil, ctor, tplNoBody(init("A"), init("B"), init("C"))))
+      assertLayout = Some("trait Foo extends A with B with C"),
+    )(Defn.Trait(Nil, pname("Foo"), Nil, ctor, tplNoBody(init("A"), init("B"), init("C")))),
   )
 
   test("(new A(), new B())")(runTestAssert[Stat]("(new A(), new B())")(Term.Tuple(
-    List(Term.New(init("A", Nil)), Term.New(init("B", Nil)))
+    List(Term.New(init("A", Nil)), Term.New(init("B", Nil))),
   )))
 
   test("new A(using b)(c)(using d, e)")(
@@ -195,15 +195,15 @@ class MinorDottySuite extends BaseDottySuite {
         pname("A"),
         Term.ArgClause(List(tname("b")), Some(Mod.Using())),
         Term.ArgClause(List(tname("c")), None),
-        Term.ArgClause(List(tname("d"), tname("e")), Some(Mod.Using()))
-      ))
-    )
+        Term.ArgClause(List(tname("d"), tname("e")), Some(Mod.Using())),
+      )),
+    ),
   )
 
   test("class A extends B(using b)(c)(using d, e)")(
     runTestAssert[Stat](
       "class A extends B(using b)(c)(using d, e)",
-      Some("class A extends B(using b)(c)(using d, e)")
+      Some("class A extends B(using b)(c)(using d, e)"),
     )(Defn.Class(
       Nil,
       pname("A"),
@@ -213,16 +213,16 @@ class MinorDottySuite extends BaseDottySuite {
         "B",
         Term.ArgClause(List(tname("b")), Some(Mod.Using())),
         Term.ArgClause(List(tname("c")), None),
-        Term.ArgClause(List(tname("d"), tname("e")), Some(Mod.Using()))
-      ))
-    ))
+        Term.ArgClause(List(tname("d"), tname("e")), Some(Mod.Using())),
+      )),
+    )),
   )
 
   // Super traits were removed in Scala 3
   test("super-trait")(runTestError[Stat]("super trait Foo", "`.` expected but `trait` found"))
 
   test("question-type")(runTestAssert[Stat]("val stat: Tree[? >: Untyped]")(
-    Decl.Val(Nil, List(patvar("stat")), papply("Tree", pwildcard(loBound("Untyped"))))
+    Decl.Val(Nil, List(patvar("stat")), papply("Tree", pwildcard(loBound("Untyped")))),
   ))
 
   test("question-type-like") {
@@ -236,7 +236,7 @@ class MinorDottySuite extends BaseDottySuite {
   }
 
   test("lazy-val-toplevel")(runTestAssert[Source]("lazy val x = 3")(Source(
-    List(Defn.Val(List(Mod.Lazy()), List(patvar("x")), None, int(3)))
+    List(Defn.Val(List(Mod.Lazy()), List(patvar("x")), None, int(3))),
   )))
 
   test("changed-operator-syntax") {
@@ -258,8 +258,8 @@ class MinorDottySuite extends BaseDottySuite {
            |    case 0 => 1
            |  }
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Source(
       Defn.Object(
         Nil,
@@ -267,9 +267,9 @@ class MinorDottySuite extends BaseDottySuite {
         tpl(
           tapply(tname("println"), str("hello")),
           tname("???"),
-          tmatch(tname("???"), Case(int(0), None, int(1)))
-        )
-      ) :: Nil
+          tmatch(tname("???"), Case(int(0), None, int(1))),
+        ),
+      ) :: Nil,
     ))
   }
 
@@ -282,19 +282,19 @@ class MinorDottySuite extends BaseDottySuite {
       pname("X"),
       List(pparam("T")),
       ctor,
-      tpl(Defn.EnumCase(Nil, tname("A"), List(pparam("_")), ctor, List(init(papply("X", "Int")))))
+      tpl(Defn.EnumCase(Nil, tname("A"), List(pparam("_")), ctor, List(init(papply("X", "Int"))))),
     ))
     runTestAssert[Stat]("extension [_](x: Int) def inc: Int = x + 1")(Defn.ExtensionGroup(
       List(pparam("_")),
       List(List(tparam("x", "Int"))),
-      Defn.Def(Nil, "inc", Nil, Some("Int"), tinfix("x", "+", lit(1)))
+      Defn.Def(Nil, "inc", Nil, Some("Int"), tinfix("x", "+", lit(1))),
     ))
     runTestAssert[Stat]("given [_](using Ord[T]): Ord[List[T]] with {}")(Defn.Given(
       Nil,
       anon,
       List(pparam("_")),
       List(List(tparamUsing("", papply("Ord", "T")))),
-      tpl(List(init(papply("Ord", papply("List", "T")))), tplBody())
+      tpl(List(init(papply("Ord", papply("List", "T")))), tplBody()),
     ))
   }
 
@@ -304,7 +304,7 @@ class MinorDottySuite extends BaseDottySuite {
       pname("Foo"),
       Nil,
       ctorp(tparam("bars", Type.ByName(Type.Repeated(pname("Int"))))),
-      tplNoBody()
+      tplNoBody(),
     ))
 
     runTestAssert[Stat]("def fx(x: => Int*): Int = 3", "def fx(x: => (Int*)): Int = 3")(Defn.Def(
@@ -313,7 +313,7 @@ class MinorDottySuite extends BaseDottySuite {
       Nil,
       List(List(tparam("x", Type.ByName(Type.Repeated(pname("Int")))))),
       Some(pname("Int")),
-      int(3)
+      int(3),
     ))
   }
 
@@ -332,14 +332,14 @@ class MinorDottySuite extends BaseDottySuite {
       Nil,
       EmptyCtor(),
       tpl(
-        Decl.Val(List(Mod.Protected(Term.This(anon)), Mod.Lazy()), List(patvar("from")), pname("Int"))
-      )
-    ))
+        Decl.Val(List(Mod.Protected(Term.This(anon)), Mod.Lazy()), List(patvar("from")), pname("Int")),
+      ),
+    )),
   )
 
   test("type-wildcard-questionmark") {
     runTestAssert[Stat]("val x: List[?] = List(1)")(
-      Defn.Val(Nil, List(patvar("x")), Some(papply("List", pwildcard)), tapply(tname("List"), int(1)))
+      Defn.Val(Nil, List(patvar("x")), Some(papply("List", pwildcard)), tapply(tname("List"), int(1))),
     )
 
     runTestAssert[Stat]("def x(a: List[?]): Unit = ()")(Defn.Def(
@@ -348,7 +348,7 @@ class MinorDottySuite extends BaseDottySuite {
       Nil,
       List(List(tparam(Nil, "a", papply("List", pwildcard)))),
       Some(pname("Unit")),
-      Lit.Unit()
+      Lit.Unit(),
     ))
   }
 
@@ -363,14 +363,14 @@ class MinorDottySuite extends BaseDottySuite {
       Nil,
       List(patinfix(patvar("a"), "::", tname("Nil"))),
       Some(Type.Annotate(Type.AnonymousName(), List(Mod.Annot(init("unchecked"))))),
-      tname("args")
+      tname("args"),
     ))
 
     runTestAssert[Stat]("val x:  @annotation.switch = 2")(Defn.Val(
       Nil,
       List(patvar("x")),
       Some(Type.Annotate(Type.AnonymousName(), List(Mod.Annot(init(pselect("annotation", "switch")))))),
-      int(2)
+      int(2),
     ))
   }
 
@@ -384,7 +384,7 @@ class MinorDottySuite extends BaseDottySuite {
       """|trait X {
          |  // comment
          |  def x(): String
-         |}""".stripMargin
+         |}""".stripMargin,
     )(Defn.Trait(
       Nil,
       pname("X"),
@@ -397,8 +397,8 @@ class MinorDottySuite extends BaseDottySuite {
         List(List()),
         pname("String"),
         begComment = Seq("// comment"),
-        endComment = None
-      ))
+        endComment = None,
+      )),
     ))
   }
 
@@ -408,7 +408,7 @@ class MinorDottySuite extends BaseDottySuite {
       """|opaque type LinearSet[Elem] =
          |  Set[Elem]
          |""".stripMargin,
-      assertLayout = Some(expected)
+      assertLayout = Some(expected),
     )(Defn.Type(List(Mod.Opaque()), pname("LinearSet"), List(pparam("Elem")), papply("Set", "Elem")))
   }
 
@@ -424,16 +424,16 @@ class MinorDottySuite extends BaseDottySuite {
         Nil,
         Ctor
           .Primary(Nil, anon, List(List(tparam("opaque", "Boolean"), tparam("transparent", "Boolean")))),
-        Nil
-      ))
-    ))
+        Nil,
+      )),
+    )),
   )
 
   test("capital-var-pattern-val")(
     runTestAssert[Stat](
       """val Private @ _ = flags()
-        |""".stripMargin
-    )(Defn.Val(Nil, List(Pat.Bind(patvar("Private"), patwildcard)), None, tapply(tname("flags"))))
+        |""".stripMargin,
+    )(Defn.Val(Nil, List(Pat.Bind(patvar("Private"), patwildcard)), None, tapply(tname("flags")))),
   )
 
   test("capital-var-pattern-case")(
@@ -441,8 +441,8 @@ class MinorDottySuite extends BaseDottySuite {
       """|flags() match {
          |  case Pattern @ _ =>
          |}
-         |""".stripMargin
-    )(tmatch(tapply(tname("flags")), Case(Pat.Bind(patvar("Pattern"), patwildcard), None, blk())))
+         |""".stripMargin,
+    )(tmatch(tapply(tname("flags")), Case(Pat.Bind(patvar("Pattern"), patwildcard), None, blk()))),
   )
 
   test("catch-end-def") {
@@ -464,7 +464,7 @@ class MinorDottySuite extends BaseDottySuite {
          |  private abstract class X()
          |}
          |""".stripMargin,
-      assertLayout = Some(layout)
+      assertLayout = Some(layout),
     )(Defn.Object(
       Nil,
       tname("X"),
@@ -476,10 +476,10 @@ class MinorDottySuite extends BaseDottySuite {
           Nil,
           None,
           Term
-            .Try(tapply(tname("action")), List(Case(patvar("ex"), None, tapply(tname("err")))), None)
+            .Try(tapply(tname("action")), List(Case(patvar("ex"), None, tapply(tname("err")))), None),
         ),
-        Defn.Class(List(Mod.Private(anon), Mod.Abstract()), pname("X"), Nil, ctorp(), tplNoBody())
-      )
+        Defn.Class(List(Mod.Private(anon), Mod.Abstract()), pname("X"), Nil, ctorp(), tplNoBody()),
+      ),
     ))
   }
 
@@ -488,15 +488,15 @@ class MinorDottySuite extends BaseDottySuite {
       """|def hello = {
          |  type T
          |}
-         |""".stripMargin
-    )(Defn.Def(Nil, tname("hello"), Nil, Nil, None, blk(Decl.Type(Nil, pname("T"), Nil, noBounds))))
+         |""".stripMargin,
+    )(Defn.Def(Nil, tname("hello"), Nil, Nil, None, blk(Decl.Type(Nil, pname("T"), Nil, noBounds)))),
   )
 
   test("operator-next-line")(
     runTestAssert[Stat](
       """|val all = "-siteroot" +: "../docs"
          |    +: "-project" +:  Nil""".stripMargin,
-      assertLayout = Some("""val all = "-siteroot" +: "../docs" +: "-project" +: Nil""")
+      assertLayout = Some("""val all = "-siteroot" +: "../docs" +: "-project" +: Nil"""),
     )(Defn.Val(
       Nil,
       List(patvar("all")),
@@ -504,9 +504,9 @@ class MinorDottySuite extends BaseDottySuite {
       tinfix(
         str("-siteroot"),
         "+:",
-        tinfix(str("../docs"), "+:", tinfix(str("-project"), "+:", tname("Nil")))
-      )
-    ))
+        tinfix(str("../docs"), "+:", tinfix(str("-project"), "+:", tname("Nil"))),
+      ),
+    )),
   )
 
   test("operator-next-line-bad-indent") {
@@ -515,7 +515,7 @@ class MinorDottySuite extends BaseDottySuite {
          |       "-siteroot" +: "../docs"
          |    +: "-project" +: Nil
          |""".stripMargin,
-      assertLayout = Some("""def withClasspath = "-siteroot" +: "../docs" +: "-project" +: Nil""")
+      assertLayout = Some("""def withClasspath = "-siteroot" +: "../docs" +: "-project" +: Nil"""),
     )(Defn.Def(
       Nil,
       tname("withClasspath"),
@@ -525,8 +525,8 @@ class MinorDottySuite extends BaseDottySuite {
       tinfix(
         str("-siteroot"),
         "+:",
-        tinfix(str("../docs"), "+:", tinfix(str("-project"), "+:", tname("Nil")))
-      )
+        tinfix(str("../docs"), "+:", tinfix(str("-project"), "+:", tname("Nil"))),
+      ),
     ))
   }
 
@@ -538,12 +538,12 @@ class MinorDottySuite extends BaseDottySuite {
         """|a match {
            |  case List(xs @ _*) =>
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(tmatch(
       tname("a"),
-      Case(Pat.Extract(tname("List"), List(Pat.Bind(patvar("xs"), Pat.SeqWildcard()))), None, blk())
-    ))
+      Case(Pat.Extract(tname("List"), List(Pat.Bind(patvar("xs"), Pat.SeqWildcard()))), None, blk()),
+    )),
   )
 
   test("at-extractor")(
@@ -554,23 +554,23 @@ class MinorDottySuite extends BaseDottySuite {
         """|a match {
            |  case List(xs @ _*) =>
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(tmatch(
       tname("a"),
-      Case(Pat.Extract(tname("List"), List(Pat.Bind(patvar("xs"), Pat.SeqWildcard()))), None, blk())
-    ))
+      Case(Pat.Extract(tname("List"), List(Pat.Bind(patvar("xs"), Pat.SeqWildcard()))), None, blk()),
+    )),
   )
 
   test("vararg-wildcard-postfix-star")(runTestAssert[Stat]("val lst = List(0, arr*)")(
-    Defn.Val(Nil, List(patvar("lst")), None, tapply(tname("List"), int(0), Term.Repeated(tname("arr"))))
+    Defn.Val(Nil, List(patvar("lst")), None, tapply(tname("List"), int(0), Term.Repeated(tname("arr")))),
   ))
 
   test("vararg-wildcard-like-postfix-star") {
     val codeOriginal = "val lst = List(0, arr`*`)"
     val codeObtained = "val lst = List(0, arr `*`)"
     runTestAssert[Stat](codeOriginal, codeObtained)(
-      Defn.Val(Nil, List(patvar("lst")), None, tapply("List", lit(0), tpostfix("arr", "*")))
+      Defn.Val(Nil, List(patvar("lst")), None, tapply("List", lit(0), tpostfix("arr", "*"))),
     )
   }
 
@@ -578,7 +578,7 @@ class MinorDottySuite extends BaseDottySuite {
     Nil,
     List(patvar("lst")),
     None,
-    tapply(tname("List"), int(0), tinfix(tname("a"), "*", tname("b")))
+    tapply(tname("List"), int(0), tinfix(tname("a"), "*", tname("b"))),
   )))
 
   test("vararg-wildcard-postfix-start-pat")(
@@ -589,9 +589,9 @@ class MinorDottySuite extends BaseDottySuite {
         """|a match {
            |  case List(xs*) =>
            |}
-           |""".stripMargin
-      )
-    )(tmatch(tname("a"), Case(Pat.Extract(tname("List"), List(Pat.Repeated(tname("xs")))), None, blk())))
+           |""".stripMargin,
+      ),
+    )(tmatch(tname("a"), Case(Pat.Extract(tname("List"), List(Pat.Repeated(tname("xs")))), None, blk()))),
   )
 
   test("vararg-wildcard-like-postfix-start-pat") {
@@ -616,9 +616,9 @@ class MinorDottySuite extends BaseDottySuite {
          |)""".stripMargin,
       assertLayout = Some(
         """|case class A(x: X)
-           |""".stripMargin
-      )
-    )(Defn.Class(List(Mod.Case()), pname("A"), Nil, ctorp(tparam("x", "X")), tplNoBody()))
+           |""".stripMargin,
+      ),
+    )(Defn.Class(List(Mod.Case()), pname("A"), Nil, ctorp(tparam("x", "X")), tplNoBody())),
   )
 
   test("complex-interpolation")(
@@ -629,14 +629,14 @@ class MinorDottySuite extends BaseDottySuite {
          |""".stripMargin,
       assertLayout = Some(
         """|val base = "" ++ (s"")
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Val(
       Nil,
       List(patvar("base")),
       None,
-      tinfix(str(""), "++", Term.Interpolate(tname("s"), List(str("")), Nil))
-    ))
+      tinfix(str(""), "++", Term.Interpolate(tname("s"), List(str("")), Nil)),
+    )),
   )
 
   test("tuple-pattern") {
@@ -649,8 +649,8 @@ class MinorDottySuite extends BaseDottySuite {
         """|def f(t: (String, String)): String = t match {
            |  case (m, _): (String, String) => m
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Def(
       Nil,
       tname("f"),
@@ -662,12 +662,12 @@ class MinorDottySuite extends BaseDottySuite {
         Case(
           Pat.Typed(
             Pat.Tuple(List(patvar("m"), patwildcard)),
-            Type.Tuple(List(pname("String"), pname("String")))
+            Type.Tuple(List(pname("String"), pname("String"))),
           ),
           None,
-          tname("m")
-        )
-      )
+          tname("m"),
+        ),
+      ),
     ))
   }
 
@@ -684,24 +684,24 @@ class MinorDottySuite extends BaseDottySuite {
            |  case other =>
            |    o
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(tmatch(
       tname("s"),
       Case(
         Pat.Typed(Pat.Extract(tname("re"), List(patvar("v"))), pname("String")),
         None,
-        tselect("v", "toDouble")
+        tselect("v", "toDouble"),
       ),
-      Case(patvar("other"), None, tname("o"))
+      Case(patvar("other"), None, tname("o")),
     ))
   }
 
   test("multi-pattern")(
     runTestAssert[Stat](
       """|val x * y = v
-         |""".stripMargin
-    )(Defn.Val(Nil, List(patinfix(patvar("x"), "*", patvar("y"))), None, tname("v")))
+         |""".stripMargin,
+    )(Defn.Val(Nil, List(patinfix(patvar("x"), "*", patvar("y"))), None, tname("v"))),
   )
 
   test("typed-typed-pattern") {
@@ -717,16 +717,16 @@ class MinorDottySuite extends BaseDottySuite {
            |  case other =>
            |    o
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(tmatch(
       tname("s"),
       Case(
         Pat.Typed(Pat.Typed(patvar("v"), pname("String")), pname("String")),
         None,
-        tselect("v", "toDouble")
+        tselect("v", "toDouble"),
       ),
-      Case(patvar("other"), None, tname("o"))
+      Case(patvar("other"), None, tname("o")),
     ))
   }
 
@@ -734,7 +734,7 @@ class MinorDottySuite extends BaseDottySuite {
     """|def hello(){
        |  println("Hello!")
        |}""".stripMargin,
-    "Procedure syntax is not supported. Convert procedure `hello` to method by adding `: Unit =`"
+    "Procedure syntax is not supported. Convert procedure `hello` to method by adding `: Unit =`",
   ))
 
   test("do-while")(runTestError[Stat](
@@ -743,7 +743,7 @@ class MinorDottySuite extends BaseDottySuite {
        |    i+= 1
        |  } while (i < 10)
        |}""".stripMargin,
-    "error: do {...} while (...) syntax is no longer supported"
+    "error: do {...} while (...) syntax is no longer supported",
   ))
 
   test("partial-function-function") {
@@ -759,15 +759,15 @@ class MinorDottySuite extends BaseDottySuite {
            |  case "Hello" => 5
            |  case "Goodbye" => 0
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Val(
       Nil,
       List(patvar("f")),
       Some(pfunc(pname("String"))(papply("PartialFunction", "String", "Int"))),
       tfunc(
-        tparam("s")
-      )(Term.PartialFunction(List(Case(str("Hello"), None, int(5)), Case(str("Goodbye"), None, int(0)))))
+        tparam("s"),
+      )(Term.PartialFunction(List(Case(str("Hello"), None, int(5)), Case(str("Goodbye"), None, int(0))))),
     ))
   }
 
@@ -785,8 +785,8 @@ class MinorDottySuite extends BaseDottySuite {
            |  type Y = -_ => Int
            |  type Z = _ => Int
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Object(
       Nil,
       tname("A"),
@@ -796,17 +796,17 @@ class MinorDottySuite extends BaseDottySuite {
           pname("X"),
           Nil,
           pfunc(Type.AnonymousParam(Some(Mod.Covariant())))(pname("Int")),
-          noBounds
+          noBounds,
         ),
         Defn.Type(
           Nil,
           pname("Y"),
           Nil,
           pfunc(Type.AnonymousParam(Some(Mod.Contravariant())))(pname("Int")),
-          noBounds
+          noBounds,
         ),
-        Defn.Type(Nil, pname("Z"), Nil, pfunc(Type.AnonymousParam(None))(pname("Int")), noBounds)
-      )
+        Defn.Type(Nil, pname("Z"), Nil, pfunc(Type.AnonymousParam(None))(pname("Int")), noBounds),
+      ),
     ))
   }
 
@@ -816,16 +816,16 @@ class MinorDottySuite extends BaseDottySuite {
          |""".stripMargin,
       assertLayout = Some(
         """|def b2 = "".foo2(using foo)[Any]
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Def(
       Nil,
       tname("b2"),
       Nil,
       Nil,
       None,
-      tapplytype(tapplyUsing(tselect(str(""), "foo2"), tname("foo")), pname("Any"))
-    ))
+      tapplytype(tapplyUsing(tselect(str(""), "foo2"), tname("foo")), pname("Any")),
+    )),
   )
 
   test("refinements") {
@@ -838,20 +838,20 @@ class MinorDottySuite extends BaseDottySuite {
            |}) {
            |  type T = String
            |})#U
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Decl.Val(
       Nil,
       List(patvar("x")),
       Type.Project(
         Type.Refine(
           Some(
-            Type.Refine(Some(pname("C")), List(Defn.Type(Nil, pname("U"), Nil, pname("T"), noBounds)))
+            Type.Refine(Some(pname("C")), List(Defn.Type(Nil, pname("U"), Nil, pname("T"), noBounds))),
           ),
-          List(Defn.Type(Nil, pname("T"), Nil, pname("String"), noBounds))
+          List(Defn.Type(Nil, pname("T"), Nil, pname("String"), noBounds)),
         ),
-        pname("U")
-      )
+        pname("U"),
+      ),
     ))
   }
 
@@ -860,11 +860,11 @@ class MinorDottySuite extends BaseDottySuite {
       """|??? match {
          |  case x2: ([V] => () => Int) => ???
          |}
-         |""".stripMargin
+         |""".stripMargin,
     )(tmatch(
       tname("???"),
-      Case(Pat.Typed(patvar("x2"), ppolyfunc(pparam("V"))(pfunc()(pname("Int")))), None, tname("???"))
-    ))
+      Case(Pat.Typed(patvar("x2"), ppolyfunc(pparam("V"))(pfunc()(pname("Int")))), None, tname("???")),
+    )),
   )
 
   test("issue-2567") {
@@ -882,14 +882,14 @@ class MinorDottySuite extends BaseDottySuite {
            |    (using i: Int) => i
            |  }
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Source(List(
       Import(
         Importer(
           tselect("_root_com", "olegych", "scastie", "api", "runtime"),
-          List(Importee.Wildcard())
-        ) :: Nil
+          List(Importee.Wildcard()),
+        ) :: Nil,
       ),
       Defn.Object(
         Nil,
@@ -898,10 +898,10 @@ class MinorDottySuite extends BaseDottySuite {
           List(init("ScastieApp")),
           List(tapply(
             tselect(tapply(tname("List"), int(1), int(2), int(3)), "map"),
-            blk(tfunc(tparam(List(Mod.Using()), "i", "Int"))(tname("i")))
-          ))
-        )
-      )
+            blk(tfunc(tparam(List(Mod.Using()), "i", "Int"))(tname("i"))),
+          )),
+        ),
+      ),
     )))
   }
 
@@ -911,28 +911,28 @@ class MinorDottySuite extends BaseDottySuite {
       """|implicit def generate[T](value: T): Clue[T] =
          |  macro MacroCompatScala2.clueImpl""".stripMargin,
       assertLayout =
-        Some("implicit def generate[T](value: T): Clue[T] = macro MacroCompatScala2.clueImpl")
+        Some("implicit def generate[T](value: T): Clue[T] = macro MacroCompatScala2.clueImpl"),
     )(Defn.Macro(
       List(Mod.Implicit()),
       tname("generate"),
       List(pparam("T")),
       List(List(tparam("value", "T"))),
       Some(papply("Clue", "T")),
-      tselect("MacroCompatScala2", "clueImpl")
+      tselect("MacroCompatScala2", "clueImpl"),
     ))
   }
 
   test("kleisli")(runTestAssert[Stat]("new (Kleisli[F, Span[F], *] ~> F) {}")(Term.NewAnonymous(tpl(
     init(Type.AnonymousLambda(
-      pinfix(papply("Kleisli", "F", papply("Span", "F"), Type.AnonymousParam(None)), "~>", pname("F"))
+      pinfix(papply("Kleisli", "F", papply("Span", "F"), Type.AnonymousParam(None)), "~>", pname("F")),
     )) :: Nil,
-    Nil
+    Nil,
   ))))
 
   test("class Baz1 @deprecated(implicit c: C)")(
     runTestAssert[Stat](
       "class Baz1 @deprecated(implicit c: C)",
-      Some("class Baz1 @deprecated (implicit c: C)")
+      Some("class Baz1 @deprecated (implicit c: C)"),
     )(Defn.Class(
       Nil,
       pname("Baz1"),
@@ -940,10 +940,10 @@ class MinorDottySuite extends BaseDottySuite {
       Ctor.Primary(
         List(Mod.Annot(init("deprecated"))),
         anon,
-        List(List(tparam(List(Mod.Implicit()), "c", "C")))
+        List(List(tparam(List(Mod.Implicit()), "c", "C"))),
       ),
-      tplNoBody()
-    ))
+      tplNoBody(),
+    )),
   )
 
   test("class Baz1 @deprecated(c: C)")(
@@ -953,15 +953,15 @@ class MinorDottySuite extends BaseDottySuite {
         pname("Baz1"),
         Nil,
         Ctor.Primary(List(Mod.Annot(init("deprecated"))), anon, List(List(tparam("c", "C")))),
-        tplNoBody()
-      )
-    )
+        tplNoBody(),
+      ),
+    ),
   )
 
   test("class Baz1 @deprecated(c: C = some)")(
     runTestAssert[Stat](
       "class Baz1 @deprecated(c: C = some)",
-      Some("class Baz1 @deprecated (c: C = some)")
+      Some("class Baz1 @deprecated (c: C = some)"),
     )(Defn.Class(
       Nil,
       pname("Baz1"),
@@ -969,16 +969,16 @@ class MinorDottySuite extends BaseDottySuite {
       Ctor.Primary(
         List(Mod.Annot(init("deprecated"))),
         anon,
-        List(List(Term.Param(Nil, tname("c"), Some(pname("C")), Some(tname("some")))))
+        List(List(Term.Param(Nil, tname("c"), Some(pname("C")), Some(tname("some"))))),
       ),
-      tplNoBody()
-    ))
+      tplNoBody(),
+    )),
   )
 
   test("class Baz1 @deprecated(foo)(c: C)")(
     runTestAssert[Stat](
       "class Baz1 @deprecated(foo)(c: C)",
-      Some("class Baz1 @deprecated(foo) (c: C)")
+      Some("class Baz1 @deprecated(foo) (c: C)"),
     )(Defn.Class(
       Nil,
       pname("Baz1"),
@@ -986,10 +986,10 @@ class MinorDottySuite extends BaseDottySuite {
       Ctor.Primary(
         List(Mod.Annot(init("deprecated", List(tname("foo"))))),
         anon,
-        List(List(tparam("c", "C")))
+        List(List(tparam("c", "C"))),
       ),
-      tplNoBody()
-    ))
+      tplNoBody(),
+    )),
   )
 
   test("expr with annotation, then match") {
@@ -1004,9 +1004,9 @@ class MinorDottySuite extends BaseDottySuite {
     runTestAssert[Stat](code, Some(layout))(tmatch(
       Term.Annotate(
         tapply(tname("underlyingStableClassRef"), tselect("mbr", "info", "loBound")),
-        List(Mod.Annot(init("unchecked")))
+        List(Mod.Annot(init("unchecked"))),
       ),
-      Case(Pat.Typed(patvar("ref"), pname("TypeRef")), None, blk())
+      Case(Pat.Typed(patvar("ref"), pname("TypeRef")), None, blk()),
     ))
   }
 
@@ -1021,7 +1021,7 @@ class MinorDottySuite extends BaseDottySuite {
          |""".stripMargin
     runTestAssert[Stat](code, Some(layout))(tmatch(
       tname("obj"),
-      Case(Pat.Typed(patvar("arr"), papply(pname("Array"), papply("Array", pwildcard))), None, blk())
+      Case(Pat.Typed(patvar("arr"), papply(pname("Array"), papply("Array", pwildcard))), None, blk()),
     ))
   }
 
@@ -1049,11 +1049,11 @@ class MinorDottySuite extends BaseDottySuite {
       tapply(tselect("partitions", "getOrElse"), tselect("rdd", "partitions", "indices")),
       Term.Ascribe(
         Term.PartialFunction(List(
-          Case(Pat.Tuple(List(patwildcard, patwildcard)), None, Term.Return(Lit.Unit()))
+          Case(Pat.Tuple(List(patwildcard, patwildcard)), None, Term.Return(Lit.Unit())),
         )),
-        pfunc(pname("Int"), papply("Array", "Int"))(pname("Unit"))
+        pfunc(pname("Int"), papply("Array", "Int"))(pname("Unit")),
       ),
-      blk(Term.Return(Lit.Unit()))
+      blk(Term.Return(Lit.Unit())),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NamedTuplesSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NamedTuplesSuite.scala
@@ -5,7 +5,7 @@ import scala.meta._
 class NamedTuplesSuite extends BaseDottySuite {
 
   test("simple-named-term")(runTestAssert[Stat]("(a = 123, b = \"123\")")(Term.Tuple(
-    List(Term.Assign(tname("a"), lit(123)), Term.Assign(tname("b"), lit("123")))
+    List(Term.Assign(tname("a"), lit(123)), Term.Assign(tname("b"), lit("123"))),
   )))
 
   test("complex-named-term")(
@@ -14,14 +14,14 @@ class NamedTuplesSuite extends BaseDottySuite {
       Term.Assign(tname("b"), lit("123")),
       Term.Assign(
         tname("c"),
-        Term.Tuple(List(Term.Assign(tname("a"), lit(123)), Term.Assign(tname("d"), lit(2.01d))))
-      )
-    )))
+        Term.Tuple(List(Term.Assign(tname("a"), lit(123)), Term.Assign(tname("d"), lit(2.01d)))),
+      ),
+    ))),
   )
 
   test("simple-named-type")(runTestAssert[Type]("(a: Int, b: String)")(Type.Tuple(List(
     Type.TypedParam(pname("a"), pname("Int"), Nil),
-    Type.TypedParam(pname("b"), pname("String"), Nil)
+    Type.TypedParam(pname("b"), pname("String"), Nil),
   ))))
 
   test("simple-named-type-assign")(runTestAssert[Stat]("type T = (a: Int, b: String)")(Defn.Type(
@@ -30,9 +30,9 @@ class NamedTuplesSuite extends BaseDottySuite {
     Nil,
     Type.Tuple(List(
       Type.TypedParam(pname("a"), pname("Int"), Nil),
-      Type.TypedParam(pname("b"), pname("String"), Nil)
+      Type.TypedParam(pname("b"), pname("String"), Nil),
     )),
-    noBounds
+    noBounds,
   )))
 
   test("named-tuple-summon") {
@@ -50,10 +50,10 @@ class NamedTuplesSuite extends BaseDottySuite {
           "<:<",
           Type.Tuple(List(
             Type.TypedParam(pname("x"), pname("Int"), Nil),
-            Type.TypedParam(pname("y"), pname("String"), Nil)
-          ))
-        )
-      )
+            Type.TypedParam(pname("y"), pname("String"), Nil),
+          )),
+        ),
+      ),
     ))
   }
 
@@ -65,11 +65,11 @@ class NamedTuplesSuite extends BaseDottySuite {
         pname("c"),
         Type.Tuple(List(
           Type.TypedParam(pname("a"), pname("Int"), Nil),
-          Type.TypedParam(pname("d"), pname("Double"), Nil)
+          Type.TypedParam(pname("d"), pname("Double"), Nil),
         )),
-        Nil
-      )
-    )))
+        Nil,
+      ),
+    ))),
   )
 
   test("simple-named-pattern")(
@@ -77,15 +77,15 @@ class NamedTuplesSuite extends BaseDottySuite {
       """|a match {
          |  case (a = 123, b = "123") =>
          |}
-         |""".stripMargin
+         |""".stripMargin,
     )(tmatch(
       tname("a"),
       Case(
         Pat.Tuple(List(Pat.Assign(tname("a"), lit(123)), Pat.Assign(tname("b"), lit("123")))),
         None,
-        blk()
-      )
-    ))
+        blk(),
+      ),
+    )),
   )
 
   test("complex-named-pattern")(
@@ -93,7 +93,7 @@ class NamedTuplesSuite extends BaseDottySuite {
       """|a match {
          |  case (a = 123, b = (c = "123", d = 123)) =>
          |}
-         |""".stripMargin
+         |""".stripMargin,
     )(tmatch(
       tname("a"),
       Case(
@@ -101,13 +101,13 @@ class NamedTuplesSuite extends BaseDottySuite {
           Pat.Assign(tname("a"), lit(123)),
           Pat.Assign(
             tname("b"),
-            Pat.Tuple(List(Pat.Assign(tname("c"), lit("123")), Pat.Assign(tname("d"), lit(123))))
-          )
+            Pat.Tuple(List(Pat.Assign(tname("c"), lit("123")), Pat.Assign(tname("d"), lit(123)))),
+          ),
         )),
         None,
-        blk()
-      )
-    ))
+        blk(),
+      ),
+    )),
   )
 
   test("extractor with named fields: all") {
@@ -121,8 +121,8 @@ class NamedTuplesSuite extends BaseDottySuite {
       Case(
         patextract(tname("Foo"), Pat.Assign("name", patvar("nme")), Pat.Assign("id", lit(123))),
         None,
-        blk()
-      )
+        blk(),
+      ),
     )
     runTestAssert[Stat](code)(tree)
   }
@@ -138,8 +138,8 @@ class NamedTuplesSuite extends BaseDottySuite {
       Case(
         patextract(tname("Foo"), Pat.Assign("x", patvar("y")), patvar("z"), Pat.Repeated("rest")),
         None,
-        blk()
-      )
+        blk(),
+      ),
     )
     runTestAssert[Stat](code)(tree)
   }
@@ -150,7 +150,7 @@ class NamedTuplesSuite extends BaseDottySuite {
       Nil,
       List(patextract("Foo", Pat.Assign("name", patvar("name")), Pat.Assign("id", patvar("id")))),
       None,
-      tapply("Foo", Term.Assign("name", lit("123")), Term.Assign("id", lit(456)))
+      tapply("Foo", Term.Assign("name", lit("123")), Term.Assign("id", lit(456))),
     )
     runTestAssert[Stat](code)(tree)
   }
@@ -160,10 +160,10 @@ class NamedTuplesSuite extends BaseDottySuite {
     val tree = Case(
       Pat.Tuple(List(
         Pat.Assign("a", lit(123)),
-        Pat.Assign("b", Pat.Tuple(List(Pat.Assign("c", lit("123")), Pat.Assign("d", lit(123)))))
+        Pat.Assign("b", Pat.Tuple(List(Pat.Assign("c", lit("123")), Pat.Assign("d", lit(123))))),
       )),
       None,
-      blk()
+      blk(),
     )
     runTestAssert[Case](code)(tree)
   }
@@ -222,7 +222,7 @@ class NamedTuplesSuite extends BaseDottySuite {
     val tree = Case(
       Pat.Tuple(List(Pat.Assign("a", lit(123)), Pat.Assign("b", Pat.Assign("c", lit(123))))),
       None,
-      blk()
+      blk(),
     )
     runTestAssert[Case](code, layout)(tree)
   }
@@ -233,10 +233,10 @@ class NamedTuplesSuite extends BaseDottySuite {
     val layout = """case (a = 123, b = (c = 123)) =>"""
     val tree = Case(
       Pat.Tuple(
-        List(Pat.Assign("a", lit(123)), Pat.Assign("b", Pat.Tuple(List(Pat.Assign("c", lit(123))))))
+        List(Pat.Assign("a", lit(123)), Pat.Assign("b", Pat.Tuple(List(Pat.Assign("c", lit(123)))))),
       ),
       None,
-      blk()
+      blk(),
     )
     runTestAssert[Case](code, layout)(tree)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NewFunctionsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/NewFunctionsSuite.scala
@@ -7,17 +7,17 @@ class NewFunctionsSuite extends BaseDottySuite {
   test("type-lambda") {
     // cannot carry +/- but can carry bounds >: , <:
     runTestAssert[Type]("[X, Y] =>> Map[Y, X]")(
-      Type.Lambda(List(pparam("X"), pparam("Y")), papply("Map", "Y", "X"))
+      Type.Lambda(List(pparam("X"), pparam("Y")), papply("Map", "Y", "X")),
     )
     runTestAssert[Type]("[X >: L <: U] =>> R")(
-      Type.Lambda(List(pparam("X", bounds("L", "U"))), pname("R"))
+      Type.Lambda(List(pparam("X", bounds("L", "U"))), pname("R")),
     )
     runTestAssert[Type]("[X] =>> (X, X)")(
-      Type.Lambda(List(pparam("X")), Type.Tuple(List(pname("X"), pname("X"))))
+      Type.Lambda(List(pparam("X")), Type.Tuple(List(pname("X"), pname("X")))),
     )
     runTestAssert[Type]("[X] =>> [Y] =>> (X, Y)")(Type.Lambda(
       List(pparam("X")),
-      Type.Lambda(List(pparam("Y")), Type.Tuple(List(pname("X"), pname("Y"))))
+      Type.Lambda(List(pparam("Y")), Type.Tuple(List(pname("X"), pname("Y")))),
     ))
   }
 
@@ -25,7 +25,7 @@ class NewFunctionsSuite extends BaseDottySuite {
     Nil,
     pname("Tuple"),
     Nil,
-    Type.Lambda(List(pparam("X")), Type.Tuple(List(pname("X"), pname("X"))))
+    Type.Lambda(List(pparam("X")), Type.Tuple(List(pname("X"), pname("X")))),
   )))
 
   test("context-function-single")(
@@ -34,8 +34,8 @@ class NewFunctionsSuite extends BaseDottySuite {
       tname("table"),
       Nil,
       List(List(tparam("init", pctxfunc(pname("Table"))(pname("Unit"))))),
-      pname("Unit")
-    ))
+      pname("Unit"),
+    )),
   )
 
   test("context-function-multi")(
@@ -44,8 +44,8 @@ class NewFunctionsSuite extends BaseDottySuite {
       tname("table"),
       Nil,
       List(List(tparam(Nil, "init", pctxfunc(pname("T1"), papply("List", "T2"))(pname("Unit"))))),
-      pname("Unit")
-    ))
+      pname("Unit"),
+    )),
   )
 
   test("context-function-as-typedef") {
@@ -53,7 +53,7 @@ class NewFunctionsSuite extends BaseDottySuite {
       Nil,
       pname("Executable"),
       List(pparam("T")),
-      pctxfunc(pname("ExecutionContext"))(pname("T"))
+      pctxfunc(pname("ExecutionContext"))(pname("T")),
     ))
 
     val code =
@@ -65,11 +65,11 @@ class NewFunctionsSuite extends BaseDottySuite {
       Case(
         Pat.Typed(
           patvar("t"),
-          Type.Annotate(pctxfunc(pname("Context"))(pname("Symbol")), List(Mod.Annot(init("unchecked"))))
+          Type.Annotate(pctxfunc(pname("Context"))(pname("Symbol")), List(Mod.Annot(init("unchecked")))),
         ),
         None,
-        blk()
-      )
+        blk(),
+      ),
     ))
   }
 
@@ -80,7 +80,7 @@ class NewFunctionsSuite extends BaseDottySuite {
       Nil,
       Nil,
       Some(pctxfunc(pname("String"))(pname("Int"))),
-      tctxfunc(tparam("s"))(int(3))
+      tctxfunc(tparam("s"))(int(3)),
     ))
 
     runTestAssert[Stat]("def fy: (String, Int) ?=> Int = (s, i) ?=> 3")(Defn.Def(
@@ -89,7 +89,7 @@ class NewFunctionsSuite extends BaseDottySuite {
       Nil,
       Nil,
       Some(pctxfunc(pname("String"), pname("Int"))(pname("Int"))),
-      tctxfunc(tparam("s"), tparam("i"))(int(3))
+      tctxfunc(tparam("s"), tparam("i"))(int(3)),
     ))
   }
 
@@ -98,13 +98,13 @@ class NewFunctionsSuite extends BaseDottySuite {
       Nil,
       List(patvar("t0")),
       None,
-      tpolyfunc(pparam("T"))(tfunc(tparam("ts", papply("List", "T")))(tselect("ts", "headOption")))
-    ))
+      tpolyfunc(pparam("T"))(tfunc(tparam("ts", papply("List", "T")))(tselect("ts", "headOption"))),
+    )),
   )
 
   test("polymorphic-func-term-identity")(runTestAssert[Stat]("val pid = [T] => (t: T) => t")(
     Defn
-      .Val(Nil, List(patvar("pid")), None, tpolyfunc(pparam("T"))(tfunc(tparam("t", "T"))(tname("t"))))
+      .Val(Nil, List(patvar("pid")), None, tpolyfunc(pparam("T"))(tfunc(tparam("t", "T"))(tname("t")))),
   ))
 
   test("polymorphic-func-term-complex")(
@@ -115,31 +115,31 @@ class NewFunctionsSuite extends BaseDottySuite {
       tpolyfunc(pparam(Nil, "F", List(pparam("_"))), pparam(Nil, "G", List(pparam("_"))), pparam("T"))(
         tfunc(
           tparam("ft", papply("F", "T")),
-          tparam(Nil, "f", pfunc(papply("F", "T"))(papply("G", "T")))
-        )(tapply(tname("f"), tname("ft")))
-      )
-    ))
+          tparam(Nil, "f", pfunc(papply("F", "T"))(papply("G", "T"))),
+        )(tapply(tname("f"), tname("ft"))),
+      ),
+    )),
   )
 
   test("poly-function-type")(runTestAssert[Stat]("type F0 = [T] => List[T] => Option[T]")(Defn.Type(
     Nil,
     pname("F0"),
     Nil,
-    ppolyfunc(pparam("T"))(pfunc(papply("List", "T"))(papply("Option", "T")))
+    ppolyfunc(pparam("T"))(pfunc(papply("List", "T"))(papply("Option", "T"))),
   )))
   test("poly-function-type")(
     runTestAssert[Stat](
       """|def foo = {
          |  f[[X] =>> String]
-         |}""".stripMargin
+         |}""".stripMargin,
     )(Defn.Def(
       Nil,
       tname("foo"),
       Nil,
       Nil,
       None,
-      blk(tapplytype(tname("f"), Type.Lambda(List(pparam("X")), pname("String"))))
-    ))
+      blk(tapplytype(tname("f"), Type.Lambda(List(pparam("X")), pname("String")))),
+    )),
   )
 
   test("poly-function-type-method")(
@@ -149,11 +149,11 @@ class NewFunctionsSuite extends BaseDottySuite {
       List(pparam("T")),
       List(List(
         tparam(Nil, "f", ppolyfunc(pparam("U"))(pfunc(pname("U"))(pname("U")))),
-        tparam("t", "T")
+        tparam("t", "T"),
       )),
       None,
-      tapply(tname("f"), tname("t"))
-    ))
+      tapply(tname("f"), tname("t")),
+    )),
   )
 
   test("poly-function-type-duo")(
@@ -161,13 +161,13 @@ class NewFunctionsSuite extends BaseDottySuite {
       Nil,
       pname("F2"),
       Nil,
-      ppolyfunc(pparam("T"), pparam("U"))(pfunc(pname("T"), pname("U"))(papply("Either", "T", "U")))
-    ))
+      ppolyfunc(pparam("T"), pparam("U"))(pfunc(pname("T"), pname("U"))(papply("Either", "T", "U"))),
+    )),
   )
 
   test("poly-function-type-error")(runTestError[Stat](
     "type F2 = [T, U] => (T, U)",
-    "polymorphic function types must have a value parameter"
+    "polymorphic function types must have a value parameter",
   ))
 
   test("poly-function-type-complex")(
@@ -176,9 +176,9 @@ class NewFunctionsSuite extends BaseDottySuite {
       pname("F1"),
       Nil,
       ppolyfunc(pparam(Nil, "F", List(pparam("_"))), pparam(Nil, "G", List(pparam("_"))), pparam("T"))(
-        pfunc(papply("F", "T"), pfunc(papply("F", "T"))(papply("G", "T")))(papply("G", "T"))
-      )
-    ))
+        pfunc(papply("F", "T"), pfunc(papply("F", "T"))(papply("G", "T")))(papply("G", "T")),
+      ),
+    )),
   )
 
   test("poly-context-function-type")(
@@ -186,8 +186,8 @@ class NewFunctionsSuite extends BaseDottySuite {
       Nil,
       pname("F0"),
       Nil,
-      ppolyfunc(pparam("T"))(pctxfunc(papply("List", "T"))(papply("Option", "T")))
-    ))
+      ppolyfunc(pparam("T"))(pctxfunc(papply("List", "T"))(papply("Option", "T"))),
+    )),
   )
 
   test("poly-context-function-complex") {
@@ -200,16 +200,16 @@ class NewFunctionsSuite extends BaseDottySuite {
          |        T
          |      ] => G[T]
          |) => f(ft)""".stripMargin,
-      assertLayout = Some("val t1 = [F[_], T] => (f: F[T] => G[T]) => f(ft)")
+      assertLayout = Some("val t1 = [F[_], T] => (f: F[T] => G[T]) => f(ft)"),
     )(Defn.Val(
       Nil,
       List(patvar("t1")),
       None,
       tpolyfunc(pparam(Nil, "F", List(pparam("_"))), pparam("T"))(
         tfunc(
-          tparam(Nil, "f", pfunc(papply("F", "T"))(papply("G", "T")))
-        )(tapply(tname("f"), tname("ft")))
-      )
+          tparam(Nil, "f", pfunc(papply("F", "T"))(papply("G", "T"))),
+        )(tapply(tname("f"), tname("ft"))),
+      ),
     ))
   }
 
@@ -223,14 +223,14 @@ class NewFunctionsSuite extends BaseDottySuite {
          |      T
          |]) => ts.headOption""".stripMargin,
       assertLayout =
-        Some("val thisIsAPolymorphicFunction = [PolymorphicFunctionTypeParam] => (polymorphicFunctionParam: List[T]) => ts.headOption")
+        Some("val thisIsAPolymorphicFunction = [PolymorphicFunctionTypeParam] => (polymorphicFunctionParam: List[T]) => ts.headOption"),
     )(Defn.Val(
       Nil,
       List(patvar("thisIsAPolymorphicFunction")),
       None,
       tpolyfunc(
-        pparam("PolymorphicFunctionTypeParam")
-      )(tfunc(tparam("polymorphicFunctionParam", papply("List", "T")))(tselect("ts", "headOption")))
+        pparam("PolymorphicFunctionTypeParam"),
+      )(tfunc(tparam("polymorphicFunctionParam", papply("List", "T")))(tselect("ts", "headOption"))),
     ))
   }
 
@@ -239,8 +239,8 @@ class NewFunctionsSuite extends BaseDottySuite {
       Nil,
       List(patvar("extractor")),
       Some(pfunc(Type.TypedParam(pname("e"), pname("Entry")))(pselect("e", "Key"))),
-      tname("extractKey")
-    ))
+      tname("extractKey"),
+    )),
   )
 
   test("dependent-type-context")(
@@ -248,8 +248,8 @@ class NewFunctionsSuite extends BaseDottySuite {
       Nil,
       List(patvar("extractor")),
       Some(pctxfunc(Type.TypedParam(pname("e"), pname("Entry")))(pselect("e", "Key"))),
-      tname("extractKey")
-    ))
+      tname("extractKey"),
+    )),
   )
 
   test("dependent-type-multi")(
@@ -258,11 +258,11 @@ class NewFunctionsSuite extends BaseDottySuite {
       List(patvar("extractor")),
       Some(
         pfunc(Type.TypedParam(pname("e"), pname("Entry")), Type.TypedParam(pname("f"), pname("Other")))(
-          pselect("e", "Key")
-        )
+          pselect("e", "Key"),
+        ),
       ),
-      tname("extractKey")
-    ))
+      tname("extractKey"),
+    )),
   )
 
   test("dependent-type-term")(runTestAssert[Stat]("type T = (e: Entry) => e.Key")(Defn.Type(
@@ -270,7 +270,7 @@ class NewFunctionsSuite extends BaseDottySuite {
     pname("T"),
     Nil,
     pfunc(Type.TypedParam(pname("e"), pname("Entry")))(pselect("e", "Key")),
-    noBounds
+    noBounds,
   )))
 
   test("dependent-type-term-context")(runTestAssert[Stat]("type T = (e: Entry) ?=> e.Key")(Defn.Type(
@@ -278,7 +278,7 @@ class NewFunctionsSuite extends BaseDottySuite {
     pname("T"),
     Nil,
     pctxfunc(Type.TypedParam(pname("e"), pname("Entry")))(pselect("e", "Key")),
-    noBounds
+    noBounds,
   )))
 
   test("dependent-type-term-multi")(
@@ -288,10 +288,10 @@ class NewFunctionsSuite extends BaseDottySuite {
       Nil,
       pfunc(
         Type.TypedParam(pname("e"), pname("Entry")),
-        Type.TypedParam(pname("o"), papply("Other", pwildcard(hiBound("P"))))
+        Type.TypedParam(pname("o"), papply("Other", pwildcard(hiBound("P")))),
       )(pselect("e", "Key")),
-      noBounds
-    ))
+      noBounds,
+    )),
   )
 
   test("dependent-type-arrow-after-nl")(
@@ -300,14 +300,14 @@ class NewFunctionsSuite extends BaseDottySuite {
          |  (e: Entry) 
          |  => e.Key
          |""".stripMargin,
-      Some("type T = (e: Entry) => e.Key")
+      Some("type T = (e: Entry) => e.Key"),
     )(Defn.Type(
       Nil,
       pname("T"),
       Nil,
       pfunc(Type.TypedParam(pname("e"), pname("Entry")))(pselect("e", "Key")),
-      noBounds
-    ))
+      noBounds,
+    )),
   )
 
   test("dependent-type-arrow-after-nl bad indent")(runTestError[Stat](
@@ -317,7 +317,7 @@ class NewFunctionsSuite extends BaseDottySuite {
        |""".stripMargin,
     """|<input>:3: error: illegal start of definition `=>`
        |=> e.Key
-       |^""".stripMargin
+       |^""".stripMargin,
   ))
 
   test("context-function-arrow-after-nl")(
@@ -326,14 +326,14 @@ class NewFunctionsSuite extends BaseDottySuite {
          |  ExecutionContext
          |  ?=> T
          |""".stripMargin,
-      Some("type Executable[T] = ExecutionContext ?=> T")
+      Some("type Executable[T] = ExecutionContext ?=> T"),
     )(Defn.Type(
       Nil,
       pname("Executable"),
       pparam("T") :: Nil,
       pctxfunc(pname("ExecutionContext"))(pname("T")),
-      noBounds
-    ))
+      noBounds,
+    )),
   )
 
   test("context-function-arrow-after-nl with parens")(
@@ -342,14 +342,14 @@ class NewFunctionsSuite extends BaseDottySuite {
          |  (ExecutionContext)
          |  ?=> T
          |""".stripMargin,
-      Some("type Executable[T] = ExecutionContext ?=> T")
+      Some("type Executable[T] = ExecutionContext ?=> T"),
     )(Defn.Type(
       Nil,
       pname("Executable"),
       pparam("T") :: Nil,
       pctxfunc(pname("ExecutionContext"))(pname("T")),
-      noBounds
-    ))
+      noBounds,
+    )),
   )
 
   test("context-function-arrow-after-nl bad indent")(runTestError[Stat](
@@ -359,7 +359,7 @@ class NewFunctionsSuite extends BaseDottySuite {
        |""".stripMargin,
     """|error: illegal start of definition `?=>`
        |?=> T
-       |^""".stripMargin
+       |^""".stripMargin,
   ))
 
   test("lambda-function-arrow-after-nl")(
@@ -368,14 +368,14 @@ class NewFunctionsSuite extends BaseDottySuite {
          |  [X]
          |  =>> (X, X)
          |""".stripMargin,
-      Some("type Tuple = [X] =>> (X, X)")
+      Some("type Tuple = [X] =>> (X, X)"),
     )(Defn.Type(
       Nil,
       pname("Tuple"),
       Nil,
       Type.Lambda(pparam("X") :: Nil, Type.Tuple(List(pname("X"), pname("X")))),
-      noBounds
-    ))
+      noBounds,
+    )),
   )
 
   test("lambda-function-arrow-after-nl no NL after =")(
@@ -383,14 +383,14 @@ class NewFunctionsSuite extends BaseDottySuite {
       """|type Tuple = [X]
          |  =>> (X, X)
          |""".stripMargin,
-      Some("type Tuple = [X] =>> (X, X)")
+      Some("type Tuple = [X] =>> (X, X)"),
     )(Defn.Type(
       Nil,
       pname("Tuple"),
       Nil,
       Type.Lambda(pparam("X") :: Nil, Type.Tuple(List(pname("X"), pname("X")))),
-      noBounds
-    ))
+      noBounds,
+    )),
   )
 
   test("lambda-function-arrow-after-nl bad indent")(runTestError[Stat](
@@ -400,11 +400,11 @@ class NewFunctionsSuite extends BaseDottySuite {
        |""".stripMargin,
     """|error: expected =>> or =>
        |  [X]
-       |     ^""".stripMargin
+       |     ^""".stripMargin,
   ))
 
   test("type-lambda-bounds")(runTestAssert[Stat]("type U <: [X] =>> Any")(
-    Decl.Type(Nil, pname("U"), Nil, bounds(hi = Type.Lambda(List(pparam("X")), pname("Any"))))
+    Decl.Type(Nil, pname("U"), Nil, bounds(hi = Type.Lambda(List(pparam("X")), pname("Any")))),
   ))
 
   test("type Macro[X] = (=> Quotes) ?=> Expr[X]")(
@@ -413,8 +413,8 @@ class NewFunctionsSuite extends BaseDottySuite {
       pname("Macro"),
       List(pparam("X")),
       pctxfunc(Type.ByName(pname("Quotes")))(papply("Expr", "X")),
-      noBounds
-    ))
+      noBounds,
+    )),
   )
 
   test("type-lmabda-bounds")(
@@ -429,14 +429,14 @@ class NewFunctionsSuite extends BaseDottySuite {
           bounds(cb =
             List(Type.Lambda(
               List(pparam(Nil, "G", List(pparam("_")))),
-              papply("MonadCancel", "G", "Throwable")
-            ))
-          )
+              papply("MonadCancel", "G", "Throwable"),
+            )),
+          ),
         )),
         ctor,
-        tplNoBody()
-      )
-    )
+        tplNoBody(),
+      ),
+    ),
   )
 
   test("#3050 function without body")(
@@ -445,11 +445,11 @@ class NewFunctionsSuite extends BaseDottySuite {
          |""".stripMargin,
       """f { (x1: A, x2: B => C) =>
         |}
-        |""".stripMargin
+        |""".stripMargin,
     )(tapply(
       tname("f"),
-      blk(tfunc(tparam("x1", "A"), tparam("x2", pfunc(pname("B"))(pname("C"))))(blk()))
-    ))
+      blk(tfunc(tparam("x1", "A"), tparam("x2", pfunc(pname("B"))(pname("C"))))(blk())),
+    )),
   )
 
   test("#3996 functions: precedence 1") {
@@ -631,7 +631,7 @@ class NewFunctionsSuite extends BaseDottySuite {
       List(pparam("T", hiBound(purefunc("A")("B")))),
       List(List(tparam("f", "T"))),
       Some(purefunc("A")("B")),
-      "???"
+      "???",
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -662,7 +662,7 @@ class NewFunctionsSuite extends BaseDottySuite {
       List(pparam("T", hiBound(purectxfunc("A")("B")))),
       List(List(tparam("f", "T"))),
       Some(purectxfunc("A")("B")),
-      "???"
+      "???",
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -677,7 +677,7 @@ class NewFunctionsSuite extends BaseDottySuite {
       List(pparam("T", hiBound(pcap(purectxfunc("A")("B"), "a", "c")))),
       List(List(tparam("f", "T"))),
       Some(purectxfunc("A")("B")),
-      "???"
+      "???",
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -699,7 +699,7 @@ class NewFunctionsSuite extends BaseDottySuite {
       "func",
       Nil,
       List(List(tparam("f", pcap(Type.PureByName("B"), "a", "b", "c")))),
-      "Unit"
+      "Unit",
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -721,7 +721,7 @@ class NewFunctionsSuite extends BaseDottySuite {
       "foo",
       Nil,
       None,
-      blk(tapply("println"), tpolyfunc(pparam("T"))(tfunc(tparam("a", "T"))("a")))
+      blk(tapply("println"), tpolyfunc(pparam("T"))(tfunc(tparam("a", "T"))("a"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -771,11 +771,11 @@ class NewFunctionsSuite extends BaseDottySuite {
             None,
             List(Init(Type.Name("F"), Name.Anonymous(), Seq.empty[Term.ArgClause])),
             Template.Body(None, Nil),
-            Nil
-          )
+            Nil,
+          ),
         ),
-        Term.PolyFunction(Type.ParamClause(List(pparam("X"), pparam("Y"))), Term.Name("Z"))
-      ))
+        Term.PolyFunction(Type.ParamClause(List(pparam("X"), pparam("Y"))), Term.Name("Z")),
+      )),
     )
     runTestAssert[Stat](code, layout)(tree)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/PatSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/PatSuite.scala
@@ -8,11 +8,11 @@ class PatSuite extends ParseSuite {
   import Pat._
 
   private def assertPat(expr: String)(
-      tree: Tree
+      tree: Tree,
   )(implicit dialect: Dialect, loc: munit.Location): Unit = assertTree(pat(expr))(tree)
 
   private def assertPatTyp(expr: String)(
-      tree: Tree
+      tree: Tree,
   )(implicit dialect: Dialect, loc: munit.Location): Unit = assertTree(patternTyp(expr))(tree)
 
   implicit val dialect: Dialect = dialects.Scala3
@@ -52,21 +52,21 @@ class PatSuite extends ParseSuite {
   test("patTyp: t Map u")(assertPatTyp("t Map u")(pinfix("t", "Map", pname("u"))))
 
   test("patTyp: t & u | v")(
-    assertPatTyp("t & u | v")(pinfix(pinfix("t", "&", pname("u")), "|", pname("v")))
+    assertPatTyp("t & u | v")(pinfix(pinfix("t", "&", pname("u")), "|", pname("v"))),
   )
 
   test("patTyp: t * u + v")(
-    assertPatTyp("t * u + v")(pinfix(pinfix("t", "*", pname("u")), "+", pname("v")))
+    assertPatTyp("t * u + v")(pinfix(pinfix("t", "*", pname("u")), "+", pname("v"))),
   )
 
   test("patTyp: t * u + v / w")(assertPatTyp("t * u + v / w")(
-    pinfix(pinfix("t", "*", pname("u")), "+", pinfix("v", "/", pname("w")))
+    pinfix(pinfix("t", "*", pname("u")), "+", pinfix("v", "/", pname("w"))),
   ))
 
   test("patTyp: t + u * v")(assertPatTyp("t + u * v")(pinfix("t", "+", pinfix("u", "*", pname("v")))))
 
   test("pat: F[t & u | v]()")(assertPat("F[t & u | v]()")(
-    Pat.Extract(tapplytype(tname("F"), pinfix(pinfix("t", "&", pname("u")), "|", pname("v"))), Nil)
+    Pat.Extract(tapplytype(tname("F"), pinfix(pinfix("t", "&", pname("u")), "|", pname("v"))), Nil),
   ))
 
   test("_: (t Map u)")(assertPat("_: (t Map u)")(Typed(Wildcard(), pinfix("t", "Map", pname("u")))))
@@ -82,7 +82,7 @@ class PatSuite extends ParseSuite {
   test("foo(_*)")(assertPat("foo(_*)")(Extract(tname("foo"), SeqWildcard() :: Nil)))
 
   test("foo(x @ _*)")(
-    assertPat("foo(x @ _*)")(Extract(tname("foo"), Bind(Var(tname("x")), SeqWildcard()) :: Nil))
+    assertPat("foo(x @ _*)")(Extract(tname("foo"), Bind(Var(tname("x")), SeqWildcard()) :: Nil)),
   )
 
   test("a :: b")(assertPat("a :: b")(patinfix(Var(tname("a")), "::", Var(tname("b")))))
@@ -109,27 +109,27 @@ class PatSuite extends ParseSuite {
   test("foo\"bar\"")(assertPat("foo\"bar\"")(Interpolate(tname("foo"), str("bar") :: Nil, Nil)))
 
   test("foo\"a $b c\"")(assertPat("foo\"a $b c\"")(
-    Interpolate(tname("foo"), str("a ") :: str(" c") :: Nil, Var(tname("b")) :: Nil)
+    Interpolate(tname("foo"), str("a ") :: str(" c") :: Nil, Var(tname("b")) :: Nil),
   ))
 
   test("foo\"${b @ foo()}\"")(assertPat("foo\"${b @ foo()}\"")(Interpolate(
     tname("foo"),
     str("") :: str("") :: Nil,
-    Bind(Var(tname("b")), Extract(tname("foo"), Nil)) :: Nil
+    Bind(Var(tname("b")), Extract(tname("foo"), Nil)) :: Nil,
   )))
 
   test("$_")(assertPat(""" q"x + $_" """)(
-    Pat.Interpolate(tname("q"), List(str("x + "), str("")), List(patwildcard))
+    Pat.Interpolate(tname("q"), List(str("x + "), str("")), List(patwildcard)),
   ))
 
   test("#501")(intercept[ParseException](pat("case List(_: BlockExpr, _: MatchExpr, x:_*)  ⇒ false")))
 
   test("<a>{_*}</a>")(
-    assertPat("<a>{_*}</a>")(Pat.Xml(List(str("<a>"), str("</a>")), List(SeqWildcard())))
+    assertPat("<a>{_*}</a>")(Pat.Xml(List(str("<a>"), str("</a>")), List(SeqWildcard()))),
   )
 
   test("<a>{ns @ _*}</a>")(assertPat("<a>{ns @ _*}</a>")(
-    Pat.Xml(List(str("<a>"), str("</a>")), List(Bind(Var(tname("ns")), SeqWildcard())))
+    Pat.Xml(List(str("<a>"), str("</a>")), List(Bind(Var(tname("ns")), SeqWildcard()))),
   ))
 
   test("a: _") {
@@ -188,11 +188,11 @@ class PatSuite extends ParseSuite {
         blk(
           Import.createWithComments(
             List(Importer("foo", List(Importee.Wildcard()))),
-            endComment = Seq("// Works fine if I remove this line")
+            endComment = Seq("// Works fine if I remove this line"),
           ),
-          tapply("x")
-        )
-      )))
+          tapply("x"),
+        ),
+      ))),
     )
     runTestAssert[Stat](code, layout)(tree)
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/Scala3SyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/Scala3SyntaxSuite.scala
@@ -7,28 +7,28 @@ class Scala3SyntaxSuite extends BaseDottySuite {
   test("given intOrd: Ord[Int] with \n{ def f(): Int = 1 }") {
     assertEquals(
       templStat("given intOrd: Ord[Int] with \n{ def f(): Int = 1 }").syntax,
-      "given intOrd: Ord[Int] with \n{ def f(): Int = 1 }".lf2nl
+      "given intOrd: Ord[Int] with \n{ def f(): Int = 1 }".lf2nl,
     )
 
     matchSubStructure[Stat](
       "given intOrd: Ord[Int] with \n{ def f(): Int = 1 }",
       { case givenDefn: Defn.Given =>
         assertEquals(givenDefn.templ.syntax, "Ord[Int] with \n{ def f(): Int = 1 }".lf2nl)
-      }
+      },
     )
   }
 
   test("private final given intOrd: Ord[Int] with \n{ def f(): Int = 1 }") {
     assertEquals(
       templStat("private final given intOrd: Ord[Int] with \n{ def f(): Int = 1 }").syntax,
-      "private final given intOrd: Ord[Int] with \n{ def f(): Int = 1 }".lf2nl
+      "private final given intOrd: Ord[Int] with \n{ def f(): Int = 1 }".lf2nl,
     )
 
     matchSubStructure[Stat](
       "private final given intOrd: Ord[Int] with \n{ def f(): Int = 1 }",
       { case givenDefn: Defn.Given =>
         assertEquals(givenDefn.templ.syntax, "Ord[Int] with \n{ def f(): Int = 1 }".lf2nl)
-      }
+      },
     )
   }
 
@@ -37,7 +37,7 @@ class Scala3SyntaxSuite extends BaseDottySuite {
     import dialects.Scala3
     assertEquals(
       templStat("enum C extends A with B { case D }").syntax,
-      "enum C extends A with B { case D }"
+      "enum C extends A with B { case D }",
     )
     stat("enum C extends A with B { case D }") match {
       case Defn.Enum(_, _, _, _, template) =>
@@ -51,7 +51,7 @@ class Scala3SyntaxSuite extends BaseDottySuite {
     import dialects.Scala3
     assertEquals(
       templStat("protected enum C extends A with B { case D }").syntax,
-      "protected enum C extends A with B { case D }"
+      "protected enum C extends A with B { case D }",
     )
     stat("protected enum C extends A with B { case D }") match {
       case Defn.Enum(_, _, _, _, template) =>
@@ -61,7 +61,7 @@ class Scala3SyntaxSuite extends BaseDottySuite {
   }
 
   test("given intOrd: Ord[Int]")(
-    assertEquals(templStat("given intOrd: Ord[Int]").syntax, "given intOrd: Ord[Int]")
+    assertEquals(templStat("given intOrd: Ord[Int]").syntax, "given intOrd: Ord[Int]"),
   )
 
   test("backticked-keywords") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/SignificantIndentationSuite.scala
@@ -11,7 +11,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
     Nil,
     Nil,
     Some(pname("String")),
-    blk(tapply(tname("fa")), tapply(tname("fb")))
+    blk(tapply(tname("fa")), tapply(tname("fb"))),
   )
 
   test("basic-example") {
@@ -20,7 +20,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |  def f: Int
          |""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some("trait A { def f: Int }"))(
-      Defn.Trait(Nil, pname("A"), Nil, EmptyCtor(), tpl(defx))
+      Defn.Trait(Nil, pname("A"), Nil, EmptyCtor(), tpl(defx)),
     )
   }
 
@@ -40,11 +40,11 @@ class SignificantIndentationSuite extends BaseDottySuite {
            |package anotherpackage {
            |  def f: Int
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Source(List(
       Pkg(tname("mysadpackage"), List(Decl.Def(Nil, tname("f"), Nil, Nil, pname("Int")))),
-      Pkg(tname("anotherpackage"), List(Decl.Def(Nil, tname("f"), Nil, Nil, pname("Int"))))
+      Pkg(tname("anotherpackage"), List(Decl.Def(Nil, tname("f"), Nil, Nil, pname("Int")))),
     )))
   }
 
@@ -54,7 +54,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |  def f: Int
          |  def y: String = { fa(); fb() }""".stripMargin
     runTestAssert[Stat](code, assertLayout = None)(
-      Defn.Trait(Nil, pname("A"), Nil, EmptyCtor(), tpl(defx, defy))
+      Defn.Trait(Nil, pname("A"), Nil, EmptyCtor(), tpl(defx, defy)),
     )
   }
 
@@ -64,7 +64,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |  def f: Int
          |""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some("new A { def f: Int }"))(Term.NewAnonymous(
-      tpl(List(init("A")), List(Decl.Def(Nil, tname("f"), Nil, Nil, pname("Int"))))
+      tpl(List(init("A")), List(Decl.Def(Nil, tname("f"), Nil, Nil, pname("Int")))),
     ))
   }
 
@@ -80,7 +80,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
       tname("x"),
       blk(Term.NewAnonymous(tpl(List(init("A")), List(Decl.Def(Nil, tname("f"), Nil, pname("Int")))))),
       Lit.Unit(),
-      Nil
+      Nil,
     ))
   }
 
@@ -98,11 +98,11 @@ class SignificantIndentationSuite extends BaseDottySuite {
            |  def f: Int
            |  def g: Int
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Term.NewAnonymous(tpl(
       Decl.Def(Nil, tname("f"), Nil, Nil, pname("Int")),
-      Decl.Def(Nil, tname("g"), Nil, Nil, pname("Int"))
+      Decl.Def(Nil, tname("g"), Nil, Nil, pname("Int")),
     )))
   }
 
@@ -123,16 +123,16 @@ class SignificantIndentationSuite extends BaseDottySuite {
           pname("C"),
           Nil,
           ctor,
-          tpl(Defn.Def(Nil, tname("f"), Nil, Nil, Some(pname("Int")), int(3)))
+          tpl(Defn.Def(Nil, tname("f"), Nil, Nil, Some(pname("Int")), int(3))),
         ),
         Defn.Trait(
           Nil,
           pname("T"),
           Nil,
           EmptyCtor(),
-          tpl(Defn.Def(Nil, tname("f"), Nil, Nil, Some(pname("Int")), int(4)))
-        )
-      )
+          tpl(Defn.Def(Nil, tname("f"), Nil, Nil, Some(pname("Int")), int(4))),
+        ),
+      ),
     ))
   }
 
@@ -156,15 +156,15 @@ class SignificantIndentationSuite extends BaseDottySuite {
            |  if (cond) truep else falsep
            |  otherStatement()
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Def(
       Nil,
       tname("fn"),
       Nil,
       Nil,
       Some(pname("Unit")),
-      blk(Term.If(tname("cond"), tname("truep"), tname("falsep")), tapply(tname("otherStatement")))
+      blk(Term.If(tname("cond"), tname("truep"), tname("falsep")), tapply(tname("otherStatement"))),
     ))
   }
 
@@ -207,8 +207,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
       EmptyCtor(),
       tpl(
         Defn
-          .Def(Nil, tname("fx"), Nil, List(List()), Some(pname("Unit")), blk(tname("f1"), tname("f2")))
-      )
+          .Def(Nil, tname("fx"), Nil, List(List()), Some(pname("Unit")), blk(tname("f1"), tname("f2"))),
+      ),
     ))
   }
 
@@ -233,8 +233,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
       EmptyCtor(),
       tpl(
         Defn.Def(Nil, tname("fx"), Nil, List(List()), Some(pname("Unit")), tname("f1")),
-        tname("f2")
-      )
+        tname("f2"),
+      ),
     ))
   }
 
@@ -261,8 +261,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
       EmptyCtor(),
       tpl(
         Defn.Def(Nil, tname("fx"), Nil, List(List()), Some(pname("Unit")), blk()),
-        Defn.Def(List(Mod.Private(anon)), tname("f2"), Nil, Nil, Some(pname("Int")), int(1))
-      )
+        Defn.Def(List(Mod.Private(anon)), tname("f2"), Nil, Nil, Some(pname("Int")), int(1)),
+      ),
     ))
   }
 
@@ -284,7 +284,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
       pname("A"),
       Nil,
       EmptyCtor(),
-      tpl(List(init("B")), self("thisPhase"), tname("expr1"), tname("expr2"))
+      tpl(List(init("B")), self("thisPhase"), tname("expr1"), tname("expr2")),
     ))
   }
 
@@ -314,11 +314,11 @@ class SignificantIndentationSuite extends BaseDottySuite {
           List(patvar("fn")),
           None,
           tfunc(tparam("pa"), tparam("pb"))(
-            blk(Defn.Def(Nil, tname("helper"), Nil, Nil, None, int(3)), int(3))
-          )
+            blk(Defn.Def(Nil, tname("helper"), Nil, Nil, None, int(3)), int(3)),
+          ),
         ),
-        Term.EndMarker(tname("fn"))
-      )
+        Term.EndMarker(tname("fn")),
+      ),
     ))
   }
 
@@ -364,14 +364,14 @@ class SignificantIndentationSuite extends BaseDottySuite {
               None,
               Term.For(
                 List(Enumerator.CaseGenerator(Pat.Typed(patvar("a"), pname("TP")), tname("body"))),
-                tname("fordo")
-              )
+                tname("fordo"),
+              ),
             ),
-            Case(patvar("b"), None, tname("ok"))
-          )
+            Case(patvar("b"), None, tname("ok")),
+          ),
         ),
-        Decl.Def(List(Mod.Private(anon)), tname("transformAnnot"), Nil, Nil, pname("Tree"))
-      )
+        Decl.Def(List(Mod.Private(anon)), tname("transformAnnot"), Nil, Nil, pname("Tree")),
+      ),
     ))
   }
 
@@ -392,8 +392,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
         Name.This(),
         List(List(tparam("msg", "String"))),
         init(Type.Singleton(Term.This(anon)), List(tname("message"), bool(false))),
-        Nil
-      ))
+        Nil,
+      )),
     ))
   }
 
@@ -422,8 +422,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
         Name.This(),
         List(List(tparam("msg", "String"))),
         init(Type.Singleton(Term.This(anon)), List(tname("message"), bool(false))),
-        List(tname("otherStat"))
-      ))
+        List(tname("otherStat")),
+      )),
     ))
   }
 
@@ -447,8 +447,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
            |    case Apply() =>
            |  }
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Def(
       Nil,
       tname("genApply"),
@@ -460,10 +460,10 @@ class SignificantIndentationSuite extends BaseDottySuite {
         Case(
           Pat.Extract(tname("Apply2"), Nil),
           None,
-          Term.Assign(tname("generatedType"), tapply(tname("genTypeApply"), tname("t")))
+          Term.Assign(tname("generatedType"), tapply(tname("genTypeApply"), tname("t"))),
         ),
-        Case(Pat.Extract(tname("Apply"), Nil), None, blk())
-      ))
+        Case(Pat.Extract(tname("Apply"), Nil), None, blk()),
+      )),
     ))
   }
 
@@ -475,7 +475,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |  finally placeholderParams = saved
          |""".stripMargin,
       assertLayout =
-        Some("def wrapPlaceholders(t: Tree) = try if (placeholderParams.isEmpty) t else new WildcardFunction(placeholderParams.reverse, t) finally placeholderParams = saved")
+        Some("def wrapPlaceholders(t: Tree) = try if (placeholderParams.isEmpty) t else new WildcardFunction(placeholderParams.reverse, t) finally placeholderParams = saved"),
     )(Defn.Def(
       Nil,
       tname("wrapPlaceholders"),
@@ -487,12 +487,12 @@ class SignificantIndentationSuite extends BaseDottySuite {
           tselect("placeholderParams", "isEmpty"),
           tname("t"),
           Term.New(
-            init(pname("WildcardFunction"), List(tselect("placeholderParams", "reverse"), tname("t")))
-          )
+            init(pname("WildcardFunction"), List(tselect("placeholderParams", "reverse"), tname("t"))),
+          ),
         ),
         Nil,
-        Some(Term.Assign(tname("placeholderParams"), tname("saved")))
-      )
+        Some(Term.Assign(tname("placeholderParams"), tname("saved"))),
+      ),
     ))
   }
 
@@ -523,8 +523,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
            |    def x: Int
            |  }
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Class(
       List(Mod.Abstract()),
       pname("Documentation"),
@@ -538,15 +538,15 @@ class SignificantIndentationSuite extends BaseDottySuite {
           EmptyCtor(),
           tpl(
             Defn.Type(Nil, pname("Node"), Nil, pname("Int")),
-            Defn.Val(Nil, List(patvar("a")), Some(pname("Int")), int(3))
-          )
+            Defn.Val(Nil, List(patvar("a")), Some(pname("Int")), int(3)),
+          ),
         ),
         Decl.Val(
           Nil,
           List(patvar("refinementTest")),
-          Type.Refine(Some(pname("Graph")), List(Decl.Def(Nil, tname("x"), Nil, Nil, pname("Int"))))
-        )
-      )
+          Type.Refine(Some(pname("Graph")), List(Decl.Def(Nil, tname("x"), Nil, Nil, pname("Int")))),
+        ),
+      ),
     ))
   }
 
@@ -555,8 +555,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
       """|val refinementTest:
          |      Int = 3
          |""".stripMargin,
-      assertLayout = Some("val refinementTest: Int = 3")
-    )(Defn.Val(Nil, List(patvar("refinementTest")), Some(pname("Int")), int(3)))
+      assertLayout = Some("val refinementTest: Int = 3"),
+    )(Defn.Val(Nil, List(patvar("refinementTest")), Some(pname("Int")), int(3))),
   )
 
   test("type-in-next-line-equals-newline")(
@@ -565,8 +565,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |      Int = 
          |3
          |""".stripMargin,
-      assertLayout = Some("val refinementTest: Int = 3")
-    )(Defn.Val(Nil, List(patvar("refinementTest")), Some(pname("Int")), int(3)))
+      assertLayout = Some("val refinementTest: Int = 3"),
+    )(Defn.Val(Nil, List(patvar("refinementTest")), Some(pname("Int")), int(3))),
   )
 
   test("type-equals-separate")(
@@ -575,15 +575,15 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |      Int = 
          |3) = a
          |""".stripMargin,
-      assertLayout = Some("def refinementTest(a: Int = 3) = a")
+      assertLayout = Some("def refinementTest(a: Int = 3) = a"),
     )(Defn.Def(
       Nil,
       tname("refinementTest"),
       Nil,
       List(List(Term.Param(Nil, tname("a"), Some(pname("Int")), Some(int(3))))),
       None,
-      tname("a")
-    ))
+      tname("a"),
+    )),
   )
 
   test("type-multi-seq")(
@@ -593,8 +593,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |  fx
          |  fy
          |""".stripMargin,
-      assertLayout = Some("val refinementTest: Int = {\n  fx\n  fy\n}")
-    )(Defn.Val(Nil, List(patvar("refinementTest")), Some(pname("Int")), blk(tname("fx"), tname("fy"))))
+      assertLayout = Some("val refinementTest: Int = {\n  fx\n  fy\n}"),
+    )(Defn.Val(Nil, List(patvar("refinementTest")), Some(pname("Int")), blk(tname("fx"), tname("fy")))),
   )
 
   test("equals-block")(
@@ -604,8 +604,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |    fx
          |    fy
          |""".stripMargin,
-      assertLayout = Some("val refinementTest: Int = {\n  fx\n  fy\n}")
-    )(Defn.Val(Nil, List(patvar("refinementTest")), Some(pname("Int")), blk(tname("fx"), tname("fy"))))
+      assertLayout = Some("val refinementTest: Int = {\n  fx\n  fy\n}"),
+    )(Defn.Val(Nil, List(patvar("refinementTest")), Some(pname("Int")), blk(tname("fx"), tname("fy")))),
   )
 
   test("given-block-indent") {
@@ -618,8 +618,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
         """|given intOrd: Ord[Int] with {
            |  def fa: Int = 1
            |  def fb: Int = 2
-           |}""".stripMargin
-      )
+           |}""".stripMargin,
+      ),
     )(Defn.Given(
       Nil,
       tname("intOrd"),
@@ -629,9 +629,9 @@ class SignificantIndentationSuite extends BaseDottySuite {
         List(init(papply("Ord", "Int"))),
         List(
           Defn.Def(Nil, tname("fa"), Nil, Nil, Some(pname("Int")), int(1)),
-          Defn.Def(Nil, tname("fb"), Nil, Nil, Some(pname("Int")), int(2))
-        )
-      )
+          Defn.Def(Nil, tname("fb"), Nil, Nil, Some(pname("Int")), int(2)),
+        ),
+      ),
     ))
   }
 
@@ -642,7 +642,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
        |""".stripMargin,
     """|<input>:2: error: `identifier` expected but `def` found
        |def fa: Int = 1
-       |^""".stripMargin
+       |^""".stripMargin,
   ))
 
   test("given-block-indent-edge-cases: coloneol") {
@@ -655,7 +655,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |  def fa: Int = 1
          |  def fb: Int = 2
          |}
-         |""".stripMargin
+         |""".stripMargin,
     )(Defn.Given(
       Nil,
       "intOrd",
@@ -664,9 +664,9 @@ class SignificantIndentationSuite extends BaseDottySuite {
         List(init(papply("Ord", "Int"))),
         List(
           Defn.Def(Nil, "fa", Nil, Some("Int"), lit(1)),
-          Defn.Def(Nil, "fb", Nil, Some("Int"), lit(2))
-        )
-      )
+          Defn.Def(Nil, "fb", Nil, Some("Int"), lit(2)),
+        ),
+      ),
     ))
   }
 
@@ -677,7 +677,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |  def fa: Int = 1
          |  def fb: Int = 2
          |""".stripMargin,
-      "`;` expected but `:` found"
+      "`;` expected but `:` found",
     )
   }
 
@@ -686,8 +686,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
       """|class A extends A with 
          |  B
          |""".stripMargin,
-      assertLayout = Some("class A extends A with B")
-    )(Defn.Class(Nil, pname("A"), Nil, EmptyCtor(), tplNoBody(init("A"), init("B"))))
+      assertLayout = Some("class A extends A with B"),
+    )(Defn.Class(Nil, pname("A"), Nil, EmptyCtor(), tplNoBody(init("A"), init("B")))),
   )
 
   test("nested-coloneol") {
@@ -697,13 +697,13 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |):
          |  def hello = 1
          |""".stripMargin,
-      assertLayout = Some("case class Test(a: A = new A) { def hello = 1 }")
+      assertLayout = Some("case class Test(a: A = new A) { def hello = 1 }"),
     )(Defn.Class(
       List(Mod.Case()),
       pname("Test"),
       Nil,
       ctorp(Term.Param(Nil, tname("a"), Some(pname("A")), Some(Term.New(init("A"))))),
-      tpl(Defn.Def(Nil, tname("hello"), Nil, Nil, None, int(1)))
+      tpl(Defn.Def(Nil, tname("hello"), Nil, Nil, None, int(1))),
     ))
   }
 
@@ -718,14 +718,14 @@ class SignificantIndentationSuite extends BaseDottySuite {
         """|val z = {
            |  val a = 0
            |  f(a)
-           |}""".stripMargin
-      )
+           |}""".stripMargin,
+      ),
     )(Defn.Val(
       Nil,
       List(patvar("z")),
       None,
-      blk(Defn.Val(Nil, List(patvar("a")), None, int(0)), tapply(tname("f"), tname("a")))
-    ))
+      blk(Defn.Val(Nil, List(patvar("a")), None, int(0)), tapply(tname("f"), tname("a"))),
+    )),
   )
 
   test("observe-indented-in-braces") {
@@ -744,7 +744,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
     runTestAssert[Stat](code, assertLayout = Some(output))(Defn.Object(
       Nil,
       tname("X"),
-      tpl(Term.If(tname("cond"), tname("f"), Lit.Unit(), Nil), tname("foo"))
+      tpl(Term.If(tname("cond"), tname("f"), Lit.Unit(), Nil), tname("foo")),
     ))
   }
 
@@ -759,19 +759,19 @@ class SignificantIndentationSuite extends BaseDottySuite {
            |  case (tp @ OrNull(tp1)): OrType =>
            |  case tp => tp
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(tmatch(
       tname("widen"),
       Case(
         Pat.Typed(
           Pat.Bind(patvar("tp"), Pat.Extract(tname("OrNull"), List(patvar("tp1")))),
-          pname("OrType")
+          pname("OrType"),
         ),
         None,
-        blk()
+        blk(),
       ),
-      Case(patvar("tp"), None, tname("tp"))
+      Case(patvar("tp"), None, tname("tp")),
     ))
   }
 
@@ -780,8 +780,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
       """|object typeAndObjects:
          |  type Ala
          |""".stripMargin,
-      assertLayout = Some("object typeAndObjects { type Ala }")
-    )(Defn.Object(Nil, tname("typeAndObjects"), tpl(Decl.Type(Nil, pname("Ala"), Nil, noBounds))))
+      assertLayout = Some("object typeAndObjects { type Ala }"),
+    )(Defn.Object(Nil, tname("typeAndObjects"), tpl(Decl.Type(Nil, pname("Ala"), Nil, noBounds)))),
   )
 
   test("old-try-catch-same-indent") {
@@ -811,7 +811,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
     runTestAssert[Stat](code, assertLayout = Some(output))(Term.Try(
       blk(tname("fx"), tname("gx")),
       List(Case(patvar("aa"), None, blk()), Case(patvar("bb"), None, blk())),
-      Some(blk(tname("cc"), tname("dd")))
+      Some(blk(tname("cc"), tname("dd"))),
     ))
   }
 
@@ -835,7 +835,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |} else gx
          |""".stripMargin
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.If(blk(tname("cond"), tname("cond2")), blk(tname("fx"), tname("gx")), tname("gx"), Nil)
+      Term.If(blk(tname("cond"), tname("cond2")), blk(tname("fx"), tname("gx")), tname("gx"), Nil),
     )
   }
 
@@ -847,7 +847,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |""".stripMargin
     val output = "for (a <- gen) fx"
     runTestAssert[Stat](code, assertLayout = Some(output))(
-      Term.For(List(Enumerator.Generator(patvar("a"), tname("gen"))), tname("fx"))
+      Term.For(List(Enumerator.Generator(patvar("a"), tname("gen"))), tname("fx")),
     )
   }
 
@@ -862,9 +862,9 @@ class SignificantIndentationSuite extends BaseDottySuite {
     runTestAssert[Stat](code, assertLayout = Some(output))(Term.ForYield(
       List(
         Enumerator.Generator(patvar("a"), tname("x")),
-        Enumerator.Generator(patvar("b"), tname("y"))
+        Enumerator.Generator(patvar("b"), tname("y")),
       ),
-      tname("fx")
+      tname("fx"),
     ))
   }
 
@@ -882,9 +882,9 @@ class SignificantIndentationSuite extends BaseDottySuite {
       List(
         Enumerator.Generator(patvar("a"), tname("x")),
         Enumerator.Generator(patvar("b"), tname("y")),
-        Enumerator.Guard(tinfix(tname("a"), "<", tname("b")))
+        Enumerator.Guard(tinfix(tname("a"), "<", tname("b"))),
       ),
-      tname("fx")
+      tname("fx"),
     ))
   }
 
@@ -902,9 +902,9 @@ class SignificantIndentationSuite extends BaseDottySuite {
       List(
         Enumerator.Generator(patvar("a"), tname("x")),
         Enumerator.Generator(patvar("b"), tname("y")),
-        Enumerator.Guard(tinfix(tname("a"), "<", tname("b")))
+        Enumerator.Guard(tinfix(tname("a"), "<", tname("b"))),
       ),
-      tname("fx")
+      tname("fx"),
     ))
   }
 
@@ -927,14 +927,14 @@ class SignificantIndentationSuite extends BaseDottySuite {
           Term.ForYield(
             List(
               Enumerator.Generator(patvar("a"), tapply(tname("List"), int(1))),
-              Enumerator.Generator(patvar("b"), tapply(tname("List"), int(2)))
+              Enumerator.Generator(patvar("b"), tapply(tname("List"), int(2))),
             ),
-            tinfix(tname("a"), "+", tname("b"))
+            tinfix(tname("a"), "+", tname("b")),
           ),
-          "toSet"
+          "toSet",
         ),
-        "size"
-      )
+        "size",
+      ),
     ))
   }
 
@@ -958,8 +958,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
            |      case false => 1
            |    }
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Val(
       Nil,
       List(patvar("hello")),
@@ -970,9 +970,9 @@ class SignificantIndentationSuite extends BaseDottySuite {
         Case(
           patinfix(patvar("x"), "::", patvar("xs1")),
           None,
-          tmatch(str("nonempty"), Case(bool(true), None, int(0)), Case(bool(false), None, int(1)))
-        )
-      )
+          tmatch(str("nonempty"), Case(bool(true), None, int(0)), Case(bool(false), None, int(1))),
+        ),
+      ),
     ))
 
   }
@@ -989,15 +989,15 @@ class SignificantIndentationSuite extends BaseDottySuite {
         """|def hackGetmembers = a match {
            |  case sym if cond => sym
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Def(
       Nil,
       tname("hackGetmembers"),
       Nil,
       Nil,
       None,
-      tmatch(tname("a"), Case(patvar("sym"), Some(tname("cond")), tname("sym")))
+      tmatch(tname("a"), Case(patvar("sym"), Some(tname("cond")), tname("sym"))),
     ))
 
   }
@@ -1017,8 +1017,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
            |    case _ =>
            |  }
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Def(
       Nil,
       tname("mapSymbols"),
@@ -1030,9 +1030,9 @@ class SignificantIndentationSuite extends BaseDottySuite {
         blk(tfunc(tparam("a"))(tmatch(
           tselect("copy", "denot"),
           Case(Pat.Typed(patvar("cd"), pname("ClassDenotation")), None, blk()),
-          Case(patwildcard, None, blk())
-        )))
-      )
+          Case(patwildcard, None, blk()),
+        ))),
+      ),
     ))
 
   }
@@ -1050,15 +1050,15 @@ class SignificantIndentationSuite extends BaseDottySuite {
            |  val a = 2 + 3
            |  a
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Def(
       Nil,
       tname("method"),
       Nil,
       Nil,
       None,
-      Term.Return(blk(Defn.Val(Nil, List(patvar("a")), None, tinfix(int(2), "+", int(3))), tname("a")))
+      Term.Return(blk(Defn.Val(Nil, List(patvar("a")), None, tinfix(int(2), "+", int(3))), tname("a"))),
     ))
   }
 
@@ -1069,8 +1069,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |     2 
          |     + 3
          |""".stripMargin,
-      assertLayout = Some("def method = return 2 + 3")
-    )(Defn.Def(Nil, tname("method"), Nil, Nil, None, Term.Return(tinfix(int(2), "+", int(3)))))
+      assertLayout = Some("def method = return 2 + 3"),
+    )(Defn.Def(Nil, tname("method"), Nil, Nil, None, Term.Return(tinfix(int(2), "+", int(3))))),
   )
 
   test("empty-return") {
@@ -1099,8 +1099,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
            |      change(-1)
            |  }
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Def(
       Nil,
       tname("skip"),
@@ -1114,18 +1114,18 @@ class SignificantIndentationSuite extends BaseDottySuite {
           None,
           blk(
             Term.If(bool(true), Term.Return(Lit.Unit()), Lit.Unit(), Nil),
-            tapply(tname("change"), int(-1))
-          )
+            tapply(tname("change"), int(-1)),
+          ),
         ),
         Case(
           tname("LBRACE"),
           None,
           blk(
             Term.If(bool(true), Term.Return(Lit.Unit()), Lit.Unit(), Nil),
-            tapply(tname("change"), int(-1))
-          )
-        )
-      ))
+            tapply(tname("change"), int(-1)),
+          ),
+        ),
+      )),
     ))
   }
 
@@ -1148,8 +1148,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
            |    case e: StorageException => false
            |  }
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Val(
       Nil,
       List(patvar("success")),
@@ -1159,9 +1159,9 @@ class SignificantIndentationSuite extends BaseDottySuite {
         blk(tfunc(tparam("suffix"))(Term.Try(
           blk(bool(true)),
           Case(Pat.Typed(patvar("e"), pname("StorageException")), None, bool(false)) :: Nil,
-          None
-        )))
-      )
+          None,
+        ))),
+      ),
     ))
   }
 
@@ -1187,8 +1187,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
            |  case _ =>
            |    NoType
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Val(
       Nil,
       List(patvar("calleeType")),
@@ -1202,11 +1202,11 @@ class SignificantIndentationSuite extends BaseDottySuite {
             tname("cond"),
             tmatch(tname("expr"), Case(patwildcard, None, tname("f"))),
             tname("NoType"),
-            Nil
-          )
+            Nil,
+          ),
         ),
-        Case(patwildcard, None, tname("NoType"))
-      )
+        Case(patwildcard, None, tname("NoType")),
+      ),
     ))
   }
 
@@ -1221,16 +1221,16 @@ class SignificantIndentationSuite extends BaseDottySuite {
            |  case Some(x) => x
            |  case None => 0
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Val(
       Nil,
       List(patvar("withDefault")),
       Some(pfunc(papply("Option", "Int"))("Int")),
       Term.PartialFunction(List(
         Case(Pat.Extract(tname("Some"), List(patvar("x"))), None, tname("x")),
-        Case(tname("None"), None, int(0))
-      ))
+        Case(tname("None"), None, int(0)),
+      )),
     ))
   }
 
@@ -1248,14 +1248,14 @@ class SignificantIndentationSuite extends BaseDottySuite {
            |  val b = 123
            |  Some(b)
            |}) yield a
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Term.ForYield(
       List(Enumerator.Generator(
         patvar("a"),
-        blk(Defn.Val(Nil, List(patvar("b")), None, int(123)), tapply(tname("Some"), tname("b")))
+        blk(Defn.Val(Nil, List(patvar("b")), None, int(123)), tapply(tname("Some"), tname("b"))),
       )),
-      tname("a")
+      tname("a"),
     ))
   }
 
@@ -1271,15 +1271,15 @@ class SignificantIndentationSuite extends BaseDottySuite {
            |  val a = 123
            |  s + a
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Val(
       Nil,
       List(patvar("a")),
       None,
       tctxfunc(
-        tparam("s", "Int")
-      )(blk(Defn.Val(Nil, List(patvar("a")), None, int(123)), tinfix(tname("s"), "+", tname("a"))))
+        tparam("s", "Int"),
+      )(blk(Defn.Val(Nil, List(patvar("a")), None, int(123)), tinfix(tname("s"), "+", tname("a")))),
     ))
   }
 
@@ -1289,15 +1289,15 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |  fun(a,b,c)
          |    (d, e)
          |""".stripMargin,
-      assertLayout = Some("def method = fun(a, b, c)(d, e)")
+      assertLayout = Some("def method = fun(a, b, c)(d, e)"),
     )(Defn.Def(
       Nil,
       tname("method"),
       Nil,
       Nil,
       None,
-      tapply(tapply(tname("fun"), tname("a"), tname("b"), tname("c")), tname("d"), tname("e"))
-    ))
+      tapply(tapply(tname("fun"), tname("a"), tname("b"), tname("c")), tname("d"), tname("e")),
+    )),
   )
 
   test("#3531 apply with optional braces and trailing comma") {
@@ -1324,10 +1324,10 @@ class SignificantIndentationSuite extends BaseDottySuite {
         tmatch(
           bool(true),
           Case(bool(true), None, tapply(tname("Some"), int(1))),
-          Case(patwildcard, None, tname("None"))
-        )
+          Case(patwildcard, None, tname("None")),
+        ),
       ),
-      Term.Assign(tname("b"), str("xxx"))
+      Term.Assign(tname("b"), str("xxx")),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1350,9 +1350,9 @@ class SignificantIndentationSuite extends BaseDottySuite {
       tname("A"),
       Term.Assign(
         tname("foo"),
-        tfunc(tparam("x"))(tmatch(tname("x"), Case(patvar("baz"), None, tname("baz"))))
+        tfunc(tparam("x"))(tmatch(tname("x"), Case(patvar("baz"), None, tname("baz")))),
       ),
-      Term.Assign(tname("bar"), tname("bar"))
+      Term.Assign(tname("bar"), tname("bar")),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -1364,7 +1364,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |    (d, e)
          |    (f, g)
          |""".stripMargin,
-      assertLayout = Some("def method = fun(a, b, c)(d, e)(f, g)")
+      assertLayout = Some("def method = fun(a, b, c)(d, e)(f, g)"),
     )(Defn.Def(
       Nil,
       tname("method"),
@@ -1374,9 +1374,9 @@ class SignificantIndentationSuite extends BaseDottySuite {
       tapply(
         tapply(tapply(tname("fun"), tname("a"), tname("b"), tname("c")), tname("d"), tname("e")),
         tname("f"),
-        tname("g")
-      )
-    ))
+        tname("g"),
+      ),
+    )),
   )
 
   test("indented-for") {
@@ -1385,16 +1385,16 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |      (source, id) <- project.sources.zipWithIndex } yield source 
          |""".stripMargin,
       assertLayout =
-        Some("for (project <- projects; (source, id) <- project.sources.zipWithIndex) yield source")
+        Some("for (project <- projects; (source, id) <- project.sources.zipWithIndex) yield source"),
     )(Term.ForYield(
       List(
         Enumerator.Generator(patvar("project"), tname("projects")),
         Enumerator.Generator(
           Pat.Tuple(List(patvar("source"), patvar("id"))),
-          tselect("project", "sources", "zipWithIndex")
-        )
+          tselect("project", "sources", "zipWithIndex"),
+        ),
       ),
-      tname("source")
+      tname("source"),
     ))
   }
 
@@ -1409,8 +1409,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
            |  fun(a, b, c)
            |  (d, e)
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Def(
       Nil,
       tname("method"),
@@ -1419,8 +1419,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
       None,
       blk(
         tapply(tname("fun"), tname("a"), tname("b"), tname("c")),
-        Term.Tuple(List(tname("d"), tname("e")))
-      )
+        Term.Tuple(List(tname("d"), tname("e"))),
+      ),
     ))
   }
 
@@ -1434,15 +1434,15 @@ class SignificantIndentationSuite extends BaseDottySuite {
         """|def method: String = fun(1, 2, 3) {
            |  4
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Def(
       Nil,
       tname("method"),
       Nil,
       Nil,
       Some(pname("String")),
-      tapply(tapply(tname("fun"), int(1), int(2), int(3)), blk(int(4)))
+      tapply(tapply(tname("fun"), int(1), int(2), int(3)), blk(int(4))),
     ))
   }
 
@@ -1459,15 +1459,15 @@ class SignificantIndentationSuite extends BaseDottySuite {
            |    4
            |  }
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Def(
       Nil,
       tname("method2"),
       Nil,
       Nil,
       Some(pname("String")),
-      blk(tapply(tname("fun"), int(1), int(2), int(3)), blk(int(4)))
+      blk(tapply(tname("fun"), int(1), int(2), int(3)), blk(int(4))),
     ))
   }
 
@@ -1483,12 +1483,12 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |""".stripMargin,
       assertLayout = Some(
         """|object ExampleThing extends CompositeThing("One", "Two", "Three", "Four")
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Object(
       Nil,
       tname("ExampleThing"),
-      tplNoBody(init("CompositeThing", List(str("One"), str("Two"), str("Three"), str("Four"))))
+      tplNoBody(init("CompositeThing", List(str("One"), str("Two"), str("Three"), str("Four")))),
     ))
   }
 
@@ -1508,15 +1508,15 @@ class SignificantIndentationSuite extends BaseDottySuite {
            |  object ExampleThing extends CompositeThing
            |  ("One", "Two", "Three", "Four")
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Defn.Object(
       Nil,
       tname("O"),
       tpl(
         Defn.Object(Nil, tname("ExampleThing"), tplNoBody(List(init("CompositeThing")))),
-        Term.Tuple(List(str("One"), str("Two"), str("Three"), str("Four")))
-      )
+        Term.Tuple(List(str("One"), str("Two"), str("Three"), str("Four"))),
+      ),
     ))
   }
 
@@ -1531,7 +1531,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |  case xhtml extends Namespace // Defn.EnumCase ends here
          |    ("http://www.w3.org/1999/xhtml") // str
          |}
-         |""".stripMargin
+         |""".stripMargin,
     )(Defn.Enum(
       Nil,
       pname("Namespace"),
@@ -1544,10 +1544,10 @@ class SignificantIndentationSuite extends BaseDottySuite {
         EmptyCtor(),
         List(init(
           Type.Name.createWithComments("Namespace", endComment = Seq("// Defn.EnumCase ends here")),
-          List(str("http://www.w3.org/1999/xhtml"))
+          List(str("http://www.w3.org/1999/xhtml")),
         )),
-        endComment = Seq("// str")
-      ))
+        endComment = Seq("// str"),
+      )),
     ))
   }
 
@@ -1558,13 +1558,13 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |    (d, e)
          |    (f, g)
          |""".stripMargin,
-      assertLayout = Some("new fun(a, b, c)(d, e)(f, g)")
+      assertLayout = Some("new fun(a, b, c)(d, e)(f, g)"),
     )(Term.New(init(
       pname("fun"),
       List(tname("a"), tname("b"), tname("c")),
       List(tname("d"), tname("e")),
-      List(tname("f"), tname("g"))
-    )))
+      List(tname("f"), tname("g")),
+    ))),
   )
 
   test("then-same-line") {
@@ -1578,7 +1578,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |      println("No")
          |""".stripMargin,
       assertLayout =
-        Some("def f = if (x.exists(x => x == 10)) println(\"Yes\") else println(\"No\")")
+        Some("def f = if (x.exists(x => x == 10)) println(\"Yes\") else println(\"No\")"),
     )(Defn.Def(
       Nil,
       tname("f"),
@@ -1589,8 +1589,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
         tapply(tselect("x", "exists"), tfunc(tparam("x"))(tinfix(tname("x"), "==", int(10)))),
         tapply(tname("println"), str("Yes")),
         tapply(tname("println"), str("No")),
-        Nil
-      )
+        Nil,
+      ),
     ))
   }
 
@@ -1605,7 +1605,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |      println("No")
          |""".stripMargin,
       assertLayout =
-        Some("def f = if (if (a > 0) true else false) println(\"Yes\") else println(\"No\")")
+        Some("def f = if (if (a > 0) true else false) println(\"Yes\") else println(\"No\")"),
     )(Defn.Def(
       Nil,
       tname("f"),
@@ -1615,8 +1615,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
         Term.If(tinfix(tname("a"), ">", int(0)), bool(true), bool(false), Nil),
         tapply(tname("println"), str("Yes")),
         tapply(tname("println"), str("No")),
-        Nil
-      )
+        Nil,
+      ),
     ))
   }
 
@@ -1635,17 +1635,17 @@ class SignificantIndentationSuite extends BaseDottySuite {
            |  class SomeOtherPackage
            |}
            |class BrokenLink
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Source(List(Pkg(
       tselect("tests", "site"),
       List(
         Pkg(
           tselect("some", "other"),
-          List(Defn.Class(Nil, pname("SomeOtherPackage"), Nil, ctor, tplNoBody()))
+          List(Defn.Class(Nil, pname("SomeOtherPackage"), Nil, ctor, tplNoBody())),
         ),
-        Defn.Class(Nil, pname("BrokenLink"), Nil, ctor, tplNoBody())
-      )
+        Defn.Class(Nil, pname("BrokenLink"), Nil, ctor, tplNoBody()),
+      ),
     ))))
   }
 
@@ -1657,7 +1657,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |      case _ =>
          |  end abc
          |""".stripMargin,
-      assertLayout = None
+      assertLayout = None,
     )(Source(List(
       Defn.Def(
         Nil,
@@ -1665,10 +1665,10 @@ class SignificantIndentationSuite extends BaseDottySuite {
         Nil,
         Nil,
         Some(pname("Unit")),
-        tmatch(tname("x"), Case(patwildcard, None, blk()))
+        tmatch(tname("x"), Case(patwildcard, None, blk())),
       ),
-      Term.EndMarker(tname("abc"))
-    )))
+      Term.EndMarker(tname("abc")),
+    ))),
   )
 
   test("infix-operator-with-alpha") {
@@ -1678,14 +1678,14 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |    ! "world"
          |    send_! "!"
          |""".stripMargin,
-      assertLayout = Some("""def send() = c ! "hello" ! "world" send_! "!"""")
+      assertLayout = Some("""def send() = c ! "hello" ! "world" send_! "!""""),
     )(Defn.Def(
       Nil,
       tname("send"),
       Nil,
       List(List()),
       None,
-      tinfix(tinfix(tinfix(tname("c"), "!", str("hello")), "!", str("world")), "send_!", str("!"))
+      tinfix(tinfix(tinfix(tname("c"), "!", str("hello")), "!", str("world")), "send_!", str("!")),
     ))
   }
 
@@ -1695,7 +1695,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |  /*inline*/ def foo: Int = ???
          |  def bar: Int = ???
          |""".stripMargin,
-      assertLayout = None
+      assertLayout = None,
     )(Defn.Object(
       Nil,
       tname("Foo"),
@@ -1708,10 +1708,10 @@ class SignificantIndentationSuite extends BaseDottySuite {
           Some(pname("Int")),
           tname("???"),
           begComment = Seq("/*inline*/"),
-          endComment = None
+          endComment = None,
         ),
-        Defn.Def(Nil, tname("bar"), Nil, Nil, Some(pname("Int")), tname("???"))
-      )
+        Defn.Def(Nil, tname("bar"), Nil, Nil, Some(pname("Int")), tname("???")),
+      ),
     ))
   }
 
@@ -1720,7 +1720,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
       """|object Foo: /* comment*/
          |  def foo: Int = ???
          |""".stripMargin,
-      assertLayout = None
+      assertLayout = None,
     )(Defn.Object(
       Nil,
       tname("Foo"),
@@ -1732,9 +1732,9 @@ class SignificantIndentationSuite extends BaseDottySuite {
         Some(pname("Int")),
         tname("???"),
         begComment = Seq("/* comment*/"),
-        endComment = None
-      ))
-    ))
+        endComment = None,
+      )),
+    )),
   )
 
   test("colon-eol-multiline-comment") {
@@ -1744,7 +1744,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |   comment */ def foo: Int = ???
          |   def bar: Int = ???
          |""".stripMargin,
-      assertLayout = None
+      assertLayout = None,
     )(Defn.Object(
       Nil,
       tname("Foo"),
@@ -1757,10 +1757,10 @@ class SignificantIndentationSuite extends BaseDottySuite {
           Some(pname("Int")),
           tname("???"),
           begComment = Seq("/* multi\n  line\n   comment */"),
-          endComment = None
+          endComment = None,
         ),
-        Defn.Def(Nil, tname("bar"), Nil, Nil, Some(pname("Int")), tname("???"))
-      )
+        Defn.Def(Nil, tname("bar"), Nil, Nil, Some(pname("Int")), tname("???")),
+      ),
     ))
   }
 
@@ -1770,7 +1770,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |   /* comment */  def foo: Int = ???
          |   def bar: Int = ???
          |""".stripMargin,
-      assertLayout = None
+      assertLayout = None,
     )(Defn.Given(
       Nil,
       anon,
@@ -1789,12 +1789,12 @@ class SignificantIndentationSuite extends BaseDottySuite {
               Some(pname("Int")),
               tname("???"),
               begComment = Seq("/* comment */"),
-              endComment = None
+              endComment = None,
             ),
-            Defn.Def(Nil, tname("bar"), Nil, Nil, Some(pname("Int")), tname("???"))
-          )
-        )
-      )
+            Defn.Def(Nil, tname("bar"), Nil, Nil, Some(pname("Int")), tname("???")),
+          ),
+        ),
+      ),
     ))
   }
 
@@ -1805,7 +1805,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |   comment */  def foo: Int = ???
          |   def bar: Int = ???
          |""".stripMargin,
-      assertLayout = None
+      assertLayout = None,
     )(Defn.Given(
       Nil,
       anon,
@@ -1824,12 +1824,12 @@ class SignificantIndentationSuite extends BaseDottySuite {
               Some(pname("Int")),
               tname("???"),
               begComment = Seq("/* multi\n   line\n   comment */"),
-              endComment = None
+              endComment = None,
             ),
-            Defn.Def(Nil, tname("bar"), Nil, Nil, Some(pname("Int")), tname("???"))
-          )
-        )
-      )
+            Defn.Def(Nil, tname("bar"), Nil, Nil, Some(pname("Int")), tname("???")),
+          ),
+        ),
+      ),
     ))
   }
 
@@ -1845,7 +1845,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
           | @A2
           |class B
           |""".stripMargin,
-      assertLayout = None
+      assertLayout = None,
     ) {
       Source {
         List(
@@ -1855,8 +1855,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
             Nil,
             EmptyCtor(),
             tplNoBody(
-              init(Type.Select(tselect("scala", "annotation"), pname("StaticAnnotation"))) :: Nil
-            )
+              init(Type.Select(tselect("scala", "annotation"), pname("StaticAnnotation"))) :: Nil,
+            ),
           ),
           Defn.Class(
             Nil,
@@ -1864,19 +1864,19 @@ class SignificantIndentationSuite extends BaseDottySuite {
             Nil,
             EmptyCtor(),
             tplNoBody(
-              init(Type.Select(tselect("scala", "annotation"), pname("StaticAnnotation"))) :: Nil
-            )
+              init(Type.Select(tselect("scala", "annotation"), pname("StaticAnnotation"))) :: Nil,
+            ),
           ),
           Defn.Class(
             List(
               Mod.Annot(init("A1")),
-              Mod.Annot.createWithComments(init("A2"), begComment = Seq("/*\n * hello\n */"))
+              Mod.Annot.createWithComments(init("A2"), begComment = Seq("/*\n * hello\n */")),
             ),
             pname("B"),
             Nil,
             EmptyCtor(),
-            tplNoBody()
-          )
+            tplNoBody(),
+          ),
         )
       }
     }
@@ -1895,8 +1895,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
            |  enum T2Enum { case EnumCase }
            |  extension (n: Int) def negate: Int = -n
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Source(List(Defn.Trait(
       Nil,
       pname("T2"),
@@ -1909,7 +1909,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
           pname("T2Enum"),
           Nil,
           EmptyCtor(),
-          tpl(Defn.EnumCase(Nil, tname("EnumCase"), Nil, EmptyCtor(), Nil))
+          tpl(Defn.EnumCase(Nil, tname("EnumCase"), Nil, EmptyCtor(), Nil)),
         ),
         Defn.ExtensionGroup(
           Nil,
@@ -1920,10 +1920,10 @@ class SignificantIndentationSuite extends BaseDottySuite {
             Nil,
             Nil,
             Some(pname("Int")),
-            Term.ApplyUnary(tname("-"), tname("n"))
-          )
-        )
-      )
+            Term.ApplyUnary(tname("-"), tname("n")),
+          ),
+        ),
+      ),
     ))))
 
   }
@@ -1947,8 +1947,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
            |  }
            |  def main(args: Array[String]): Unit = fun()
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(Source(
       Defn.Object(
         Nil,
@@ -1961,11 +1961,11 @@ class SignificantIndentationSuite extends BaseDottySuite {
             tfunc()(Term.If(
               bool(true),
               blk(Term.NewAnonymous(
-                tpl(List(init("Object")), self("obj"), tapply(tname("println"), tname("toString")))
+                tpl(List(init("Object")), self("obj"), tapply(tname("println"), tname("toString"))),
               )),
               Lit.Unit(),
-              Nil
-            ))
+              Nil,
+            )),
           ),
           Defn.Def(
             Nil,
@@ -1973,10 +1973,10 @@ class SignificantIndentationSuite extends BaseDottySuite {
             Nil,
             List(List(tparam("args", papply("Array", "String")))),
             Some(pname("Unit")),
-            tapply(tname("fun"))
-          )
-        )
-      ) :: Nil
+            tapply(tname("fun")),
+          ),
+        ),
+      ) :: Nil,
     ))
   }
 
@@ -2000,9 +2000,9 @@ class SignificantIndentationSuite extends BaseDottySuite {
           pname("T2Enum"),
           Nil,
           ctor,
-          tpl(Defn.EnumCase(Nil, tname("EnumCase"), Nil, ctor, Nil))
-        )
-      )
+          tpl(Defn.EnumCase(Nil, tname("EnumCase"), Nil, ctor, Nil)),
+        ),
+      ),
     )
     runTestAssert[Stat](
       """|trait T2 {
@@ -2011,7 +2011,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |  enum T2Enum:
          |    case EnumCase
          |}""".stripMargin,
-      assertLayout = Some(layout)
+      assertLayout = Some(layout),
     )(tree)
     runTestAssert[Stat](
       """|trait T2:
@@ -2021,7 +2021,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
          |  enum T2Enum:
          |    case EnumCase
          |""".stripMargin,
-      assertLayout = Some(layout)
+      assertLayout = Some(layout),
     )(tree)
   }
 
@@ -2048,9 +2048,9 @@ class SignificantIndentationSuite extends BaseDottySuite {
         None,
         blk(
           Defn.Class(List(Mod.Case()), pname("A6"), Nil, ctorp(tparam("a7", "A8")), tplNoBody()),
-          Defn.Object(Nil, tname("A9"), tplNoBody())
-        )
-      )
+          Defn.Object(Nil, tname("A9"), tplNoBody()),
+        ),
+      ),
     )
     runTestAssert[Stat](code, assertLayout = Some(layout))(tree)
   }
@@ -2080,10 +2080,10 @@ class SignificantIndentationSuite extends BaseDottySuite {
           tname("foo"),
           Nil,
           Some(pname("Bar")),
-          Term.PartialFunction(List(Case(patvar("sym"), Some(tname("baz")), blk())))
+          Term.PartialFunction(List(Case(patvar("sym"), Some(tname("baz")), blk()))),
         ),
-        Term.EndMarker(tname("foo"))
-      )
+        Term.EndMarker(tname("foo")),
+      ),
     ))
   }
 
@@ -2109,7 +2109,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
         .PartialFunction(List(Case(Pat.Typed(patvar("msg1"), "Int"), None, tinfix("msg1", "+", lit(1))))),
       Term
         .PartialFunction(List(Case(Pat.Typed(patvar("msg2"), "Int"), None, tinfix("msg2", "+", lit(2))))),
-      Nil
+      Nil,
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2139,9 +2139,9 @@ class SignificantIndentationSuite extends BaseDottySuite {
         Some(pname("Bar")),
         blk(
           Defn.Class(List(Mod.Case()), pname("Baz"), Nil, ctorp(tparam("baz", "Int")), tplNoBody()),
-          Term.New(init("Baz", List(int(0))))
-        )
-      ))
+          Term.New(init("Baz", List(int(0)))),
+        ),
+      )),
     ))
   }
 
@@ -2163,8 +2163,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
         tname("A"),
         Term.Assign(tname("b"), Term.New(init("B"))),
         Term.Assign(tname("c"), tname("d")),
-        Term.Assign(tname("e"), tname("f"))
-      ))
+        Term.Assign(tname("e"), tname("f")),
+      )),
     ))
   }
 
@@ -2186,8 +2186,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
         tname("A"),
         Term.Assign(tname("b"), Term.New(init("B", List(int(0))))),
         Term.Assign(tname("c"), tname("d")),
-        Term.Assign(tname("e"), tname("f"))
-      ))
+        Term.Assign(tname("e"), tname("f")),
+      )),
     ))
   }
 
@@ -2211,12 +2211,12 @@ class SignificantIndentationSuite extends BaseDottySuite {
           tname("b"),
           Term.NewAnonymous(tpl(
             List(init("B", List(int(0)))),
-            List(Defn.Def(Nil, tname("foo"), Nil, None, tname("???")))
-          ))
+            List(Defn.Def(Nil, tname("foo"), Nil, None, tname("???"))),
+          )),
         ),
         Term.Assign(tname("c"), tname("d")),
-        Term.Assign(tname("e"), tname("f"))
-      ))
+        Term.Assign(tname("e"), tname("f")),
+      )),
     ))
   }
 
@@ -2236,8 +2236,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
       tpl(tapply(
         tname("A"),
         Term.Assign(tname("b"), Term.New(init("B"))),
-        Term.Assign(tname("c"), tname("d"))
-      ))
+        Term.Assign(tname("c"), tname("d")),
+      )),
     ))
   }
 
@@ -2258,10 +2258,10 @@ class SignificantIndentationSuite extends BaseDottySuite {
         tname("A"),
         Term.Assign(
           tname("b"),
-          Term.If(tinfix(tname("a"), "+", tname("b")), tname("c"), Lit.Unit(), Nil)
+          Term.If(tinfix(tname("a"), "+", tname("b")), tname("c"), Lit.Unit(), Nil),
         ),
-        Term.Assign(tname("c"), tname("d"))
-      ))
+        Term.Assign(tname("c"), tname("d")),
+      )),
     ))
   }
 
@@ -2298,12 +2298,12 @@ class SignificantIndentationSuite extends BaseDottySuite {
           tmatch(
             tname("Nil"),
             Case(tname("Nil"), None, str("empty")),
-            Case(patwildcard, None, str("nonempty"))
+            Case(patwildcard, None, str("nonempty")),
           ),
           Case(str("empty"), None, int(0)),
-          Case(str("nonempty"), None, int(1))
-        )
-      ))
+          Case(str("nonempty"), None, int(1)),
+        ),
+      )),
     ))
   }
 
@@ -2346,13 +2346,13 @@ class SignificantIndentationSuite extends BaseDottySuite {
             tmatch(
               tname("Nil"),
               Case(tname("Nil"), None, str("empty")),
-              Case(patwildcard, None, str("nonempty"))
-            )
+              Case(patwildcard, None, str("nonempty")),
+            ),
           ),
           Case(str("empty"), None, int(0)),
-          Case(str("nonempty"), None, int(1))
-        )
-      ))
+          Case(str("nonempty"), None, int(1)),
+        ),
+      )),
     ))
   }
 
@@ -2388,15 +2388,15 @@ class SignificantIndentationSuite extends BaseDottySuite {
           tmatch(
             tname("Nil"),
             Case(tname("Nil"), None, str("empty")),
-            Case(patwildcard, None, str("nonempty"))
+            Case(patwildcard, None, str("nonempty")),
           ),
           Case(str("empty"), None, bool(true)),
-          Case(str("nonempty"), None, bool(false))
+          Case(str("nonempty"), None, bool(false)),
         ),
         tname("bar"),
         Lit.Unit(),
-        Nil
-      ))
+        Nil,
+      )),
     ))
   }
 
@@ -2438,16 +2438,16 @@ class SignificantIndentationSuite extends BaseDottySuite {
             tmatch(
               tname("Nil"),
               Case(tname("Nil"), None, str("empty")),
-              Case(patwildcard, None, str("nonempty"))
-            )
+              Case(patwildcard, None, str("nonempty")),
+            ),
           ),
           Case(str("empty"), None, bool(true)),
-          Case(str("nonempty"), None, bool(false))
+          Case(str("nonempty"), None, bool(false)),
         ),
         tname("bar"),
         Lit.Unit(),
-        Nil
-      ))
+        Nil,
+      )),
     ))
   }
 
@@ -2486,14 +2486,14 @@ class SignificantIndentationSuite extends BaseDottySuite {
           tmatch(
             tname("Nil"),
             Case(tname("Nil"), None, str("empty")),
-            Case(patwildcard, None, str("nonempty"))
+            Case(patwildcard, None, str("nonempty")),
           ),
           Case(str("empty"), None, int(0)),
-          Case(str("nonempty"), None, int(1))
+          Case(str("nonempty"), None, int(1)),
         ),
         Case(patvar("e"), None, tapply(tselect("e", "getMessage"))) :: Nil,
-        None
-      ))
+        None,
+      )),
     ))
   }
 
@@ -2538,15 +2538,15 @@ class SignificantIndentationSuite extends BaseDottySuite {
             tmatch(
               tname("Nil"),
               Case(tname("Nil"), None, str("empty")),
-              Case(patwildcard, None, str("nonempty"))
-            )
+              Case(patwildcard, None, str("nonempty")),
+            ),
           ),
           Case(str("empty"), None, int(0)),
-          Case(str("nonempty"), None, int(1))
+          Case(str("nonempty"), None, int(1)),
         ),
         Case(patvar("e"), None, tapply(tselect("e", "getMessage"))) :: Nil,
-        None
-      ))
+        None,
+      )),
     ))
   }
 
@@ -2575,11 +2575,11 @@ class SignificantIndentationSuite extends BaseDottySuite {
       tname("small"),
       tpl(Term.Try(
         Term.PartialFunction(
-          List(Case(tname("Nil"), None, str("empty")), Case(patwildcard, None, str("nonempty")))
+          List(Case(tname("Nil"), None, str("empty")), Case(patwildcard, None, str("nonempty"))),
         ),
         Case(patvar("e"), None, tapply(tselect("e", "getMessage"))) :: Nil,
-        None
-      ))
+        None,
+      )),
     ))
   }
 
@@ -2617,8 +2617,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
       tpl(
         Defn.Class(List(Mod.Case()), pname("Foo"), Nil, ctorp(Nil), tplNoBody()),
         blk(tapplytype(tname("deriveEncoder"), pname("Foo"))),
-        blk(tapplytype(tname("deriveEncoder"), pname("Foo")))
-      )
+        blk(tapplytype(tname("deriveEncoder"), pname("Foo"))),
+      ),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -2657,8 +2657,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
       tpl(
         Defn.Class(List(Mod.Case()), pname("Foo"), Nil, ctorp(), tplNoBody(init("Bar"))),
         blk(tapplytype(tname("deriveEncoder"), pname("Foo"))),
-        blk(tapplytype(tname("deriveEncoder"), pname("Foo")))
-      )
+        blk(tapplytype(tname("deriveEncoder"), pname("Foo"))),
+      ),
     )
     runTestAssert[Stat](code, Some(layout))(tree)
   }
@@ -2743,7 +2743,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
       """|new A { def b: C = ??? }
          |""".stripMargin
     val tree = Term.NewAnonymous(
-      tpl(List(init("A")), List(Defn.Def(Nil, tname("b"), Nil, Some(pname("C")), tname("???"))))
+      tpl(List(init("A")), List(Defn.Def(Nil, tname("b"), Nil, Some(pname("C")), tname("???")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2760,7 +2760,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
       """|new A { def b: C = ??? }
          |""".stripMargin
     val tree = Term.NewAnonymous(
-      tpl(List(init("A")), List(Defn.Def(Nil, tname("b"), Nil, Some(pname("C")), tname("???"))))
+      tpl(List(init("A")), List(Defn.Def(Nil, tname("b"), Nil, Some(pname("C")), tname("???")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2803,7 +2803,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
     val tree = Defn.Object(
       Nil,
       tname("A"),
-      tpl(tapply(tselect("foo", "map"), blk(tinfix(tname("bar"), "+", tname("baz")))))
+      tpl(tapply(tselect("foo", "map"), blk(tinfix(tname("bar"), "+", tname("baz"))))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2825,7 +2825,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
     val tree = Defn.Object(
       Nil,
       tname("A"),
-      tpl(tinfix(tapply(tselect("foo", "map"), blk(tname("bar"))), "+", tname("baz")))
+      tpl(tinfix(tapply(tselect("foo", "map"), blk(tname("bar"))), "+", tname("baz"))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2851,8 +2851,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
       tpl(tinfix(
         tmatch(tname("foo"), Case(patvar("bar"), None, tinfix(tname("bar"), "*", tname("bar")))),
         "+",
-        tname("baz")
-      ))
+        tname("baz"),
+      )),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2875,10 +2875,10 @@ class SignificantIndentationSuite extends BaseDottySuite {
       tpl(Term.ForYield(
         List(
           Enumerator.Generator(patvar("a"), tname("foo")),
-          Enumerator.Generator(patvar("b"), tname("bar"))
+          Enumerator.Generator(patvar("b"), tname("bar")),
         ),
-        tinfix(tname("a"), "+", tname("b"))
-      ))
+        tinfix(tname("a"), "+", tname("b")),
+      )),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2902,10 +2902,10 @@ class SignificantIndentationSuite extends BaseDottySuite {
       tpl(Term.ForYield(
         List(
           Enumerator.Generator(patvar("a"), tname("foo")),
-          Enumerator.Generator(patvar("b"), tname("bar"))
+          Enumerator.Generator(patvar("b"), tname("bar")),
         ),
-        tinfix(tname("a"), "+", tname("b"))
-      ))
+        tinfix(tname("a"), "+", tname("b")),
+      )),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2929,10 +2929,10 @@ class SignificantIndentationSuite extends BaseDottySuite {
       tpl(Term.ForYield(
         List(
           Enumerator.Generator(patvar("a"), tname("foo")),
-          Enumerator.Generator(patvar("b"), tname("bar"))
+          Enumerator.Generator(patvar("b"), tname("bar")),
         ),
-        tinfix(tname("a"), "+", tname("b"))
-      ))
+        tinfix(tname("a"), "+", tname("b")),
+      )),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -2970,7 +2970,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
     val tree = Defn.Object(
       Nil,
       tname("A"),
-      tpl(Term.While(tinfix(tname("a"), "<", tname("b")), tinfix(tname("a"), "+", tname("b"))))
+      tpl(Term.While(tinfix(tname("a"), "<", tname("b")), tinfix(tname("a"), "+", tname("b")))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -3000,10 +3000,10 @@ class SignificantIndentationSuite extends BaseDottySuite {
           List(patvar("baz")),
           None,
           Term.If(tname("qux"), tname("quux"), tname("fred"), Nil),
-          endComment = Seq("// not very, but a somewhat long comment")
+          endComment = Seq("// not very, but a somewhat long comment"),
         ),
-        Term.Tuple(List(tname("baz"), Lit.Null()))
-      )
+        Term.Tuple(List(tname("baz"), Lit.Null())),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -3038,11 +3038,11 @@ class SignificantIndentationSuite extends BaseDottySuite {
           Nil,
           Nil,
           None,
-          tmatch(tselect("bar", "baz"), Case(patvar("none"), None, lit(false)))
+          tmatch(tselect("bar", "baz"), Case(patvar("none"), None, lit(false))),
         ),
         Defn.Class(Nil, pname("Qux"), Nil, ctor, tpl(Nil, tplBody("self"))),
-        Term.EndMarker("Qux")
-      )
+        Term.EndMarker("Qux"),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -3071,8 +3071,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
       Some("Int"),
       tapply(
         "c",
-        blk(tfunc(tparam("D"))(tfunc(tparam("e"))(blk(Defn.Def(Nil, "f", Nil, None, "e"), "f"))))
-      )
+        blk(tfunc(tparam("D"))(tfunc(tparam("e"))(blk(Defn.Def(Nil, "f", Nil, None, "e"), "f")))),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -3101,8 +3101,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
       Some("Int"),
       tapply(
         "c",
-        blk(tpolyfunc(pparam("D"))(tfunc(tparam("e"))(blk(Defn.Def(Nil, "f", Nil, None, "e"), "f"))))
-      )
+        blk(tpolyfunc(pparam("D"))(tfunc(tparam("e"))(blk(Defn.Def(Nil, "f", Nil, None, "e"), "f")))),
+      ),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -3126,8 +3126,8 @@ class SignificantIndentationSuite extends BaseDottySuite {
       Term.PartialFunction(List(Case(
         Pat.Tuple(List(patvar("x"), patvar("y"))),
         None,
-        Term.PartialFunction(List(Case(lit("abc"), None, lit())))
-      )))
+        Term.PartialFunction(List(Case(lit("abc"), None, lit()))),
+      ))),
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -3178,7 +3178,7 @@ class SignificantIndentationSuite extends BaseDottySuite {
     val tree = tapply(
       "transformAfter",
       "phase",
-      tfunc(tparam("sd"))(blk(tapply(tselect("sd", "setFlag"), "flags"), "sd"))
+      tfunc(tparam("sd"))(blk(tapply(tselect("sd", "setFlag"), "flags"), "sd")),
     )
     runTestAssert[Stat](code, layout)(tree)
   }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TemplateSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TemplateSuite.scala
@@ -32,11 +32,11 @@ class TemplateSuite extends BaseDottySuite {
         List(Init(
           Type.Apply(Type.Name("F"), Type.ArgClause(List(Type.Name("Int")))),
           Name.Anonymous(),
-          Seq.empty[Term.ArgClause]
+          Seq.empty[Term.ArgClause],
         )),
         Template.Body(None, Nil),
-        Nil
-      )
+        Nil,
+      ),
     )
     checkStat(code, "trait B extends F[Int]")(tree)
     checkStat(code2, "trait B extends F[Int]")(tree)

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/TypeSuite.scala
@@ -22,14 +22,14 @@ class TypeSuite extends BaseDottySuite {
         """|type A = AnyRef {
            |  type T >: Null
            |}
-           |""".stripMargin
+           |""".stripMargin,
     )(Defn.Type(
       Nil,
       pname("A"),
       Nil,
       Type.Refine(Some(pname("AnyRef")), List(Decl.Type(Nil, pname("T"), Nil, loBound("Null")))),
-      noBounds
-    ))
+      noBounds,
+    )),
   )
 
   test("with-type2") {
@@ -41,16 +41,16 @@ class TypeSuite extends BaseDottySuite {
         """|type A = AnyRef with Product {
            |  type T >: Null
            |}
-           |""".stripMargin
+           |""".stripMargin,
     )(Defn.Type(
       Nil,
       pname("A"),
       Nil,
       Type.Refine(
         Some(Type.With(pname("AnyRef"), pname("Product"))),
-        List(Decl.Type(Nil, pname("T"), Nil, loBound("Null")))
+        List(Decl.Type(Nil, pname("T"), Nil, loBound("Null"))),
       ),
-      noBounds
+      noBounds,
     ))
   }
 
@@ -67,7 +67,7 @@ class TypeSuite extends BaseDottySuite {
            |    type D <: Product
            |  }
            |}
-           |""".stripMargin
+           |""".stripMargin,
     )(Defn.Type(
       Nil,
       pname("A"),
@@ -79,11 +79,11 @@ class TypeSuite extends BaseDottySuite {
           pname("T"),
           Nil,
           bounds(lo =
-            Type.Refine(Some(pname("Null")), List(Decl.Type(Nil, pname("D"), Nil, hiBound("Product"))))
-          )
-        ))
+            Type.Refine(Some(pname("Null")), List(Decl.Type(Nil, pname("D"), Nil, hiBound("Product")))),
+          ),
+        )),
       ),
-      noBounds
+      noBounds,
     ))
   }
 
@@ -99,7 +99,7 @@ class TypeSuite extends BaseDottySuite {
            |    type D <: Product
            |  }
            |}
-           |""".stripMargin
+           |""".stripMargin,
     )(Defn.Type(
       Nil,
       pname("A"),
@@ -111,11 +111,11 @@ class TypeSuite extends BaseDottySuite {
           pname("T"),
           Nil,
           bounds(lo =
-            Type.Refine(Some(pname("Null")), List(Decl.Type(Nil, pname("D"), Nil, hiBound("Product"))))
-          )
-        ))
+            Type.Refine(Some(pname("Null")), List(Decl.Type(Nil, pname("D"), Nil, hiBound("Product")))),
+          ),
+        )),
       ),
-      noBounds
+      noBounds,
     ))
   }
 
@@ -127,7 +127,7 @@ class TypeSuite extends BaseDottySuite {
        |""".stripMargin,
     """|<input>:3: error: illegal start of definition `with`
        | with
-       | ^""".stripMargin
+       | ^""".stripMargin,
   ))
 
   test("with-indent-error")(
@@ -136,8 +136,8 @@ class TypeSuite extends BaseDottySuite {
       """|type A = Product
          |  type T>: Null
          |""".stripMargin,
-      assertLayout = Some("type A = Product")
-    )(Defn.Type(Nil, pname("A"), Nil, pname("Product"), noBounds))
+      assertLayout = Some("type A = Product"),
+    )(Defn.Type(Nil, pname("A"), Nil, pname("Product"), noBounds)),
   )
 
   test("with-followed-by-brace-indent") {
@@ -154,7 +154,7 @@ class TypeSuite extends BaseDottySuite {
            |    type T >: Int
            |  }
            |}
-           |""".stripMargin
+           |""".stripMargin,
     )(Defn.Type(
       Nil,
       pname("AA"),
@@ -167,11 +167,11 @@ class TypeSuite extends BaseDottySuite {
           Nil,
           loBound(Type.Refine(
             Some(pname("Null")),
-            Decl.Type(Nil, pname("T"), Nil, loBound(pname("Int"))) :: Nil
-          ))
-        ) :: Nil
+            Decl.Type(Nil, pname("T"), Nil, loBound(pname("Int"))) :: Nil,
+          )),
+        ) :: Nil,
       ),
-      noBounds
+      noBounds,
     ))
   }
 
@@ -187,7 +187,7 @@ class TypeSuite extends BaseDottySuite {
            |    type T >: Int
            |  }
            |}
-           |""".stripMargin
+           |""".stripMargin,
     )(Defn.Type(
       Nil,
       pname("AA"),
@@ -199,11 +199,11 @@ class TypeSuite extends BaseDottySuite {
           pname("T"),
           Nil,
           bounds(lo =
-            Type.Refine(Some(pname("Null")), List(Decl.Type(Nil, pname("T"), Nil, loBound("Int"))))
-          )
-        ))
+            Type.Refine(Some(pname("Null")), List(Decl.Type(Nil, pname("T"), Nil, loBound("Int")))),
+          ),
+        )),
       ),
-      noBounds
+      noBounds,
     ))
   }
 
@@ -226,8 +226,8 @@ class TypeSuite extends BaseDottySuite {
            |    type T >: Int
            |  }
            |}
-           |""".stripMargin
-      )
+           |""".stripMargin,
+      ),
     )(blk(
       Defn.Type(
         Nil,
@@ -235,11 +235,11 @@ class TypeSuite extends BaseDottySuite {
         Nil,
         Type.Refine(
           Some(Type.With(pname("String"), pname("Int"))),
-          Decl.Type(Nil, pname("T"), Nil, loBound("Null")) :: Nil
+          Decl.Type(Nil, pname("T"), Nil, loBound("Null")) :: Nil,
         ),
-        noBounds
+        noBounds,
       ),
-      blk(Decl.Type(Nil, pname("T"), Nil, loBound("Int")))
+      blk(Decl.Type(Nil, pname("T"), Nil, loBound("Int"))),
     ))
   }
 
@@ -258,7 +258,7 @@ class TypeSuite extends BaseDottySuite {
   test("A + B * C")(assertTpe("A + B * C")(pinfix("A", "+", pinfix("B", "*", pname("C")))))
 
   test("A * B + C / D")(
-    assertTpe("A * B + C / D")(pinfix(pinfix("A", "*", pname("B")), "+", pinfix("C", "/", pname("D"))))
+    assertTpe("A * B + C / D")(pinfix(pinfix("A", "*", pname("B")), "+", pinfix("C", "/", pname("D")))),
   )
 
   test("f.T")(assertTpe("f.T")(pselect("f", "T")))
@@ -272,7 +272,7 @@ class TypeSuite extends BaseDottySuite {
   test("(A, B)")(assertTpe("(A, B)")(Tuple(TypeName("A") :: TypeName("B") :: Nil)))
 
   test("(A, B) => C")(
-    assertTpe("(A, B) => C")(Function(TypeName("A") :: TypeName("B") :: Nil, TypeName("C")))
+    assertTpe("(A, B) => C")(Function(TypeName("A") :: TypeName("B") :: Nil, TypeName("C"))),
   )
 
   test("T @foo")(assertTpe("T @foo")(Annotate(TypeName("T"), Mod.Annot(init("foo")) :: Nil)))
@@ -280,7 +280,7 @@ class TypeSuite extends BaseDottySuite {
   test("A with B")(assertTpe("A with B")(With(TypeName("A"), TypeName("B"))))
 
   test("A & B is not a special type")(
-    assertTpe("A & B")(ApplyInfix(TypeName("A"), TypeName("&"), TypeName("B")))
+    assertTpe("A & B")(ApplyInfix(TypeName("A"), TypeName("&"), TypeName("B"))),
   )
 
   test("A with B {}")(assertTpe("A with B {}")(Refine(Some(With(TypeName("A"), TypeName("B"))), Nil)))
@@ -291,7 +291,7 @@ class TypeSuite extends BaseDottySuite {
     Some(TypeName("A")),
     Decl.Def(Nil, TermName("x"), Nil, Nil, TypeName("Int")) ::
       Decl.Val(Nil, List(patvar("y")), TypeName("B")) ::
-      Decl.Type(Nil, TypeName("C"), Nil, noBounds) :: Nil
+      Decl.Type(Nil, TypeName("C"), Nil, noBounds) :: Nil,
   )))
 
   test("F[_ >: lo <: hi]") {
@@ -328,19 +328,19 @@ class TypeSuite extends BaseDottySuite {
     assertTpe("F[_]")(AnonymousLambda(Apply(TypeName("F"), List(AnonymousParam(None)))))
     assertTpe("F[+_]")(AnonymousLambda(Apply(TypeName("F"), List(AnonymousParam(Some(Mod.Covariant()))))))
     assertTpe("F[-_]")(AnonymousLambda(
-      Apply(TypeName("F"), List(AnonymousParam(Some(Mod.Contravariant()))))
+      Apply(TypeName("F"), List(AnonymousParam(Some(Mod.Contravariant())))),
     ))
     runTestError[Stat](
       "F[`+`_]",
       """|<input>:1: error: `]` expected but `_` found
          |F[`+`_]
-         |     ^""".stripMargin
+         |     ^""".stripMargin,
     )
     runTestError[Stat](
       "F[`-`_]",
       """|<input>:1: error: `]` expected but `_` found
          |F[`-`_]
-         |     ^""".stripMargin
+         |     ^""".stripMargin,
     )
   }
 
@@ -350,7 +350,7 @@ class TypeSuite extends BaseDottySuite {
     assertTpe("F[*]")(AnonymousLambda(Apply(TypeName("F"), List(AnonymousParam(None)))))
     assertTpe("F[+*]")(AnonymousLambda(Apply(TypeName("F"), List(AnonymousParam(Some(Mod.Covariant()))))))
     assertTpe("F[-*]")(AnonymousLambda(
-      Apply(TypeName("F"), List(AnonymousParam(Some(Mod.Contravariant()))))
+      Apply(TypeName("F"), List(AnonymousParam(Some(Mod.Contravariant())))),
     ))
   }
 
@@ -364,15 +364,15 @@ class TypeSuite extends BaseDottySuite {
 
   test("F[T] forSome { type T }")(assertTpe("F[T] forSome { type T }")(Existential(
     Apply(TypeName("F"), TypeName("T") :: Nil),
-    Decl.Type(Nil, TypeName("T"), Nil, noBounds) :: Nil
+    Decl.Type(Nil, TypeName("T"), Nil, noBounds) :: Nil,
   )))
 
   test("a.T forSome { val a: A }")(assertTpe("a.T forSome { val a: A }")(
-    Existential(pselect("a", "T"), Decl.Val(Nil, patvar("a") :: Nil, TypeName("A")) :: Nil)
+    Existential(pselect("a", "T"), Decl.Val(Nil, patvar("a") :: Nil, TypeName("A")) :: Nil),
   ))
 
   test("A | B is not a special type")(
-    assertTpe("A | B")(ApplyInfix(TypeName("A"), TypeName("|"), TypeName("B")))
+    assertTpe("A | B")(ApplyInfix(TypeName("A"), TypeName("|"), TypeName("B"))),
   )
 
   test("42.type") {
@@ -408,7 +408,7 @@ class TypeSuite extends BaseDottySuite {
     implicit val parser: String => Type = parseType
     matchSubStructure(
       "+_ => Int",
-      { case Type.Function(List(Type.Name("+_")), Type.Name("Int")) => () }
+      { case Type.Function(List(Type.Name("+_")), Type.Name("Int")) => () },
     )
     assertTpe("Option[- _]")(papply(pname("Option"), pname("-_")))
   }
@@ -442,8 +442,8 @@ class TypeSuite extends BaseDottySuite {
       tapplytype(
         tselect("bar", "baz"),
         pwildcard,
-        Type.AnonymousLambda(papply("F", Type.AnonymousParam(None)))
-      )
+        Type.AnonymousLambda(papply("F", Type.AnonymousParam(None))),
+      ),
     ))
   }
 
@@ -458,8 +458,8 @@ class TypeSuite extends BaseDottySuite {
       tapplytype(
         tselect("bar", "baz"),
         Type.AnonymousParam(None),
-        Type.AnonymousLambda(papply("F", Type.AnonymousParam(None)))
-      )
+        Type.AnonymousLambda(papply("F", Type.AnonymousParam(None))),
+      ),
     ))
   }
 
@@ -467,7 +467,7 @@ class TypeSuite extends BaseDottySuite {
     implicit val dialect: Dialect = dialects.Scala30
     runTestAssert[Stat]("gr.pure[Resource[F, _]]")(tapplytype(
       tselect("gr", "pure"),
-      Type.AnonymousLambda(papply("Resource", "F", Type.AnonymousParam(None)))
+      Type.AnonymousLambda(papply("Resource", "F", Type.AnonymousParam(None))),
     ))
   }
 
@@ -475,7 +475,7 @@ class TypeSuite extends BaseDottySuite {
     implicit val dialect: Dialect = dialects.Scala3.withAllowUnderscoreAsTypePlaceholder(true)
     runTestAssert[Stat]("gr.pure[Resource[F, _]]")(tapplytype(
       tselect("gr", "pure"),
-      Type.AnonymousLambda(papply("Resource", "F", Type.AnonymousParam(None)))
+      Type.AnonymousLambda(papply("Resource", "F", Type.AnonymousParam(None))),
     ))
   }
 
@@ -486,14 +486,14 @@ class TypeSuite extends BaseDottySuite {
          |given Conversion[*.type, List[*.type]] with
          |  def apply(ast: *.type) = ast :: Nil
          |""".stripMargin,
-      Some("given Conversion[*.type, List[*.type]] with { def apply(ast: *.type) = ast :: Nil }")
+      Some("given Conversion[*.type, List[*.type]] with { def apply(ast: *.type) = ast :: Nil }"),
     )(Defn.Given(
       Nil,
       anon,
       None,
       tpl(
         init(
-          papply("Conversion", Type.Singleton(tname("*")), papply("List", Type.Singleton(tname("*"))))
+          papply("Conversion", Type.Singleton(tname("*")), papply("List", Type.Singleton(tname("*")))),
         ) :: Nil,
         List(Defn.Def(
           Nil,
@@ -501,9 +501,9 @@ class TypeSuite extends BaseDottySuite {
           Nil,
           List(List(tparam("ast", Type.Singleton(tname("*"))))),
           None,
-          tinfix(tname("ast"), "::", tname("Nil"))
-        ))
-      )
+          tinfix(tname("ast"), "::", tname("Nil")),
+        )),
+      ),
     ))
   }
 
@@ -538,7 +538,7 @@ class TypeSuite extends BaseDottySuite {
       pname("Foo"),
       Nil,
       ctor,
-      tpl(Defn.EnumCase(Nil, tname("Bar"), Nil, ctor, Nil))
+      tpl(Defn.EnumCase(Nil, tname("Bar"), Nil, ctor, Nil)),
     )
     runTestAssert[Stat](code, assertLayout = Some("into enum Foo { case Bar }"))(tree)
   }
@@ -585,11 +585,11 @@ class TypeSuite extends BaseDottySuite {
             pname("U"),
             Type.ParamClause(Nil),
             pname("Int"),
-            noBounds
-          ))
+            noBounds,
+          )),
         ),
-        Nil
-      )
+        Nil,
+      ),
     )
     runTestAssert[Stat](code, assertLayout = Some("object Test { into opaque type U = Int }"))(tree)
   }
@@ -604,12 +604,12 @@ class TypeSuite extends BaseDottySuite {
         tapplytype(
           tname("construct"),
           Type.Assign(pname("Coll"), pname("List")),
-          Type.Assign(pname("Elem"), pname("Int"))
+          Type.Assign(pname("Elem"), pname("Int")),
         ),
         lit(1),
         lit(2),
-        lit(3)
-      )
+        lit(3),
+      ),
     )
     runTestAssert[Stat](code)(tree)
   }
@@ -650,7 +650,7 @@ class TypeSuite extends BaseDottySuite {
       "p",
       Nil,
       Some(papply("Pair", pcap(purefunc("Int")("String"), "ct"), pcap("Logger", "fs"))),
-      tapply("Pair", "x", "y")
+      tapply("Pair", "x", "y"),
     )
 
     runTestAssert[Stat](code, layout)(tree)
@@ -668,10 +668,10 @@ class TypeSuite extends BaseDottySuite {
       List(pparam("A")),
       List(
         List(tparam("t", "NThread")),
-        List(tparam("fn", pcap(purectxfunc(pcap("Foo", "t"))(aCapThis), anonThis)))
+        List(tparam("fn", pcap(purectxfunc(pcap("Foo", "t"))(aCapThis), anonThis))),
       ),
       Some(aCapThis),
-      "???"
+      "???",
     )
     runTestAssert[Stat](code, layout)(tree)
   }
@@ -705,7 +705,7 @@ class TypeSuite extends BaseDottySuite {
       pname("Foo"),
       Nil,
       ctor,
-      tpl(Decl.Type(Nil, pname("Key"), Nil, bounds(cb = List(pselect("cats", "Show")))))
+      tpl(Decl.Type(Nil, pname("Key"), Nil, bounds(cb = List(pselect("cats", "Show"))))),
     )
 
     runTestAssert[Stat](code, layout)(tree)
@@ -726,8 +726,8 @@ class TypeSuite extends BaseDottySuite {
         Nil,
         pname("Value"),
         Nil,
-        bounds(cb = List(pselect("cats", "Show"), pselect("cats", "Traverse")))
-      ))
+        bounds(cb = List(pselect("cats", "Show"), pselect("cats", "Traverse"))),
+      )),
     )
 
     runTestAssert[Stat](code, layout)(tree)
@@ -756,19 +756,19 @@ class TypeSuite extends BaseDottySuite {
                 Nil,
                 "l",
                 List(pparam("a")),
-                Type.Tuple(List(papply("S", "a"), pfunc("a")(papply("Free", "S", "A"))))
-              )))
+                Type.Tuple(List(papply("S", "a"), pfunc("a")(papply("Free", "S", "A")))),
+              ))),
             ),
-            "l"
+            "l",
           ),
           Type.Project(
             Type.Refine(None, Stat.Block(List(Defn.Type(Nil, "l", List(pparam("a")), pname("B"))))),
-            "l"
-          )
-        )
+            "l",
+          ),
+        ),
       ))),
       Some("B"),
-      "???"
+      "???",
     )
 
     val codeFolded =

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/PublicSuite.scala
@@ -37,61 +37,61 @@ class PublicSuite extends TreeSuiteBase {
   }
 
   test("scala.meta.dialects.Scala3.toString")(
-    assertNoDiff(scala.meta.dialects.Scala3.toString, "Scala38")
+    assertNoDiff(scala.meta.dialects.Scala3.toString, "Scala38"),
   )
 
   test("scala.meta.dialects.Scala30.toString")(
-    assertNoDiff(scala.meta.dialects.Scala30.toString, "Scala30")
+    assertNoDiff(scala.meta.dialects.Scala30.toString, "Scala30"),
   )
 
   test("scala.meta.dialects.Scala31.toString")(
-    assertNoDiff(scala.meta.dialects.Scala31.toString, "Scala32")
+    assertNoDiff(scala.meta.dialects.Scala31.toString, "Scala32"),
   )
 
   test("scala.meta.dialects.Scala32.toString")(
-    assertNoDiff(scala.meta.dialects.Scala32.toString, "Scala32")
+    assertNoDiff(scala.meta.dialects.Scala32.toString, "Scala32"),
   )
 
   test("scala.meta.dialects.Scala33.toString")(
-    assertNoDiff(scala.meta.dialects.Scala33.toString, "Scala33")
+    assertNoDiff(scala.meta.dialects.Scala33.toString, "Scala33"),
   )
 
   test("scala.meta.dialects.Scala34.toString")(
-    assertNoDiff(scala.meta.dialects.Scala34.toString, "Scala34")
+    assertNoDiff(scala.meta.dialects.Scala34.toString, "Scala34"),
   )
 
   test("scala.meta.dialects.Scala35.toString")(
-    assertNoDiff(scala.meta.dialects.Scala35.toString, "Scala35")
+    assertNoDiff(scala.meta.dialects.Scala35.toString, "Scala35"),
   )
 
   test("scala.meta.dialects.Scala36.toString")(
-    assertNoDiff(scala.meta.dialects.Scala36.toString, "Scala36")
+    assertNoDiff(scala.meta.dialects.Scala36.toString, "Scala36"),
   )
 
   test("scala.meta.dialects.Scala37.toString")(
-    assertNoDiff(scala.meta.dialects.Scala37.toString, "Scala37")
+    assertNoDiff(scala.meta.dialects.Scala37.toString, "Scala37"),
   )
 
   test("scala.meta.dialects.Scala38.toString")(
-    assertNoDiff(scala.meta.dialects.Scala38.toString, "Scala38")
+    assertNoDiff(scala.meta.dialects.Scala38.toString, "Scala38"),
   )
 
   test("scala.meta.dialects.Scala3Future.toString")(
-    assertNoDiff(scala.meta.dialects.Scala3Future.toString.substring(0, 6), "Scala3")
+    assertNoDiff(scala.meta.dialects.Scala3Future.toString.substring(0, 6), "Scala3"),
   )
 
   test("scala.meta.dialects.Dotty")(
     // NOTE(olafur): `Dotty` and `Scala3` are identical so it's expected that
     // `toString` returns "Scala3" instead of "Dotty".
-    assertEquals(scala.meta.dialects.Dotty, scala.meta.dialects.Scala3)
+    assertEquals(scala.meta.dialects.Dotty, scala.meta.dialects.Scala3),
   )
 
   test("scala.meta.dialects.Sbt0136.toString")(
-    assertNoDiff(scala.meta.dialects.Sbt0136.toString, "Sbt0136")
+    assertNoDiff(scala.meta.dialects.Sbt0136.toString, "Sbt0136"),
   )
 
   test("scala.meta.dialects.Sbt0137.toString")(
-    assertNoDiff(scala.meta.dialects.Sbt0137.toString, "Sbt0137")
+    assertNoDiff(scala.meta.dialects.Sbt0137.toString, "Sbt0137"),
   )
 
   test("scala.meta.dialects.Sbt.toString")(assertNoDiff(scala.meta.dialects.Sbt.toString, "Sbt1"))
@@ -99,55 +99,55 @@ class PublicSuite extends TreeSuiteBase {
   test("scala.meta.dialects.Sbt1.toString")(assertNoDiff(scala.meta.dialects.Sbt1.toString, "Sbt1"))
 
   test("scala.meta.dialects.Scala210.toString")(
-    assertNoDiff(scala.meta.dialects.Scala210.toString, "Scala210")
+    assertNoDiff(scala.meta.dialects.Scala210.toString, "Scala210"),
   )
 
   test("scala.meta.dialects.Scala211.toString")(
-    assertNoDiff(scala.meta.dialects.Scala211.toString, "Scala211")
+    assertNoDiff(scala.meta.dialects.Scala211.toString, "Scala211"),
   )
 
   test("scala.meta.dialects.Scala212.toString")(
-    assertNoDiff(scala.meta.dialects.Scala212.toString, "Scala212")
+    assertNoDiff(scala.meta.dialects.Scala212.toString, "Scala212"),
   )
 
   test("scala.meta.dialects.Scala212Source3.toString")(
-    assertNoDiff(scala.meta.dialects.Scala212Source3.toString, "Scala212Source3")
+    assertNoDiff(scala.meta.dialects.Scala212Source3.toString, "Scala212Source3"),
   )
 
   test("scala.meta.dialects.Scala213.toString")(
-    assertNoDiff(scala.meta.dialects.Scala213.toString, "Scala213")
+    assertNoDiff(scala.meta.dialects.Scala213.toString, "Scala213"),
   )
 
   test("scala.meta.dialects.Scala213Source3.toString")(
-    assertNoDiff(scala.meta.dialects.Scala213Source3.toString, "Scala213Source3")
+    assertNoDiff(scala.meta.dialects.Scala213Source3.toString, "Scala213Source3"),
   )
 
   test("scala.meta.dialects.Scala.toString")(
-    assertNoDiff(scala.meta.dialects.Scala.toString, "Scala213")
+    assertNoDiff(scala.meta.dialects.Scala.toString, "Scala213"),
   )
 
   test("scala.meta.dialects.Typelevel211.toString")(
-    assertNoDiff(scala.meta.dialects.Typelevel211.toString, "Typelevel211")
+    assertNoDiff(scala.meta.dialects.Typelevel211.toString, "Typelevel211"),
   )
 
   test("scala.meta.dialects.Typelevel212.toString")(
-    assertNoDiff(scala.meta.dialects.Typelevel212.toString, "Typelevel212")
+    assertNoDiff(scala.meta.dialects.Typelevel212.toString, "Typelevel212"),
   )
 
   test("scala.meta.dialects.Paradise211.toString")(
-    assertNoDiff(scala.meta.dialects.Paradise211.toString, "Paradise211")
+    assertNoDiff(scala.meta.dialects.Paradise211.toString, "Paradise211"),
   )
 
   test("scala.meta.dialects.Paradise212.toString")(
-    assertNoDiff(scala.meta.dialects.Paradise212.toString, "Paradise212")
+    assertNoDiff(scala.meta.dialects.Paradise212.toString, "Paradise212"),
   )
 
   test("scala.meta.dialects.ParadiseTypelevel211.toString")(
-    assertNoDiff(scala.meta.dialects.ParadiseTypelevel211.toString, "ParadiseTypelevel211")
+    assertNoDiff(scala.meta.dialects.ParadiseTypelevel211.toString, "ParadiseTypelevel211"),
   )
 
   test("scala.meta.dialects.ParadiseTypelevel212.toString")(
-    assertNoDiff(scala.meta.dialects.ParadiseTypelevel212.toString, "ParadiseTypelevel212")
+    assertNoDiff(scala.meta.dialects.ParadiseTypelevel212.toString, "ParadiseTypelevel212"),
   )
 
   test("scala.meta.inputs.Input.None.toString")(assertEquals(Input.None.toString, "Input.None"))
@@ -210,7 +210,7 @@ class PublicSuite extends TreeSuiteBase {
   }
 
   test("scala.meta.inputs.Position.None.toString")(
-    assertEquals(Position.None.toString, "Position.None")
+    assertEquals(Position.None.toString, "Position.None"),
   )
 
   test("scala.meta.inputs.Position.Range.toString")("foo + bar".parse[Term].get match {
@@ -226,10 +226,10 @@ class PublicSuite extends TreeSuiteBase {
           ex.toString,
           """|<input>:1: error: `end of file` expected but `class` found
              |foo + class
-             |      ^""".stripMargin.lf2nl
+             |      ^""".stripMargin.lf2nl,
         )
         throw ex
-    }
+    },
   ))
 
   test("scala.meta.parsers.Parsed.Error.toString") {
@@ -242,7 +242,7 @@ class PublicSuite extends TreeSuiteBase {
       parsed.toString,
       """|<input>:1: error: `end of file` expected but `class` found
          |foo + class
-         |      ^""".stripMargin.lf2nl
+         |      ^""".stripMargin.lf2nl,
     )
   }
 
@@ -288,7 +288,7 @@ class PublicSuite extends TreeSuiteBase {
     val tokens = "foo + bar".tokenize.get
     assertEquals(
       tokens.structure,
-      "Tokens(BOF [0..0), Ident(foo) [0..3), Space [3..4), Ident(+) [4..5), Space [5..6), Ident(bar) [6..9), EOF [9..9))"
+      "Tokens(BOF [0..0), Ident(foo) [0..3), Space [3..4), Ident(+) [4..5), Space [5..6), Ident(bar) [6..9), EOF [9..9))",
     )
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/TreeSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/prettyprinters/TreeSyntaxSuite.scala
@@ -13,7 +13,7 @@ class TreeSyntaxSuite extends scala.meta.tests.parsers.ParseSuite {
   implicit val dialect: Dialect = dialects.Scala211
 
   private def testBlock(statStr: String, needNL: Boolean, syntaxStr: String = null)(implicit
-      loc: munit.Location
+      loc: munit.Location,
   ): Unit = {
     val stat = statStr.trim // make sure no trailing newlines
     def testWithSuffix(suffix: String): Unit = test(s"${loc.line}: $stat [$suffix]") {
@@ -42,19 +42,19 @@ class TreeSyntaxSuite extends scala.meta.tests.parsers.ParseSuite {
     testWithSuffix(
       """|{
          |  a
-         |}""".stripMargin
+         |}""".stripMargin,
     )
     testWithSuffix(
       """|{
          |  a
          |} + {
          |  b
-         |}""".stripMargin
+         |}""".stripMargin,
     )
     testWithSuffix(
       """|{
          |  a
-         |}.b""".stripMargin
+         |}.b""".stripMargin,
     )
   }
 
@@ -85,16 +85,16 @@ class TreeSyntaxSuite extends scala.meta.tests.parsers.ParseSuite {
       s"$k Foo extends { val foo = 1 } with Bar",
       s"""|$k Foo extends {
           |  val foo = 1
-          |} with Bar""".stripMargin
-    )
+          |} with Bar""".stripMargin,
+    ),
   )
   testBlockAfterClass(k =>
     testBlockNoNL(
       s"$k Foo extends { val foo = 1 } with Bar { val bar = 2 }",
       s"""|$k Foo extends {
           |  val foo = 1
-          |} with Bar { val bar = 2 }""".stripMargin
-    )
+          |} with Bar { val bar = 2 }""".stripMargin,
+    ),
   )
   testBlockAddNL("this")
   testBlockAddNL("Foo")

--- a/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/DottySuccessSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/DottySuccessSuite.scala
@@ -35,15 +35,15 @@ class DottySuccessSuite extends TreeSuiteBase {
     assertTrees(paramss(0): _*)(cparam)
     assertTrees(paramss(1): _*)(
       tparam(List(Mod.Using()), "", "Context"),
-      tparam(List(Mod.Using()), "x", "Int")
+      tparam(List(Mod.Using()), "x", "Int"),
     )
     assertTrees(paramss(2): _*)(
       tparam(List(Mod.Using()), "y", "String"),
-      tparam(List(Mod.Using()), "", "File")
+      tparam(List(Mod.Using()), "", "File"),
     )
 
     assertTrees(stats: _*)(
-      Defn.Def(Nil, Term.Name("crc"), Nil, Nil, Some(Type.Name("Int")), Lit.Int(2))
+      Defn.Def(Nil, Term.Name("crc"), Nil, Nil, Some(Type.Name("Int")), Lit.Int(2)),
     )
   }
 
@@ -62,15 +62,15 @@ class DottySuccessSuite extends TreeSuiteBase {
     assertTrees(paramss(0): _*)(cparam)
     assertTrees(paramss(1): _*)(
       tparam(List(Mod.Using()), "", "Context"),
-      tparam(List(Mod.Using()), "x", "Int")
+      tparam(List(Mod.Using()), "x", "Int"),
     )
     assertTrees(paramss(2): _*)(
       tparam(List(Mod.Using()), "y", "String"),
-      tparam(List(Mod.Using()), "", "File")
+      tparam(List(Mod.Using()), "", "File"),
     )
 
     assertTrees(stats: _*)(
-      Defn.Def(Nil, Term.Name("crc"), Nil, Nil, Some(Type.Name("Int")), Lit.Int(2))
+      Defn.Def(Nil, Term.Name("crc"), Nil, Nil, Some(Type.Name("Int")), Lit.Int(2)),
     )
   }
 
@@ -88,7 +88,7 @@ class DottySuccessSuite extends TreeSuiteBase {
     assertTrees(params: _*)(cparam)
 
     assertTrees(stats: _*)(
-      Defn.Def(Nil, Term.Name("crc"), Nil, Nil, Some(Type.Name("Int")), Lit.Int(2))
+      Defn.Def(Nil, Term.Name("crc"), Nil, Nil, Some(Type.Name("Int")), Lit.Int(2)),
     )
   }
 
@@ -106,7 +106,7 @@ class DottySuccessSuite extends TreeSuiteBase {
     assertTrees(params: _*)(cparam)
 
     assertTrees(stats: _*)(
-      Defn.Def(Nil, Term.Name("crc"), Nil, Nil, Some(Type.Name("Int")), Lit.Int(2))
+      Defn.Def(Nil, Term.Name("crc"), Nil, Nil, Some(Type.Name("Int")), Lit.Int(2)),
     )
   }
 
@@ -126,7 +126,7 @@ class DottySuccessSuite extends TreeSuiteBase {
 
     assertTrees(stats: _*)(
       Defn.Def(Nil, Term.Name("crb"), Nil, Nil, Some(Type.Name("Int")), Lit.Int(1)),
-      Defn.Def(Nil, Term.Name("crc"), Nil, Nil, Some(Type.Name("Int")), Lit.Int(2))
+      Defn.Def(Nil, Term.Name("crc"), Nil, Nil, Some(Type.Name("Int")), Lit.Int(2)),
     )
   }
 
@@ -146,7 +146,7 @@ class DottySuccessSuite extends TreeSuiteBase {
 
     assertTrees(stats: _*)(
       Defn.Def(Nil, Term.Name("crb"), Nil, Nil, Some(Type.Name("Int")), Lit.Int(1)),
-      Defn.Def(Nil, Term.Name("crc"), Nil, Nil, Some(Type.Name("Int")), Lit.Int(2))
+      Defn.Def(Nil, Term.Name("crc"), Nil, Nil, Some(Type.Name("Int")), Lit.Int(2)),
     )
   }
 
@@ -156,7 +156,7 @@ class DottySuccessSuite extends TreeSuiteBase {
 
     checkTreesWithSyntax(paramss: _*)("(x: Int)", "(y: Int)")(paramsExpected: _*)
     assertTree(q"..$mods def $name(...$paramss): $tpe")(
-      Decl.Def(Nil, Term.Name("f"), pcg(paramsExpected: _*) :: Nil, Type.Name("Unit"))
+      Decl.Def(Nil, Term.Name("f"), pcg(paramsExpected: _*) :: Nil, Type.Name("Unit")),
     )
   }
 
@@ -169,7 +169,7 @@ class DottySuccessSuite extends TreeSuiteBase {
     checkTreesWithSyntax(paramss: _*)("(x: Int)", "(y: Int)")(paramsExpected: _*)
     assertTree(q"..$mods def $name[..$tparams](...$paramss): $tpe")(
       Decl
-        .Def(Nil, Term.Name("f"), pcg(tparamsExpected, paramsExpected: _*) :: Nil, Type.Name("Unit"))
+        .Def(Nil, Term.Name("f"), pcg(tparamsExpected, paramsExpected: _*) :: Nil, Type.Name("Unit")),
     )
   }
 
@@ -181,7 +181,7 @@ class DottySuccessSuite extends TreeSuiteBase {
 
     checkTreesWithSyntax(paramss: _*)("(x: Int)", "[A](y: Int)", "[B]")(pcGroups: _*)
     assertTree(q"..$mods def $name(....$paramss): $tpe")(
-      Decl.Def(Nil, Term.Name("f"), pcGroups, Type.Name("Unit"))
+      Decl.Def(Nil, Term.Name("f"), pcGroups, Type.Name("Unit")),
     )
   }
 
@@ -198,7 +198,7 @@ class DottySuccessSuite extends TreeSuiteBase {
          |Space [17..18)
          |Constant.String(any message) [18..31)
          |EOF [31..31)
-         |""".stripMargin
+         |""".stripMargin,
     )
     val pos = quoted.pos
     assertNoDiff(pos.toString, """[0,31) in str(`${fooTypes(0)}`; "any message")""")
@@ -208,7 +208,7 @@ class DottySuccessSuite extends TreeSuiteBase {
       """|<stats1>Lit.String "any message"</stats1> [18:"any message":31)
          |""".stripMargin,
       showPosition = true,
-      showFieldName = true
+      showFieldName = true,
     )
 
     val syntax =
@@ -237,7 +237,7 @@ class DottySuccessSuite extends TreeSuiteBase {
          |Space [17..18)
          |Constant.String(any message) [18..31)
          |EOF [31..31)
-         |""".stripMargin
+         |""".stripMargin,
     )
     val pos = quoted.pos
     assertNoDiff(pos.toString, """[0,31) in str(/* .. */`$terms`; "any message")""")
@@ -247,7 +247,7 @@ class DottySuccessSuite extends TreeSuiteBase {
       """|<stats1>Lit.String "any message"</stats1> [18:"any message":31)
          |""".stripMargin,
       showPosition = true,
-      showFieldName = true
+      showFieldName = true,
     )
 
     val syntax =

--- a/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -61,7 +61,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertTree(p"case $x @ $y => ")(Case(
       Pat.Bind(patvar("x"), Pat.Extract(tname("List"), List(int(1), int(2), int(3)))),
       None,
-      blk()
+      blk(),
     ))
   }
 
@@ -77,7 +77,7 @@ class SuccessSuite extends TreeSuiteBase {
     val term = q"x"
     val terms = List(q"y", q"z")
     assertTree(q"foo($term, ..$terms, $term)")(
-      tapply(tname("foo"), tname("x"), tname("y"), tname("z"), tname("x"))
+      tapply(tname("foo"), tname("x"), tname("y"), tname("z"), tname("x")),
     )
   }
 
@@ -106,7 +106,7 @@ class SuccessSuite extends TreeSuiteBase {
     val a = tparam"+A"
     val b = t"B"
     assertTree(q"type $name[$a] = $b")(
-      Defn.Type(Nil, pname("List"), List(pparam(List(Mod.Covariant()), "A")), pname("B"), noBounds)
+      Defn.Type(Nil, pname("List"), List(pparam(List(Mod.Covariant()), "A")), pname("B"), noBounds),
     )
   }
 
@@ -242,7 +242,7 @@ class SuccessSuite extends TreeSuiteBase {
     val tpes = List(t"T", t"U")
     val exprs = List(q"1", q"b")
     assertTree(q"$expr $name[..$tpes] (..$exprs)")(
-      tinfix(tname("x"), "method", List(pname("T"), pname("U")), int(1), tname("b"))
+      tinfix(tname("x"), "method", List(pname("T"), pname("U")), int(1), tname("b")),
     )
   }
 
@@ -341,7 +341,7 @@ class SuccessSuite extends TreeSuiteBase {
     val exprs = List(List(q"a", q"b"))
     val expr2 = q"bar"
     assertTree(q"$expr1(...$exprs) = $expr2")(
-      Term.Assign(tapply(tname("foo"), tname("a"), tname("b")), tname("bar"))
+      Term.Assign(tapply(tname("foo"), tname("a"), tname("b")), tname("bar")),
     )
   }
 
@@ -361,7 +361,7 @@ class SuccessSuite extends TreeSuiteBase {
     val exprs2 = List(q"c")
     val expr2 = q"bar"
     assertTree(q"$expr1(..$exprs1)(..$exprs2) = $expr2")(
-      Term.Assign(tapply(tapply(tname("foo"), tname("a"), tname("b")), tname("c")), tname("bar"))
+      Term.Assign(tapply(tapply(tname("foo"), tname("a"), tname("b")), tname("c")), tname("bar")),
     )
   }
 
@@ -373,7 +373,7 @@ class SuccessSuite extends TreeSuiteBase {
   test("2 q\"(x, y: Int)\"") {
     val x = q"x: X"
     assertTree(q"($x, y: Int)")(Term.Tuple(
-      List(Term.Ascribe(tname("x"), pname("X")), Term.Ascribe(tname("y"), pname("Int")))
+      List(Term.Ascribe(tname("x"), pname("X")), Term.Ascribe(tname("y"), pname("Int"))),
     ))
   }
 
@@ -388,7 +388,7 @@ class SuccessSuite extends TreeSuiteBase {
     val r = q"1"
     assertTree(q"f($q, y: Y) = $r")(Term.Assign(
       tapply(tname("f"), Term.Ascribe(tname("x"), pname("X")), Term.Ascribe(tname("y"), pname("Y"))),
-      int(1)
+      int(1),
     ))
   }
 
@@ -436,7 +436,7 @@ class SuccessSuite extends TreeSuiteBase {
     val mods = List(mod"@w", mod"@e")
     assertTree(q"foo: @q ..@$mods @r")(Term.Annotate(
       tname("foo"),
-      List(Mod.Annot(init("q")), Mod.Annot(init("w")), Mod.Annot(init("e")), Mod.Annot(init("r")))
+      List(Mod.Annot(init("q")), Mod.Annot(init("w")), Mod.Annot(init("e")), Mod.Annot(init("r"))),
     ))
   }
 
@@ -456,14 +456,14 @@ class SuccessSuite extends TreeSuiteBase {
     assertEquals(params.toString, "List(x: Int, y: String)")
     assertTrees(params: _*)(
       Term.Ascribe(tname("x"), pname("Int")),
-      Term.Ascribe(tname("y"), pname("String"))
+      Term.Ascribe(tname("y"), pname("String")),
     )
   }
 
   test("2 val q\"(..params)\" = q\"(x: Int, y: String)\"") {
     val params = List(q"x: Int", q"y: String")
     assertTree(q"(..$params)")(Term.Tuple(
-      List(Term.Ascribe(tname("x"), pname("Int")), Term.Ascribe(tname("y"), pname("String")))
+      List(Term.Ascribe(tname("x"), pname("Int")), Term.Ascribe(tname("y"), pname("String"))),
     ))
   }
 
@@ -472,7 +472,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertEquals(statz.toString, "List(val a = x, val b = y)")
     assertTrees(statz: _*)(
       Defn.Val(Nil, List(patvar("a")), None, tname("x")),
-      Defn.Val(Nil, List(patvar("b")), None, tname("y"))
+      Defn.Val(Nil, List(patvar("b")), None, tname("y")),
     )
     assertTree(astat)(Defn.Val(Nil, List(patvar("c")), None, tname("z")))
   }
@@ -481,7 +481,7 @@ class SuccessSuite extends TreeSuiteBase {
     val stats = List(q"val x = 1", q"val y = 2")
     assertTree(q"{ ..$stats }")(blk(
       Defn.Val(Nil, List(patvar("x")), None, int(1)),
-      Defn.Val(Nil, List(patvar("y")), None, int(2))
+      Defn.Val(Nil, List(patvar("y")), None, int(2)),
     ))
   }
 
@@ -497,7 +497,7 @@ class SuccessSuite extends TreeSuiteBase {
     val expr2 = q"a"
     val expr3 = q"b"
     assertTree(q"if ($expr1) $expr2 else $expr3")(
-      Term.If(tinfix(int(1), ">", int(2)), tname("a"), tname("b"), Nil)
+      Term.If(tinfix(int(1), ">", int(2)), tname("a"), tname("b"), Nil),
     )
   }
 
@@ -521,11 +521,11 @@ class SuccessSuite extends TreeSuiteBase {
     assertTree(expr)(tname("foo"))
     assertWithOriginalSyntax(casez: _*)("case bar => baz;", "case _ => foo")(
       "case bar => baz",
-      "case _ => foo"
+      "case _ => foo",
     )
     assertTrees(casez: _*)(
       Case(patvar("bar"), None, tname("baz")),
-      Case(patwildcard, None, tname("foo"))
+      Case(patwildcard, None, tname("foo")),
     )
   }
 
@@ -533,7 +533,7 @@ class SuccessSuite extends TreeSuiteBase {
     val expr = q"foo"
     val casez = List(p"case a => b", p"case q => w")
     assertTree(q"$expr match { ..case $casez }")(
-      tmatch(tname("foo"), Case(patvar("a"), None, tname("b")), Case(patvar("q"), None, tname("w")))
+      tmatch(tname("foo"), Case(patvar("a"), None, tname("b")), Case(patvar("q"), None, tname("w"))),
     )
   }
 
@@ -543,7 +543,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertTree(expr)(tname("foo"))
     assertWithOriginalSyntax(cases: _*)("case _ => bar;", "case 1 => 2;")(
       "case _ => bar",
-      "case 1 => 2"
+      "case 1 => 2",
     )
     assertTrees(cases: _*)(Case(patwildcard, None, tname("bar")), Case(int(1), None, int(2)))
     assertTree(case1)(Case(patvar("a"), None, tname("b")))
@@ -564,10 +564,10 @@ class SuccessSuite extends TreeSuiteBase {
           Case(patvar("a"), None, tname("b")),
           Case(patwildcard, None, tname("bar")),
           Case(int(1), None, int(2)),
-          Case(patvar("q"), None, tname("w"))
+          Case(patvar("q"), None, tname("w")),
         ),
-        Some(tname("baz"))
-      )
+        Some(tname("baz")),
+      ),
     )
   }
 
@@ -590,7 +590,7 @@ class SuccessSuite extends TreeSuiteBase {
     val exprr = q"pf"
     val expropt = q"{ bar }"
     assertTree(q"try $expr catch $exprr finally $expropt")(
-      Term.TryWithHandler(blk(tname("foo")), tname("pf"), Some(blk(tname("bar"))))
+      Term.TryWithHandler(blk(tname("foo")), tname("pf"), Some(blk(tname("bar")))),
     )
   }
 
@@ -622,21 +622,21 @@ class SuccessSuite extends TreeSuiteBase {
     val e = param"z: Z"
     val r = q"1"
     assertTree(q"(..$q, y: Y, $e) => $r")(
-      tfunc(tparam("x", "X"), tparam("y", "Y"), tparam("z", "Z"))(int(1))
+      tfunc(tparam("x", "X"), tparam("y", "Y"), tparam("z", "Z"))(int(1)),
     )
   }
 
   test("1 q\"{ ..case cases }\"") {
     val q"{ ..case $cases }" = q"{ case i: Int => i + 1 }"
     assertTrees(cases: _*)(
-      Case(Pat.Typed(patvar("i"), pname("Int")), None, tinfix(tname("i"), "+", int(1)))
+      Case(Pat.Typed(patvar("i"), pname("Int")), None, tinfix(tname("i"), "+", int(1))),
     )
   }
 
   test("2 q\"{ ..case cases }\"") {
     val cases = List(p"case i: Int => i + 1")
     assertTree(q"{ ..case $cases }")(Term.PartialFunction(List(
-      Case(Pat.Typed(patvar("i"), pname("Int")), None, tinfix(tname("i"), "+", int(1)))
+      Case(Pat.Typed(patvar("i"), pname("Int")), None, tinfix(tname("i"), "+", int(1))),
     )))
   }
 
@@ -670,7 +670,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertEquals(enumerators.toString, "List(x <- xs, y <- ys)")
     assertTrees(enumerators: _*)(
       Enumerator.Generator(patvar("x"), tname("xs")),
-      Enumerator.Generator(patvar("y"), tname("ys"))
+      Enumerator.Generator(patvar("y"), tname("ys")),
     )
     assertTree(cond)(tname("bar"))
     assertTree(enum1)(Enumerator.Generator(patvar("a"), tname("as")))
@@ -685,9 +685,9 @@ class SuccessSuite extends TreeSuiteBase {
     assertTree(q"for (..$ab) foo")(Term.For(
       List(
         Enumerator.Generator(patvar("a"), tname("as")),
-        Enumerator.Generator(patvar("b"), tname("bs"))
+        Enumerator.Generator(patvar("b"), tname("bs")),
       ),
-      tname("foo")
+      tname("foo"),
     ))
   }
 
@@ -697,7 +697,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertEquals(enumerators.toString, "List(x <- xs, y <- ys)")
     assertTrees(enumerators: _*)(
       Enumerator.Generator(patvar("x"), tname("xs")),
-      Enumerator.Generator(patvar("y"), tname("ys"))
+      Enumerator.Generator(patvar("y"), tname("ys")),
     )
     assertTree(expr)(tapply(tname("foo"), tname("x"), tname("y")))
   }
@@ -709,9 +709,9 @@ class SuccessSuite extends TreeSuiteBase {
     assertTree(q"for (..$ab) yield foo")(Term.ForYield(
       List(
         Enumerator.Generator(patvar("a"), tname("as")),
-        Enumerator.Generator(patvar("b"), tname("bs"))
+        Enumerator.Generator(patvar("b"), tname("bs")),
       ),
-      tname("foo")
+      tname("foo"),
     ))
   }
 
@@ -744,12 +744,12 @@ class SuccessSuite extends TreeSuiteBase {
     assertTree(q"new {..$stats; val b = 4} with $a {$self1 => ..$statz}")(Term.NewAnonymous(Template(
       List(
         Defn.Val(Nil, List(patvar("a")), None, int(2)),
-        Defn.Val(Nil, List(patvar("b")), None, int(4))
+        Defn.Val(Nil, List(patvar("b")), None, int(4)),
       ),
       List(init("A")),
       self("self", "A"),
       List(Defn.Val(Nil, List(patvar("b")), None, int(3))),
-      Nil
+      Nil,
     )))
   }
 
@@ -884,7 +884,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertEquals(stats.toString, "{ val a: A; val b: B }")
     assertTrees(stats: _*)(
       Decl.Val(Nil, List(patvar("a")), pname("A")),
-      Decl.Val(Nil, List(patvar("b")), pname("B"))
+      Decl.Val(Nil, List(patvar("b")), pname("B")),
     )
   }
 
@@ -893,7 +893,7 @@ class SuccessSuite extends TreeSuiteBase {
     val stats = List(q"val a: A", q"val b: B")
     assertTree(t"$tpe { ..$stats }")(Type.Refine(
       Some(Type.With(pname("X"), pname("Y"))),
-      List(Decl.Val(Nil, List(patvar("a")), pname("A")), Decl.Val(Nil, List(patvar("b")), pname("B")))
+      List(Decl.Val(Nil, List(patvar("a")), pname("A")), Decl.Val(Nil, List(patvar("b")), pname("B"))),
     ))
   }
 
@@ -903,7 +903,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertEquals(stats.toString, "{ val a: A; val b: B }")
     assertTrees(stats: _*)(
       Decl.Val(Nil, List(patvar("a")), pname("A")),
-      Decl.Val(Nil, List(patvar("b")), pname("B"))
+      Decl.Val(Nil, List(patvar("b")), pname("B")),
     )
   }
 
@@ -912,7 +912,7 @@ class SuccessSuite extends TreeSuiteBase {
     val stats = List(q"val a:A", q"val b:B")
     assertTree(t"$tpe forSome { ..$stats }")(Type.Existential(
       pname("X"),
-      List(Decl.Val(Nil, List(patvar("a")), pname("A")), Decl.Val(Nil, List(patvar("b")), pname("B")))
+      List(Decl.Val(Nil, List(patvar("a")), pname("A")), Decl.Val(Nil, List(patvar("b")), pname("B"))),
     ))
   }
 
@@ -927,7 +927,7 @@ class SuccessSuite extends TreeSuiteBase {
     val tpe = t"X"
     val annots = List(mod"@a", mod"@b")
     assertTree(t"$tpe ..@$annots")(
-      Type.Annotate(pname("X"), List(Mod.Annot(init("a")), Mod.Annot(init("b"))))
+      Type.Annotate(pname("X"), List(Mod.Annot(init("a")), Mod.Annot(init("b")))),
     )
   }
 
@@ -942,7 +942,7 @@ class SuccessSuite extends TreeSuiteBase {
     val tparams = List(tparam"T")
     val tpe = t"(T, T)"
     assertTree(t"[..$tparams] =>> $tpe")(
-      Type.Lambda(List(pparam("T")), Type.Tuple(List(pname("T"), pname("T"))))
+      Type.Lambda(List(pparam("T")), Type.Tuple(List(pname("T"), pname("T")))),
     )
   }
 
@@ -1060,7 +1060,7 @@ class SuccessSuite extends TreeSuiteBase {
     val tpes = List(t"A", t"B")
     val pats = List(q"Q", q"W")
     assertTree(p"$ref[..$tpes](..$pats)")(
-      Pat.Extract(tapplytype(tname("x"), pname("A"), pname("B")), List(tname("Q"), tname("W")))
+      Pat.Extract(tapplytype(tname("x"), pname("A"), pname("B")), List(tname("Q"), tname("W"))),
     )
   }
 
@@ -1069,7 +1069,7 @@ class SuccessSuite extends TreeSuiteBase {
     val tpes = List(t"`A`", t"B")
     val pats = List(p"`Q`", q"W")
     assertTree(p"$ref[..$tpes](..$pats)")(
-      Pat.Extract(tapplytype(tname("x"), pname("A"), pname("B")), List(tname("Q"), tname("W")))
+      Pat.Extract(tapplytype(tname("x"), pname("A"), pname("B")), List(tname("Q"), tname("W"))),
     )
   }
 
@@ -1081,7 +1081,7 @@ class SuccessSuite extends TreeSuiteBase {
     val tpes = List(t"A", t"B")
     val pats = List(q"Q", q"W")
     assertTree(p"$ref[..$tpes](..$pats)")(
-      Pat.Extract(tapplytype(tselect("x", "a"), pname("A"), pname("B")), List(tname("Q"), tname("W")))
+      Pat.Extract(tapplytype(tselect("x", "a"), pname("A"), pname("B")), List(tname("Q"), tname("W"))),
     )
   }
 
@@ -1164,7 +1164,7 @@ class SuccessSuite extends TreeSuiteBase {
   }
 
   test("1 p\"_*\"")(assertTree(p"case List(_*) =>")(
-    Case(Pat.Extract(tname("List"), List(Pat.SeqWildcard())), None, blk())
+    Case(Pat.Extract(tname("List"), List(Pat.SeqWildcard())), None, blk()),
   ))
 
   test("2 p\"_*\"")(assertTree(p"_*")(Pat.SeqWildcard()))
@@ -1193,7 +1193,7 @@ class SuccessSuite extends TreeSuiteBase {
     val pats = List(p"x", p"y")
     val tpe = t"T"
     assertTree(q"..$mods val ..$pats: $tpe")(
-      Decl.Val(List(Mod.Private(anon), Mod.Final()), List(patvar("x"), patvar("y")), pname("T"))
+      Decl.Val(List(Mod.Private(anon), Mod.Final()), List(patvar("x"), patvar("y")), pname("T")),
     )
   }
 
@@ -1211,7 +1211,7 @@ class SuccessSuite extends TreeSuiteBase {
     val pats = List(p"x", p"y")
     val tpe = t"T"
     assertTree(q"..$mods var ..$pats: $tpe")(
-      Decl.Var(List(Mod.Private(anon), Mod.Final()), List(patvar("x"), patvar("y")), pname("T"))
+      Decl.Var(List(Mod.Private(anon), Mod.Final()), List(patvar("x"), patvar("y")), pname("T")),
     )
   }
 
@@ -1224,7 +1224,7 @@ class SuccessSuite extends TreeSuiteBase {
     checkTree(tparams, "[T, W]")(ppc(pparam("T"), pparam("W")))
     assertEquals(paramss.lengthCompare(1), 0)
     checkTreesWithSyntax(paramss: _*)("(x: X, y: Y)")(Term.ParamClause(
-      List(tparam("x", "X"), tparam("y", "Y"))
+      List(tparam("x", "X"), tparam("y", "Y")),
     ))
     assertTree(tpe)(pname("R"))
   }
@@ -1240,7 +1240,7 @@ class SuccessSuite extends TreeSuiteBase {
       tname("m"),
       List(pparam("T"), pparam("W")),
       List(List(tparam("x", "X"), tparam("x", "Y"))),
-      pname("R")
+      pname("R"),
     ))
   }
 
@@ -1266,7 +1266,7 @@ class SuccessSuite extends TreeSuiteBase {
       List(Mod.Private(anon), Mod.Final()),
       pname("T"),
       List(pparam("T"), pparam("W")),
-      bounds("A", "A")
+      bounds("A", "A"),
     ))
   }
 
@@ -1289,7 +1289,7 @@ class SuccessSuite extends TreeSuiteBase {
       List(Mod.Private(anon), Mod.Final()),
       List(patvar("x"), patvar("y")),
       Some(pname("T")),
-      tname("t")
+      tname("t"),
     ))
   }
 
@@ -1312,7 +1312,7 @@ class SuccessSuite extends TreeSuiteBase {
       List(Mod.Private(anon), Mod.Final()),
       List(patvar("x"), patvar("y")),
       Some(pname("T")),
-      Some(tname("t"))
+      Some(tname("t")),
     ))
   }
 
@@ -1324,7 +1324,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertTree(name)(tname("m"))
     checkTree(tparams, "[T, W]")(ppc(pparam("T"), pparam("W")))
     checkTreesWithSyntax(paramss: _*)("(x: X, y: Y)")(Term.ParamClause(
-      List(tparam("x", "X"), tparam("y", "Y"))
+      List(tparam("x", "X"), tparam("y", "Y")),
     ))
     assertTree(tpeopt)(Some(pname("R")))
     assertTree(expr)(tname("r"))
@@ -1343,7 +1343,7 @@ class SuccessSuite extends TreeSuiteBase {
       List(pparam("T"), pparam("W")),
       List(List(tparam("x", "X"), tparam("x", "Y"))),
       Some(pname("R")),
-      tname("r")
+      tname("r"),
     ))
   }
 
@@ -1355,7 +1355,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertTree(name)(tname("m"))
     checkTree(tparams, "[T, W]")(ppc(pparam("T"), pparam("W")))
     checkTreesWithSyntax(paramss: _*)("(x: X, y: Y)")(Term.ParamClause(
-      List(tparam("x", "X"), tparam("y", "Y"))
+      List(tparam("x", "X"), tparam("y", "Y")),
     ))
     assertTree(tpeopt)(Some(pname("R")))
     assertTree(expr)(tname("r"))
@@ -1374,7 +1374,7 @@ class SuccessSuite extends TreeSuiteBase {
       List(pparam("T"), pparam("W")),
       List(List(tparam("x", "X"), tparam("x", "Y"))),
       Some(pname("R")),
-      tname("r")
+      tname("r"),
     ))
   }
 
@@ -1398,7 +1398,7 @@ class SuccessSuite extends TreeSuiteBase {
       pname("Q"),
       List(pparam("T"), pparam("W")),
       pname("R"),
-      noBounds
+      noBounds,
     ))
   }
 
@@ -1412,7 +1412,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertTree(tparams)(ppc(pparam("T"), pparam("W")))
     assertTree(mod)(Mod.Private(anon))
     checkTreesWithSyntax(paramss: _*)("(x: X, y: Y)")(Term.ParamClause(
-      List(tparam("x", "X"), tparam("y", "Y"))
+      List(tparam("x", "X"), tparam("y", "Y")),
     ))
     assertTree(template)(tplNoBody(init("Y")))
   }
@@ -1427,11 +1427,11 @@ class SuccessSuite extends TreeSuiteBase {
     assertTree(tparams)(ppc(pparam("T"), pparam("W")))
     assertTree(mod)(Mod.Protected(anon))
     checkTreesWithSyntax(paramss: _*)("(x: X, y: Y)")(Term.ParamClause(
-      List(tparam("x", "X"), tparam("y", "Y"))
+      List(tparam("x", "X"), tparam("y", "Y")),
     ))
     assertTree(template)(tpl(
       Defn.Def(Nil, tname("m1"), Nil, Nil, None, int(42)),
-      Defn.Def(Nil, tname("m2"), Nil, Nil, None, int(666))
+      Defn.Def(Nil, tname("m2"), Nil, Nil, None, int(666)),
     ))
   }
 
@@ -1447,7 +1447,7 @@ class SuccessSuite extends TreeSuiteBase {
       pname("Q"),
       List(pparam("T"), pparam("W")),
       Ctor.Primary(List(Mod.Protected(anon)), anon, List(List(tparam("x", "X"), tparam("x", "Y")))),
-      tpl(List(init("F")), List(Defn.Def(Nil, tname("m"), Nil, Nil, None, int(42))))
+      tpl(List(init("F")), List(Defn.Def(Nil, tname("m"), Nil, Nil, None, int(42)))),
     ))
   }
 
@@ -1471,7 +1471,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertTree(tparams)(ppc(pparam("T"), pparam("W")))
     assertTree(template)(tpl(
       Defn.Def(Nil, tname("m1"), Nil, Nil, None, int(42)),
-      Defn.Def(Nil, tname("m2"), Nil, Nil, None, int(666))
+      Defn.Def(Nil, tname("m2"), Nil, Nil, None, int(666)),
     ))
   }
 
@@ -1485,7 +1485,7 @@ class SuccessSuite extends TreeSuiteBase {
       pname("Q"),
       List(pparam("T"), pparam("W")),
       EmptyCtor(),
-      tpl(List(init("F")), List(Defn.Def(Nil, tname("m"), Nil, Nil, None, int(42))))
+      tpl(List(init("F")), List(Defn.Def(Nil, tname("m"), Nil, Nil, None, int(42)))),
     ))
   }
 
@@ -1505,7 +1505,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertTree(name)(tname("Q"))
     assertTree(template)(tpl(
       Defn.Def(Nil, tname("m1"), Nil, Nil, None, int(42)),
-      Defn.Def(Nil, tname("m2"), Nil, Nil, None, int(666))
+      Defn.Def(Nil, tname("m2"), Nil, Nil, None, int(666)),
     ))
   }
 
@@ -1516,7 +1516,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertTree(q"..$mods object $name $template")(Defn.Object(
       List(Mod.Private(anon), Mod.Final()),
       tname("Q"),
-      tpl(List(init("F")), List(Defn.Def(Nil, tname("m"), Nil, Nil, None, int(42))))
+      tpl(List(init("F")), List(Defn.Def(Nil, tname("m"), Nil, Nil, None, int(42)))),
     ))
   }
 
@@ -1532,7 +1532,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertTree(name)(tname("Q"))
     assertTree(template)(tpl(
       Defn.Def(Nil, tname("m1"), Nil, Nil, None, int(42)),
-      Defn.Def(Nil, tname("m2"), Nil, Nil, None, int(666))
+      Defn.Def(Nil, tname("m2"), Nil, Nil, None, int(666)),
     ))
   }
 
@@ -1542,7 +1542,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertTree(q"package object $name $template")(Pkg.Object(
       Nil,
       tname("Q"),
-      tpl(List(init("F")), List(Defn.Def(Nil, tname("m"), Nil, Nil, None, int(42))))
+      tpl(List(init("F")), List(Defn.Def(Nil, tname("m"), Nil, Nil, None, int(42)))),
     ))
   }
 
@@ -1552,7 +1552,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertEquals(stats.toString, "{ class A; object B }")
     assertTree(stats)(Pkg.Body(List(
       Defn.Class(Nil, pname("A"), Nil, ctor, tplNoBody()),
-      Defn.Object(Nil, tname("B"), tplNoBody())
+      Defn.Object(Nil, tname("B"), tplNoBody()),
     )))
   }
 
@@ -1563,8 +1563,8 @@ class SuccessSuite extends TreeSuiteBase {
       tname("p"),
       List(
         Defn.Class(Nil, pname("A"), Nil, ctor, tplNoBody()),
-        Defn.Object(Nil, tname("B"), tplNoBody())
-      )
+        Defn.Object(Nil, tname("B"), tplNoBody()),
+      ),
     ))
   }
 
@@ -1578,8 +1578,8 @@ class SuccessSuite extends TreeSuiteBase {
       tselect("p", "a"),
       List(
         Defn.Class(Nil, pname("A"), Nil, ctor, tplNoBody()),
-        Defn.Object(Nil, tname("B"), tplNoBody())
-      )
+        Defn.Object(Nil, tname("B"), tplNoBody()),
+      ),
     ))
   }
 
@@ -1588,7 +1588,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertEquals(mods.toString, "List(private)")
     assertTrees(mods: _*)(Mod.Private(anon))
     checkTreesWithSyntax(paramss: _*)("(x: X, y: Y)")(Term.ParamClause(
-      List(tparam("x", "X"), tparam("y", "Y"))
+      List(tparam("x", "X"), tparam("y", "Y")),
     ))
   }
 
@@ -1596,7 +1596,7 @@ class SuccessSuite extends TreeSuiteBase {
     val mods = List(mod"private")
     val paramss = List(List(param"x: X", param"x: Y"))
     assertTree(q"..$mods def this(...$paramss)")(
-      Ctor.Primary(List(Mod.Private(anon)), anon, List(List(tparam("x", "X"), tparam("x", "Y"))))
+      Ctor.Primary(List(Mod.Private(anon)), anon, List(List(tparam("x", "X"), tparam("x", "Y")))),
     )
   }
 
@@ -1606,7 +1606,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertEquals(mods.toString, "List(private, final)")
     assertTrees(mods: _*)(Mod.Private(anon), Mod.Final())
     checkTreesWithSyntax(paramss: _*)("(x: X, y: Y)")(Term.ParamClause(
-      List(tparam("x", "X"), tparam("y", "Y"))
+      List(tparam("x", "X"), tparam("y", "Y")),
     ))
     assertTree(tinit)(init(Type.Singleton(Term.This(anon)), List(tname("foo"), tname("bar"))))
   }
@@ -1620,7 +1620,7 @@ class SuccessSuite extends TreeSuiteBase {
       Name.This(),
       List(List(tparam("x", "X"), tparam("x", "Y"))),
       init("C", List(tname("foo"), tname("bar"))),
-      Nil
+      Nil,
     ))
   }
 
@@ -1638,7 +1638,7 @@ class SuccessSuite extends TreeSuiteBase {
     val tpeopt = t"X"
     val expropt = q"42"
     assertTree(param"..$mods $paramname: $tpeopt = $expropt")(
-      Term.Param(List(Mod.Private(anon), Mod.Final()), tname("x"), Some(pname("X")), Some(int(42)))
+      Term.Param(List(Mod.Private(anon), Mod.Final()), tname("x"), Some(pname("X")), Some(int(42))),
     )
   }
 
@@ -1667,7 +1667,7 @@ class SuccessSuite extends TreeSuiteBase {
     val tpes1 = List(t"T with Y")
     val tpes2 = List(t"U with I")
     assertTree(
-      tparam"..$mods $tparamname[..$tparams] >: $tpeopt1 <: $tpeopt2 <% ..$tpes1 : ..$tpes2"
+      tparam"..$mods $tparamname[..$tparams] >: $tpeopt1 <: $tpeopt2 <% ..$tpes1 : ..$tpes2",
     )(pparam(
       List(Mod.Covariant()),
       "Z",
@@ -1676,8 +1676,8 @@ class SuccessSuite extends TreeSuiteBase {
         "E",
         "R",
         cb = List(Type.With(pname("U"), pname("I"))),
-        vb = List(Type.With(pname("T"), pname("Y")))
-      )
+        vb = List(Type.With(pname("T"), pname("Y"))),
+      ),
     ))
   }
 
@@ -1704,7 +1704,7 @@ class SuccessSuite extends TreeSuiteBase {
   test("2 init\"this(...exprss)\"") {
     val exprss = List(List(q"40"), List(q"2"))
     assertTree(init"this(...$exprss)")(
-      init(Type.Singleton(Term.This(anon)), List(int(40)), List(int(2)))
+      init(Type.Singleton(Term.This(anon)), List(int(40)), List(int(2))),
     )
   }
 
@@ -1741,7 +1741,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertEquals(stats1.toString, "Some({ val a = 2; val b = 2 })")
     assertTree(stats1)(Some(stats(
       Defn.Val(Nil, List(patvar("a")), None, int(2)),
-      Defn.Val(Nil, List(patvar("b")), None, int(2))
+      Defn.Val(Nil, List(patvar("b")), None, int(2)),
     )))
     assertEquals(inits.toString, "List(T, U)")
     assertTrees(inits: _*)(init("T"), init("U"))
@@ -1749,7 +1749,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertEquals(stats2.toString, "List(def m = 2, def n = 2)")
     assertTrees(stats2: _*)(
       Defn.Def(Nil, tname("m"), Nil, Nil, None, int(2)),
-      Defn.Def(Nil, tname("n"), Nil, Nil, None, int(2))
+      Defn.Def(Nil, tname("n"), Nil, Nil, None, int(2)),
     )
   }
 
@@ -1761,15 +1761,15 @@ class SuccessSuite extends TreeSuiteBase {
     assertTree(template"{ ..$stats1 } with ..$inits { $self1 => ..$stats2 }")(Template(
       List(
         Defn.Val(Nil, List(patvar("a")), None, int(2)),
-        Defn.Val(Nil, List(patvar("b")), None, int(2))
+        Defn.Val(Nil, List(patvar("b")), None, int(2)),
       ),
       List(init("T"), init("U")),
       self("self", "S"),
       List(
         Defn.Def(Nil, tname("m"), Nil, Nil, None, int(2)),
-        Defn.Def(Nil, tname("n"), Nil, Nil, None, int(2))
+        Defn.Def(Nil, tname("n"), Nil, Nil, None, int(2)),
       ),
-      Nil
+      Nil,
     ))
   }
 
@@ -1949,7 +1949,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertWithOriginalSyntax(stats: _*)("class A { val a = 'a'}")("class A { val a = 'a' }")
     assertTrees(stats: _*)(
       Defn
-        .Class(Nil, pname("A"), Nil, EmptyCtor(), tpl(Defn.Val(Nil, List(patvar("a")), None, lit('a'))))
+        .Class(Nil, pname("A"), Nil, EmptyCtor(), tpl(Defn.Val(Nil, List(patvar("a")), None, lit('a')))),
     )
   }
 
@@ -1959,7 +1959,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertWithOriginalSyntax(stats: _*)("class A { val a = 'a'}")("class A { val a = 'a' }")
     assertTrees(stats: _*)(
       Defn
-        .Class(Nil, pname("A"), Nil, EmptyCtor(), tpl(Defn.Val(Nil, List(patvar("a")), None, lit('a'))))
+        .Class(Nil, pname("A"), Nil, EmptyCtor(), tpl(Defn.Val(Nil, List(patvar("a")), None, lit('a')))),
     )
   }
 
@@ -1967,7 +1967,7 @@ class SuccessSuite extends TreeSuiteBase {
     val stats = List(q"class A { val x = 1 }", q"object B")
     assertTree(source"..$stats")(Source(List(
       Defn.Class(Nil, pname("A"), Nil, ctor, tpl(Defn.Val(Nil, List(patvar("x")), None, int(1)))),
-      Defn.Object(Nil, tname("B"), tplNoBody())
+      Defn.Object(Nil, tname("B"), tplNoBody()),
     )))
   }
 
@@ -1996,7 +1996,7 @@ class SuccessSuite extends TreeSuiteBase {
     checkTree(tparams, "")(noPpc)
     checkTreesWithSyntax(paramss: _*)("(x: Int)")(tpc(tparam("x", "Int")))
     assertTree(q"..$mods def $name[..$tparams](...$paramss): $tpe = $rhs")(
-      Defn.Def(Nil, tname("f"), Nil, List(List(tparam("x", "Int"))), None, tname("???"))
+      Defn.Def(Nil, tname("f"), Nil, List(List(tparam("x", "Int"))), None, tname("???")),
     )
   }
 
@@ -2005,7 +2005,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertTree(tparams)(ppc(pparam("A")))
     checkTreesWithSyntax(paramss: _*)("(x: Int)")(tpc(tparam("x", "Int")))
     assertTree(q"..$mods def $name[..$tparams](...$paramss): $tpe = $rhs")(
-      Defn.Def(Nil, tname("f"), List(pparam("A")), List(List(tparam("x", "Int"))), None, tname("???"))
+      Defn.Def(Nil, tname("f"), List(pparam("A")), List(List(tparam("x", "Int"))), None, tname("???")),
     )
   }
 
@@ -2017,7 +2017,7 @@ class SuccessSuite extends TreeSuiteBase {
       pname("C"),
       Nil,
       EmptyCtor(),
-      tpl(Defn.Def(List(Mod.Private(anon)), tname("x"), Nil, Nil, None, int(2)))
+      tpl(Defn.Def(List(Mod.Private(anon)), tname("x"), Nil, Nil, None, int(2))),
     ))
   }
 
@@ -2036,7 +2036,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertEquals(q"class C extends $parent".syntax, "class C extends _root_.scala.AnyVal")
     assert(
       q"class C extends $parent with $parent".syntax ==
-        "class C extends _root_.scala.AnyVal with _root_.scala.AnyVal"
+        "class C extends _root_.scala.AnyVal with _root_.scala.AnyVal",
     )
   }
 
@@ -2047,14 +2047,14 @@ class SuccessSuite extends TreeSuiteBase {
       """|{
          |  class C
          |  class C
-         |}""".stripMargin.lf2nl
+         |}""".stripMargin.lf2nl,
     )
     assertEquals(
       q"{ $stat; $stat }".syntax,
       """|{
          |  class C
          |  class C
-         |}""".stripMargin.lf2nl
+         |}""".stripMargin.lf2nl,
     )
   }
 
@@ -2074,7 +2074,7 @@ class SuccessSuite extends TreeSuiteBase {
          |  def foo = bar
          |  println("another stat")
          |  def baz: Unit = {}
-         |}""".stripMargin.lf2nl
+         |}""".stripMargin.lf2nl,
     )
   }
 
@@ -2120,7 +2120,7 @@ class SuccessSuite extends TreeSuiteBase {
   test("#468 - primary constructor III") {
     val q"case class A(..$params)" = q"case class A(a: Int, b: String)"
     checkTreesWithSyntax(params)("(a: Int, b: String)")(Term.ParamClause(
-      List(tparam("a", "Int"), tparam("b", "String"))
+      List(tparam("a", "Int"), tparam("b", "String")),
     ))
   }
 
@@ -2129,7 +2129,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertEquals(paramss.length, 2)
     checkTreesWithSyntax(paramss: _*)("(a: Int)", "(b: String)")(
       tpc(tparam("a", "Int")),
-      tpc(tparam("b", "String"))
+      tpc(tparam("b", "String")),
     )
   }
 
@@ -2147,7 +2147,7 @@ class SuccessSuite extends TreeSuiteBase {
   test("#468 - function parameter list III") {
     val q"def foo(..$params): Int = a" = q"def foo(a: Int, b: String): Int = a"
     checkTreesWithSyntax(params)("(a: Int, b: String)")(Term.ParamClause(
-      List(tparam("a", "Int"), tparam("b", "String"))
+      List(tparam("a", "Int"), tparam("b", "String")),
     ))
   }
 
@@ -2156,7 +2156,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertEquals(paramss.length, 2)
     checkTreesWithSyntax(paramss: _*)("(a: Int)", "(b: String)")(
       tpc(tparam("a", "Int")),
-      tpc(tparam("b", "String"))
+      tpc(tparam("b", "String")),
     )
   }
 
@@ -2208,7 +2208,7 @@ class SuccessSuite extends TreeSuiteBase {
          |  x
          |  y
          |  z
-         |}""".stripMargin.lf2nl
+         |}""".stripMargin.lf2nl,
     )
   }
 
@@ -2231,7 +2231,7 @@ class SuccessSuite extends TreeSuiteBase {
   test("#2841 non-empty, no extends") {
     val q"..$mods object $ename $template" = q"object X extends Y { def foo }"
     assertTree(template)(
-      tpl(List(init("Y")), List(Decl.Def(Nil, tname("foo"), Nil, Nil, pname("Unit"))))
+      tpl(List(init("Y")), List(Decl.Def(Nil, tname("foo"), Nil, Nil, pname("Unit")))),
     )
     assertEquals(mods, Nil)
   }
@@ -2302,7 +2302,7 @@ class SuccessSuite extends TreeSuiteBase {
 
     def assertOriginType(obtained: Tree, expected: Class[_ <: Origin]): Unit = assertEquals(
       obtained.origin.getClass.asInstanceOf[Class[Origin]],
-      expected.asInstanceOf[Class[Origin]]
+      expected.asInstanceOf[Class[Origin]],
     )
 
     assertOriginType(valX, classOf[Origin.Parsed])
@@ -2319,7 +2319,7 @@ class SuccessSuite extends TreeSuiteBase {
   test("comments: single-line: literal") {
     val content = q""""real content""""
     assertTree(q"0 // $content has been unquoted")(
-      Lit.Int.createWithComments(0, endComment = Seq("// real content has been unquoted"))
+      Lit.Int.createWithComments(0, endComment = Seq("// real content has been unquoted")),
     )
   }
 
@@ -2328,7 +2328,7 @@ class SuccessSuite extends TreeSuiteBase {
     val begComment = List("/* bc1 */", "/* real content bc */", "/* bc2 */")
     val endComment = List("/* ec1 */", "/* real content ec */", "/* ec2 */")
     assertTree(q"/* bc1 */ /* $content bc */ /* bc2 */ 0 /* ec1 */ /* $content ec */ /* ec2 */")(
-      Lit.Int.createWithComments(0, begComment = begComment, endComment = endComment)
+      Lit.Int.createWithComments(0, begComment = begComment, endComment = endComment),
     )
   }
 
@@ -2344,7 +2344,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertTree(tree)(tapply(
       "foo",
       Lit.Int.createWithComments(0, endComment = List("/* c1 */", "/* real content c */", "/* c2 */")),
-      lit(1)
+      lit(1),
     ))
   }
 
@@ -2359,7 +2359,7 @@ class SuccessSuite extends TreeSuiteBase {
     assertTree(tree)(tapply(
       "foo",
       lit(0),
-      Lit.Int.createWithComments(1, begComment = List("/* c1 */", "/* real content c */", "/* c2 */"))
+      Lit.Int.createWithComments(1, begComment = List("/* c1 */", "/* real content c */", "/* c2 */")),
     ))
   }
 
@@ -2370,7 +2370,7 @@ class SuccessSuite extends TreeSuiteBase {
       List(Pat.Var(Term.Name("foo"))),
       None,
       lit(0),
-      endComment = Seq("// real content has been unquoted")
+      endComment = Seq("// real content has been unquoted"),
     )
     assertTree(q"val foo = 0 // $content has been unquoted")(tree)
   }
@@ -2382,7 +2382,7 @@ class SuccessSuite extends TreeSuiteBase {
       List(Pat.Var(Term.Name("foo"))),
       None,
       lit(0),
-      endComment = Seq("/* real content has been unquoted */")
+      endComment = Seq("/* real content has been unquoted */"),
     )
     assertTree(q"val foo = 0 /* $content has been unquoted */")(tree)
   }
@@ -2399,7 +2399,7 @@ class SuccessSuite extends TreeSuiteBase {
          |Space [17..18)
          |Constant.String(any message) [18..31)
          |EOF [31..31)
-         |""".stripMargin
+         |""".stripMargin,
     )
     val pos = quoted.pos
     assertNoDiff(pos.toString, """[0,31) in str(`${fooTypes(0)}`; "any message")""")
@@ -2409,7 +2409,7 @@ class SuccessSuite extends TreeSuiteBase {
       """|<stats1>Lit.String "any message"</stats1> [18:"any message":31)
          |""".stripMargin,
       showPosition = true,
-      showFieldName = true
+      showFieldName = true,
     )
 
     val syntax =
@@ -2437,7 +2437,7 @@ class SuccessSuite extends TreeSuiteBase {
          |Space [17..18)
          |Constant.String(any message) [18..31)
          |EOF [31..31)
-         |""".stripMargin
+         |""".stripMargin,
     )
     val pos = quoted.pos
     assertNoDiff(pos.toString, """[0,31) in str(/* .. */`$terms`; "any message")""")
@@ -2447,7 +2447,7 @@ class SuccessSuite extends TreeSuiteBase {
       """|<stats1>Lit.String "any message"</stats1> [18:"any message":31)
          |""".stripMargin,
       showPosition = true,
-      showFieldName = true
+      showFieldName = true,
     )
 
     val syntax =

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/BaseTokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/BaseTokenizerSuite.scala
@@ -14,7 +14,7 @@ abstract class BaseTokenizerSuite extends TreeSuiteBase {
   }
 
   def assertTokens(code: String, dialect: Dialect = this.dialect)(
-      expected: PartialFunction[Tokens, Unit]
+      expected: PartialFunction[Tokens, Unit],
   )(implicit location: munit.Location) = {
     implicit val implicitDialect = dialect
     val obtained = tokenize(code)
@@ -24,7 +24,7 @@ abstract class BaseTokenizerSuite extends TreeSuiteBase {
   def assertLegacyScannedAsStringLines(
       code: String,
       expected: String,
-      dialect: Dialect = this.dialect
+      dialect: Dialect = this.dialect,
   )(implicit loc: Location): Unit = {
     import scala.meta.internal.tokenizers._
     import scala.meta.tests.parsers.MoreHelpers._
@@ -43,7 +43,7 @@ abstract class BaseTokenizerSuite extends TreeSuiteBase {
 
   protected def testTokenizedStructLines(
       options: munit.TestOptions,
-      testDialect: Dialect = dialect
+      testDialect: Dialect = dialect,
   )(codeTemplate: String, expected: String)(implicit loc: munit.Location): Unit = test(options) {
     implicit val dialect: Dialect = testDialect
     assertTokenizedAsStructureLines(codeTemplate.replace("'''", "\"\"\""), expected.nl2lf)
@@ -51,11 +51,11 @@ abstract class BaseTokenizerSuite extends TreeSuiteBase {
 
   protected def testTokenizedStructLinesEscaped(
       options: munit.TestOptions,
-      testDialect: Dialect = dialect
+      testDialect: Dialect = dialect,
   )(codeTemplate: String, expected: String)(implicit loc: munit.Location): Unit =
     testTokenizedStructLines(options, testDialect)(
       codeTemplate.replace("\\\\", "\\"),
-      expected.replace("\\\\", "\\")
+      expected.replace("\\\\", "\\"),
     )
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/GranularWhitespaceTokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/GranularWhitespaceTokenizerSuite.scala
@@ -14,7 +14,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
     new TokenizerOptions(groupWhitespace = false)
 
   test("showCode without comments - simple")(
-    assertTokenizedAsSyntax("class C  {\t val x = 2}\n\n", "class C  {\t val x = 2}\n\n")
+    assertTokenizedAsSyntax("class C  {\t val x = 2}\n\n", "class C  {\t val x = 2}\n\n"),
   )
 
   test("showcode without comments - hard") {
@@ -80,7 +80,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
         |  val hello = 42
         |  val `world` = 42
         |}
-        |""".stripMargin.tq()
+        |""".stripMargin.tq(),
     )
   }
 
@@ -113,13 +113,13 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
         |  qQQQclass $YQQQ
         |  qQQQclass ${Y}QQQ
         |}
-        |""".stripMargin.tq()
+        |""".stripMargin.tq(),
     )
   }
 
   test("showCode with comments - easy")(assertTokenizedAsSyntax(
     "class C  /*hello world*/{\t val x = 2}\n//bye-bye world\n",
-    "class C  /*hello world*/{\t val x = 2}\n//bye-bye world\n"
+    "class C  /*hello world*/{\t val x = 2}\n//bye-bye world\n",
   ))
 
   test("showCode with comments - tricky") {
@@ -161,7 +161,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
       |LF [22..23)
       |LF [23..24)
       |EOF [24..24)
-      |""".stripMargin
+      |""".stripMargin,
   )
 
   testTokenizedStructLines("tokenized-wrong-number-braces1")(
@@ -186,7 +186,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
        |RightBrace [22..23)
        |LF [23..24)
        |EOF [24..24)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   testTokenizedStructLines("tokenized-wrong-number-braces2")(
@@ -213,7 +213,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
        |LeftBrace [24..25)
        |RightBrace [25..26)
        |EOF [26..26)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   testTokenizedStructLines("showRaw without comments - hard")(
@@ -526,7 +526,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
       |LF [470..471)
       |RightBrace [471..472)
       |EOF [472..472)
-      |""".stripMargin.tq()
+      |""".stripMargin.tq(),
   )
 
   testTokenizedStructLines("showRaw without comments - insane")(
@@ -662,7 +662,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
       |LF [153..154)
       |RightBrace [154..155)
       |EOF [155..155)
-      |""".stripMargin.tq()
+      |""".stripMargin.tq(),
   )
 
   testTokenizedStructLines("showRaw with comments - easy")(
@@ -690,7 +690,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
       |Comment(bye-bye world) [38..53)
       |LF [53..54)
       |EOF [54..54)
-      |""".stripMargin
+      |""".stripMargin,
   )
 
   testTokenizedStructLines("showRaw with comments - tricky")(
@@ -703,7 +703,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
       |Comment() [3..7)
       |Ident(y) [7..8)
       |EOF [8..8)
-      |""".stripMargin
+      |""".stripMargin,
   )
 
   testTokenizedStructLines("showRaw with comments - skip unicode escape 1")(
@@ -711,7 +711,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
     """|BOF [0..0)
        |Comment( Note: '\\u000A' = '\\n') [0..24)
        |EOF [24..24)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   testTokenizedStructLines("showRaw with comments - skip unicode escape 2")(
@@ -719,7 +719,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
     """|BOF [0..0)
        |Comment( Note: '\\u000A' = '\\n' ) [0..27)
        |EOF [27..27)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   testTokenizedStructLines("interpolation start & end - episode 01")(
@@ -731,7 +731,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
       |Interpolation.Part() [2..2)
       |Interpolation.End(") [2..3)
       |EOF [3..3)
-      |""".stripMargin
+      |""".stripMargin,
   )
 
   testTokenizedStructLines("interpolation start & end - episode 02")(
@@ -744,7 +744,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
       |Interpolation.End(") [2..3)
       |Semicolon [3..4)
       |EOF [4..4)
-      |""".stripMargin
+      |""".stripMargin,
   )
 
   testTokenizedStructLines("interpolation start & end - episode 03")(
@@ -756,7 +756,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
       |Interpolation.Part(a) [2..3)
       |Interpolation.End(") [3..4)
       |EOF [4..4)
-      |""".stripMargin
+      |""".stripMargin,
   )
 
   testTokenizedStructLines("interpolation start & end - episode 04")(
@@ -769,7 +769,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
       |Interpolation.End(") [3..4)
       |Semicolon [4..5)
       |EOF [5..5)
-      |""".stripMargin
+      |""".stripMargin,
   )
 
   testTokenizedStructLines("interpolation start & end - episode 05")(
@@ -781,7 +781,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
       |Interpolation.Part() [4..4)
       |Interpolation.End(QQQ) [4..7)
       |EOF [7..7)
-      |""".stripMargin.tq()
+      |""".stripMargin.tq(),
   )
 
   testTokenizedStructLines("interpolation start & end - episode 06")(
@@ -794,7 +794,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
       |Interpolation.End(QQQ) [4..7)
       |Semicolon [7..8)
       |EOF [8..8)
-      |""".stripMargin.tq()
+      |""".stripMargin.tq(),
   )
 
   testTokenizedStructLines("interpolation start & end - episode 07")(
@@ -806,7 +806,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
       |Interpolation.Part(a) [4..5)
       |Interpolation.End(QQQ) [5..8)
       |EOF [8..8)
-      |""".stripMargin.tq()
+      |""".stripMargin.tq(),
   )
 
   testTokenizedStructLines("interpolation start & end - episode 08")(
@@ -819,7 +819,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
       |Interpolation.End(QQQ) [5..8)
       |Semicolon [8..9)
       |EOF [9..9)
-      |""".stripMargin.tq()
+      |""".stripMargin.tq(),
   )
 
   testTokenizedStructLines("interpolation start & end - episode 09")(
@@ -832,7 +832,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
       |Interpolation.End(") [3..4)
       |CRLF [4..6)
       |EOF [6..6)
-      |""".stripMargin
+      |""".stripMargin,
   )
 
   testTokenizedStructLines("interpolation-underscore")(
@@ -847,7 +847,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
        |Interpolation.Part() [32..32)
        |Interpolation.End(") [32..33)
        |EOF [33..33)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   testTokenizedStructLines("$this")(
@@ -863,7 +863,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
       |Interpolation.Part() [7..7)
       |Interpolation.End(") [7..8)
       |EOF [8..8)
-      |""".stripMargin
+      |""".stripMargin,
   )
 
   testTokenizedStructLines("monocle 1")(
@@ -876,7 +876,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
       |Space [4..5)
       |Ident(x) [5..6)
       |EOF [6..6)
-      |""".stripMargin
+      |""".stripMargin,
   )
 
   testTokenizedStructLines("monocle 2")(
@@ -889,7 +889,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
       |Space [3..4)
       |Ident(x) [4..5)
       |EOF [5..5)
-      |""".stripMargin
+      |""".stripMargin,
   )
 
   testTokenizedStructLines("monocle 3")(
@@ -911,7 +911,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
       |Ident(x) [22..23)
       |RightParen [23..24)
       |EOF [24..24)
-      |""".stripMargin
+      |""".stripMargin,
   )
 
   testTokenizedStructLines("monocle 4")(
@@ -933,7 +933,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
       |Ident(x) [21..22)
       |RightParen [22..23)
       |EOF [23..23)
-      |""".stripMargin
+      |""".stripMargin,
   )
 
   testTokenizedStructLines("-2147483648")(
@@ -943,7 +943,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
       |Ident(-) [0..1)
       |Constant.Int(2147483648) [1..11)
       |EOF [11..11)
-      |""".stripMargin.tq()
+      |""".stripMargin.tq(),
   )
 
   testTokenizedStructLines("simple xml literal - 1")(
@@ -954,7 +954,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
       |Xml.Part(<foo>bar</foo>) [0..14)
       |Xml.End [14..14)
       |EOF [14..14)
-      |""".stripMargin.tq()
+      |""".stripMargin.tq(),
   )
 
   testTokenizedStructLines("simple xml literal - 2")(
@@ -966,7 +966,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
       |Xml.End [14..14)
       |Space [14..15)
       |EOF [15..15)
-      |""".stripMargin.tq()
+      |""".stripMargin.tq(),
   )
 
   testTokenizedStructLines("incomplete xml literal - 1")(
@@ -986,7 +986,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
        |Xml.Part(<foo>bar</fo>) [11..24)
        |Xml.End [24..24)
        |EOF [24..24)
-       |""".stripMargin.tq()
+       |""".stripMargin.tq(),
   )
 
   test("incomplete xml literal - 2") {
@@ -999,7 +999,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
       """|<input>:3: error: malformed xml literal, expected:
          |Expected ("{{" | "}}" | "&" | "&#" | "&#x" | "{" | "<xml:unparsed" | "<![CDATA[" | "<!--" | "</"):3:29, found "<?\n"
          |  val b = <baz qux="...">cde<?
-         |                            ^""".stripMargin.lf2nl
+         |                            ^""".stripMargin.lf2nl,
     )(code.asInput.parseRule(_.entrypointStat()))
   }
 
@@ -1009,7 +1009,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
     interceptMessage[ParseException](
       """|<input>:1: error: xml literals are not supported
          |<foo>bar</foo>
-         |^""".stripMargin.lf2nl
+         |^""".stripMargin.lf2nl,
     )(code.asInput.parseRule(_.entrypointStat()))
   }
 
@@ -1019,13 +1019,13 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
     interceptMessage[ParseException](
       """|<input>:1: error: xml literals are not supported
          |val a = <foo>bar</foo>
-         |        ^""".stripMargin.lf2nl
+         |        ^""".stripMargin.lf2nl,
     )(code.asInput.parseRule(_.entrypointStat()))
   }
 
   testTokenizedStructLines(
     "unsupported xml literal - 3 plus/no space",
-    dialects.Scala213.withAllowXmlLiterals(false)
+    dialects.Scala213.withAllowXmlLiterals(false),
   )(
     """|a+<foo>bar</foo>
        |""".stripMargin,
@@ -1040,7 +1040,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
        |Ident(>) [15..16)
        |LF [16..17)
        |EOF [17..17)
-       |""".stripMargin.tq()
+       |""".stripMargin.tq(),
   )
 
   test("parsed trees don't have BOF/EOF in their tokens") {
@@ -1048,7 +1048,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
     assert(tree.pos != Position.None)
     assertEquals(
       tree.tokens.structure,
-      "Tokens(BOF [0..0), Ident(foo) [0..3), Space [3..4), Ident(+) [4..5), Space [5..6), Ident(bar) [6..9), EOF [9..9))"
+      "Tokens(BOF [0..0), Ident(foo) [0..3), Space [3..4), Ident(+) [4..5), Space [5..6), Ident(bar) [6..9), EOF [9..9))",
     )
   }
 
@@ -1060,7 +1060,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
     assertEquals(tree.tokens.structure, tokensStructure)
     assertEquals(
       tokensStructure,
-      "Tokens(BOF [0..0), Ident(foo) [0..3), Space [3..4), Ident(+) [4..5), Space [5..6), Ident(bar) [6..9), EOF [9..9))"
+      "Tokens(BOF [0..0), Ident(foo) [0..3), Space [3..4), Ident(+) [4..5), Space [5..6), Ident(bar) [6..9), EOF [9..9))",
     )
   }
 
@@ -1089,7 +1089,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
         assertEquals(crlf.text, "\r\n")
         assertEquals(part.len, 3)
         assertEquals(crlf.len, 2)
-    }
+    },
   )
 
   test("Interpolated tree parsed succesfully with windows newline, with LF escaped") {
@@ -1104,7 +1104,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
         |Interpolation.End(") [6..7)
         |LF [7..8)
         |EOF [14..14)
-        |""".stripMargin
+        |""".stripMargin,
     )
   }
 
@@ -1113,7 +1113,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
       case Tokens(bof, _, _, _, part: Interpolation.Part, _, lf: LF, eof) =>
         assertEquals(part.value, "foo")
         assertEquals(lf.syntax, "\n")
-    }
+    },
   )
 
   test("Interpolated with quote escape 1") {
@@ -1130,7 +1130,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
             Interpolation.SpliceEnd(),
             Interpolation.Part("\" in quotes"),
             Interpolation.End(),
-            EOF()
+            EOF(),
           ) =>
     }
 
@@ -1149,7 +1149,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
          |Constant.String( in quotes) [11..21)
          |EOF [22..22)
          |""".stripMargin,
-      dialects.Scala212
+      dialects.Scala212,
     )
   }
 
@@ -1166,7 +1166,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
             Interpolation.Part("$"),
             Interpolation.End(),
             RightParen(),
-            EOF()
+            EOF(),
           ) =>
     }
 
@@ -1200,7 +1200,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
             Interpolation.SpliceEnd(),
             Interpolation.Part(""),
             Interpolation.End(),
-            EOF()
+            EOF(),
           ) =>
     }
     assertTokens("s\"$enum\"", dialects.Scala213) {
@@ -1214,7 +1214,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
             Interpolation.SpliceEnd(),
             Interpolation.Part(""),
             Interpolation.End(),
-            EOF()
+            EOF(),
           ) =>
     }
     assertTokenizedAsStructureLines(
@@ -1231,7 +1231,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
          |Interpolation.End(") [7..8)
          |EOF [8..8)
          |""".stripMargin,
-      dialects.Scala3
+      dialects.Scala3,
     )
   }
 
@@ -1246,7 +1246,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
             Ident("a"),
             Space(),
             RightBrace(),
-            EOF()
+            EOF(),
           ) =>
     }
 
@@ -1260,7 +1260,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
             Ident("a"),
             Space(),
             RightBrace(),
-            EOF()
+            EOF(),
           ) =>
     }
   }
@@ -1274,12 +1274,12 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
     "0x_1234",
     "0b_0101",
     "123_456__789",
-    "0x__123_456__789"
+    "0x__123_456__789",
   ).foreach(value =>
     test(s"numeric literal separator ok scala213: $value") {
       implicit val dialect: Dialect = dialects.Scala213
       tokenize(value) // no exception
-    }
+    },
   )
 
   Seq(
@@ -1287,74 +1287,74 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
       "123_456_",
       """|<input>:1: error: trailing number separator
          |123_456_
-         |       ^""".stripMargin
+         |       ^""".stripMargin,
     ),
     (
       "123_456_L",
       """|<input>:1: error: trailing number separator
          |123_456_L
-         |       ^""".stripMargin
+         |       ^""".stripMargin,
     ),
     (
       "3_14_E-2",
       """|<input>:1: error: trailing number separator
          |3_14_E-2
-         |    ^""".stripMargin
+         |    ^""".stripMargin,
     ),
     (
       "3_14E-_2",
       """|<input>:1: error: leading number separator
          |3_14E-_2
-         |      ^""".stripMargin
+         |      ^""".stripMargin,
     ),
     (
       "3_14E",
       """|<input>:1: error: Invalid literal floating-point number, exponent not followed by integer
          |3_14E
-         |     ^""".stripMargin
+         |     ^""".stripMargin,
     ),
     (
       "3_14E_2",
       """|<input>:1: error: leading number separator
          |3_14E_2
-         |     ^""".stripMargin
+         |     ^""".stripMargin,
     ),
     (
       "3_14E_F",
       """|<input>:1: error: Invalid literal floating-point number, exponent not followed by integer
          |3_14E_F
-         |     ^""".stripMargin
+         |     ^""".stripMargin,
     ),
     (
       "3_14ef",
       """|<input>:1: error: Invalid literal floating-point number, exponent not followed by integer
          |3_14ef
-         |     ^""".stripMargin
+         |     ^""".stripMargin,
     ),
     (
       "3_14E-2_",
       """|<input>:1: error: trailing number separator
          |3_14E-2_
-         |       ^""".stripMargin
+         |       ^""".stripMargin,
     ),
     (
       "3.1_4_",
       """|<input>:1: error: trailing number separator
          |3.1_4_
-         |     ^""".stripMargin
+         |     ^""".stripMargin,
     ),
     (
       "3.1_4_d",
       """|<input>:1: error: trailing number separator
          |3.1_4_d
-         |     ^""".stripMargin
+         |     ^""".stripMargin,
     ),
     (
       "3.1_4_dd",
       """|<input>:1: error: trailing number separator
          |3.1_4_dd
-         |     ^""".stripMargin
-    )
+         |     ^""".stripMargin,
+    ),
   ).foreach { case (value, error) =>
     test(s"numeric literal separator fail scala213: $value") {
       implicit val dialect: Dialect = dialects.Scala213
@@ -1366,7 +1366,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
     "1_024",
     """|<input>:1: error: numeric separators are not allowed
        |1_024
-       | ^""".stripMargin
+       | ^""".stripMargin,
   )).foreach { case (value, error) =>
     test(s"numeric literal separator fail scala212: $value") {
       implicit val dialect: Dialect = dialects.Scala212
@@ -1393,7 +1393,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
           Interpolation.SpliceEnd(),
           Interpolation.Part(""),
           Interpolation.End(),
-          EOF()
+          EOF(),
         ) =>
   })
 
@@ -1409,7 +1409,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
        |Interpolation.Part() [11..11)
        |Invalid(unclosed single-line string interpolation) [11..11)
        |Interpolation.End() [11..11)
-       |EOF [11..11)""".stripMargin
+       |EOF [11..11)""".stripMargin,
   )
 
   test("Multiline interpolated string - ignore escape")(
@@ -1428,9 +1428,9 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
             Interpolation.SpliceEnd(),
             Interpolation.Part("\\"),
             Interpolation.End(),
-            EOF()
+            EOF(),
           ) =>
-    }
+    },
   )
 
   test("#3328") {
@@ -1450,7 +1450,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
        |Space [7..8)
        |Ident(Double) [8..14)
        |EOF [14..14)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   test("#3402") {
@@ -1475,56 +1475,56 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
       """|BOF [0..0)
          |Constant.Double(0) [0..2)
          |EOF [2..2)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0.0",
       """|BOF [0..0)
          |Constant.Double(0.0) [0..3)
          |EOF [3..3)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "00e0",
       """|BOF [0..0)
          |Constant.Double(0) [0..4)
          |EOF [4..4)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "00e0f",
       """|BOF [0..0)
          |Constant.Float(0) [0..5)
          |EOF [5..5)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0xe1",
       """|BOF [0..0)
          |Constant.Int(225) [0..4)
          |EOF [4..4)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0xd",
       """|BOF [0..0)
          |Constant.Int(13) [0..3)
          |EOF [3..3)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0f",
       """|BOF [0..0)
          |Constant.Float(0) [0..2)
          |EOF [2..2)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0.0f",
       """|BOF [0..0)
          |Constant.Float(0.0) [0..4)
          |EOF [4..4)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0.f",
@@ -1533,7 +1533,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
          |Dot [1..2)
          |Ident(f) [2..3)
          |EOF [3..3)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       ".f",
@@ -1541,7 +1541,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
          |Dot [0..1)
          |Ident(f) [1..2)
          |EOF [2..2)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "1. + 2.",
@@ -1554,7 +1554,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
          |Constant.Int(2) [5..6)
          |Dot [6..7)
          |EOF [7..7)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "1.0 + 2.0f",
@@ -1565,7 +1565,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
          |Space [5..6)
          |Constant.Float(2.0) [6..10)
          |EOF [10..10)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "1d + 2f",
@@ -1576,56 +1576,56 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
          |Space [4..5)
          |Constant.Float(2) [5..7)
          |EOF [7..7)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0xf",
       """|BOF [0..0)
          |Constant.Int(15) [0..3)
          |EOF [3..3)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0",
       """|BOF [0..0)
          |Constant.Int(0) [0..1)
          |EOF [1..1)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0l",
       """|BOF [0..0)
          |Constant.Long(0) [0..2)
          |EOF [2..2)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0L",
       """|BOF [0..0)
          |Constant.Long(0) [0..2)
          |EOF [2..2)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0x80000000",
       """|BOF [0..0)
          |Constant.Int(2147483648) [0..10)
          |EOF [10..10)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0x8000000000000000L",
       """|BOF [0..0)
          |Constant.Long(9223372036854775808) [0..19)
          |EOF [19..19)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "3.4028235e38f",
       """|BOF [0..0)
          |Constant.Float(3.4028235E+38) [0..13)
          |EOF [13..13)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "-3.4028235e38f",
@@ -1633,14 +1633,14 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
          |Ident(-) [0..1)
          |Constant.Float(3.4028235E+38) [1..14)
          |EOF [14..14)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "1.7976931348623157e+308d",
       """|BOF [0..0)
          |Constant.Double(1.7976931348623157E+308) [0..24)
          |EOF [24..24)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "-1.7976931348623157e+308d",
@@ -1648,28 +1648,28 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
          |Ident(-) [0..1)
          |Constant.Double(1.7976931348623157E+308) [1..25)
          |EOF [25..25)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0b00101010",
       """|BOF [0..0)
          |Constant.Int(42) [0..10)
          |EOF [10..10)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0B_0010_1010",
       """|BOF [0..0)
          |Constant.Int(42) [0..12)
          |EOF [12..12)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0b_0010_1010L",
       """|BOF [0..0)
          |Constant.Long(42) [0..13)
          |EOF [13..13)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0b01.2",
@@ -1677,7 +1677,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
          |Constant.Int(1) [0..4)
          |Constant.Double(0.2) [4..6)
          |EOF [6..6)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0b01.toString",
@@ -1686,11 +1686,11 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
          |Dot [4..5)
          |Ident(toString) [5..13)
          |EOF [13..13)
-         |""".stripMargin
-    )
+         |""".stripMargin,
+    ),
   ).foreach { case (code, value) =>
     test(s"numeric literal ok scala213: $code")(
-      assertTokenizedAsStructureLines(code, value, dialects.Scala213)
+      assertTokenizedAsStructureLines(code, value, dialects.Scala213),
     )
   }
 
@@ -1699,56 +1699,56 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
       "00",
       """|<input>:1: error: Non-zero integral values may not have a leading zero.
          |00
-         |^""".stripMargin
+         |^""".stripMargin,
     ),
     (
       "00l",
       """|<input>:1: error: Non-zero integral values may not have a leading zero.
          |00l
-         |^""".stripMargin
+         |^""".stripMargin,
     ),
     (
       "0b01d",
       """|<input>:1: error: Invalid literal number, followed by identifier character
          |0b01d
-         |    ^""".stripMargin
+         |    ^""".stripMargin,
     ),
     (
       "0b01f",
       """|<input>:1: error: Invalid literal number, followed by identifier character
          |0b01f
-         |    ^""".stripMargin
+         |    ^""".stripMargin,
     ),
     (
       "0b0123",
       """|<input>:1: error: Invalid literal number, followed by identifier character
          |0b0123
-         |    ^""".stripMargin
+         |    ^""".stripMargin,
     ),
     (
       "3.4028236e38f",
       """|<input>:1: error: floating-point value out of range for Float
          |3.4028236e38f
-         |^""".stripMargin
+         |^""".stripMargin,
     ),
     (
       "-3.4028236e38f",
       """|<input>:1: error: floating-point value out of range for Float
          |-3.4028236e38f
-         | ^""".stripMargin
+         | ^""".stripMargin,
     ),
     (
       "1.7976931348623158e+308d",
       """|<input>:1: error: floating-point value out of range for Double
          |1.7976931348623158e+308d
-         |^""".stripMargin
+         |^""".stripMargin,
     ),
     (
       "-1.7976931348623158e+308d",
       """|<input>:1: error: floating-point value out of range for Double
          |-1.7976931348623158e+308d
-         | ^""".stripMargin
-    )
+         | ^""".stripMargin,
+    ),
   ).foreach { case (code, error) =>
     test(s"numeric literal fail scala213: $code") {
       implicit val dialect: Dialect = dialects.Scala213
@@ -1759,32 +1759,32 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
   Seq(
     // regular or half-surrogate char codes
     55297,
-    56375
+    56375,
   ).foreach(ch =>
     test(s"#3690 any character with char code $ch") {
       implicit val dialect = dialects.Scala213
       tokenize(
         s"""|"${ch.toChar}"
-            |""".stripMargin
+            |""".stripMargin,
       ) match {
         case Tokens(_: BOF, Constant.String(str), _: LF, _: EOF) =>
           assertEquals(str.length, 1)
           assertEquals(str, s"${ch.toChar}")
         case tokens => fail(s"unexpected tokens: ${tokens.structure}")
       }
-    }
+    },
   )
 
   Seq(
     // full-surrogate char code pairs
     (55297, 56375),
-    (0xdbff, 0xdfff)
+    (0xdbff, 0xdfff),
   ).foreach { case (hi, lo) =>
     test(s"#3690 full-surrogate with char codes $hi and $lo") {
       implicit val dialect = dialects.Scala213
       tokenize(
         s"""|"${hi.toChar}${lo.toChar}"
-            |""".stripMargin
+            |""".stripMargin,
       ) match {
         case Tokens(_: BOF, Constant.String(str), _: LF, _: EOF) =>
           assertEquals(str, s"${hi.toChar}${lo.toChar}")
@@ -1870,7 +1870,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
        |Ident(b) [95..96)
        |CRLF [96..98)
        |EOF [98..98)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   testTokenizedStructLines("code with Shebang line", dialects.Scala3)(
@@ -1901,7 +1901,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
        |RightParen [81..82)
        |CRLF [82..84)
        |EOF [84..84)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   testTokenizedStructLines("code with non-matching braces 1", dialects.Scala3)(
@@ -1948,7 +1948,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
        |Interpolation.End(") [48..49)
        |LF [49..50)
        |EOF [50..50)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   testTokenizedStructLines("code with non-matching braces 2", dialects.Scala3)(
@@ -1999,7 +1999,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
        |RightBrace [49..50)
        |LF [50..51)
        |EOF [51..51)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   testTokenizedStructLines("code with incomplete interpolation: 2.13", dialects.Scala213)(
@@ -2034,7 +2034,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
        |RightBrace [29..30)
        |LF [30..31)
        |EOF [31..31)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   testTokenizedStructLines("code with incomplete interpolation: 3", dialects.Scala3)(
@@ -2066,12 +2066,12 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
        |RightBrace [29..30)
        |LF [30..31)
        |EOF [31..31)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   testTokenizedStructLines(
     "code with double-quote string within single-line quasiquotes",
-    dialects.Scala213.unquoteTerm(multiline = false)
+    dialects.Scala213.unquoteTerm(multiline = false),
   )(
     " \"...\" ",
     """|BOF [0..0)
@@ -2080,12 +2080,12 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
        |Invalid(double quotes are not allowed in single-line quasiquotes) [1..1)
        |Space [6..7)
        |EOF [7..7)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   testTokenizedStructLines(
     "code with interpolation within single-line quasiquotes",
-    dialects.Scala213.unquoteTerm(multiline = false)
+    dialects.Scala213.unquoteTerm(multiline = false),
   )(
     " s\"...\" ",
     """|BOF [0..0)
@@ -2097,7 +2097,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
        |Interpolation.End(") [6..7)
        |Space [7..8)
        |EOF [8..8)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   testTokenizedStructLines("interpolator with $ character")(
@@ -2112,7 +2112,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
        |Interpolation.Part($) [8..10)
        |Interpolation.End(") [10..11)
        |EOF [11..11) 
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   testTokenizedStructLines("broken-interpolator")(
@@ -2144,7 +2144,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
        |Ident(stripMargin) [218..229)
        |LF [229..230)
        |EOF [230..230)
-       |""".stripMargin.replace("'''", "\"\"\"")
+       |""".stripMargin.replace("'''", "\"\"\""),
   )
 
   testTokenizedStructLines("unexpected-character")(
@@ -2164,7 +2164,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
        |LF [12..13)
        |LF [13..14)
        |EOF [14..14)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   Seq(
@@ -2199,7 +2199,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
            |Constant.Int(0) [22..23)
            |LF [23..24)
            |EOF [24..24)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase {
@@ -2224,7 +2224,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
            |Space [3..4)
            |LF [18..19)
            |EOF [19..19)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase {
@@ -2251,7 +2251,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
            |Invalid(unclosed quoted identifier) [13..18)
            |LF [18..19)
            |EOF [19..19)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase {
@@ -2278,7 +2278,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
            |Constant.Int(0) [18..19)
            |LF [19..20)
            |EOF [20..20)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase {
@@ -2299,7 +2299,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
            |Constant.String("foo") [0..17)
            |LF [17..18)
            |EOF [18..18)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase {
@@ -2316,7 +2316,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
            |Constant.String(""foo"") [0..29)
            |LF [29..30)
            |EOF [30..30)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase {
@@ -2333,7 +2333,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
            |Constant.String(\\\\u0022foo\\\\u0022) [0..21)
            |LF [21..22)
            |EOF [22..22)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase((
@@ -2349,7 +2349,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
          |Constant.Char(') [0..8)
          |LF [8..9)
          |EOF [9..9)
-         |""".stripMargin
+         |""".stripMargin,
     )),
     TestCase {
       (
@@ -2375,7 +2375,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
            |Ident(u0027) [3..8)
            |LF [8..9)
            |EOF [9..9)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase {
@@ -2394,7 +2394,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
            |Invalid(can't use unescaped LF in character literals) [8..8)
            |LF [8..9)
            |EOF [9..9)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase((
@@ -2410,7 +2410,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
          |Constant.Char(a) [0..8)
          |LF [8..9)
          |EOF [9..9)
-         |""".stripMargin
+         |""".stripMargin,
     )),
     TestCase {
       (
@@ -2426,7 +2426,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
            |Constant.String(a) [0..8)
            |LF [8..9)
            |EOF [9..9)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase {
@@ -2443,7 +2443,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
            |Constant.String(") [0..8)
            |LF [8..9)
            |EOF [9..9)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase {
@@ -2466,7 +2466,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
            |Interpolation.End(") [8..9)
            |LF [9..10)
            |EOF [10..10)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase {
@@ -2489,7 +2489,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
            |Interpolation.End(") [8..9)
            |LF [9..10)
            |EOF [10..10)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase {
@@ -2512,7 +2512,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
            |Interpolation.End(") [10..11)
            |LF [11..12)
            |EOF [12..12)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase {
@@ -2535,7 +2535,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
            |Interpolation.End(") [10..11)
            |LF [11..12)
            |EOF [12..12)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase {
@@ -2552,7 +2552,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
            |Constant.String(\\\\u0061) [0..12)
            |LF [12..13)
            |EOF [13..13)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase((
@@ -2568,7 +2568,7 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
          |Ident(a) [0..8)
          |LF [8..9)
          |EOF [9..9)
-         |""".stripMargin
+         |""".stripMargin,
     )),
     TestCase {
       (
@@ -2585,9 +2585,9 @@ class GranularWhitespaceTokenizerSuite extends BaseTokenizerSuite {
            |Ident(u0061) [1..6)
            |LF [6..7)
            |EOF [7..7)
-           |""".stripMargin
+           |""".stripMargin,
       )
-    }
+    },
   ).foreach { c =>
     val TestTokenizedWithDialects(title, code, exp212, exp213, exp3) = c.obj
     implicit val loc: munit.Location = c.loc

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizerSuite.scala
@@ -15,7 +15,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
     new TokenizerOptions(groupWhitespace = true)
 
   test("showCode without comments - simple")(
-    assertTokenizedAsSyntax("class C  {\t val x = 2}\n\n", "class C  {\t val x = 2}\n\n")
+    assertTokenizedAsSyntax("class C  {\t val x = 2}\n\n", "class C  {\t val x = 2}\n\n"),
   )
 
   test("showcode without comments - hard") {
@@ -81,7 +81,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
         |  val hello = 42
         |  val `world` = 42
         |}
-        |""".stripMargin.tq()
+        |""".stripMargin.tq(),
     )
   }
 
@@ -114,13 +114,13 @@ class TokenizerSuite extends BaseTokenizerSuite {
         |  qQQQclass $YQQQ
         |  qQQQclass ${Y}QQQ
         |}
-        |""".stripMargin.tq()
+        |""".stripMargin.tq(),
     )
   }
 
   test("showCode with comments - easy")(assertTokenizedAsSyntax(
     "class C  /*hello world*/{\t val x = 2}\n//bye-bye world\n",
-    "class C  /*hello world*/{\t val x = 2}\n//bye-bye world\n"
+    "class C  /*hello world*/{\t val x = 2}\n//bye-bye world\n",
   ))
 
   test("showCode with comments - tricky") {
@@ -159,7 +159,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
       |RightBrace [21..22)
       |MultiNL(2) [22..24)
       |EOF [24..24)
-      |""".stripMargin
+      |""".stripMargin,
   )
 
   testTokenizedStructLines("tokenized-wrong-number-braces1")(
@@ -182,7 +182,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
        |RightBrace [22..23)
        |LF [23..24)
        |EOF [24..24)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   testTokenizedStructLines("tokenized-wrong-number-braces2")(
@@ -207,7 +207,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
        |LeftBrace [24..25)
        |RightBrace [25..26)
        |EOF [26..26)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   testTokenizedStructLines("showRaw without comments - hard")(
@@ -493,7 +493,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
       |LF [470..471)
       |RightBrace [471..472)
       |EOF [472..472)
-      |""".stripMargin.tq()
+      |""".stripMargin.tq(),
   )
 
   testTokenizedStructLines("showRaw without comments - insane")(
@@ -619,7 +619,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
       |LF [153..154)
       |RightBrace [154..155)
       |EOF [155..155)
-      |""".stripMargin.tq()
+      |""".stripMargin.tq(),
   )
 
   testTokenizedStructLines("showRaw with comments - easy")(
@@ -645,7 +645,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
       |Comment(bye-bye world) [38..53)
       |LF [53..54)
       |EOF [54..54)
-      |""".stripMargin
+      |""".stripMargin,
   )
 
   testTokenizedStructLines("showRaw with comments - tricky")(
@@ -658,7 +658,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
       |Comment() [3..7)
       |Ident(y) [7..8)
       |EOF [8..8)
-      |""".stripMargin
+      |""".stripMargin,
   )
 
   testTokenizedStructLines("showRaw with comments - skip unicode escape 1")(
@@ -666,7 +666,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
     """|BOF [0..0)
        |Comment( Note: '\\u000A' = '\\n') [0..24)
        |EOF [24..24)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   testTokenizedStructLines("showRaw with comments - skip unicode escape 2")(
@@ -674,7 +674,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
     """|BOF [0..0)
        |Comment( Note: '\\u000A' = '\\n' ) [0..27)
        |EOF [27..27)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   testTokenizedStructLines("interpolation start & end - episode 01")(
@@ -686,7 +686,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
       |Interpolation.Part() [2..2)
       |Interpolation.End(") [2..3)
       |EOF [3..3)
-      |""".stripMargin
+      |""".stripMargin,
   )
 
   testTokenizedStructLines("interpolation start & end - episode 02")(
@@ -699,7 +699,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
       |Interpolation.End(") [2..3)
       |Semicolon [3..4)
       |EOF [4..4)
-      |""".stripMargin
+      |""".stripMargin,
   )
 
   testTokenizedStructLines("interpolation start & end - episode 03")(
@@ -711,7 +711,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
       |Interpolation.Part(a) [2..3)
       |Interpolation.End(") [3..4)
       |EOF [4..4)
-      |""".stripMargin
+      |""".stripMargin,
   )
 
   testTokenizedStructLines("interpolation start & end - episode 04")(
@@ -724,7 +724,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
       |Interpolation.End(") [3..4)
       |Semicolon [4..5)
       |EOF [5..5)
-      |""".stripMargin
+      |""".stripMargin,
   )
 
   testTokenizedStructLines("interpolation start & end - episode 05")(
@@ -736,7 +736,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
       |Interpolation.Part() [4..4)
       |Interpolation.End(QQQ) [4..7)
       |EOF [7..7)
-      |""".stripMargin.tq()
+      |""".stripMargin.tq(),
   )
 
   testTokenizedStructLines("interpolation start & end - episode 06")(
@@ -749,7 +749,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
       |Interpolation.End(QQQ) [4..7)
       |Semicolon [7..8)
       |EOF [8..8)
-      |""".stripMargin.tq()
+      |""".stripMargin.tq(),
   )
 
   testTokenizedStructLines("interpolation start & end - episode 07")(
@@ -761,7 +761,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
       |Interpolation.Part(a) [4..5)
       |Interpolation.End(QQQ) [5..8)
       |EOF [8..8)
-      |""".stripMargin.tq()
+      |""".stripMargin.tq(),
   )
 
   testTokenizedStructLines("interpolation start & end - episode 08")(
@@ -774,7 +774,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
       |Interpolation.End(QQQ) [5..8)
       |Semicolon [8..9)
       |EOF [9..9)
-      |""".stripMargin.tq()
+      |""".stripMargin.tq(),
   )
 
   testTokenizedStructLines("interpolation start & end - episode 09")(
@@ -787,7 +787,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
       |Interpolation.End(") [3..4)
       |CRLF [4..6)
       |EOF [6..6)
-      |""".stripMargin
+      |""".stripMargin,
   )
 
   testTokenizedStructLines("interpolation-underscore")(
@@ -802,7 +802,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
        |Interpolation.Part() [32..32)
        |Interpolation.End(") [32..33)
        |EOF [33..33)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   testTokenizedStructLines("$this")(
@@ -818,7 +818,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
       |Interpolation.Part() [7..7)
       |Interpolation.End(") [7..8)
       |EOF [8..8)
-      |""".stripMargin
+      |""".stripMargin,
   )
 
   testTokenizedStructLines("monocle 1")(
@@ -831,7 +831,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
       |Space [4..5)
       |Ident(x) [5..6)
       |EOF [6..6)
-      |""".stripMargin
+      |""".stripMargin,
   )
 
   testTokenizedStructLines("monocle 2")(
@@ -844,7 +844,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
       |Space [3..4)
       |Ident(x) [4..5)
       |EOF [5..5)
-      |""".stripMargin
+      |""".stripMargin,
   )
 
   testTokenizedStructLines("monocle 3")(
@@ -866,7 +866,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
       |Ident(x) [22..23)
       |RightParen [23..24)
       |EOF [24..24)
-      |""".stripMargin
+      |""".stripMargin,
   )
 
   testTokenizedStructLines("monocle 4")(
@@ -888,7 +888,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
       |Ident(x) [21..22)
       |RightParen [22..23)
       |EOF [23..23)
-      |""".stripMargin
+      |""".stripMargin,
   )
 
   testTokenizedStructLines("-2147483648")(
@@ -898,7 +898,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
       |Ident(-) [0..1)
       |Constant.Int(2147483648) [1..11)
       |EOF [11..11)
-      |""".stripMargin.tq()
+      |""".stripMargin.tq(),
   )
 
   testTokenizedStructLines("simple xml literal - 1")(
@@ -909,7 +909,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
       |Xml.Part(<foo>bar</foo>) [0..14)
       |Xml.End [14..14)
       |EOF [14..14)
-      |""".stripMargin.tq()
+      |""".stripMargin.tq(),
   )
 
   testTokenizedStructLines("simple xml literal - 2")(
@@ -921,7 +921,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
       |Xml.End [14..14)
       |Space [14..15)
       |EOF [15..15)
-      |""".stripMargin.tq()
+      |""".stripMargin.tq(),
   )
 
   testTokenizedStructLines("incomplete xml literal - 1")(
@@ -939,7 +939,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
        |Xml.Part(<foo>bar</fo>) [11..24)
        |Xml.End [24..24)
        |EOF [24..24)
-       |""".stripMargin.tq()
+       |""".stripMargin.tq(),
   )
 
   test("incomplete xml literal - 2") {
@@ -952,7 +952,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
       """|<input>:3: error: malformed xml literal, expected:
          |Expected ("{{" | "}}" | "&" | "&#" | "&#x" | "{" | "<xml:unparsed" | "<![CDATA[" | "<!--" | "</"):3:29, found "<?\n"
          |  val b = <baz qux="...">cde<?
-         |                            ^""".stripMargin.lf2nl
+         |                            ^""".stripMargin.lf2nl,
     )(code.asInput.parseRule(_.entrypointStat()))
   }
 
@@ -962,7 +962,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
     interceptMessage[ParseException](
       """|<input>:1: error: xml literals are not supported
          |<foo>bar</foo>
-         |^""".stripMargin.lf2nl
+         |^""".stripMargin.lf2nl,
     )(code.asInput.parseRule(_.entrypointStat()))
   }
 
@@ -972,13 +972,13 @@ class TokenizerSuite extends BaseTokenizerSuite {
     interceptMessage[ParseException](
       """|<input>:1: error: xml literals are not supported
          |val a = <foo>bar</foo>
-         |        ^""".stripMargin.lf2nl
+         |        ^""".stripMargin.lf2nl,
     )(code.asInput.parseRule(_.entrypointStat()))
   }
 
   testTokenizedStructLines(
     "unsupported xml literal - 3 plus/no space",
-    dialects.Scala213.withAllowXmlLiterals(false)
+    dialects.Scala213.withAllowXmlLiterals(false),
   )(
     """|a+<foo>bar</foo>
        |""".stripMargin,
@@ -993,7 +993,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
        |Ident(>) [15..16)
        |LF [16..17)
        |EOF [17..17)
-       |""".stripMargin.tq()
+       |""".stripMargin.tq(),
   )
 
   test("parsed trees don't have BOF/EOF in their tokens") {
@@ -1001,7 +1001,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
     assert(tree.pos != Position.None)
     assertEquals(
       tree.tokens.structure,
-      "Tokens(BOF [0..0), Ident(foo) [0..3), Space [3..4), Ident(+) [4..5), Space [5..6), Ident(bar) [6..9), EOF [9..9))"
+      "Tokens(BOF [0..0), Ident(foo) [0..3), Space [3..4), Ident(+) [4..5), Space [5..6), Ident(bar) [6..9), EOF [9..9))",
     )
   }
 
@@ -1013,7 +1013,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
     assertEquals(tree.tokens.structure, tokensStructure)
     assertEquals(
       tokensStructure,
-      "Tokens(BOF [0..0), Ident(foo) [0..3), Space [3..4), Ident(+) [4..5), Space [5..6), Ident(bar) [6..9), EOF [9..9))"
+      "Tokens(BOF [0..0), Ident(foo) [0..3), Space [3..4), Ident(+) [4..5), Space [5..6), Ident(bar) [6..9), EOF [9..9))",
     )
   }
 
@@ -1042,7 +1042,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
         assertEquals(crlf.text, "\r\n")
         assertEquals(part.len, 3)
         assertEquals(crlf.len, 2)
-    }
+    },
   )
 
   test("Interpolated tree parsed succesfully with windows newline, with LF escaped") {
@@ -1057,7 +1057,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
         |Interpolation.End(") [6..7)
         |LF [7..8)
         |EOF [14..14)
-        |""".stripMargin
+        |""".stripMargin,
     )
   }
 
@@ -1066,7 +1066,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
       case Tokens(bof, _, _, _, part: Interpolation.Part, _, lf: LF, eof) =>
         assertEquals(part.value, "foo")
         assertEquals(lf.syntax, "\n")
-    }
+    },
   )
 
   test("Interpolated with quote escape 1") {
@@ -1083,7 +1083,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
             Interpolation.SpliceEnd(),
             Interpolation.Part("\" in quotes"),
             Interpolation.End(),
-            EOF()
+            EOF(),
           ) =>
     }
 
@@ -1102,7 +1102,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
          |Constant.String( in quotes) [11..21)
          |EOF [22..22)
          |""".stripMargin,
-      dialects.Scala212
+      dialects.Scala212,
     )
   }
 
@@ -1121,7 +1121,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
          |RightParen [23..24)
          |EOF [24..24)
          |""".stripMargin,
-      dialects.Scala212
+      dialects.Scala212,
     )
 
     assertTokenizedAsStructureLines(
@@ -1136,7 +1136,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
          |RightParen [23..24)
          |EOF [24..24)
          |""".stripMargin,
-      dialects.Scala3
+      dialects.Scala3,
     )
   }
 
@@ -1168,7 +1168,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
             Interpolation.SpliceEnd(),
             Interpolation.Part(""),
             Interpolation.End(),
-            EOF()
+            EOF(),
           ) =>
     }
     assertTokens("s\"$enum\"", dialects.Scala213) {
@@ -1182,7 +1182,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
             Interpolation.SpliceEnd(),
             Interpolation.Part(""),
             Interpolation.End(),
-            EOF()
+            EOF(),
           ) =>
     }
     assertTokenizedAsStructureLines(
@@ -1199,7 +1199,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
          |Interpolation.End(") [7..8)
          |EOF [8..8)
          |""".stripMargin,
-      dialects.Scala3
+      dialects.Scala3,
     )
   }
 
@@ -1214,7 +1214,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
             Ident("a"),
             Space(),
             RightBrace(),
-            EOF()
+            EOF(),
           ) =>
     }
 
@@ -1228,7 +1228,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
             Ident("a"),
             Space(),
             RightBrace(),
-            EOF()
+            EOF(),
           ) =>
     }
   }
@@ -1242,12 +1242,12 @@ class TokenizerSuite extends BaseTokenizerSuite {
     "0x_1234",
     "0b_0101",
     "123_456__789",
-    "0x__123_456__789"
+    "0x__123_456__789",
   ).foreach(value =>
     test(s"numeric literal separator ok scala213: $value") {
       implicit val dialect: Dialect = dialects.Scala213
       tokenize(value) // no exception
-    }
+    },
   )
 
   Seq(
@@ -1255,74 +1255,74 @@ class TokenizerSuite extends BaseTokenizerSuite {
       "123_456_",
       """|<input>:1: error: trailing number separator
          |123_456_
-         |       ^""".stripMargin
+         |       ^""".stripMargin,
     ),
     (
       "123_456_L",
       """|<input>:1: error: trailing number separator
          |123_456_L
-         |       ^""".stripMargin
+         |       ^""".stripMargin,
     ),
     (
       "3_14_E-2",
       """|<input>:1: error: trailing number separator
          |3_14_E-2
-         |    ^""".stripMargin
+         |    ^""".stripMargin,
     ),
     (
       "3_14E-_2",
       """|<input>:1: error: leading number separator
          |3_14E-_2
-         |      ^""".stripMargin
+         |      ^""".stripMargin,
     ),
     (
       "3_14E",
       """|<input>:1: error: Invalid literal floating-point number, exponent not followed by integer
          |3_14E
-         |     ^""".stripMargin
+         |     ^""".stripMargin,
     ),
     (
       "3_14E_2",
       """|<input>:1: error: leading number separator
          |3_14E_2
-         |     ^""".stripMargin
+         |     ^""".stripMargin,
     ),
     (
       "3_14E_F",
       """|<input>:1: error: Invalid literal floating-point number, exponent not followed by integer
          |3_14E_F
-         |     ^""".stripMargin
+         |     ^""".stripMargin,
     ),
     (
       "3_14ef",
       """|<input>:1: error: Invalid literal floating-point number, exponent not followed by integer
          |3_14ef
-         |     ^""".stripMargin
+         |     ^""".stripMargin,
     ),
     (
       "3_14E-2_",
       """|<input>:1: error: trailing number separator
          |3_14E-2_
-         |       ^""".stripMargin
+         |       ^""".stripMargin,
     ),
     (
       "3.1_4_",
       """|<input>:1: error: trailing number separator
          |3.1_4_
-         |     ^""".stripMargin
+         |     ^""".stripMargin,
     ),
     (
       "3.1_4_d",
       """|<input>:1: error: trailing number separator
          |3.1_4_d
-         |     ^""".stripMargin
+         |     ^""".stripMargin,
     ),
     (
       "3.1_4_dd",
       """|<input>:1: error: trailing number separator
          |3.1_4_dd
-         |     ^""".stripMargin
-    )
+         |     ^""".stripMargin,
+    ),
   ).foreach { case (value, error) =>
     test(s"numeric literal separator fail scala213: $value") {
       implicit val dialect: Dialect = dialects.Scala213
@@ -1334,7 +1334,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
     "1_024",
     """|<input>:1: error: numeric separators are not allowed
        |1_024
-       | ^""".stripMargin
+       | ^""".stripMargin,
   )).foreach { case (value, error) =>
     test(s"numeric literal separator fail scala212: $value") {
       implicit val dialect: Dialect = dialects.Scala212
@@ -1361,7 +1361,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
           Interpolation.SpliceEnd(),
           Interpolation.Part(""),
           Interpolation.End(),
-          EOF()
+          EOF(),
         ) =>
   })
 
@@ -1377,7 +1377,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
        |Interpolation.Part() [11..11)
        |Invalid(unclosed single-line string interpolation) [11..11)
        |Interpolation.End() [11..11)
-       |EOF [11..11)""".stripMargin
+       |EOF [11..11)""".stripMargin,
   )
 
   test("Multiline interpolated string - ignore escape")(
@@ -1396,9 +1396,9 @@ class TokenizerSuite extends BaseTokenizerSuite {
             Interpolation.SpliceEnd(),
             Interpolation.Part("\\"),
             Interpolation.End(),
-            EOF()
+            EOF(),
           ) =>
-    }
+    },
   )
 
   test("#3328") {
@@ -1418,7 +1418,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
        |Space [7..8)
        |Ident(Double) [8..14)
        |EOF [14..14)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   test("#3402") {
@@ -1443,56 +1443,56 @@ class TokenizerSuite extends BaseTokenizerSuite {
       """|BOF [0..0)
          |Constant.Double(0) [0..2)
          |EOF [2..2)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0.0",
       """|BOF [0..0)
          |Constant.Double(0.0) [0..3)
          |EOF [3..3)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "00e0",
       """|BOF [0..0)
          |Constant.Double(0) [0..4)
          |EOF [4..4)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "00e0f",
       """|BOF [0..0)
          |Constant.Float(0) [0..5)
          |EOF [5..5)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0xe1",
       """|BOF [0..0)
          |Constant.Int(225) [0..4)
          |EOF [4..4)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0xd",
       """|BOF [0..0)
          |Constant.Int(13) [0..3)
          |EOF [3..3)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0f",
       """|BOF [0..0)
          |Constant.Float(0) [0..2)
          |EOF [2..2)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0.0f",
       """|BOF [0..0)
          |Constant.Float(0.0) [0..4)
          |EOF [4..4)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0.f",
@@ -1501,7 +1501,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
          |Dot [1..2)
          |Ident(f) [2..3)
          |EOF [3..3)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       ".f",
@@ -1509,7 +1509,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
          |Dot [0..1)
          |Ident(f) [1..2)
          |EOF [2..2)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "1. + 2.",
@@ -1522,7 +1522,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
          |Constant.Int(2) [5..6)
          |Dot [6..7)
          |EOF [7..7)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "1.0 + 2.0f",
@@ -1533,7 +1533,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
          |Space [5..6)
          |Constant.Float(2.0) [6..10)
          |EOF [10..10)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "1d + 2f",
@@ -1544,56 +1544,56 @@ class TokenizerSuite extends BaseTokenizerSuite {
          |Space [4..5)
          |Constant.Float(2) [5..7)
          |EOF [7..7)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0xf",
       """|BOF [0..0)
          |Constant.Int(15) [0..3)
          |EOF [3..3)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0",
       """|BOF [0..0)
          |Constant.Int(0) [0..1)
          |EOF [1..1)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0l",
       """|BOF [0..0)
          |Constant.Long(0) [0..2)
          |EOF [2..2)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0L",
       """|BOF [0..0)
          |Constant.Long(0) [0..2)
          |EOF [2..2)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0x80000000",
       """|BOF [0..0)
          |Constant.Int(2147483648) [0..10)
          |EOF [10..10)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0x8000000000000000L",
       """|BOF [0..0)
          |Constant.Long(9223372036854775808) [0..19)
          |EOF [19..19)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "3.4028235e38f",
       """|BOF [0..0)
          |Constant.Float(3.4028235E+38) [0..13)
          |EOF [13..13)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "-3.4028235e38f",
@@ -1601,14 +1601,14 @@ class TokenizerSuite extends BaseTokenizerSuite {
          |Ident(-) [0..1)
          |Constant.Float(3.4028235E+38) [1..14)
          |EOF [14..14)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "1.7976931348623157e+308d",
       """|BOF [0..0)
          |Constant.Double(1.7976931348623157E+308) [0..24)
          |EOF [24..24)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "-1.7976931348623157e+308d",
@@ -1616,28 +1616,28 @@ class TokenizerSuite extends BaseTokenizerSuite {
          |Ident(-) [0..1)
          |Constant.Double(1.7976931348623157E+308) [1..25)
          |EOF [25..25)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0b00101010",
       """|BOF [0..0)
          |Constant.Int(42) [0..10)
          |EOF [10..10)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0B_0010_1010",
       """|BOF [0..0)
          |Constant.Int(42) [0..12)
          |EOF [12..12)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0b_0010_1010L",
       """|BOF [0..0)
          |Constant.Long(42) [0..13)
          |EOF [13..13)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0b01.2",
@@ -1645,7 +1645,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
          |Constant.Int(1) [0..4)
          |Constant.Double(0.2) [4..6)
          |EOF [6..6)
-         |""".stripMargin
+         |""".stripMargin,
     ),
     (
       "0b01.toString",
@@ -1654,11 +1654,11 @@ class TokenizerSuite extends BaseTokenizerSuite {
          |Dot [4..5)
          |Ident(toString) [5..13)
          |EOF [13..13)
-         |""".stripMargin
-    )
+         |""".stripMargin,
+    ),
   ).foreach { case (code, value) =>
     test(s"numeric literal ok scala213: $code")(
-      assertTokenizedAsStructureLines(code, value, dialects.Scala213)
+      assertTokenizedAsStructureLines(code, value, dialects.Scala213),
     )
   }
 
@@ -1667,56 +1667,56 @@ class TokenizerSuite extends BaseTokenizerSuite {
       "00",
       """|<input>:1: error: Non-zero integral values may not have a leading zero.
          |00
-         |^""".stripMargin
+         |^""".stripMargin,
     ),
     (
       "00l",
       """|<input>:1: error: Non-zero integral values may not have a leading zero.
          |00l
-         |^""".stripMargin
+         |^""".stripMargin,
     ),
     (
       "0b01d",
       """|<input>:1: error: Invalid literal number, followed by identifier character
          |0b01d
-         |    ^""".stripMargin
+         |    ^""".stripMargin,
     ),
     (
       "0b01f",
       """|<input>:1: error: Invalid literal number, followed by identifier character
          |0b01f
-         |    ^""".stripMargin
+         |    ^""".stripMargin,
     ),
     (
       "0b0123",
       """|<input>:1: error: Invalid literal number, followed by identifier character
          |0b0123
-         |    ^""".stripMargin
+         |    ^""".stripMargin,
     ),
     (
       "3.4028236e38f",
       """|<input>:1: error: floating-point value out of range for Float
          |3.4028236e38f
-         |^""".stripMargin
+         |^""".stripMargin,
     ),
     (
       "-3.4028236e38f",
       """|<input>:1: error: floating-point value out of range for Float
          |-3.4028236e38f
-         | ^""".stripMargin
+         | ^""".stripMargin,
     ),
     (
       "1.7976931348623158e+308d",
       """|<input>:1: error: floating-point value out of range for Double
          |1.7976931348623158e+308d
-         |^""".stripMargin
+         |^""".stripMargin,
     ),
     (
       "-1.7976931348623158e+308d",
       """|<input>:1: error: floating-point value out of range for Double
          |-1.7976931348623158e+308d
-         | ^""".stripMargin
-    )
+         | ^""".stripMargin,
+    ),
   ).foreach { case (code, error) =>
     test(s"numeric literal fail scala213: $code") {
       implicit val dialect: Dialect = dialects.Scala213
@@ -1727,32 +1727,32 @@ class TokenizerSuite extends BaseTokenizerSuite {
   Seq(
     // regular or half-surrogate char codes
     55297,
-    56375
+    56375,
   ).foreach(ch =>
     test(s"#3690 any character with char code $ch") {
       implicit val dialect = dialects.Scala213
       tokenize(
         s"""|"${ch.toChar}"
-            |""".stripMargin
+            |""".stripMargin,
       ) match {
         case Tokens(_: BOF, Constant.String(str), _: LF, _: EOF) =>
           assertEquals(str.length, 1)
           assertEquals(str, s"${ch.toChar}")
         case tokens => fail(s"unexpected tokens: ${tokens.structure}")
       }
-    }
+    },
   )
 
   Seq(
     // full-surrogate char code pairs
     (55297, 56375),
-    (0xdbff, 0xdfff)
+    (0xdbff, 0xdfff),
   ).foreach { case (hi, lo) =>
     test(s"#3690 full-surrogate with char codes $hi and $lo") {
       implicit val dialect = dialects.Scala213
       tokenize(
         s"""|"${hi.toChar}${lo.toChar}"
-            |""".stripMargin
+            |""".stripMargin,
       ) match {
         case Tokens(_: BOF, Constant.String(str), _: LF, _: EOF) =>
           assertEquals(str, s"${hi.toChar}${lo.toChar}")
@@ -1820,7 +1820,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
        |Ident(b) [95..96)
        |CRLF [96..98)
        |EOF [98..98)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   testTokenizedStructLines("code with Shebang line", dialects.Scala3)(
@@ -1849,7 +1849,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
        |RightParen [81..82)
        |CRLF [82..84)
        |EOF [84..84)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   testTokenizedStructLines("code with non-matching braces 1", dialects.Scala3)(
@@ -1892,7 +1892,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
        |Interpolation.End(") [48..49)
        |LF [49..50)
        |EOF [50..50)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   testTokenizedStructLines("code with non-matching braces 2", dialects.Scala3)(
@@ -1937,7 +1937,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
        |RightBrace [49..50)
        |LF [50..51)
        |EOF [51..51)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   testTokenizedStructLines("code with incomplete interpolation: 2.13", dialects.Scala213)(
@@ -1971,7 +1971,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
        |RightBrace [29..30)
        |LF [30..31)
        |EOF [31..31)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   testTokenizedStructLines("code with incomplete interpolation: 3", dialects.Scala3)(
@@ -2002,12 +2002,12 @@ class TokenizerSuite extends BaseTokenizerSuite {
        |RightBrace [29..30)
        |LF [30..31)
        |EOF [31..31)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   testTokenizedStructLines(
     "code with double-quote string within single-line quasiquotes",
-    dialects.Scala213.unquoteTerm(multiline = false)
+    dialects.Scala213.unquoteTerm(multiline = false),
   )(
     " \"...\" ",
     """|BOF [0..0)
@@ -2016,12 +2016,12 @@ class TokenizerSuite extends BaseTokenizerSuite {
        |Invalid(double quotes are not allowed in single-line quasiquotes) [1..1)
        |Space [6..7)
        |EOF [7..7)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   testTokenizedStructLines(
     "code with interpolation within single-line quasiquotes",
-    dialects.Scala213.unquoteTerm(multiline = false)
+    dialects.Scala213.unquoteTerm(multiline = false),
   )(
     " s\"...\" ",
     """|BOF [0..0)
@@ -2033,7 +2033,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
        |Interpolation.End(") [6..7)
        |Space [7..8)
        |EOF [8..8)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   testTokenizedStructLines("interpolator with $ character")(
@@ -2048,7 +2048,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
        |Interpolation.Part($) [8..10)
        |Interpolation.End(") [10..11)
        |EOF [11..11) 
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   testTokenizedStructLines("broken-interpolator")(
@@ -2080,7 +2080,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
        |Ident(stripMargin) [218..229)
        |LF [229..230)
        |EOF [230..230)
-       |""".stripMargin.replace("'''", "\"\"\"")
+       |""".stripMargin.replace("'''", "\"\"\""),
   )
 
   testTokenizedStructLines("unexpected-character")(
@@ -2098,7 +2098,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
        |Constant.Int(123) [9..12)
        |MultiNL(2) [12..14)
        |EOF [14..14)
-       |""".stripMargin
+       |""".stripMargin,
   )
 
   Seq(
@@ -2133,7 +2133,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
            |Constant.Int(0) [22..23)
            |LF [23..24)
            |EOF [24..24)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase {
@@ -2157,7 +2157,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
            |Invalid(unclosed quoted identifier) [4..18)
            |LF [18..19)
            |EOF [19..19)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase {
@@ -2184,7 +2184,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
            |Invalid(unclosed quoted identifier) [13..18)
            |LF [18..19)
            |EOF [19..19)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase {
@@ -2211,7 +2211,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
            |Constant.Int(0) [18..19)
            |LF [19..20)
            |EOF [20..20)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase {
@@ -2232,7 +2232,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
            |Constant.String("foo") [0..17)
            |LF [17..18)
            |EOF [18..18)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase {
@@ -2249,7 +2249,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
            |Constant.String(""foo"") [0..29)
            |LF [29..30)
            |EOF [30..30)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase {
@@ -2266,7 +2266,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
            |Constant.String(\\\\u0022foo\\\\u0022) [0..21)
            |LF [21..22)
            |EOF [22..22)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase((
@@ -2282,7 +2282,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
          |Constant.Char(') [0..8)
          |LF [8..9)
          |EOF [9..9)
-         |""".stripMargin
+         |""".stripMargin,
     )),
     TestCase {
       (
@@ -2308,7 +2308,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
            |Ident(u0027) [3..8)
            |LF [8..9)
            |EOF [9..9)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase {
@@ -2327,7 +2327,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
            |Invalid(can't use unescaped LF in character literals) [8..8)
            |LF [8..9)
            |EOF [9..9)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase((
@@ -2343,7 +2343,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
          |Constant.Char(a) [0..8)
          |LF [8..9)
          |EOF [9..9)
-         |""".stripMargin
+         |""".stripMargin,
     )),
     TestCase {
       (
@@ -2359,7 +2359,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
            |Constant.String(a) [0..8)
            |LF [8..9)
            |EOF [9..9)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase {
@@ -2376,7 +2376,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
            |Constant.String(") [0..8)
            |LF [8..9)
            |EOF [9..9)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase {
@@ -2399,7 +2399,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
            |Interpolation.End(") [8..9)
            |LF [9..10)
            |EOF [10..10)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase {
@@ -2422,7 +2422,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
            |Interpolation.End(") [8..9)
            |LF [9..10)
            |EOF [10..10)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase {
@@ -2445,7 +2445,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
            |Interpolation.End(") [10..11)
            |LF [11..12)
            |EOF [12..12)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase {
@@ -2468,7 +2468,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
            |Interpolation.End(") [10..11)
            |LF [11..12)
            |EOF [12..12)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase {
@@ -2485,7 +2485,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
            |Constant.String(\\\\u0061) [0..12)
            |LF [12..13)
            |EOF [13..13)
-           |""".stripMargin
+           |""".stripMargin,
       )
     },
     TestCase((
@@ -2501,7 +2501,7 @@ class TokenizerSuite extends BaseTokenizerSuite {
          |Ident(a) [0..8)
          |LF [8..9)
          |EOF [9..9)
-         |""".stripMargin
+         |""".stripMargin,
     )),
     TestCase {
       (
@@ -2518,9 +2518,9 @@ class TokenizerSuite extends BaseTokenizerSuite {
            |Ident(u0061) [1..6)
            |LF [6..7)
            |EOF [7..7)
-           |""".stripMargin
+           |""".stripMargin,
       )
-    }
+    },
   ).foreach { c =>
     val TestTokenizedWithDialects(title, code, exp212, exp213, exp3) = c.obj
     implicit val loc: munit.Location = c.loc
@@ -2537,7 +2537,7 @@ object TokenizerSuite {
       code: String,
       exp212: String,
       exp213: String,
-      exp3: String
+      exp3: String,
   )
 
   import scala.language.implicitConversions

--- a/tests/shared/src/test/scala/scala/meta/tests/transversers/ApiExtensionsSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/transversers/ApiExtensionsSuite.scala
@@ -20,7 +20,7 @@ class ApiExtensionsSuite extends TreeSuiteBase {
          |)""".stripMargin.lf2nl,
       """Pat.Var(Term.Name("x"))""",
       """Term.Name("x")""",
-      """Lit.Int(2)"""
+      """Lit.Int(2)""",
     )
     def dfsTraverse = {
       val buf = new ListBuffer[String]
@@ -46,7 +46,7 @@ class ApiExtensionsSuite extends TreeSuiteBase {
          |)""".stripMargin.lf2nl,
       """Pat.Var(Term.Name("x"))""",
       """Lit.Int(2)""",
-      """Term.Name("x")"""
+      """Term.Name("x")""",
     )
     def bfsTraverse = {
       val buf = new ListBuffer[String]

--- a/tests/shared/src/test/scala/scala/meta/tests/transversers/SimpleTraverserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/transversers/SimpleTraverserSuite.scala
@@ -63,7 +63,7 @@ class SimpleTraverserSuite extends TreeSuiteBase {
          |x
          |x
          |???
-         |""".stripMargin
+         |""".stripMargin,
     )
   }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/trees/ChildrenSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/trees/ChildrenSuite.scala
@@ -15,7 +15,7 @@ class ChildrenSuite extends ParseSuite {
          |  import bar.baz.one
          |  import bar.baz.two
          |}
-         |""".stripMargin
+         |""".stripMargin,
     )
     assertEquals(tree.children.length, 4)
     assertEquals(tree.children(0).productPrefix, "Type.Name")
@@ -36,7 +36,7 @@ class ChildrenSuite extends ParseSuite {
     }
     assert(
       containsBinaryCompatFields,
-      "Binary compatible fields should be contained in the children method"
+      "Binary compatible fields should be contained in the children method",
     )
   }
 }


### PR DESCRIPTION
Now that 2.11 support has been removed, we can enable this rule.