### PR TITLE
Specify class loader when loading `Tokenize` service.

### DIFF
--- a/scalameta/trees2/jvm/src/main/scala/scala/meta/tokenizers/PlatformCompat.scala
+++ b/scalameta/trees2/jvm/src/main/scala/scala/meta/tokenizers/PlatformCompat.scala
@@ -5,7 +5,7 @@ import java.util.ServiceLoader
 object PlatformCompat {
 
   lazy val loadTokenize: Option[Tokenize] = {
-    val factories = ServiceLoader.load(classOf[Tokenize]).iterator()
+    val factories = ServiceLoader.load(classOf[Tokenize], getClass().getClassLoader()).iterator()
     if (factories.hasNext) Some(factories.next()) else None
   }
 


### PR DESCRIPTION
This resolves #4621 by specify the class loader.

As a general rule, `getClass.getClassLoader` should be used, and `Thread.currentThread.getContextClassLoader` should be avoided.

[This StackOverflow answer](https://stackoverflow.com/questions/1771679/difference-between-threads-context-class-loader-and-normal-classloader) has a good summary of class loading best practices.

[The ServiceLoader docs](https://docs.oracle.com/en/java/javase/26/docs/api/java.base/java/util/ServiceLoader.html#load(java.lang.Class)) contain more details on the specifics. I haven't looked through these in detail, so there might be a better approach.

I couldn't think of a way to unit test this, so didn't add tests to reproduce / resolve the issue.