### PR TITLE
Document scala-library synthetic symbols in the SemanticDB spec

### DIFF
--- a/docs/semanticdb/specification.md
+++ b/docs/semanticdb/specification.md
@@ -2405,6 +2405,69 @@ package object symbols and object symbols are:
 **Packages** [\[61\]][61] are not included in the
 ["Symbols"](#symbolinformation) section.
 
+<a name="scala-builtin-symbols"></a>
+
+#### Built-in symbols
+
+A handful of core types from the Scala standard library [\[98\]][98] — `scala.Any`,
+`scala.AnyVal`, `scala.AnyRef`, `scala.Nothing`, `scala.Null` and `scala.Singleton` — are
+defined by the SLS but cannot be recovered from `scala-library.jar` the way ordinary definitions
+are. Most of them have no classfile at all; the one that does (`AnyVal`) carries a classfile
+payload that is not, on its own, a satisfactory description of the symbol. To give these types a
+stable, uniform representation, SemanticDB predeclares the following definitions for the whole
+set:
+
+```scala
+package scala
+
+abstract class Any {
+  def equals(that: Any): Boolean
+  final def ==(that: Any): Boolean
+  final def !=(that: Any): Boolean
+  def hashCode(): Int
+  final def ##(): Int
+  def toString(): String
+  final def getClass(): Class
+  final def isInstanceOf[A](): Boolean
+  final def asInstanceOf[A](): A
+}
+
+abstract class AnyVal extends Any
+
+class AnyRef extends Any {
+  final def eq(that: AnyRef): Boolean
+  final def ne(that: AnyRef): Boolean
+  final def synchronized[T](body: T): T
+}
+
+abstract class Nothing extends Any
+
+abstract class Null extends AnyRef
+
+trait Singleton extends Any
+```
+
+Notes:
+
+- `equals`, `hashCode` and `toString` are `ABSTRACT`; the other methods of `Any` and all methods
+  of `AnyRef` are `FINAL`.
+- `Nothing` and `Null` are additionally `FINAL`.
+- Every built-in class (but not the `Singleton` trait) carries a synthesized primary constructor
+  `<init>()`.
+- `getClass` is given the return type `java/lang/Class#`. Its actual return type cannot be
+  expressed in the SemanticDB type system — it is special-cased by both the Scala and Java
+  compilers — so producers approximate it with the raw `Class` type.
+- `AnyRef` does not declare the members of `java.lang.Object`, nor is its relationship to
+  `Object` otherwise represented. This is a known limitation, tracked in
+  [scalameta/scalameta#1564](https://github.com/scalameta/scalameta/issues/1564).
+
+These definitions are not embedded in the SemanticDB payloads of ordinary source files. They are
+predeclared Scala symbols that producers and consumers are expected to know about. Scalameta's
+`GlobalSymbolTable` preloads them so that references to them resolve, and `metacp` materializes
+them as six standalone `scala/*.class` SemanticDB payloads — packaged in a
+`scala-library-synthetics.jar` for file-based consumers — only when run with
+`--include-scala-library-synthetics` (excluded by default).
+
 <a name="scala-annotation"></a>
 
 ### AnnotationTree
@@ -3977,5 +4040,7 @@ We may improve on this in the future.
 [95]: https://docs.oracle.com/javase/specs/jls/se8/html/jls-4.html#jls-4.8
 [96]: https://docs.oracle.com/javase/specs/jls/se8/html/jls-4.html#jls-4.3
 [97]: https://docs.oracle.com/javase/specs/jls/se8/html/jls-7.html#jls-7.4.2
+[98]:
+  https://www.scala-lang.org/files/archive/spec/2.12/12-the-scala-standard-library.html
 [99]:
   https://www.scala-lang.org/files/archive/spec/2.12/05-classes-and-objects.html#templates

--- a/semanticdb/README.md
+++ b/semanticdb/README.md
@@ -7,6 +7,6 @@ communication between tools.
 
 [Protobuf schema](semanticdb/src/main/proto/semanticdb.proto)
 
-[Specification](semanticdb.md)
+[Specification](../docs/semanticdb/specification.md)
 
 [Quickstart guide](guide.md)

--- a/semanticdb/guide.md
+++ b/semanticdb/guide.md
@@ -9,7 +9,7 @@ In this document, we introduce practical aspects of working with SemanticDB. We
 describe the tools that can be used to produce SemanticDB payloads, the tools
 can be used to consume SemanticDB payloads and useful tips & tricks for working
 with SemanticDB. If you're looking for a comprehensive reference of SemanticDB
-features, check out [the specification](semanticdb.md).
+features, check out [the specification](../docs/semanticdb/specification.md).
 
 - [Installation](#installation)
 - [Example](#example)
@@ -158,7 +158,7 @@ Occurrences:
 ```
 
 Metap prettyprints various parts of the SemanticDB payload in correspondence
-with [the SemanticDB specification](semanticdb.md). Here are the most
+with [the SemanticDB specification](../docs/semanticdb/specification.md). Here are the most
 important parts:
   * `Uri` stores the URI of the source file relative to
     the directory where the SemanticDB producer was invoked.
@@ -178,7 +178,7 @@ important parts:
 ## What is SemanticDB good for?
 
 SemanticDB decouples producers and consumers of semantic information about
-programs and establishes [a rigorous specification](semanticdb.md) of the
+programs and establishes [a rigorous specification](../docs/semanticdb/specification.md) of the
 interchange format.
 
 Thanks to that, SemanticDB-based tools like [Scalafix](#scalafix),


### PR DESCRIPTION
Closes #1368.

Adds a **Built-in symbols** subsection to the Scala `SymbolInformation` section of the spec, documenting the six synthetic scala-library symbols that can't be recovered from `scala-library.jar` — `Any`, `AnyVal`, `AnyRef`, `Nothing`, `Null`, `Singleton`. It gives:
- their exact modelled definitions (signatures verified against `tests-semanticdb/src/test/resources/scalalib.expect`);
- the `getClass(): Class` caveat (true return type isn't expressible in SemanticDB, so it's approximated as raw `java/lang/Class#`);
- the unmodelled `AnyRef`/`java.lang.Object` relationship (known limitation, #1564);
- the producer/consumer contract: predeclared symbols that `metacp` materializes only under `--include-scala-library-synthetics` (off by default).

### Notes
Repoints the module `semanticdb/README.md` and `semanticdb/guide.md` spec links from the stale in-repo copy (`semanticdb/semanticdb.md`, ~274 lines behind) to the maintained `docs/semanticdb/specification.md`. Fully consolidating the two copies is left to a follow-up #4653.
