### PR TITLE
Remove stale SuperType FIXME in metacp TypeOps (closes #1291)

### DIFF
--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/scalacp/TypeOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/scalacp/TypeOps.scala
@@ -37,14 +37,11 @@ trait TypeOps {
         case ThisType(sym) =>
           val ssym = sym.ssym
           s.ThisType(ssym)
-        // // FIXME: https://github.com/scalameta/scalameta/issues/1291
-        // case g.SuperType(gpre, gmix) =>
-        //   ???
-        // // FIXME: Could it be that this missing pattern matching case may have been
-        // // the reason for mysterious Metacp crashes?
-        // // https://github.com/scalameta/scalameta/issues/1494
-        // case g.ConstantType(g.Constant(sym: g.TermSymbol)) if sym.hasFlag(gf.JAVA_ENUM) =>
-        //   ???
+        // NOTE: There is deliberately no SuperType case. SuperType (`This.super[Mixin]`) is the
+        // type of `super` references, an expression-level type that scalac never pickles (pickles
+        // store declaration signatures, not method bodies), and scalap has no SUPERtpe parser -- so
+        // metacp can never receive one. The scalac/TextDocumentOps path handles SuperType because it
+        // walks typed source trees. See https://github.com/scalameta/scalameta/issues/1291.
         case ConstantType(underlying: ExternalSymbol) =>
           // NOTE(olafur): manually construct a term symbol for external Java
           // enum symbols because `underlying.entry.entryType == 9` which by

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/scalacp/TypeOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/scalacp/TypeOps.scala
@@ -39,9 +39,10 @@ trait TypeOps {
           s.ThisType(ssym)
         // NOTE: There is deliberately no SuperType case. SuperType (`This.super[Mixin]`) is the
         // type of `super` references, an expression-level type that scalac never pickles (pickles
-        // store declaration signatures, not method bodies), and scalap has no SUPERtpe parser -- so
-        // metacp can never receive one. The scalac/TextDocumentOps path handles SuperType because it
-        // walks typed source trees. See https://github.com/scalameta/scalameta/issues/1291.
+        // store declaration signatures, not method bodies), and scalap's pickle reader has no case
+        // for the SUPERtpe pickle tag (scala.reflect.internal.pickling.PickleFormat) -- so metacp
+        // can never receive one. The scalac/TextDocumentOps path handles SuperType because it walks
+        // typed source trees. See https://github.com/scalameta/scalameta/issues/1291.
         case ConstantType(underlying: ExternalSymbol) =>
           // NOTE(olafur): manually construct a term symbol for external Java
           // enum symbols because `underlying.entry.entryType == 9` which by


### PR DESCRIPTION
Closes #1291.

`metacp` reads only pickled *signatures* (the declared `info` of symbols) out of `.class` files via the upstream `scalap` library. `SuperType` (`This.super[Mixin]`) is the type of `super` references - an **expression-level** type. scalac never pickles it (pickles store declaration signatures, not method bodies), and scalap's `ScalaSig` type parser has no `SUPERtpe` case in its `Type` ADT, so `metacp` can never receive a `SuperType`. The scalac/`TextDocumentOps` path handles `SuperType` because it walks fully-typed source trees; the pickle path provably doesn't need to.

So #1291 is a can't-happen case, not a missing feature. This replaces the stale commented-out FIXME in `scalacp/TypeOps.scala` (which used an invalid `g.` prefix copied from the scalac-side TypeOps and would not compile here) with an accurate explanatory comment. The block's second half — the `#1494` JAVA_ENUM concern - is already handled by the live `ConstantType(underlying: ExternalSymbol)` case just below it, so it's dropped.

Comment-only change: no behavioral change, no MiMa impact, no expect-file regeneration. A test is not expressible, since no input can make scalap emit a `SuperType`; the existing `case other => sys.error(...)` catch-all already covers any surprise.
