### PR TITLE
SymbolInformation: use explicit Seq field values

### DIFF
--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/javacp/Javacp.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/javacp/Javacp.scala
@@ -47,6 +47,7 @@ object Javacp {
         displayName = displayName,
         signature = sig,
         annotations = sannotations(access),
+        overriddenSymbols = Nil,
         access = saccess(access, symbol, kind),
       )
       buf += info
@@ -309,6 +310,8 @@ object Javacp {
       kind = k.TYPE_PARAMETER,
       displayName = displayName,
       signature = sig,
+      annotations = Nil,
+      overriddenSymbols = Nil,
     )
   }
 

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/scalacp/Scalalib.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/scalacp/Scalalib.scala
@@ -113,6 +113,8 @@ object Scalalib {
       displayName = dn.Constructor,
       signature = ctorSig,
       access = s.PublicAccess(),
+      annotations = Nil,
+      overriddenSymbols = Nil,
     )
     val builtinSig = {
       val tparams = Some(s.Scope(Nil))
@@ -128,6 +130,8 @@ object Scalalib {
       displayName = className,
       signature = builtinSig,
       access = s.PublicAccess(),
+      annotations = Nil,
+      overriddenSymbols = Nil,
     )
     val infos = builtin :: (if (kind.isClass) ctor :: symbols else symbols)
     val relativeUri = "scala/" + NameTransformer.encode(className) + ".class"
@@ -152,10 +156,11 @@ object Scalalib {
         symbol = tparamSymbol,
         language = l.SCALA,
         kind = k.TYPE_PARAMETER,
-        properties = 0,
         displayName = tparamName,
         signature = tparamSig,
         access = s.NoAccess,
+        annotations = Nil,
+        overriddenSymbols = Nil,
       )
     }
     val params = paramDsls.map { case (paramName, paramTpeSymbol) =>
@@ -165,9 +170,10 @@ object Scalalib {
         symbol = paramSymbol,
         language = l.SCALA,
         kind = k.PARAMETER,
-        properties = 0,
         displayName = paramName,
         signature = paramSig,
+        annotations = Nil,
+        overriddenSymbols = Nil,
       )
     }
     val methodSig = {
@@ -183,6 +189,8 @@ object Scalalib {
       displayName = methodName,
       signature = methodSig,
       access = s.PublicAccess(),
+      annotations = Nil,
+      overriddenSymbols = Nil,
     )
     List(method) ++ tparams ++ params
   }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/scalacp/SymbolInformationOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/scalacp/SymbolInformationOps.scala
@@ -194,6 +194,7 @@ trait SymbolInformationOps {
       displayName = displayName,
       signature = sig(linkMode),
       annotations = annotations,
+      overriddenSymbols = Nil,
       access = access,
     )
   }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/scalacp/Synthetics.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/scalacp/Synthetics.scala
@@ -28,10 +28,10 @@ object Synthetics {
       symbol = paramSym,
       language = l.SCALA,
       kind = k.PARAMETER,
-      properties = 0,
       displayName = "x$1",
       signature = paramSig,
       annotations = Nil,
+      overriddenSymbols = Nil,
       access = s.NoAccess,
     )
 
@@ -43,15 +43,12 @@ object Synthetics {
       }
       s.MethodSignature(Some(s.Scope()), setterParamss, unit)
     }
-    val setterInfo = s.SymbolInformation(
+    val setterInfo = getterInfo.copy(
       symbol = setterSym,
       language = l.SCALA,
       kind = k.METHOD,
-      properties = getterInfo.properties,
       displayName = getterInfo.displayName + "_=",
       signature = setterSig,
-      annotations = getterInfo.annotations,
-      access = getterInfo.access,
     )
 
     linkMode match {

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/symtab/GlobalSymbolTable.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/symtab/GlobalSymbolTable.scala
@@ -53,6 +53,8 @@ final class GlobalSymbolTable private (classpath: Classpath, includeJdk: Boolean
           symbol = symbol,
           kind = SymbolInformation.Kind.PACKAGE,
           displayName = symbol.desc.value,
+          annotations = Nil,
+          overriddenSymbols = Nil,
         )
         Some(info)
       } else None

--- a/semanticdb/semanticdb/shared/src/main/scala/scala/meta/internal/metap/SymbolInformationPrinter.scala
+++ b/semanticdb/semanticdb/shared/src/main/scala/scala/meta/internal/metap/SymbolInformationPrinter.scala
@@ -325,7 +325,12 @@ trait SymbolInformationPrinter extends BasePrinter {
       val symtabInfo = noteSymtab.get(sym).orElse(symtab.info(sym))
       val info = symtabInfo.getOrElse {
         val displayName = if (sym.isGlobal) sym.desc.value else sym
-        SymbolInformation(symbol = sym, displayName = displayName)
+        SymbolInformation(
+          symbol = sym,
+          displayName = displayName,
+          annotations = Nil,
+          overriddenSymbols = Nil,
+        )
       }
       visit(info)
     }

--- a/semanticdb/semanticdb/shared/src/main/scala/scala/meta/internal/semanticdb/package.scala
+++ b/semanticdb/semanticdb/shared/src/main/scala/scala/meta/internal/semanticdb/package.scala
@@ -88,7 +88,8 @@ package object semanticdb {
     def symbols: List[String] =
       if (scope.symlinks.nonEmpty) scope.symlinks.toList else scope.hardlinks.map(_.symbol).toList
     def infos: List[SymbolInformation] =
-      if (scope.symlinks.nonEmpty) scope.symlinks.map(symbol => SymbolInformation(symbol = symbol))
+      if (scope.symlinks.nonEmpty) scope.symlinks
+        .map(symbol => SymbolInformation(symbol = symbol, annotations = Nil, overriddenSymbols = Nil))
         .toList
       else scope.hardlinks.toList
   }


### PR DESCRIPTION
In order to be able to use scala 2.13 version of semanticdb-scalac-core with scala 3 version of semanticdb-shared, let's not use default values of scala.Seq which changes between these two versions.