### PR TITLE
skip inaccessible paths in recursive file walks

### DIFF
--- a/scalameta/io/jvm/src/main/scala/scala/meta/internal/io/PlatformFileIO.scala
+++ b/scalameta/io/jvm/src/main/scala/scala/meta/internal/io/PlatformFileIO.scala
@@ -2,12 +2,12 @@ package scala.meta.internal.io
 
 import scala.meta.io._
 
+import java.io.IOException
 import java.net.URI
 import java.nio.charset.Charset
-import java.nio.file.{FileSystem, FileSystemAlreadyExistsException, FileSystems, Files, OpenOption,
-  Path}
+import java.nio.file._
+import java.nio.file.attribute.BasicFileAttributes
 import java.util
-import java.util.stream.Collectors
 
 object PlatformFileIO {
 
@@ -46,11 +46,27 @@ object PlatformFileIO {
 
   def listAllFilesRecursively(root: AbsolutePath): ListFiles = {
     val relativeFiles = List.newBuilder[RelativePath]
-    val iter = Files.walk(root.toNIO).iterator()
-    while (iter.hasNext) {
-      val path = iter.next()
-      if (Files.isRegularFile(path)) relativeFiles += RelativePath(root.toNIO.relativize(path))
-    }
+    // FOLLOW_LINKS so a symlink's target attributes are used (symlinked files are listed); note this
+    // also traverses symlinked directories.
+    Files.walkFileTree(
+      root.toNIO,
+      util.EnumSet.of(FileVisitOption.FOLLOW_LINKS),
+      Integer.MAX_VALUE,
+      new SimpleFileVisitor[Path] {
+        override def visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult = {
+          if (attrs.isRegularFile) relativeFiles += RelativePath(root.toNIO.relativize(file))
+          FileVisitResult.CONTINUE
+        }
+        // #1168: skip unreadable paths (AccessDeniedException); FOLLOW_LINKS can also raise
+        // FileSystemLoopException on a symlink cycle, so skip that too. Any other I/O error
+        // propagates, so a partial scan is never reported as complete. postVisitDirectory is left
+        // to SimpleFileVisitor, which likewise rethrows a non-null exception.
+        override def visitFileFailed(file: Path, exc: IOException): FileVisitResult = exc match {
+          case _: AccessDeniedException | _: FileSystemLoopException => FileVisitResult.CONTINUE
+          case _ => throw exc
+        }
+      },
+    )
     ListFiles(root, relativeFiles.result())
   }
 

--- a/tests/jvm/src/test/scala/scala/meta/tests/io/PlatformFileIOSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/io/PlatformFileIOSuite.scala
@@ -10,22 +10,27 @@ import java.nio.file.{FileSystems, Files}
 import munit.FunSuite
 
 class PlatformFileIOSuite extends FunSuite {
-  // #1168: listAllFilesRecursively aborts the walk when it meets an unreadable directory
-  test("listAllFilesRecursively aborts on unreadable directories") {
+  // #1168: an unreadable subdirectory must be skipped, not abort the whole traversal
+  test("listAllFilesRecursively skips unreadable directories") {
     assume(
       FileSystems.getDefault.supportedFileAttributeViews.contains("posix"),
       "POSIX file permissions not supported on this platform",
     )
     val root = AbsolutePath(Files.createTempDirectory("scalameta-1168"))
+    val ok = root.resolve("ok.txt")
+    Files.write(ok.toNIO, "ok".getBytes)
     val secret = root.resolve("secret")
     Files.createDirectory(secret.toNIO)
     Files.setPosixFilePermissions(secret.toNIO, PosixFilePermissions.fromString("---------"))
     // running as root bypasses permission checks, so the directory stays readable: skip then
     assume(!Files.isReadable(secret.toNIO), "directory still readable (running as root?)")
-    try intercept[java.io.UncheckedIOException](FileIO.listAllFilesRecursively(root))
-    finally {
+    try {
+      val obtained = FileIO.listAllFilesRecursively(root) // must not throw
+      assert(obtained.contains(ok), s"$ok missing from:\n${obtained.mkString("\n")}")
+    } finally {
       // restore permissions and delete the temporary tree
       Files.setPosixFilePermissions(secret.toNIO, PosixFilePermissions.fromString("rwx------"))
+      Files.delete(ok.toNIO)
       Files.delete(secret.toNIO)
       Files.delete(root.toNIO)
     }

--- a/tests/jvm/src/test/scala/scala/meta/tests/io/PlatformFileIOSuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/io/PlatformFileIOSuite.scala
@@ -1,0 +1,33 @@
+package scala.meta.tests
+package io
+
+import scala.meta._
+import scala.meta.internal.io._
+
+import java.nio.file.attribute.PosixFilePermissions
+import java.nio.file.{FileSystems, Files}
+
+import munit.FunSuite
+
+class PlatformFileIOSuite extends FunSuite {
+  // #1168: listAllFilesRecursively aborts the walk when it meets an unreadable directory
+  test("listAllFilesRecursively aborts on unreadable directories") {
+    assume(
+      FileSystems.getDefault.supportedFileAttributeViews.contains("posix"),
+      "POSIX file permissions not supported on this platform",
+    )
+    val root = AbsolutePath(Files.createTempDirectory("scalameta-1168"))
+    val secret = root.resolve("secret")
+    Files.createDirectory(secret.toNIO)
+    Files.setPosixFilePermissions(secret.toNIO, PosixFilePermissions.fromString("---------"))
+    // running as root bypasses permission checks, so the directory stays readable: skip then
+    assume(!Files.isReadable(secret.toNIO), "directory still readable (running as root?)")
+    try intercept[java.io.UncheckedIOException](FileIO.listAllFilesRecursively(root))
+    finally {
+      // restore permissions and delete the temporary tree
+      Files.setPosixFilePermissions(secret.toNIO, PosixFilePermissions.fromString("rwx------"))
+      Files.delete(secret.toNIO)
+      Files.delete(root.toNIO)
+    }
+  }
+}


### PR DESCRIPTION
Closes #1168.

`Files.walk` returns a lazy `Stream<Path>` that throws `UncheckedIOException` (wrapping `AccessDeniedException`) the moment it reaches a directory the process can't read - aborting the whole traversal. The stream is also never closed.

This replaces `Files.walk` with `Files.walkFileTree` + a `SimpleFileVisitor` whose:

- `visitFileFailed` skips **`AccessDeniedException`** (the reported bug) and **`FileSystemLoopException`**, and lets any other `IOException` propagate - so  a genuine I/O failure aborts loudly instead of returning a partial listing as if it were complete.
- `FOLLOW_LINKS` is set so a symlink's *target* attributes are used, i.e. `attrs.isRegularFile()` lists symlinked files (matching the old `Files.walk` + `Files.isRegularFile`). N.B. this also traverses symlinked directories, whose cycle case is the `FileSystemLoopException` skipped above. 

Since #4635, `Locator` (the SemanticDB load path) and the benchmark `FileFixtures` both go through `FileIO.listAllFilesRecursively`, so this fix makes them resilient too. JS/Native keep their own recursive implementations and are unaffected.

Structured as two commits per review:
1. a JVM test that reproduces the `AccessDeniedException`;
2. the fix, which flips that test to assert the unreadable directory is skipped.
