### PR TITLE
Add regression test for parenthesized infix synthetic position (#1223)

### DIFF
--- a/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/Issue1223Suite.scala
+++ b/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/Issue1223Suite.scala
@@ -1,0 +1,40 @@
+package scala.meta.tests.semanticdb
+
+// https://github.com/scalameta/scalameta/issues/1223
+// Wrapping an infix application in parentheses must not shift the synthetic off
+// the application. In scalameta 2.1.2 the implicit-argument synthetic was attached
+// at the second operand instead of spanning the whole `a zip b` application.
+//
+// Snippets are wrapped in `object Wrapped { ... }` by PrintSuiteBase, so source
+// lines start at line 2. Synthetic ranges are printed by Print.synthetic (Compact).
+class Issue1223Suite extends PrintSuiteBase {
+
+  // Cross-version: the `*[Int]` type-application tracks `:: Nil` (cols 3..9),
+  // shifted by exactly the leading `(` relative to an un-parenthesized `2 :: Nil`.
+  checkSynthetics(
+    "(2 :: Nil)",
+    """|[2:3..2:9): :: Nil => *[Int]
+       |""".stripMargin,
+  )
+
+  private val zip = "class C(nums: Seq[Int], strs: Seq[String]) { (nums zip strs) }"
+
+  if (ScalaVersion.is212)
+    // 2.12: zip takes an implicit CanBuildFrom. The synthetic spans the full
+    // parenthesized application `nums zip strs`, not just the second operand.
+    checkSynthetics(
+      zip,
+      """|[2:46..2:59): nums zip strs => *(Seq.canBuildFrom[Tuple2[Int, String]])
+         |[2:46..2:54): nums zip => *[Int, String, Seq[Tuple2[Int, String]]]
+         |""".stripMargin,
+    )
+  else
+    // 2.13: zip is a plain type-application (no CanBuildFrom). Same invariant:
+    // the synthetic tracks the infix application, not the `(`.
+    checkSynthetics(
+      zip,
+      """|[2:46..2:54): nums zip => *[String]
+         |""".stripMargin,
+    )
+
+}


### PR DESCRIPTION
Wrapping an infix application in parentheses must not shift the implicit synthetic off the application. In scalameta 2.1.2 (reported in #1223) the `CanBuildFrom` synthetic for `(a zip b)` was attached at the second operand instead of spanning the whole application.

The current range-based synthetics already handle this correctly. This adds a focused `Issue1223Suite` (extending `PrintSuiteBase`) asserting the exact synthetic ranges:

- `(2 :: Nil)` → `[2:3..2:9): :: Nil => *[Int]` — cross-version; the type-application tracks `:: Nil`, shifted only by the leading `(`.
- `(nums zip strs)` on **2.12** → `[2:46..2:59): nums zip strs => *(Seq.canBuildFrom[Tuple2[Int, String]])` — the implicit-arg synthetic spans the whole parenthesized application (the exact 2.1.2 failure).
- Same snippet on **2.13** → `[2:46..2:54): nums zip => *[String]` (`zip` no longer takes `CanBuildFrom`); the positioning invariant still holds.

Closes #1223