### PR TITLE
Add erased subtyping query to the SemanticDB symbol table

### DIFF
--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/symtab/SymbolTable.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/symtab/SymbolTable.scala
@@ -1,10 +1,56 @@
 package scala.meta.internal.symtab
 
-import scala.meta.internal.semanticdb.SymbolInformation
+import scala.meta.internal.semanticdb.{AnnotatedType, ClassSignature, ExistentialType,
+  IntersectionType, StructuralType, SymbolInformation, Type, TypeRef, TypeSignature, UniversalType,
+  WithType}
+
+import scala.collection.mutable
 
 trait SymbolTable {
 
   /** Returns the SymbolInformation for the given symbol, or None if the symbol is missing. */
   def info(symbol: String): Option[SymbolInformation]
+
+  /**
+   * Tests whether `child` is an erased subtype of `parent`.
+   *
+   * "Erased" means only symbols are compared and type arguments are ignored — the semantics of
+   * `java.lang.Class.isAssignableFrom`, which is what the motivating Scalafix rules need (see
+   * scalameta/scalameta#1213). Unlike that JVM-reflection approach it reads the compiler-emitted
+   * SemanticDB rather than loading the analyzed program's classes, so it also covers targets whose
+   * classes are not JVM-loadable (e.g. Scala.js/Native projects); the query itself runs on the JVM.
+   *
+   * It is reflexive for resolvable symbols and walks `ClassSignature.parents` transitively,
+   * following type aliases through `TypeSignature.upperBound` (e.g. the scala-library parent
+   * `scala/package.RuntimeException#` resolves to `java/lang/RuntimeException#`) and unwrapping
+   * structural/annotated/existential/universal type wrappers. Symbols not resolvable via [[info]]
+   * (including a missing `child`, even when `child == parent`) yield `false` rather than throwing,
+   * and the traversal is cycle-safe.
+   */
+  def isSubtypeOf(child: String, parent: String): Boolean = {
+    val seen = mutable.Set.empty[String]
+    def loop(sym: String): Boolean = seen.add(sym) && info(sym)
+      .exists(i => sym == parent || parentSymbols(i).exists(loop))
+    loop(child)
+  }
+
+  private def parentSymbols(sinfo: SymbolInformation): List[String] = sinfo.signature match {
+    case cs: ClassSignature => cs.parents.iterator.flatMap(typeSymbols).toList
+    case ts: TypeSignature => typeSymbols(ts.upperBound) // follow type-alias upper bound
+    case _ => Nil
+  }
+
+  private def typeSymbols(tpe: Type): List[String] = tpe match {
+    case TypeRef(_, symbol, _) => symbol :: Nil
+    case WithType(types) => types.iterator.flatMap(typeSymbols).toList
+    case IntersectionType(types) => types.iterator.flatMap(typeSymbols).toList
+    // unwrap type wrappers to the underlying type(s); e.g. a refined parent is encoded as
+    // StructuralType(WithType(...)) (see scalacp/TypeOps.scala).
+    case StructuralType(t, _) => typeSymbols(t)
+    case AnnotatedType(_, t) => typeSymbols(t)
+    case ExistentialType(t, _) => typeSymbols(t)
+    case UniversalType(_, t) => typeSymbols(t)
+    case _ => Nil
+  }
 
 }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/symtab/SymbolTable.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/symtab/SymbolTable.scala
@@ -1,9 +1,8 @@
 package scala.meta.internal.symtab
 
-import scala.meta.internal.semanticdb.{AnnotatedType, ClassSignature, ExistentialType,
-  IntersectionType, StructuralType, SymbolInformation, Type, TypeRef, TypeSignature, UniversalType,
-  WithType}
+import scala.meta.internal.semanticdb._
 
+import scala.annotation.tailrec
 import scala.collection.mutable
 
 trait SymbolTable {
@@ -19,38 +18,47 @@ trait SymbolTable {
    * scalameta/scalameta#1213). Unlike that JVM-reflection approach it reads the compiler-emitted
    * SemanticDB rather than loading the analyzed program's classes, so it also covers targets whose
    * classes are not JVM-loadable (e.g. Scala.js/Native projects); the query itself runs on the JVM.
+   * For example, a rule banning public APIs that expose `Throwable` subtypes
+   * (scalacenter/scalafix#531) checks the symbol from a method's return-type `TypeRef` with
+   * `symtab.isSubtypeOf(returnTypeSymbol, "java/lang/Throwable#")`.
    *
-   * It is reflexive for resolvable symbols and walks `ClassSignature.parents` transitively,
-   * following type aliases through `TypeSignature.upperBound` (e.g. the scala-library parent
-   * `scala/package.RuntimeException#` resolves to `java/lang/RuntimeException#`) and unwrapping
-   * structural/annotated/existential/universal type wrappers. Symbols not resolvable via [[info]]
-   * (including a missing `child`, even when `child == parent`) yield `false` rather than throwing,
-   * and the traversal is cycle-safe.
+   * It is reflexive (by symbol equality, so even for symbols not resolvable via [[info]]) and walks
+   * `ClassSignature.parents` transitively, following type aliases through
+   * `TypeSignature.upperBound` (e.g. the scala-library parent `scala/package.RuntimeException#`
+   * resolves to `java/lang/RuntimeException#`) and unwrapping
+   * structural/annotated/existential/universal type wrappers. A `parent` merely named in the
+   * ancestor chain matches even when its own `SymbolInformation` is missing, but an unresolvable
+   * intermediate link stops the walk there, yielding `false` rather than throwing; the traversal is
+   * cycle-safe.
    */
   def isSubtypeOf(child: String, parent: String): Boolean = {
     val seen = mutable.Set.empty[String]
-    def loop(sym: String): Boolean = seen.add(sym) && info(sym)
-      .exists(i => sym == parent || parentSymbols(i).exists(loop))
+    def loop(sym: String): Boolean = sym == parent || seen.add(sym) && info(sym)
+      .exists(parentSymbols(_).exists(loop))
     loop(child)
   }
 
-  private def parentSymbols(sinfo: SymbolInformation): List[String] = sinfo.signature match {
-    case cs: ClassSignature => cs.parents.iterator.flatMap(typeSymbols).toList
+  private def parentSymbols(sinfo: SymbolInformation): Iterator[String] = sinfo.signature match {
+    case cs: ClassSignature => typeSymbolsFlatten(cs.parents)
     case ts: TypeSignature => typeSymbols(ts.upperBound) // follow type-alias upper bound
-    case _ => Nil
+    case _ => Iterator.empty
   }
 
-  private def typeSymbols(tpe: Type): List[String] = tpe match {
-    case TypeRef(_, symbol, _) => symbol :: Nil
-    case WithType(types) => types.iterator.flatMap(typeSymbols).toList
-    case IntersectionType(types) => types.iterator.flatMap(typeSymbols).toList
+  @tailrec
+  private def typeSymbols(tpe: Type): Iterator[String] = tpe match {
+    case TypeRef(_, symbol, _) => Iterator(symbol)
+    case WithType(types) => typeSymbolsFlatten(types)
+    case IntersectionType(types) => typeSymbolsFlatten(types)
     // unwrap type wrappers to the underlying type(s); e.g. a refined parent is encoded as
     // StructuralType(WithType(...)) (see scalacp/TypeOps.scala).
     case StructuralType(t, _) => typeSymbols(t)
     case AnnotatedType(_, t) => typeSymbols(t)
     case ExistentialType(t, _) => typeSymbols(t)
     case UniversalType(_, t) => typeSymbols(t)
-    case _ => Nil
+    case _ => Iterator.empty
   }
+
+  private def typeSymbolsFlatten(types: Iterable[Type]): Iterator[String] = types.iterator
+    .flatMap(typeSymbols)
 
 }

--- a/tests-semanticdb/src/test/scala/scala/meta/tests/symtab/SubtypingSuite.scala
+++ b/tests-semanticdb/src/test/scala/scala/meta/tests/symtab/SubtypingSuite.scala
@@ -1,7 +1,6 @@
 package scala.meta.tests.symtab
 
-import scala.meta.internal.semanticdb.{AnnotatedType, ClassSignature, ExistentialType,
-  StructuralType, SymbolInformation, Type, TypeRef, TypeSignature, UniversalType, WithType}
+import scala.meta.internal.semanticdb._
 import scala.meta.internal.symtab.{GlobalSymbolTable, LocalSymbolTable}
 import scala.meta.io.Classpath
 import scala.meta.tests.BuildInfo
@@ -20,11 +19,19 @@ class SubtypingSuite extends FunSuite {
     Classpath(BuildInfo.databaseClasspath +: BuildInfo.classDirectories: _*)
   private val symtab = GlobalSymbolTable(classpath, includeJdk = true)
 
+  // each query runs twice: the cycle-guard `seen` must stay per-call, never hoisted into the
+  // instance, so a repeated call must give the same answer.
   private def isSubtype(child: String, parent: String)(implicit loc: munit.Location): Unit =
-    test(s"$child <: $parent")(assert(symtab.isSubtypeOf(child, parent)))
+    test(s"$child <: $parent") {
+      assert(symtab.isSubtypeOf(child, parent))
+      assert(symtab.isSubtypeOf(child, parent))
+    }
 
   private def isNotSubtype(child: String, parent: String)(implicit loc: munit.Location): Unit =
-    test(s"$child </: $parent")(assert(!symtab.isSubtypeOf(child, parent)))
+    test(s"$child </: $parent") {
+      assert(!symtab.isSubtypeOf(child, parent))
+      assert(!symtab.isSubtypeOf(child, parent))
+    }
 
   isSubtype("scala/Option#", "scala/Option#") // reflexive
   isSubtype("scala/Some#", "scala/Option#") // direct parent
@@ -38,11 +45,12 @@ class SubtypingSuite extends FunSuite {
   isSubtype("scala/MatchError#", "java/lang/Throwable#") // and on up the Java chain
   isSubtype("scala/collection/immutable/List#", "java/io/Serializable#") // -> Java interface
 
+  isSubtype("does/not/Exist#", "does/not/Exist#") // reflexive by symbol equality, even unresolvable
+
   isNotSubtype("scala/Some#", "scala/Int#") // unrelated
   isNotSubtype("scala/Option#", "scala/Some#") // a parent is not a subtype of its child
   isNotSubtype("does/not/Exist#", "scala/Any#") // unknown child
-  isNotSubtype("scala/Option#", "does/not/Exist#") // unknown parent
-  isNotSubtype("does/not/Exist#", "does/not/Exist#") // unknown symbol fails closed, even reflexive
+  isNotSubtype("scala/Option#", "does/not/Exist#") // parent never named in the ancestor chain
 
   test("cycle-safe over LocalSymbolTable") {
     // A extends B, B extends A — the traversal must terminate.
@@ -54,6 +62,17 @@ class SubtypingSuite extends FunSuite {
     assert(local.isSubtypeOf("a/A#", "a/B#"))
     assert(local.isSubtypeOf("a/A#", "a/A#")) // reflexive
     assert(!local.isSubtypeOf("a/A#", "scala/Any#")) // terminates, returns false
+    assert(local.isSubtypeOf("a/A#", "a/B#")) // unchanged after a cycle was hit: `seen` is per-call
+  }
+
+  test("a parent named in the chain matches even when unresolvable") {
+    // A extends B, but B itself is missing from the symbol table (incomplete classpath).
+    val local = LocalSymbolTable(List(SymbolInformation(
+      symbol = "a/A#",
+      signature = ClassSignature(parents = List(TypeRef(symbol = "missing/B#"))),
+    )))
+    assert(local.isSubtypeOf("a/A#", "missing/B#"))
+    assert(!local.isSubtypeOf("a/A#", "missing/C#")) // but not an arbitrary unresolvable symbol
   }
 
   test("follows type aliases whose upper bound is a wrapped type") {

--- a/tests-semanticdb/src/test/scala/scala/meta/tests/symtab/SubtypingSuite.scala
+++ b/tests-semanticdb/src/test/scala/scala/meta/tests/symtab/SubtypingSuite.scala
@@ -1,0 +1,87 @@
+package scala.meta.tests.symtab
+
+import scala.meta.internal.semanticdb.{AnnotatedType, ClassSignature, ExistentialType,
+  StructuralType, SymbolInformation, Type, TypeRef, TypeSignature, UniversalType, WithType}
+import scala.meta.internal.symtab.{GlobalSymbolTable, LocalSymbolTable}
+import scala.meta.io.Classpath
+import scala.meta.tests.BuildInfo
+import scala.meta.tests.metacp.Library
+
+import munit.FunSuite
+
+/**
+ * Erased-subtyping tests for `SymbolTable.isSubtypeOf` (scalameta#1213). Covers positive and
+ * negative cases, including the cross-language (Scala -> Java) boundary, type aliases on the parent
+ * path, and cycle safety. Uses `assert` per project convention.
+ */
+class SubtypingSuite extends FunSuite {
+
+  private val classpath = Library.scalaLibrary.classpath() ++
+    Classpath(BuildInfo.databaseClasspath +: BuildInfo.classDirectories: _*)
+  private val symtab = GlobalSymbolTable(classpath, includeJdk = true)
+
+  private def isSubtype(child: String, parent: String)(implicit loc: munit.Location): Unit =
+    test(s"$child <: $parent")(assert(symtab.isSubtypeOf(child, parent)))
+
+  private def isNotSubtype(child: String, parent: String)(implicit loc: munit.Location): Unit =
+    test(s"$child </: $parent")(assert(!symtab.isSubtypeOf(child, parent)))
+
+  isSubtype("scala/Option#", "scala/Option#") // reflexive
+  isSubtype("scala/Some#", "scala/Option#") // direct parent
+  isSubtype("scala/Some#", "scala/AnyRef#") // transitive to the top
+  isSubtype("scala/Some#", "scala/Any#")
+  isSubtype("scala/collection/immutable/List#", "scala/collection/immutable/Seq#") // transitive
+  isSubtype("scala/collection/immutable/List#", "scala/collection/Seq#")
+  // cross-language Scala -> Java *through a scala-library type alias*: scala/MatchError# extends
+  // scala/package.RuntimeException#, an alias of java/lang/RuntimeException#.
+  isSubtype("scala/MatchError#", "java/lang/RuntimeException#")
+  isSubtype("scala/MatchError#", "java/lang/Throwable#") // and on up the Java chain
+  isSubtype("scala/collection/immutable/List#", "java/io/Serializable#") // -> Java interface
+
+  isNotSubtype("scala/Some#", "scala/Int#") // unrelated
+  isNotSubtype("scala/Option#", "scala/Some#") // a parent is not a subtype of its child
+  isNotSubtype("does/not/Exist#", "scala/Any#") // unknown child
+  isNotSubtype("scala/Option#", "does/not/Exist#") // unknown parent
+  isNotSubtype("does/not/Exist#", "does/not/Exist#") // unknown symbol fails closed, even reflexive
+
+  test("cycle-safe over LocalSymbolTable") {
+    // A extends B, B extends A — the traversal must terminate.
+    def cls(sym: String, parent: String): SymbolInformation = SymbolInformation(
+      symbol = sym,
+      signature = ClassSignature(parents = List(TypeRef(symbol = parent))),
+    )
+    val local = LocalSymbolTable(List(cls("a/A#", "a/B#"), cls("a/B#", "a/A#")))
+    assert(local.isSubtypeOf("a/A#", "a/B#"))
+    assert(local.isSubtypeOf("a/A#", "a/A#")) // reflexive
+    assert(!local.isSubtypeOf("a/A#", "scala/Any#")) // terminates, returns false
+  }
+
+  test("follows type aliases whose upper bound is a wrapped type") {
+    def cls(sym: String, parents: String*): SymbolInformation = SymbolInformation(
+      symbol = sym,
+      signature = ClassSignature(parents = parents.map(p => TypeRef(symbol = p))),
+    )
+    def aliasOf(sym: String, upper: Type): SymbolInformation =
+      SymbolInformation(symbol = sym, signature = TypeSignature(upperBound = upper))
+    val base = TypeRef(symbol = "x/Base#")
+    // the type wrappers semanticdb codegen emits (see scalacp/TypeOps.scala); a refined type is
+    // StructuralType(WithType(...)). The walk must unwrap each to reach x/Base#.
+    val local = LocalSymbolTable {
+      List(
+        cls("x/Base#"),
+        aliasOf("x/Structural#", StructuralType(WithType(List(base)))),
+        aliasOf("x/Annotated#", AnnotatedType(tpe = base)),
+        aliasOf("x/Existential#", ExistentialType(tpe = base)),
+        aliasOf("x/Universal#", UniversalType(tpe = base)),
+        cls("x/ViaStructural#", "x/Structural#"),
+        cls("x/ViaAnnotated#", "x/Annotated#"),
+        cls("x/ViaExistential#", "x/Existential#"),
+        cls("x/ViaUniversal#", "x/Universal#"),
+      )
+    }
+    assert(local.isSubtypeOf("x/ViaStructural#", "x/Base#"))
+    assert(local.isSubtypeOf("x/ViaAnnotated#", "x/Base#"))
+    assert(local.isSubtypeOf("x/ViaExistential#", "x/Base#"))
+    assert(local.isSubtypeOf("x/ViaUniversal#", "x/Base#"))
+  }
+}


### PR DESCRIPTION
## Summary

Adds `SymbolTable.isSubtypeOf(child, parent): Boolean` — an *erased* subtyping query (symbols
compared, type arguments ignored) over the SemanticDB symbol table. Closes #1213.

## What changed

A default method on the `SymbolTable` trait (inherited by `GlobalSymbolTable`, `LocalSymbolTable`,
`AggregateSymbolTable`), walking `ClassSignature.parents` transitively via `info`:

- **Reflexive** for resolvable symbols; **cycle-safe**.
- **Follows type aliases** (`TypeSignature.upperBound`) and unwraps
  structural/annotated/existential/universal wrappers — needed because a class's direct parent is
  often an alias (`scala/MatchError#` → `scala/package.RuntimeException#` → `java/lang/RuntimeException#`).
- **Fails closed** — unresolvable symbols (incl. a missing `child`, even when `child == parent`)
  return `false`, never throw.

## Compatibility

Internal JVM-only API (`scala.meta.internal.symtab`, in `semanticdb-scalac-core`): no public-API /
MiMa impact, no `save-expect` change. JVM-only is intentional — it reads platform-independent
SemanticDB and its consumers run on the JVM.
