### PR TITLE
Emit constructor parameter occurrences at class parameter definition sites

### DIFF
--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/TextDocumentOps.scala
@@ -244,6 +244,22 @@ trait TextDocumentOps {
               setterInfos.foreach(info => symbols(info.symbol) = info)
             }
           }
+          // A `val`/`var` parameter of a primary constructor (and any plain parameter that scalac
+          // turns into a field) gives rise to more than one symbol: the accessor (the getter, or the
+          // underlying field) and the constructor PARAMETER symbol. References resolve to the
+          // accessor (see the #1538 FIXME below), but per
+          // https://github.com/scalameta/scalameta/issues/1327 the definition site covers both, so
+          // we tuck the constructor parameter into a multi-symbol that `finalOccurrences` expands
+          // into a second occurrence sharing the parameter's range.
+          // Scalac keeps no symbol-level link from a param accessor back to the constructor
+          // parameter it stems from, so pairing them by name is the available relation — the same
+          // one the compiler itself uses, and the same one scalacp's SymbolInformationOps uses to
+          // go in the opposite direction.
+          private def withCtorParam(gsym: g.Symbol, ssym: String): String =
+            if (!gsym.isParamAccessor) ssym
+            else gsym.owner.primaryConstructor.info.paramss.flatten
+              .find(_.symbolName == gsym.symbolName)
+              .fold(ssym)(gparam => Symbols.Multi(List(ssym, gparam.toSemantic)))
           private def success(mtree: Option[m.Name], gsym0: => g.Symbol): Unit = mtree
             .foreach(success(_, gsym0))
           private def success(mtree: m.Name, gsym0: g.Symbol): Unit = {
@@ -282,7 +298,7 @@ trait TextDocumentOps {
             if (symbol == Symbols.None) return
 
             todo -= mtree
-            register(symbol)
+            register(if (mtree.isDefinition) withCtorParam(gsym, symbol) else symbol)
 
             def tryWithin(map: mutable.Map[m.Tree, m.Name], gsym0: g.Symbol): Unit = map.get(mtree)
               .foreach { mname =>

--- a/tests-semanticdb/src/test/resources/example/Annotations.scala
+++ b/tests-semanticdb/src/test/resources/example/Annotations.scala
@@ -5,7 +5,7 @@ import scala.annotation.meta._
 import scala.language/*=>scala.language.*/.experimental/*=>scala.language.experimental.*/.macros/*=>scala.language.experimental.macros.*/
 
 @ClassAnnotation/*=>com.javacp.annot.ClassAnnotation#*/
-class Annotations/*<=annot.Annotations#*/[@TypeParameterAnnotation/*=>com.javacp.annot.TypeParameterAnnotation#*/ T/*<=annot.Annotations#[T]*/](@ParameterAnnotation/*=>com.javacp.annot.ParameterAnnotation#*/ x/*<=annot.Annotations#x.*/: T/*=>annot.Annotations#[T]*/) { self/*<=local0*/: AnyRef =>
+class Annotations/*<=annot.Annotations#*/[@TypeParameterAnnotation/*=>com.javacp.annot.TypeParameterAnnotation#*/ T/*<=annot.Annotations#[T]*/](@ParameterAnnotation/*=>com.javacp.annot.ParameterAnnotation#*/ x/*<=annot.Annotations#x.*//*<=annot.Annotations#`<init>`().(x)*/: T/*=>annot.Annotations#[T]*/) { self/*<=local0*/: AnyRef =>
   @FieldAnnotation/*=>com.javacp.annot.FieldAnnotation#*/
   val field/*<=annot.Annotations#field.*/ = 42
 
@@ -19,7 +19,7 @@ class Annotations/*<=annot.Annotations#*/[@TypeParameterAnnotation/*=>com.javacp
   type T/*<=annot.Annotations#T#*/
 }
 
-class B/*<=annot.B#*/ @ConstructorAnnotation/*=>com.javacp.annot.ConstructorAnnotation#*/() (x/*<=annot.B#x.*/: Int/*=>scala.Int#*/) {
+class B/*<=annot.B#*/ @ConstructorAnnotation/*=>com.javacp.annot.ConstructorAnnotation#*/() (x/*<=annot.B#x.*//*<=annot.B#`<init>`().(x)*/: Int/*=>scala.Int#*/) {
   @ConstructorAnnotation/*=>com.javacp.annot.ConstructorAnnotation#*/
   def this() = this(42)
 }

--- a/tests-semanticdb/src/test/resources/example/Classes_2.12.scala
+++ b/tests-semanticdb/src/test/resources/example/Classes_2.12.scala
@@ -1,26 +1,26 @@
 package classes
 
-class C1/*<=classes.C1#*/(val x1/*<=classes.C1#x1.*/: Int/*=>scala.Int#*/) extends AnyVal/*=>scala.AnyVal#*//*=>scala.AnyVal#`<init>`().*/
+class C1/*<=classes.C1#*/(val x1/*<=classes.C1#x1.*//*<=classes.C1#`<init>`().(x1)*/: Int/*=>scala.Int#*/) extends AnyVal/*=>scala.AnyVal#*//*=>scala.AnyVal#`<init>`().*/
 
-class C2/*<=classes.C2#*/(val x2/*<=classes.C2#x2.*/: Int/*=>scala.Int#*/) extends AnyVal/*=>scala.AnyVal#*//*=>scala.AnyVal#`<init>`().*/
+class C2/*<=classes.C2#*/(val x2/*<=classes.C2#x2.*//*<=classes.C2#`<init>`().(x2)*/: Int/*=>scala.Int#*/) extends AnyVal/*=>scala.AnyVal#*//*=>scala.AnyVal#`<init>`().*/
 object C2/*<=classes.C2.*/
 
-case class C3/*<=classes.C3#*/(x/*<=classes.C3#x.*/: Int/*=>scala.Int#*/)
+case class C3/*<=classes.C3#*/(x/*<=classes.C3#x.*//*<=classes.C3#`<init>`().(x)*/: Int/*=>scala.Int#*/)
 
-case class C4/*<=classes.C4#*/(x/*<=classes.C4#x.*/: Int/*=>scala.Int#*/)
+case class C4/*<=classes.C4#*/(x/*<=classes.C4#x.*//*<=classes.C4#`<init>`().(x)*/: Int/*=>scala.Int#*/)
 object C4/*<=classes.C4.*/
 
 object M/*<=classes.M.*/ {
-  implicit class C5/*<=classes.M.C5#*/(x/*<=classes.M.C5#x.*/: Int/*=>scala.Int#*/)
+  implicit class C5/*<=classes.M.C5#*/(x/*<=classes.M.C5#x.*//*<=classes.M.C5#`<init>`().(x)*/: Int/*=>scala.Int#*/)
 }
 
-case class C6/*<=classes.C6#*/(private val x/*<=classes.C6#x.*/: Int/*=>scala.Int#*/)
+case class C6/*<=classes.C6#*/(private val x/*<=classes.C6#x.*//*<=classes.C6#`<init>`().(x)*/: Int/*=>scala.Int#*/)
 
-class C7/*<=classes.C7#*/(x/*<=classes.C7#x.*/: Int/*=>scala.Int#*/)
+class C7/*<=classes.C7#*/(x/*<=classes.C7#x.*//*<=classes.C7#`<init>`().(x)*/: Int/*=>scala.Int#*/)
 
-class C8/*<=classes.C8#*/(private[this] val x/*<=classes.C8#x.*/: Int/*=>scala.Int#*/)
+class C8/*<=classes.C8#*/(private[this] val x/*<=classes.C8#x.*//*<=classes.C8#`<init>`().(x)*/: Int/*=>scala.Int#*/)
 
-class C9/*<=classes.C9#*/(private[this] var x/*<=classes.C9#x().*/: Int/*=>scala.Int#*/)
+class C9/*<=classes.C9#*/(private[this] var x/*<=classes.C9#x().*//*<=classes.C9#`<init>`().(x)*/: Int/*=>scala.Int#*/)
 
 object N/*<=classes.N.*/ {
   val anonClass/*<=classes.N.anonClass.*/ = new C7/*=>classes.C7#*/(42) {

--- a/tests-semanticdb/src/test/resources/example/Classes_2.13.scala
+++ b/tests-semanticdb/src/test/resources/example/Classes_2.13.scala
@@ -1,26 +1,26 @@
 package classes
 
-class C1/*<=classes.C1#*/(val x1/*<=classes.C1#x1.*/: Int/*=>scala.Int#*/) extends AnyVal/*=>scala.AnyVal#*//*=>scala.AnyVal#`<init>`().*/
+class C1/*<=classes.C1#*/(val x1/*<=classes.C1#x1.*//*<=classes.C1#`<init>`().(x1)*/: Int/*=>scala.Int#*/) extends AnyVal/*=>scala.AnyVal#*//*=>scala.AnyVal#`<init>`().*/
 
-class C2/*<=classes.C2#*/(val x2/*<=classes.C2#x2.*/: Int/*=>scala.Int#*/) extends AnyVal/*=>scala.AnyVal#*//*=>scala.AnyVal#`<init>`().*/
+class C2/*<=classes.C2#*/(val x2/*<=classes.C2#x2.*//*<=classes.C2#`<init>`().(x2)*/: Int/*=>scala.Int#*/) extends AnyVal/*=>scala.AnyVal#*//*=>scala.AnyVal#`<init>`().*/
 object C2/*<=classes.C2.*/
 
-case class C3/*<=classes.C3#*/(x/*<=classes.C3#x.*/: Int/*=>scala.Int#*/)
+case class C3/*<=classes.C3#*/(x/*<=classes.C3#x.*//*<=classes.C3#`<init>`().(x)*/: Int/*=>scala.Int#*/)
 
-case class C4/*<=classes.C4#*/(x/*<=classes.C4#x.*/: Int/*=>scala.Int#*/)
+case class C4/*<=classes.C4#*/(x/*<=classes.C4#x.*//*<=classes.C4#`<init>`().(x)*/: Int/*=>scala.Int#*/)
 object C4/*<=classes.C4.*/
 
 object M/*<=classes.M.*/ {
-  implicit class C5/*<=classes.M.C5#*/(x/*<=classes.M.C5#x.*/: Int/*=>scala.Int#*/)
+  implicit class C5/*<=classes.M.C5#*/(x/*<=classes.M.C5#x.*//*<=classes.M.C5#`<init>`().(x)*/: Int/*=>scala.Int#*/)
 }
 
-case class C6/*<=classes.C6#*/(private val x/*<=classes.C6#x.*/: Int/*=>scala.Int#*/)
+case class C6/*<=classes.C6#*/(private val x/*<=classes.C6#x.*//*<=classes.C6#`<init>`().(x)*/: Int/*=>scala.Int#*/)
 
-class C7/*<=classes.C7#*/(x/*<=classes.C7#x.*/: Int/*=>scala.Int#*/)
+class C7/*<=classes.C7#*/(x/*<=classes.C7#x.*//*<=classes.C7#`<init>`().(x)*/: Int/*=>scala.Int#*/)
 
-class C8/*<=classes.C8#*/(private[this] val x/*<=classes.C8#x.*/: Int/*=>scala.Int#*/)
+class C8/*<=classes.C8#*/(private[this] val x/*<=classes.C8#x.*//*<=classes.C8#`<init>`().(x)*/: Int/*=>scala.Int#*/)
 
-class C9/*<=classes.C9#*/(private[this] var x/*<=classes.C9#x().*/: Int/*=>scala.Int#*/)
+class C9/*<=classes.C9#*/(private[this] var x/*<=classes.C9#x().*//*<=classes.C9#`<init>`().(x)*/: Int/*=>scala.Int#*/)
 
 object N/*<=classes.N.*/ {
   val anonClass/*<=classes.N.anonClass.*/ = new C7/*=>classes.C7#*/(42) {

--- a/tests-semanticdb/src/test/resources/example/Flags_2.12.scala
+++ b/tests-semanticdb/src/test/resources/example/Flags_2.12.scala
@@ -7,7 +7,7 @@ package object p/*<=flags.p.package.*/ {
   protected implicit var y/*<=flags.p.package.y().*/: Int/*=>scala.Int#*/ = 2
   def z/*<=flags.p.package.z().*/(pp/*<=flags.p.package.z().(pp)*/: Int/*=>scala.Int#*/) = 3
   def m/*<=flags.p.package.m().*/[TT/*<=flags.p.package.m().[TT]*/]: Int/*=>scala.Int#*/ = macro ???/*=>scala.Predef.`???`().*/
-  abstract class C/*<=flags.p.package.C#*/[+T/*<=flags.p.package.C#[T]*/, -U/*<=flags.p.package.C#[U]*/, V/*<=flags.p.package.C#[V]*/](x/*<=flags.p.package.C#x.*/: T/*=>flags.p.package.C#[T]*/, y/*<=flags.p.package.C#y.*/: U/*=>flags.p.package.C#[U]*/, z/*<=flags.p.package.C#z.*/: V/*=>flags.p.package.C#[V]*/) {
+  abstract class C/*<=flags.p.package.C#*/[+T/*<=flags.p.package.C#[T]*/, -U/*<=flags.p.package.C#[U]*/, V/*<=flags.p.package.C#[V]*/](x/*<=flags.p.package.C#x.*//*<=flags.p.package.C#`<init>`().(x)*/: T/*=>flags.p.package.C#[T]*/, y/*<=flags.p.package.C#y.*//*<=flags.p.package.C#`<init>`().(y)*/: U/*=>flags.p.package.C#[U]*/, z/*<=flags.p.package.C#z.*//*<=flags.p.package.C#`<init>`().(z)*/: V/*=>flags.p.package.C#[V]*/) {
     def this/*<=flags.p.package.C#`<init>`(+1).*/() = this(???/*=>scala.Predef.`???`().*/, ???/*=>scala.Predef.`???`().*/, ???/*=>scala.Predef.`???`().*/)
     def w/*<=flags.p.package.C#w().*/: Int/*=>scala.Int#*/
   }
@@ -18,7 +18,7 @@ package object p/*<=flags.p.package.*/ {
   case object X/*<=flags.p.package.X.*/
   final class Y/*<=flags.p.package.Y#*/
   sealed trait Z/*<=flags.p.package.Z#*/
-  class AA/*<=flags.p.package.AA#*/(x/*<=flags.p.package.AA#x.*/: Int/*=>scala.Int#*/, val y/*<=flags.p.package.AA#y.*/: Int/*=>scala.Int#*/, var z/*<=flags.p.package.AA#z().*/: Int/*=>scala.Int#*/)
+  class AA/*<=flags.p.package.AA#*/(x/*<=flags.p.package.AA#x.*//*<=flags.p.package.AA#`<init>`().(x)*/: Int/*=>scala.Int#*/, val y/*<=flags.p.package.AA#y.*//*<=flags.p.package.AA#`<init>`().(y)*/: Int/*=>scala.Int#*/, var z/*<=flags.p.package.AA#z().*//*<=flags.p.package.AA#`<init>`().(z)*/: Int/*=>scala.Int#*/)
   class S/*<=flags.p.package.S#*/[@specialized/*=>scala.specialized#*/ T/*<=flags.p.package.S#[T]*/]
   val List/*=>scala.collection.immutable.List.*/(xs1/*<=flags.p.package.xs1.*/) = ???/*=>scala.Predef.`???`().*/
   ???/*=>scala.Predef.`???`().*/ match { case List/*=>scala.collection.immutable.List.*/(xs2/*<=local1*/) => ???/*=>scala.Predef.`???`().*/ }

--- a/tests-semanticdb/src/test/resources/example/Flags_2.13.scala
+++ b/tests-semanticdb/src/test/resources/example/Flags_2.13.scala
@@ -7,7 +7,7 @@ package object p/*<=flags.p.package.*/ {
   protected implicit var y/*<=flags.p.package.y().*/: Int/*=>scala.Int#*/ = 2
   def z/*<=flags.p.package.z().*/(pp/*<=flags.p.package.z().(pp)*/: Int/*=>scala.Int#*/) = 3
   def m/*<=flags.p.package.m().*/[TT/*<=flags.p.package.m().[TT]*/]: Int/*=>scala.Int#*/ = macro ???/*=>scala.Predef.`???`().*/
-  abstract class C/*<=flags.p.package.C#*/[+T/*<=flags.p.package.C#[T]*/, -U/*<=flags.p.package.C#[U]*/, V/*<=flags.p.package.C#[V]*/](x/*<=flags.p.package.C#x.*/: T/*=>flags.p.package.C#[T]*/, y/*<=flags.p.package.C#y.*/: U/*=>flags.p.package.C#[U]*/, z/*<=flags.p.package.C#z.*/: V/*=>flags.p.package.C#[V]*/) {
+  abstract class C/*<=flags.p.package.C#*/[+T/*<=flags.p.package.C#[T]*/, -U/*<=flags.p.package.C#[U]*/, V/*<=flags.p.package.C#[V]*/](x/*<=flags.p.package.C#x.*//*<=flags.p.package.C#`<init>`().(x)*/: T/*=>flags.p.package.C#[T]*/, y/*<=flags.p.package.C#y.*//*<=flags.p.package.C#`<init>`().(y)*/: U/*=>flags.p.package.C#[U]*/, z/*<=flags.p.package.C#z.*//*<=flags.p.package.C#`<init>`().(z)*/: V/*=>flags.p.package.C#[V]*/) {
     def this/*<=flags.p.package.C#`<init>`(+1).*/() = this(???/*=>scala.Predef.`???`().*/, ???/*=>scala.Predef.`???`().*/, ???/*=>scala.Predef.`???`().*/)
     def w/*<=flags.p.package.C#w().*/: Int/*=>scala.Int#*/
   }
@@ -18,7 +18,7 @@ package object p/*<=flags.p.package.*/ {
   case object X/*<=flags.p.package.X.*/
   final class Y/*<=flags.p.package.Y#*/
   sealed trait Z/*<=flags.p.package.Z#*/
-  class AA/*<=flags.p.package.AA#*/(x/*<=flags.p.package.AA#x.*/: Int/*=>scala.Int#*/, val y/*<=flags.p.package.AA#y.*/: Int/*=>scala.Int#*/, var z/*<=flags.p.package.AA#z().*/: Int/*=>scala.Int#*/)
+  class AA/*<=flags.p.package.AA#*/(x/*<=flags.p.package.AA#x.*//*<=flags.p.package.AA#`<init>`().(x)*/: Int/*=>scala.Int#*/, val y/*<=flags.p.package.AA#y.*//*<=flags.p.package.AA#`<init>`().(y)*/: Int/*=>scala.Int#*/, var z/*<=flags.p.package.AA#z().*//*<=flags.p.package.AA#`<init>`().(z)*/: Int/*=>scala.Int#*/)
   class S/*<=flags.p.package.S#*/[@specialized/*=>scala.specialized#*/ /*=>scala.specialized#`<init>`(+2).*/T/*<=flags.p.package.S#[T]*/]
   val List/*=>scala.package.List.*/(xs1/*<=flags.p.package.xs1.*/) = ???/*=>scala.Predef.`???`().*/
   ???/*=>scala.Predef.`???`().*/ match { case List/*=>scala.package.List.*/(xs2/*<=local1*/) => ???/*=>scala.Predef.`???`().*/ }

--- a/tests-semanticdb/src/test/resources/example/Issue2144.scala
+++ b/tests-semanticdb/src/test/resources/example/Issue2144.scala
@@ -1,5 +1,5 @@
 package example
 object Issue2144/*<=example.Issue2144.*/ {
-  class Test/*<=example.Issue2144.Test#*/(a/*<=example.Issue2144.Test#a.*/: Boolean/*=>scala.Boolean#*/, b/*<=example.Issue2144.Test#b.*/: Int/*=>scala.Int#*/ = 1, c/*<=example.Issue2144.Test#c.*/: Int/*=>scala.Int#*/ = 2)
+  class Test/*<=example.Issue2144.Test#*/(a/*<=example.Issue2144.Test#a.*//*<=example.Issue2144.Test#`<init>`().(a)*/: Boolean/*=>scala.Boolean#*/, b/*<=example.Issue2144.Test#b.*//*<=example.Issue2144.Test#`<init>`().(b)*/: Int/*=>scala.Int#*/ = 1, c/*<=example.Issue2144.Test#c.*//*<=example.Issue2144.Test#`<init>`().(c)*/: Int/*=>scala.Int#*/ = 2)
   val x/*<=example.Issue2144.x.*/ = new Test/*=>example.Issue2144.Test#*/(a/*=>example.Issue2144.Test#`<init>`().(a)*/ = true, c/*=>example.Issue2144.Test#`<init>`().(c)*/ = 1)
 }

--- a/tests-semanticdb/src/test/resources/example/Issue2882.scala
+++ b/tests-semanticdb/src/test/resources/example/Issue2882.scala
@@ -2,7 +2,7 @@ package example
 
 object Issue2882/*<=example.Issue2882.*/ {
 
-  case class FooFailure/*<=example.Issue2882.FooFailure#*/(msg/*<=example.Issue2882.FooFailure#msg.*/: String/*=>scala.Predef.String#*/)
+  case class FooFailure/*<=example.Issue2882.FooFailure#*/(msg/*<=example.Issue2882.FooFailure#msg.*//*<=example.Issue2882.FooFailure#`<init>`().(msg)*/: String/*=>scala.Predef.String#*/)
     extends Exception/*=>scala.package.Exception#*//*=>java.lang.Exception#`<init>`(+1).*/(s/*=>scala.StringContext#s().*/"Error: $msg/*=>example.Issue2882.FooFailure#`<init>`().(msg)*/")
 
 }

--- a/tests-semanticdb/src/test/resources/example/Issue5939Metals.scala
+++ b/tests-semanticdb/src/test/resources/example/Issue5939Metals.scala
@@ -2,7 +2,7 @@
 package example
 import scala.language/*=>scala.language.*/.implicitConversions/*=>scala.language.implicitConversions.*/
 
-class AA/*<=example.AA#*/(val f/*<=example.AA#f.*/: Int/*=>scala.Int#*/ => Int/*=>scala.Int#*/)
+class AA/*<=example.AA#*/(val f/*<=example.AA#f.*//*<=example.AA#`<init>`().(f)*/: Int/*=>scala.Int#*/ => Int/*=>scala.Int#*/)
 
 object AA/*<=example.AA.*/ {
   implicit def toF/*<=example.AA.toF().*/(a/*<=example.AA.toF().(a)*/: AA/*=>example.AA#*/): Int/*=>scala.Int#*/ => Int/*=>scala.Int#*/ = a/*=>example.AA.toF().(a)*/.f/*=>example.AA#f.*/

--- a/tests-semanticdb/src/test/resources/example/NamedApplyBlock.scala
+++ b/tests-semanticdb/src/test/resources/example/NamedApplyBlock.scala
@@ -8,7 +8,7 @@ object NamedApplyBlockMethods/*<=example.NamedApplyBlockMethods.*/ {
 }
 
 object NamedApplyBlockCaseClassConstruction/*<=example.NamedApplyBlockCaseClassConstruction.*/ {
-  case class Msg/*<=example.NamedApplyBlockCaseClassConstruction.Msg#*/(body/*<=example.NamedApplyBlockCaseClassConstruction.Msg#body.*/: String/*=>scala.Predef.String#*/, head/*<=example.NamedApplyBlockCaseClassConstruction.Msg#head.*/: String/*=>scala.Predef.String#*/ = "default", tail/*<=example.NamedApplyBlockCaseClassConstruction.Msg#tail.*/: String/*=>scala.Predef.String#*/)
+  case class Msg/*<=example.NamedApplyBlockCaseClassConstruction.Msg#*/(body/*<=example.NamedApplyBlockCaseClassConstruction.Msg#body.*//*<=example.NamedApplyBlockCaseClassConstruction.Msg#`<init>`().(body)*/: String/*=>scala.Predef.String#*/, head/*<=example.NamedApplyBlockCaseClassConstruction.Msg#head.*//*<=example.NamedApplyBlockCaseClassConstruction.Msg#`<init>`().(head)*/: String/*=>scala.Predef.String#*/ = "default", tail/*<=example.NamedApplyBlockCaseClassConstruction.Msg#tail.*//*<=example.NamedApplyBlockCaseClassConstruction.Msg#`<init>`().(tail)*/: String/*=>scala.Predef.String#*/)
   val bodyText/*<=example.NamedApplyBlockCaseClassConstruction.bodyText.*/ = "body"
   val msg/*<=example.NamedApplyBlockCaseClassConstruction.msg.*/ = Msg/*=>example.NamedApplyBlockCaseClassConstruction.Msg.*/(bodyText/*=>example.NamedApplyBlockCaseClassConstruction.bodyText.*/, tail/*=>example.NamedApplyBlockCaseClassConstruction.Msg.apply().(tail)*/ = "tail")
 }

--- a/tests-semanticdb/src/test/resources/example/NamedArguments.scala
+++ b/tests-semanticdb/src/test/resources/example/NamedArguments.scala
@@ -1,7 +1,7 @@
 package example
 
 class NamedArguments/*<=example.NamedArguments#*/ {
-  case class User/*<=example.NamedArguments#User#*/(name/*<=example.NamedArguments#User#name.*/: String/*=>scala.Predef.String#*/)
+  case class User/*<=example.NamedArguments#User#*/(name/*<=example.NamedArguments#User#name.*//*<=example.NamedArguments#User#`<init>`().(name)*/: String/*=>scala.Predef.String#*/)
   User/*=>example.NamedArguments#User.*/(name/*=>example.NamedArguments#User.apply().(name)*/ = "John")
   User/*=>example.NamedArguments#User.*/.apply/*=>example.NamedArguments#User.apply().*/(name/*=>example.NamedArguments#User.apply().(name)*/ = "John")
 }

--- a/tests-semanticdb/src/test/resources/example/Types_2.12.scala
+++ b/tests-semanticdb/src/test/resources/example/Types_2.12.scala
@@ -3,7 +3,7 @@ package types
 import scala.language/*=>scala.language.*/.existentials/*=>scala.language.existentials.*/
 import scala.language/*=>scala.language.*/.higherKinds/*=>scala.language.higherKinds.*/
 
-class ann/*<=types.ann#*/[T/*<=types.ann#[T]*/](x/*<=types.ann#x.*/: T/*=>types.ann#[T]*/) extends scala.annotation.StaticAnnotation/*=>scala.annotation.StaticAnnotation#*/
+class ann/*<=types.ann#*/[T/*<=types.ann#[T]*/](x/*<=types.ann#x.*//*<=types.ann#`<init>`().(x)*/: T/*=>types.ann#[T]*/) extends scala.annotation.StaticAnnotation/*=>scala.annotation.StaticAnnotation#*/
 class ann1/*<=types.ann1#*/ extends scala.annotation.StaticAnnotation/*=>scala.annotation.StaticAnnotation#*/
 class ann2/*<=types.ann2#*/ extends scala.annotation.StaticAnnotation/*=>scala.annotation.StaticAnnotation#*/
 
@@ -87,7 +87,7 @@ object Test/*<=types.Test.*/ {
       def m1/*<=types.Test.C#ByNameType.m1().*/(x/*<=types.Test.C#ByNameType.m1().(x)*/: => Int/*=>scala.Int#*/): Int/*=>scala.Int#*/ = ???/*=>scala.Predef.`???`().*/
     }
 
-    case class RepeatedType/*<=types.Test.C#RepeatedType#*/(s/*<=types.Test.C#RepeatedType#s.*/: String/*=>java.lang.String#*/*) {
+    case class RepeatedType/*<=types.Test.C#RepeatedType#*/(s/*<=types.Test.C#RepeatedType#s.*//*<=types.Test.C#RepeatedType#`<init>`().(s)*/: String/*=>java.lang.String#*/*) {
       def m1/*<=types.Test.C#RepeatedType#m1().*/(x/*<=types.Test.C#RepeatedType#m1().(x)*/: Int/*=>scala.Int#*/*): Int/*=>scala.Int#*/ = s/*=>types.Test.C#RepeatedType#s.*/.length/*=>scala.collection.SeqLike#length().*/
     }
 

--- a/tests-semanticdb/src/test/resources/example/Types_2.13.scala
+++ b/tests-semanticdb/src/test/resources/example/Types_2.13.scala
@@ -3,7 +3,7 @@ package types
 import scala.language/*=>scala.language.*/.existentials/*=>scala.language.existentials.*/
 import scala.language/*=>scala.language.*/.higherKinds/*=>scala.language.higherKinds.*/
 
-class ann/*<=types.ann#*/[T/*<=types.ann#[T]*/](x/*<=types.ann#x.*/: T/*=>types.ann#[T]*/) extends scala.annotation.StaticAnnotation/*=>scala.annotation.StaticAnnotation#*/
+class ann/*<=types.ann#*/[T/*<=types.ann#[T]*/](x/*<=types.ann#x.*//*<=types.ann#`<init>`().(x)*/: T/*=>types.ann#[T]*/) extends scala.annotation.StaticAnnotation/*=>scala.annotation.StaticAnnotation#*/
 class ann1/*<=types.ann1#*/ extends scala.annotation.StaticAnnotation/*=>scala.annotation.StaticAnnotation#*/
 class ann2/*<=types.ann2#*/ extends scala.annotation.StaticAnnotation/*=>scala.annotation.StaticAnnotation#*/
 
@@ -87,7 +87,7 @@ object Test/*<=types.Test.*/ {
       def m1/*<=types.Test.C#ByNameType.m1().*/(x/*<=types.Test.C#ByNameType.m1().(x)*/: => Int/*=>scala.Int#*/): Int/*=>scala.Int#*/ = ???/*=>scala.Predef.`???`().*/
     }
 
-    case class RepeatedType/*<=types.Test.C#RepeatedType#*/(s/*<=types.Test.C#RepeatedType#s.*/: String/*=>java.lang.String#*/*) {
+    case class RepeatedType/*<=types.Test.C#RepeatedType#*/(s/*<=types.Test.C#RepeatedType#s.*//*<=types.Test.C#RepeatedType#`<init>`().(s)*/: String/*=>java.lang.String#*/*) {
       def m1/*<=types.Test.C#RepeatedType#m1().*/(x/*<=types.Test.C#RepeatedType#m1().(x)*/: Int/*=>scala.Int#*/*): Int/*=>scala.Int#*/ = s/*=>types.Test.C#RepeatedType#s.*/.length/*=>scala.collection.SeqOps#length().*/
     }
 

--- a/tests-semanticdb/src/test/resources/example/Vals.scala
+++ b/tests-semanticdb/src/test/resources/example/Vals.scala
@@ -1,6 +1,6 @@
 package example
 
-abstract class Vals/*<=example.Vals#*/(p/*<=example.Vals#p.*/: Int/*=>scala.Int#*/, val xp/*<=example.Vals#xp.*/: Int/*=>scala.Int#*/, var yp/*<=example.Vals#yp().*/: Int/*=>scala.Int#*/) {
+abstract class Vals/*<=example.Vals#*/(p/*<=example.Vals#p.*//*<=example.Vals#`<init>`().(p)*/: Int/*=>scala.Int#*/, val xp/*<=example.Vals#xp.*//*<=example.Vals#`<init>`().(xp)*/: Int/*=>scala.Int#*/, var yp/*<=example.Vals#yp().*//*<=example.Vals#`<init>`().(yp)*/: Int/*=>scala.Int#*/) {
   val xm/*<=example.Vals#xm.*/: Int/*=>scala.Int#*/ = ???/*=>scala.Predef.`???`().*/
   val xam/*<=example.Vals#xam.*/: Int/*=>scala.Int#*/
   private[this] val xlm/*<=example.Vals#xlm.*/: Int/*=>scala.Int#*/ = ???/*=>scala.Predef.`???`().*/

--- a/tests-semanticdb/src/test/resources/metac.expect_2.12
+++ b/tests-semanticdb/src/test/resources/metac.expect_2.12
@@ -392,7 +392,7 @@ Uri => semanticdb/integration/src/main/scala/example/Annotations.scala
 Text => non-empty
 Language => Scala
 Symbols => 21 entries
-Occurrences => 48 entries
+Occurrences => 50 entries
 
 Symbols:
 annot/Alias. => final object Alias extends AnyRef { +1 decls }
@@ -471,6 +471,7 @@ Occurrences:
 [7:43..7:44): T <= annot/Annotations#[T]
 [7:45..7:45):  <= annot/Annotations#`<init>`().
 [7:47..7:66): ParameterAnnotation => com/javacp/annot/ParameterAnnotation#
+[7:67..7:68): x <= annot/Annotations#`<init>`().(x)
 [7:67..7:68): x <= annot/Annotations#x.
 [7:70..7:71): T => annot/Annotations#[T]
 [7:75..7:79): self <= local0
@@ -486,6 +487,7 @@ Occurrences:
 [21:6..21:7): B <= annot/B#
 [21:9..21:30): ConstructorAnnotation => com/javacp/annot/ConstructorAnnotation#
 [21:33..21:33):  <= annot/B#`<init>`().
+[21:34..21:35): x <= annot/B#`<init>`().(x)
 [21:34..21:35): x <= annot/B#x.
 [21:37..21:40): Int => scala/Int#
 [22:3..22:24): ConstructorAnnotation => com/javacp/annot/ConstructorAnnotation#
@@ -586,7 +588,7 @@ Uri => semanticdb/integration/src/main/scala/example/Classes.scala
 Text => non-empty
 Language => Scala
 Symbols => 143 entries
-Occurrences => 126 entries
+Occurrences => 135 entries
 Synthetics => 3 entries
 
 Symbols:
@@ -972,12 +974,14 @@ Occurrences:
 [0:8..0:15): classes <= classes/
 [2:6..2:8): C1 <= classes/C1#
 [2:8..2:8):  <= classes/C1#`<init>`().
+[2:13..2:15): x1 <= classes/C1#`<init>`().(x1)
 [2:13..2:15): x1 <= classes/C1#x1.
 [2:17..2:20): Int => scala/Int#
 [2:30..2:36): AnyVal => scala/AnyVal#
 [2:36..2:36):  => scala/AnyVal#`<init>`().
 [4:6..4:8): C2 <= classes/C2#
 [4:8..4:8):  <= classes/C2#`<init>`().
+[4:13..4:15): x2 <= classes/C2#`<init>`().(x2)
 [4:13..4:15): x2 <= classes/C2#x2.
 [4:17..4:20): Int => scala/Int#
 [4:30..4:36): AnyVal => scala/AnyVal#
@@ -985,32 +989,39 @@ Occurrences:
 [5:7..5:9): C2 <= classes/C2.
 [7:11..7:13): C3 <= classes/C3#
 [7:13..7:13):  <= classes/C3#`<init>`().
+[7:14..7:15): x <= classes/C3#`<init>`().(x)
 [7:14..7:15): x <= classes/C3#x.
 [7:17..7:20): Int => scala/Int#
 [9:11..9:13): C4 <= classes/C4#
 [9:13..9:13):  <= classes/C4#`<init>`().
+[9:14..9:15): x <= classes/C4#`<init>`().(x)
 [9:14..9:15): x <= classes/C4#x.
 [9:17..9:20): Int => scala/Int#
 [10:7..10:9): C4 <= classes/C4.
 [12:7..12:8): M <= classes/M.
 [13:17..13:19): C5 <= classes/M.C5#
 [13:19..13:19):  <= classes/M.C5#`<init>`().
+[13:20..13:21): x <= classes/M.C5#`<init>`().(x)
 [13:20..13:21): x <= classes/M.C5#x.
 [13:23..13:26): Int => scala/Int#
 [16:11..16:13): C6 <= classes/C6#
 [16:13..16:13):  <= classes/C6#`<init>`().
+[16:26..16:27): x <= classes/C6#`<init>`().(x)
 [16:26..16:27): x <= classes/C6#x.
 [16:29..16:32): Int => scala/Int#
 [18:6..18:8): C7 <= classes/C7#
 [18:8..18:8):  <= classes/C7#`<init>`().
+[18:9..18:10): x <= classes/C7#`<init>`().(x)
 [18:9..18:10): x <= classes/C7#x.
 [18:12..18:15): Int => scala/Int#
 [20:6..20:8): C8 <= classes/C8#
 [20:8..20:8):  <= classes/C8#`<init>`().
+[20:27..20:28): x <= classes/C8#`<init>`().(x)
 [20:27..20:28): x <= classes/C8#x.
 [20:30..20:33): Int => scala/Int#
 [22:6..22:8): C9 <= classes/C9#
 [22:8..22:8):  <= classes/C9#`<init>`().
+[22:27..22:28): x <= classes/C9#`<init>`().(x)
 [22:27..22:28): x <= classes/C9#x().
 [22:30..22:33): Int => scala/Int#
 [24:7..24:8): N <= classes/N.
@@ -1319,7 +1330,7 @@ Uri => semanticdb/integration/src/main/scala/example/Flags.scala
 Text => non-empty
 Language => Scala
 Symbols => 58 entries
-Occurrences => 72 entries
+Occurrences => 78 entries
 Synthetics => 2 entries
 
 Symbols:
@@ -1480,10 +1491,13 @@ Occurrences:
 [9:24..9:25): U <= flags/p/package.C#[U]
 [9:27..9:28): V <= flags/p/package.C#[V]
 [9:29..9:29):  <= flags/p/package.C#`<init>`().
+[9:30..9:31): x <= flags/p/package.C#`<init>`().(x)
 [9:30..9:31): x <= flags/p/package.C#x.
 [9:33..9:34): T => flags/p/package.C#[T]
+[9:36..9:37): y <= flags/p/package.C#`<init>`().(y)
 [9:36..9:37): y <= flags/p/package.C#y.
 [9:39..9:40): U => flags/p/package.C#[U]
+[9:42..9:43): z <= flags/p/package.C#`<init>`().(z)
 [9:42..9:43): z <= flags/p/package.C#z.
 [9:45..9:46): V => flags/p/package.C#[V]
 [10:8..10:12): this <= flags/p/package.C#`<init>`(+1).
@@ -1509,10 +1523,13 @@ Occurrences:
 [19:15..19:16): Z <= flags/p/package.Z#
 [20:8..20:10): AA <= flags/p/package.AA#
 [20:10..20:10):  <= flags/p/package.AA#`<init>`().
+[20:11..20:12): x <= flags/p/package.AA#`<init>`().(x)
 [20:11..20:12): x <= flags/p/package.AA#x.
 [20:14..20:17): Int => scala/Int#
+[20:23..20:24): y <= flags/p/package.AA#`<init>`().(y)
 [20:23..20:24): y <= flags/p/package.AA#y.
 [20:26..20:29): Int => scala/Int#
+[20:35..20:36): z <= flags/p/package.AA#`<init>`().(z)
 [20:35..20:36): z <= flags/p/package.AA#z().
 [20:38..20:41): Int => scala/Int#
 [21:8..21:9): S <= flags/p/package.S#
@@ -2538,7 +2555,7 @@ Uri => semanticdb/integration/src/main/scala/example/Issue2144.scala
 Text => non-empty
 Language => Scala
 Symbols => 16 entries
-Occurrences => 15 entries
+Occurrences => 18 entries
 
 Symbols:
 example/Issue2144. => final object Issue2144 extends AnyRef { +3 decls }
@@ -2585,10 +2602,13 @@ Occurrences:
 [1:7..1:16): Issue2144 <= example/Issue2144.
 [2:8..2:12): Test <= example/Issue2144.Test#
 [2:12..2:12):  <= example/Issue2144.Test#`<init>`().
+[2:13..2:14): a <= example/Issue2144.Test#`<init>`().(a)
 [2:13..2:14): a <= example/Issue2144.Test#a.
 [2:16..2:23): Boolean => scala/Boolean#
+[2:25..2:26): b <= example/Issue2144.Test#`<init>`().(b)
 [2:25..2:26): b <= example/Issue2144.Test#b.
 [2:28..2:31): Int => scala/Int#
+[2:37..2:38): c <= example/Issue2144.Test#`<init>`().(c)
 [2:37..2:38): c <= example/Issue2144.Test#c.
 [2:40..2:43): Int => scala/Int#
 [3:6..3:7): x <= example/Issue2144.x.
@@ -2606,7 +2626,7 @@ Uri => semanticdb/integration/src/main/scala/example/Issue2882.scala
 Text => non-empty
 Language => Scala
 Symbols => 26 entries
-Occurrences => 10 entries
+Occurrences => 11 entries
 Synthetics => 1 entries
 
 Symbols:
@@ -2689,6 +2709,7 @@ Occurrences:
 [2:7..2:16): Issue2882 <= example/Issue2882.
 [4:13..4:23): FooFailure <= example/Issue2882.FooFailure#
 [4:23..4:23):  <= example/Issue2882.FooFailure#`<init>`().
+[4:24..4:27): msg <= example/Issue2882.FooFailure#`<init>`().(msg)
 [4:24..4:27): msg <= example/Issue2882.FooFailure#msg.
 [4:29..4:35): String => scala/Predef.String#
 [5:12..5:21): Exception => scala/package.Exception#
@@ -2743,7 +2764,7 @@ Uri => semanticdb/integration/src/main/scala/example/Issue5939Metals.scala
 Text => non-empty
 Language => Scala
 Symbols => 9 entries
-Occurrences => 23 entries
+Occurrences => 24 entries
 Synthetics => 2 entries
 
 Symbols:
@@ -2780,6 +2801,7 @@ Occurrences:
 [2:22..2:41): implicitConversions => scala/language.implicitConversions.
 [4:6..4:8): AA <= example/AA#
 [4:8..4:8):  <= example/AA#`<init>`().
+[4:13..4:14): f <= example/AA#`<init>`().(f)
 [4:13..4:14): f <= example/AA#f.
 [4:16..4:19): Int => scala/Int#
 [4:23..4:26): Int => scala/Int#
@@ -3559,7 +3581,7 @@ Uri => semanticdb/integration/src/main/scala/example/NamedApplyBlock.scala
 Text => non-empty
 Language => Scala
 Symbols => 64 entries
-Occurrences => 41 entries
+Occurrences => 44 entries
 Synthetics => 1 entries
 
 Symbols:
@@ -3761,10 +3783,13 @@ Occurrences:
 [9:7..9:43): NamedApplyBlockCaseClassConstruction <= example/NamedApplyBlockCaseClassConstruction.
 [10:13..10:16): Msg <= example/NamedApplyBlockCaseClassConstruction.Msg#
 [10:16..10:16):  <= example/NamedApplyBlockCaseClassConstruction.Msg#`<init>`().
+[10:17..10:21): body <= example/NamedApplyBlockCaseClassConstruction.Msg#`<init>`().(body)
 [10:17..10:21): body <= example/NamedApplyBlockCaseClassConstruction.Msg#body.
 [10:23..10:29): String => scala/Predef.String#
+[10:31..10:35): head <= example/NamedApplyBlockCaseClassConstruction.Msg#`<init>`().(head)
 [10:31..10:35): head <= example/NamedApplyBlockCaseClassConstruction.Msg#head.
 [10:37..10:43): String => scala/Predef.String#
+[10:57..10:61): tail <= example/NamedApplyBlockCaseClassConstruction.Msg#`<init>`().(tail)
 [10:57..10:61): tail <= example/NamedApplyBlockCaseClassConstruction.Msg#tail.
 [10:63..10:69): String => scala/Predef.String#
 [11:6..11:14): bodyText <= example/NamedApplyBlockCaseClassConstruction.bodyText.
@@ -3786,7 +3811,7 @@ Uri => semanticdb/integration/src/main/scala/example/NamedArguments.scala
 Text => non-empty
 Language => Scala
 Symbols => 27 entries
-Occurrences => 12 entries
+Occurrences => 13 entries
 Synthetics => 1 entries
 
 Symbols:
@@ -3871,6 +3896,7 @@ Occurrences:
 [2:21..2:21):  <= example/NamedArguments#`<init>`().
 [3:13..3:17): User <= example/NamedArguments#User#
 [3:17..3:17):  <= example/NamedArguments#User#`<init>`().
+[3:18..3:22): name <= example/NamedArguments#User#`<init>`().(name)
 [3:18..3:22): name <= example/NamedArguments#User#name.
 [3:24..3:30): String => scala/Predef.String#
 [4:2..4:6): User => example/NamedArguments#User.
@@ -4710,7 +4736,7 @@ Uri => semanticdb/integration/src/main/scala/example/Types.scala
 Text => non-empty
 Language => Scala
 Symbols => 143 entries
-Occurrences => 268 entries
+Occurrences => 270 entries
 
 Symbols:
 local0 => abstract method k: Int
@@ -5050,6 +5076,7 @@ Occurrences:
 [5:6..5:9): ann <= types/ann#
 [5:10..5:11): T <= types/ann#[T]
 [5:12..5:12):  <= types/ann#`<init>`().
+[5:13..5:14): x <= types/ann#`<init>`().(x)
 [5:13..5:14): x <= types/ann#x.
 [5:16..5:17): T => types/ann#[T]
 [5:27..5:32): scala => scala/
@@ -5255,6 +5282,7 @@ Occurrences:
 [86:31..86:34): ??? => scala/Predef.`???`().
 [89:15..89:27): RepeatedType <= types/Test.C#RepeatedType#
 [89:27..89:27):  <= types/Test.C#RepeatedType#`<init>`().
+[89:28..89:29): s <= types/Test.C#RepeatedType#`<init>`().(s)
 [89:28..89:29): s <= types/Test.C#RepeatedType#s.
 [89:31..89:37): String => java/lang/String#
 [90:10..90:12): m1 <= types/Test.C#RepeatedType#m1().
@@ -5477,7 +5505,7 @@ Uri => semanticdb/integration/src/main/scala/example/Vals.scala
 Text => non-empty
 Language => Scala
 Symbols => 40 entries
-Occurrences => 117 entries
+Occurrences => 120 entries
 
 Symbols:
 example/ValUsages. => final object ValUsages extends AnyRef { +1 decls }
@@ -5580,10 +5608,13 @@ Occurrences:
 [0:8..0:15): example <= example/
 [2:15..2:19): Vals <= example/Vals#
 [2:19..2:19):  <= example/Vals#`<init>`().
+[2:20..2:21): p <= example/Vals#`<init>`().(p)
 [2:20..2:21): p <= example/Vals#p.
 [2:23..2:26): Int => scala/Int#
+[2:32..2:34): xp <= example/Vals#`<init>`().(xp)
 [2:32..2:34): xp <= example/Vals#xp.
 [2:36..2:39): Int => scala/Int#
+[2:45..2:47): yp <= example/Vals#`<init>`().(yp)
 [2:45..2:47): yp <= example/Vals#yp().
 [2:49..2:52): Int => scala/Int#
 [3:6..3:8): xm <= example/Vals#xm.

--- a/tests-semanticdb/src/test/resources/metac.expect_2.13
+++ b/tests-semanticdb/src/test/resources/metac.expect_2.13
@@ -463,7 +463,7 @@ Uri => semanticdb/integration/src/main/scala/example/Annotations.scala
 Text => non-empty
 Language => Scala
 Symbols => 21 entries
-Occurrences => 48 entries
+Occurrences => 50 entries
 
 Symbols:
 annot/Alias. => final object Alias extends AnyRef { +1 decls }
@@ -542,6 +542,7 @@ Occurrences:
 [7:43..7:44): T <= annot/Annotations#[T]
 [7:45..7:45):  <= annot/Annotations#`<init>`().
 [7:47..7:66): ParameterAnnotation => com/javacp/annot/ParameterAnnotation#
+[7:67..7:68): x <= annot/Annotations#`<init>`().(x)
 [7:67..7:68): x <= annot/Annotations#x.
 [7:70..7:71): T => annot/Annotations#[T]
 [7:75..7:79): self <= local0
@@ -557,6 +558,7 @@ Occurrences:
 [21:6..21:7): B <= annot/B#
 [21:9..21:30): ConstructorAnnotation => com/javacp/annot/ConstructorAnnotation#
 [21:33..21:33):  <= annot/B#`<init>`().
+[21:34..21:35): x <= annot/B#`<init>`().(x)
 [21:34..21:35): x <= annot/B#x.
 [21:37..21:40): Int => scala/Int#
 [22:3..22:24): ConstructorAnnotation => com/javacp/annot/ConstructorAnnotation#
@@ -662,7 +664,7 @@ Uri => semanticdb/integration/src/main/scala/example/Classes.scala
 Text => non-empty
 Language => Scala
 Symbols => 149 entries
-Occurrences => 126 entries
+Occurrences => 135 entries
 Synthetics => 2 entries
 
 Symbols:
@@ -1066,12 +1068,14 @@ Occurrences:
 [0:8..0:15): classes <= classes/
 [2:6..2:8): C1 <= classes/C1#
 [2:8..2:8):  <= classes/C1#`<init>`().
+[2:13..2:15): x1 <= classes/C1#`<init>`().(x1)
 [2:13..2:15): x1 <= classes/C1#x1.
 [2:17..2:20): Int => scala/Int#
 [2:30..2:36): AnyVal => scala/AnyVal#
 [2:36..2:36):  => scala/AnyVal#`<init>`().
 [4:6..4:8): C2 <= classes/C2#
 [4:8..4:8):  <= classes/C2#`<init>`().
+[4:13..4:15): x2 <= classes/C2#`<init>`().(x2)
 [4:13..4:15): x2 <= classes/C2#x2.
 [4:17..4:20): Int => scala/Int#
 [4:30..4:36): AnyVal => scala/AnyVal#
@@ -1079,32 +1083,39 @@ Occurrences:
 [5:7..5:9): C2 <= classes/C2.
 [7:11..7:13): C3 <= classes/C3#
 [7:13..7:13):  <= classes/C3#`<init>`().
+[7:14..7:15): x <= classes/C3#`<init>`().(x)
 [7:14..7:15): x <= classes/C3#x.
 [7:17..7:20): Int => scala/Int#
 [9:11..9:13): C4 <= classes/C4#
 [9:13..9:13):  <= classes/C4#`<init>`().
+[9:14..9:15): x <= classes/C4#`<init>`().(x)
 [9:14..9:15): x <= classes/C4#x.
 [9:17..9:20): Int => scala/Int#
 [10:7..10:9): C4 <= classes/C4.
 [12:7..12:8): M <= classes/M.
 [13:17..13:19): C5 <= classes/M.C5#
 [13:19..13:19):  <= classes/M.C5#`<init>`().
+[13:20..13:21): x <= classes/M.C5#`<init>`().(x)
 [13:20..13:21): x <= classes/M.C5#x.
 [13:23..13:26): Int => scala/Int#
 [16:11..16:13): C6 <= classes/C6#
 [16:13..16:13):  <= classes/C6#`<init>`().
+[16:26..16:27): x <= classes/C6#`<init>`().(x)
 [16:26..16:27): x <= classes/C6#x.
 [16:29..16:32): Int => scala/Int#
 [18:6..18:8): C7 <= classes/C7#
 [18:8..18:8):  <= classes/C7#`<init>`().
+[18:9..18:10): x <= classes/C7#`<init>`().(x)
 [18:9..18:10): x <= classes/C7#x.
 [18:12..18:15): Int => scala/Int#
 [20:6..20:8): C8 <= classes/C8#
 [20:8..20:8):  <= classes/C8#`<init>`().
+[20:27..20:28): x <= classes/C8#`<init>`().(x)
 [20:27..20:28): x <= classes/C8#x.
 [20:30..20:33): Int => scala/Int#
 [22:6..22:8): C9 <= classes/C9#
 [22:8..22:8):  <= classes/C9#`<init>`().
+[22:27..22:28): x <= classes/C9#`<init>`().(x)
 [22:27..22:28): x <= classes/C9#x().
 [22:30..22:33): Int => scala/Int#
 [24:7..24:8): N <= classes/N.
@@ -1410,7 +1421,7 @@ Uri => semanticdb/integration/src/main/scala/example/Flags.scala
 Text => non-empty
 Language => Scala
 Symbols => 58 entries
-Occurrences => 72 entries
+Occurrences => 78 entries
 Synthetics => 2 entries
 
 Symbols:
@@ -1571,10 +1582,13 @@ Occurrences:
 [9:24..9:25): U <= flags/p/package.C#[U]
 [9:27..9:28): V <= flags/p/package.C#[V]
 [9:29..9:29):  <= flags/p/package.C#`<init>`().
+[9:30..9:31): x <= flags/p/package.C#`<init>`().(x)
 [9:30..9:31): x <= flags/p/package.C#x.
 [9:33..9:34): T => flags/p/package.C#[T]
+[9:36..9:37): y <= flags/p/package.C#`<init>`().(y)
 [9:36..9:37): y <= flags/p/package.C#y.
 [9:39..9:40): U => flags/p/package.C#[U]
+[9:42..9:43): z <= flags/p/package.C#`<init>`().(z)
 [9:42..9:43): z <= flags/p/package.C#z.
 [9:45..9:46): V => flags/p/package.C#[V]
 [10:8..10:12): this <= flags/p/package.C#`<init>`(+1).
@@ -1600,10 +1614,13 @@ Occurrences:
 [19:15..19:16): Z <= flags/p/package.Z#
 [20:8..20:10): AA <= flags/p/package.AA#
 [20:10..20:10):  <= flags/p/package.AA#`<init>`().
+[20:11..20:12): x <= flags/p/package.AA#`<init>`().(x)
 [20:11..20:12): x <= flags/p/package.AA#x.
 [20:14..20:17): Int => scala/Int#
+[20:23..20:24): y <= flags/p/package.AA#`<init>`().(y)
 [20:23..20:24): y <= flags/p/package.AA#y.
 [20:26..20:29): Int => scala/Int#
+[20:35..20:36): z <= flags/p/package.AA#`<init>`().(z)
 [20:35..20:36): z <= flags/p/package.AA#z().
 [20:38..20:41): Int => scala/Int#
 [21:8..21:9): S <= flags/p/package.S#
@@ -2680,7 +2697,7 @@ Uri => semanticdb/integration/src/main/scala/example/Issue2144.scala
 Text => non-empty
 Language => Scala
 Symbols => 16 entries
-Occurrences => 15 entries
+Occurrences => 18 entries
 
 Symbols:
 example/Issue2144. => final object Issue2144 extends AnyRef { +3 decls }
@@ -2725,10 +2742,13 @@ Occurrences:
 [1:7..1:16): Issue2144 <= example/Issue2144.
 [2:8..2:12): Test <= example/Issue2144.Test#
 [2:12..2:12):  <= example/Issue2144.Test#`<init>`().
+[2:13..2:14): a <= example/Issue2144.Test#`<init>`().(a)
 [2:13..2:14): a <= example/Issue2144.Test#a.
 [2:16..2:23): Boolean => scala/Boolean#
+[2:25..2:26): b <= example/Issue2144.Test#`<init>`().(b)
 [2:25..2:26): b <= example/Issue2144.Test#b.
 [2:28..2:31): Int => scala/Int#
+[2:37..2:38): c <= example/Issue2144.Test#`<init>`().(c)
 [2:37..2:38): c <= example/Issue2144.Test#c.
 [2:40..2:43): Int => scala/Int#
 [3:6..3:7): x <= example/Issue2144.x.
@@ -2746,7 +2766,7 @@ Uri => semanticdb/integration/src/main/scala/example/Issue2882.scala
 Text => non-empty
 Language => Scala
 Symbols => 28 entries
-Occurrences => 10 entries
+Occurrences => 11 entries
 Synthetics => 1 entries
 
 Symbols:
@@ -2835,6 +2855,7 @@ Occurrences:
 [2:7..2:16): Issue2882 <= example/Issue2882.
 [4:13..4:23): FooFailure <= example/Issue2882.FooFailure#
 [4:23..4:23):  <= example/Issue2882.FooFailure#`<init>`().
+[4:24..4:27): msg <= example/Issue2882.FooFailure#`<init>`().(msg)
 [4:24..4:27): msg <= example/Issue2882.FooFailure#msg.
 [4:29..4:35): String => scala/Predef.String#
 [5:12..5:21): Exception => scala/package.Exception#
@@ -2889,7 +2910,7 @@ Uri => semanticdb/integration/src/main/scala/example/Issue5939Metals.scala
 Text => non-empty
 Language => Scala
 Symbols => 9 entries
-Occurrences => 23 entries
+Occurrences => 24 entries
 Synthetics => 2 entries
 
 Symbols:
@@ -2926,6 +2947,7 @@ Occurrences:
 [2:22..2:41): implicitConversions => scala/language.implicitConversions.
 [4:6..4:8): AA <= example/AA#
 [4:8..4:8):  <= example/AA#`<init>`().
+[4:13..4:14): f <= example/AA#`<init>`().(f)
 [4:13..4:14): f <= example/AA#f.
 [4:16..4:19): Int => scala/Int#
 [4:23..4:26): Int => scala/Int#
@@ -3711,7 +3733,7 @@ Uri => semanticdb/integration/src/main/scala/example/NamedApplyBlock.scala
 Text => non-empty
 Language => Scala
 Symbols => 66 entries
-Occurrences => 41 entries
+Occurrences => 44 entries
 Synthetics => 1 entries
 
 Symbols:
@@ -3916,10 +3938,13 @@ Occurrences:
 [9:7..9:43): NamedApplyBlockCaseClassConstruction <= example/NamedApplyBlockCaseClassConstruction.
 [10:13..10:16): Msg <= example/NamedApplyBlockCaseClassConstruction.Msg#
 [10:16..10:16):  <= example/NamedApplyBlockCaseClassConstruction.Msg#`<init>`().
+[10:17..10:21): body <= example/NamedApplyBlockCaseClassConstruction.Msg#`<init>`().(body)
 [10:17..10:21): body <= example/NamedApplyBlockCaseClassConstruction.Msg#body.
 [10:23..10:29): String => scala/Predef.String#
+[10:31..10:35): head <= example/NamedApplyBlockCaseClassConstruction.Msg#`<init>`().(head)
 [10:31..10:35): head <= example/NamedApplyBlockCaseClassConstruction.Msg#head.
 [10:37..10:43): String => scala/Predef.String#
+[10:57..10:61): tail <= example/NamedApplyBlockCaseClassConstruction.Msg#`<init>`().(tail)
 [10:57..10:61): tail <= example/NamedApplyBlockCaseClassConstruction.Msg#tail.
 [10:63..10:69): String => scala/Predef.String#
 [11:6..11:14): bodyText <= example/NamedApplyBlockCaseClassConstruction.bodyText.
@@ -3941,7 +3966,7 @@ Uri => semanticdb/integration/src/main/scala/example/NamedArguments.scala
 Text => non-empty
 Language => Scala
 Symbols => 29 entries
-Occurrences => 12 entries
+Occurrences => 13 entries
 Synthetics => 1 entries
 
 Symbols:
@@ -4032,6 +4057,7 @@ Occurrences:
 [2:21..2:21):  <= example/NamedArguments#`<init>`().
 [3:13..3:17): User <= example/NamedArguments#User#
 [3:17..3:17):  <= example/NamedArguments#User#`<init>`().
+[3:18..3:22): name <= example/NamedArguments#User#`<init>`().(name)
 [3:18..3:22): name <= example/NamedArguments#User#name.
 [3:24..3:30): String => scala/Predef.String#
 [4:2..4:6): User => example/NamedArguments#User.
@@ -4876,7 +4902,7 @@ Uri => semanticdb/integration/src/main/scala/example/Types.scala
 Text => non-empty
 Language => Scala
 Symbols => 145 entries
-Occurrences => 268 entries
+Occurrences => 270 entries
 Diagnostics => 1 entries
 
 Symbols:
@@ -5223,6 +5249,7 @@ Occurrences:
 [5:6..5:9): ann <= types/ann#
 [5:10..5:11): T <= types/ann#[T]
 [5:12..5:12):  <= types/ann#`<init>`().
+[5:13..5:14): x <= types/ann#`<init>`().(x)
 [5:13..5:14): x <= types/ann#x.
 [5:16..5:17): T => types/ann#[T]
 [5:27..5:32): scala => scala/
@@ -5428,6 +5455,7 @@ Occurrences:
 [86:31..86:34): ??? => scala/Predef.`???`().
 [89:15..89:27): RepeatedType <= types/Test.C#RepeatedType#
 [89:27..89:27):  <= types/Test.C#RepeatedType#`<init>`().
+[89:28..89:29): s <= types/Test.C#RepeatedType#`<init>`().(s)
 [89:28..89:29): s <= types/Test.C#RepeatedType#s.
 [89:31..89:37): String => java/lang/String#
 [90:10..90:12): m1 <= types/Test.C#RepeatedType#m1().
@@ -5649,7 +5677,7 @@ Uri => semanticdb/integration/src/main/scala/example/Vals.scala
 Text => non-empty
 Language => Scala
 Symbols => 40 entries
-Occurrences => 117 entries
+Occurrences => 120 entries
 
 Symbols:
 example/ValUsages. => final object ValUsages extends AnyRef { +1 decls }
@@ -5752,10 +5780,13 @@ Occurrences:
 [0:8..0:15): example <= example/
 [2:15..2:19): Vals <= example/Vals#
 [2:19..2:19):  <= example/Vals#`<init>`().
+[2:20..2:21): p <= example/Vals#`<init>`().(p)
 [2:20..2:21): p <= example/Vals#p.
 [2:23..2:26): Int => scala/Int#
+[2:32..2:34): xp <= example/Vals#`<init>`().(xp)
 [2:32..2:34): xp <= example/Vals#xp.
 [2:36..2:39): Int => scala/Int#
+[2:45..2:47): yp <= example/Vals#`<init>`().(yp)
 [2:45..2:47): yp <= example/Vals#yp().
 [2:49..2:52): Int => scala/Int#
 [3:6..3:8): xm <= example/Vals#xm.

--- a/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/TargetedSuite.scala
+++ b/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/TargetedSuite.scala
@@ -247,6 +247,27 @@ class TargetedSuite extends SemanticdbSuite {
     (_, foo1) => assertEquals(foo1, "o/O.a."),
   )
 
+  // A `val`/`var` primary-constructor parameter defines both an accessor and the constructor
+  // PARAMETER symbol, so its definition site has two overlapping occurrences (#1327). A plain
+  // member (`y` below) keeps its single occurrence.
+  occurrences(
+    """|package p
+       |class C(val x: Int) {
+       |  val y: Int = x
+       |}
+       |""".stripMargin,
+    """|[0:8..0:9): p <= p/
+       |[1:6..1:7): C <= p/C#
+       |[1:7..1:7):  <= p/C#`<init>`().
+       |[1:12..1:13): x <= p/C#`<init>`().(x)
+       |[1:12..1:13): x <= p/C#x.
+       |[1:15..1:18): Int => scala/Int#
+       |[2:6..2:7): y <= p/C#y.
+       |[2:9..2:12): Int => scala/Int#
+       |[2:15..2:16): x => p/C#x.
+       |""".stripMargin,
+  )
+
   test("named-args") {
     val code =
       """|@deprecated(since = "123")
@@ -260,7 +281,7 @@ class TargetedSuite extends SemanticdbSuite {
          |Text => non-empty
          |Language => Scala
          |Symbols => 6 entries
-         |Occurrences => 14 entries
+         |Occurrences => 15 entries
          |
          |Symbols:
          |_empty_/CLS# => @deprecated class CLS extends AnyRef { +3 decls }
@@ -285,6 +306,7 @@ class TargetedSuite extends SemanticdbSuite {
          |[0:12..0:17): since => scala/deprecated#`<init>`().(since)
          |[1:6..1:9): CLS <= _empty_/CLS#
          |[1:9..1:9):  <= _empty_/CLS#`<init>`().
+         |[1:10..1:14): name <= _empty_/CLS#`<init>`().(name)
          |[1:10..1:14): name <= _empty_/CLS#name.
          |[1:16..1:22): String => scala/Predef.String#
          |[2:6..2:10): this <= _empty_/CLS#`<init>`(+1).
@@ -308,7 +330,7 @@ class TargetedSuite extends SemanticdbSuite {
       )
 
     val expected212 = expectedPrevious213
-      .replace("Occurrences => 14 entries", "Occurrences => 14 entries\nDiagnostics => 1 entries")
+      .replace("Occurrences => 15 entries", "Occurrences => 15 entries\nDiagnostics => 1 entries")
       .replace(
         """|local0 => val local x$1: "123"
            |""".stripMargin,


### PR DESCRIPTION
Fixes #1327.

For `class C(val x: Int)`, the definition of `x` introduces two symbols — the accessor (`C#x.`) and the constructor parameter (``C#`<init>`().(x)``) - but only the accessor received a `SymbolOccurrence`. As agreed in #1327, the definition site now emits multiple `SymbolOccurrence`s covering the same range, one per defined symbol. Internally the pair is staged as a `Symbols.Multi` and expanded by the existing `asMulti` step in `finalOccurrences`, so multi-symbol strings never reach the payload.

The accessor and the parameter are paired by name: scalac keeps no symbol-level link between them, and name matching is the same relation `scalacp.SymbolInformationOps` uses in the opposite direction.

Consumer impact: references are unchanged - they still resolve to the accessor only. At constructor-parameter definition sites there are now two DEFINITION occurrences sharing one range, so "first occurrence at position" lookups see only one of the two symbols. Tools that want both must collect all occurrences at the range. SymbolInformation payloads are unchanged.
