### PR TITLE
Add unit tests for SemanticDB symbol construction/deconstruction utilities

### DIFF
--- a/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/DescriptorSuite.scala
+++ b/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/DescriptorSuite.scala
@@ -1,0 +1,129 @@
+package scala.meta.tests.semanticdb
+
+import scala.meta.internal.semanticdb.Scala._
+
+import munit.FunSuite
+
+class DescriptorSuite extends FunSuite {
+
+  // Builds a stable label for test names without relying on Descriptor.toString.
+  private def label(desc: Descriptor): String = desc match {
+    case Descriptor.None => "None"
+    case Descriptor.Term(value) => s"Term($value)"
+    case Descriptor.Method(value, disambiguator) => s"Method($value,$disambiguator)"
+    case Descriptor.Type(value) => s"Type($value)"
+    case Descriptor.Package(value) => s"Package($value)"
+    case Descriptor.Parameter(value) => s"Parameter($value)"
+    case Descriptor.TypeParameter(value) => s"TypeParameter($value)"
+  }
+
+  def checkValue(desc: Descriptor, expected: String): Unit =
+    test("  value: " + label(desc))(assertEquals(desc.value, expected))
+
+  def checkName(desc: Descriptor, expected: Names.Name): Unit =
+    test("   name: " + label(desc))(assertEquals(desc.name, expected))
+
+  def checkToString(desc: Descriptor, expected: String): Unit =
+    test("toString: " + label(desc))(assertEquals(desc.toString, expected))
+
+  def checkEncode(value: String, expected: String): Unit =
+    test(" encode: [" + value + "]")(assertEquals(Names.encode(value), expected))
+
+  // value: the descriptor's bare name; Method drops its disambiguator.
+  checkValue(Descriptor.Term("x"), "x")
+  checkValue(Descriptor.Method("f", "()"), "f")
+  checkValue(Descriptor.Type("T"), "T")
+  checkValue(Descriptor.Package("p"), "p")
+  checkValue(Descriptor.Parameter("x"), "x")
+  checkValue(Descriptor.TypeParameter("A"), "A")
+
+  // name: Term/Method/Package/Parameter -> TermName; Type/TypeParameter -> TypeName. Method drops the
+  // disambiguator.
+  checkName(Descriptor.Term("x"), Names.TermName("x"))
+  checkName(Descriptor.Method("f", "()"), Names.TermName("f"))
+  checkName(Descriptor.Type("T"), Names.TypeName("T"))
+  checkName(Descriptor.Package("p"), Names.TermName("p"))
+  checkName(Descriptor.Parameter("x"), Names.TermName("x"))
+  checkName(Descriptor.TypeParameter("A"), Names.TypeName("A"))
+
+  // predicates: each descriptor satisfies its own predicate and no sibling's. In particular a Method
+  // is isMethod but NOT isTerm.
+  test("pred: Term") {
+    assert(Descriptor.Term("x").isTerm)
+    assert(!Descriptor.Term("x").isMethod)
+    assert(!Descriptor.Term("x").isType)
+    assert(!Descriptor.Term("x").isNone)
+  }
+  test("pred: Method") {
+    assert(Descriptor.Method("f", "()").isMethod)
+    assert(!Descriptor.Method("f", "()").isTerm)
+    assert(!Descriptor.Method("f", "()").isType)
+  }
+  test("pred: Type") {
+    assert(Descriptor.Type("T").isType)
+    assert(!Descriptor.Type("T").isTerm)
+    assert(!Descriptor.Type("T").isTypeParameter)
+  }
+  test("pred: Package") {
+    assert(Descriptor.Package("p").isPackage)
+    assert(!Descriptor.Package("p").isTerm)
+    assert(!Descriptor.Package("p").isType)
+  }
+  test("pred: Parameter") {
+    assert(Descriptor.Parameter("x").isParameter)
+    assert(!Descriptor.Parameter("x").isTypeParameter)
+    assert(!Descriptor.Parameter("x").isTerm)
+  }
+  test("pred: TypeParameter") {
+    assert(Descriptor.TypeParameter("A").isTypeParameter)
+    assert(!Descriptor.TypeParameter("A").isParameter)
+    assert(!Descriptor.TypeParameter("A").isType)
+  }
+  test("pred: None") {
+    assert(Descriptor.None.isNone)
+    assert(!Descriptor.None.isTerm)
+    assert(!Descriptor.None.isType)
+  }
+
+  // toString: formats the descriptor as it appears inside a symbol, backtick-encoding awkward names.
+  checkToString(Descriptor.Term("foo"), "foo.")
+  checkToString(Descriptor.Method("foo", "()"), "foo().")
+  checkToString(Descriptor.Method("foo", "(+1)"), "foo(+1).")
+  checkToString(Descriptor.Type("Foo"), "Foo#")
+  checkToString(Descriptor.Package("foo"), "foo/")
+  checkToString(Descriptor.Parameter("x"), "(x)")
+  checkToString(Descriptor.TypeParameter("A"), "[A]")
+  checkToString(Descriptor.Term("a b"), "`a b`.")
+  checkToString(Descriptor.Term("+"), "`+`.")
+  checkToString(Descriptor.Type(""), "``#")
+  checkToString(Descriptor.Method("<init>", "()"), "`<init>`().")
+  checkToString(Descriptor.Term("a;b"), "`a;b`.")
+
+  // Names.encode: "" -> ``; valid Java identifiers pass through (including $-led names); anything with
+  // an illegal start or part is backtick-wrapped.
+  checkEncode("", "``")
+  checkEncode("foo", "foo")
+  checkEncode("Foo123", "Foo123")
+  checkEncode("foo_bar", "foo_bar")
+  checkEncode("$anonfun", "$anonfun")
+  checkEncode("a b", "`a b`")
+  checkEncode("+", "`+`")
+  checkEncode("1abc", "`1abc`")
+  checkEncode("<init>", "`<init>`")
+  checkEncode("a;b", "`a;b`")
+  // Unicode letters are valid Java identifier characters, so they pass through unquoted.
+  checkEncode("naïve", "naïve")
+
+  test("Names constants") {
+    assertEquals(Names.RootPackage.value, "_root_")
+    assertEquals(Names.EmptyPackage.value, "_empty_")
+    assertEquals(Names.PackageObject.value, "package")
+    assertEquals(Names.Constructor.value, "<init>")
+  }
+
+  test("Name toString is its value") {
+    assertEquals(Names.TermName("x").toString, "x")
+    assertEquals(Names.TypeName("A").toString, "A")
+  }
+
+}

--- a/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/SymbolSuite.scala
+++ b/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/SymbolSuite.scala
@@ -12,10 +12,16 @@ class SymbolSuite extends FunSuite {
       assertEquals(obtained, expected)
     }
 
+  // Symbols.Multi(symbols).asMulti must reconstruct the original members. Note that it flattens
+  // nesting: an already-multi member (e.g. ";a.;b.") is concatenated verbatim by Multi and then
+  // re-split by asMulti, so the round-trip target is symbols.distinct.flatMap(_.asMulti). The empty
+  // list is the one asymmetric case: Multi(Nil) == "" while "".asMulti == List(""), not Nil.
   def checkMultiRoundtrip(symbols: List[String]): Unit = test("  multi: " + symbols.toString) {
-    val symbol = Symbols.Multi(symbols)
-    val expected = symbol.asMulti
-    assertEquals(symbol.asMulti, expected)
+    val expected = symbols.distinct.flatMap(_.asMulti) match {
+      case Nil => List("")
+      case xs => xs
+    }
+    assertEquals(Symbols.Multi(symbols).asMulti, expected)
   }
 
   def checkGlobal(symbol: String): Unit = test(" global: " + symbol)(assert(symbol.isGlobal))
@@ -28,11 +34,41 @@ class SymbolSuite extends FunSuite {
 
   def check(sym: String)(f: String => Boolean): Unit = test(sym)(assert(f(sym)))
 
+  // Named boolean assertion, used when a predicate is exercised on a symbol that other tests also
+  // use: test names must be unique, so we cannot reuse `check`, which names the test after the symbol.
+  def checkProp(name: String)(cond: => Boolean): Unit = test(name)(assert(cond))
+
+  // Symbols.Global builds a global symbol from an owner and a descriptor, and the result deconstructs
+  // back: .desc returns the descriptor and .owner returns the owner. The RootPackage owner is elided
+  // from the string (Global("_root_/", Package("scala")) == "scala/", not "_root_/scala/"), yet .owner
+  // still reconstructs "_root_/". The only symbol whose .owner does not round-trip is the root package
+  // itself, which has no owner (Symbols.None).
+  def checkGlobalSym(owner: String, desc: Descriptor, expected: String): Unit =
+    test(" Global: " + expected) {
+      assertEquals(Symbols.Global(owner, desc), expected)
+      assertEquals(expected.desc, desc)
+      if (!expected.isRootPackage) assertEquals(expected.owner, owner)
+    }
+
+  def checkLocalSym(id: Int, expected: String): Unit =
+    test("  Local: " + expected)(assertEquals(Symbols.Local(id), expected))
+
+  def checkOwner(symbol: String, expected: String): Unit =
+    test("  owner: " + symbol)(assertEquals(symbol.owner, expected))
+
+  def checkOwnerChain(symbol: String, expected: List[String]): Unit =
+    test("  chain: " + symbol)(assertEquals(symbol.ownerChain, expected))
+
+  def checkDesc(symbol: String, expected: Descriptor): Unit =
+    test("   desc: " + symbol)(assertEquals(symbol.desc, expected))
+
   checkMultiSyntax(Nil, "")
   checkMultiSyntax("a." :: Nil, "a.")
   checkMultiSyntax("a." :: "a." :: Nil, "a.")
   checkMultiSyntax("a." :: "b." :: Nil, ";a.;b.")
   checkMultiSyntax(";a.;b." :: ";c.;d." :: Nil, ";a.;b.;c.;d.")
+  // A single element that is itself a multi-symbol is returned unchanged.
+  checkMultiSyntax(";a.;b." :: Nil, ";a.;b.")
 
   checkMultiRoundtrip(Nil)
   checkMultiRoundtrip("com/Bar#" :: Nil)
@@ -40,6 +76,9 @@ class SymbolSuite extends FunSuite {
   checkMultiRoundtrip("com/`; ;`#" :: "com.`; ;`." :: Nil)
   checkMultiRoundtrip("a" :: "b" :: "" :: Nil)
   checkMultiRoundtrip(";_root_/;_empty_/" :: "_star_." :: Nil)
+  checkMultiRoundtrip("com/Bar#" :: "com/Bar#" :: Nil)
+  checkMultiRoundtrip("a." :: "b." :: "a." :: Nil)
+  checkMultiRoundtrip(";a.;b." :: Nil)
 
   checkGlobal("com/Bar#")
   checkGlobal("com/Bar.")
@@ -65,5 +104,126 @@ class SymbolSuite extends FunSuite {
   check(";com/;org/")(!_.isPackage)
   check("com/Class#(a)")(_.isParameter)
   check("com/Class#[A]")(_.isTypeParameter)
+
+  // isNone / isRootPackage / isEmptyPackage / isMulti, positive and negative.
+  checkProp("isNone: empty")(Symbols.None.isNone)
+  checkProp("!isNone: root")(!Symbols.RootPackage.isNone)
+  checkProp("!isNone: local")(!"local1".isNone)
+  checkProp("!isNone: global")(!"com/Bar#".isNone)
+
+  checkProp("isRootPackage: _root_")(Symbols.RootPackage.isRootPackage)
+  checkProp("!isRootPackage: _empty_")(!Symbols.EmptyPackage.isRootPackage)
+  checkProp("!isRootPackage: empty")(!Symbols.None.isRootPackage)
+
+  checkProp("isEmptyPackage: _empty_")(Symbols.EmptyPackage.isEmptyPackage)
+  checkProp("!isEmptyPackage: _root_")(!Symbols.RootPackage.isEmptyPackage)
+  checkProp("!isEmptyPackage: empty")(!Symbols.None.isEmptyPackage)
+
+  checkProp("isMulti: two")(";a.;b.".isMulti)
+  checkProp("!isMulti: single")(!"a.".isMulti)
+  checkProp("!isMulti: empty")(!Symbols.None.isMulti)
+  checkProp("!isMulti: local")(!"local1".isMulti)
+
+  // The type predicates are all guarded by !isNone && !isMulti: confirm both guards bite, and that a
+  // term is not a type (and vice versa).
+  checkProp("!isTerm: empty")(!Symbols.None.isTerm)
+  checkProp("!isType: empty")(!Symbols.None.isType)
+  checkProp("!isPackage: empty")(!Symbols.None.isPackage)
+  checkProp("!isParameter: empty")(!Symbols.None.isParameter)
+  checkProp("!isTypeParameter: empty")(!Symbols.None.isTypeParameter)
+  checkProp("!isTerm: multi")(!";com/Predef.;org/Predef.".isTerm)
+  checkProp("!isType: multi")(!";com/A#;org/B#".isType)
+  checkProp("!isType: term")(!"com/Predef.".isType)
+  checkProp("!isTerm: type")(!"com/Class#".isTerm)
+
+  // Symbols.Global construction + round-trip through .owner/.desc.
+  checkGlobalSym(Symbols.RootPackage, Descriptor.Package("scala"), "scala/")
+  checkGlobalSym("scala/", Descriptor.Type("Int"), "scala/Int#")
+  checkGlobalSym("scala/", Descriptor.Term("Predef"), "scala/Predef.")
+  checkGlobalSym("scala/Int#", Descriptor.Method("foo", "()"), "scala/Int#foo().")
+  checkGlobalSym("scala/Int#", Descriptor.Method("foo", "(+1)"), "scala/Int#foo(+1).")
+  checkGlobalSym("scala/Int#foo().", Descriptor.Parameter("x"), "scala/Int#foo().(x)")
+  checkGlobalSym("scala/Int#foo().", Descriptor.TypeParameter("A"), "scala/Int#foo().[A]")
+  // EmptyPackage is NOT elided (only RootPackage is).
+  checkGlobalSym(Symbols.EmptyPackage, Descriptor.Type("Foo"), "_empty_/Foo#")
+  // The constructor name <init> is not a valid identifier, so Global backtick-encodes it.
+  checkGlobalSym(
+    "scala/Foo#",
+    Descriptor.Method(Names.Constructor.value, "()"),
+    "scala/Foo#`<init>`().",
+  )
+
+  // The root, empty, and none symbols match the SemanticDB spec. Both the root and empty package
+  // symbols are constructible via Symbols.Global from the root package (their names are
+  // Names.RootPackage / Names.EmptyPackage); the RootPackage-owner elision even collapses
+  // Global(_root_/, Package("_root_")) back to "_root_/" itself.
+  test("spec values") {
+    assertEquals(Symbols.RootPackage, "_root_/")
+    assertEquals(Symbols.EmptyPackage, "_empty_/")
+    assertEquals(Symbols.None, "")
+  }
+  checkGlobalSym(
+    Symbols.RootPackage,
+    Descriptor.Package(Names.RootPackage.value),
+    Symbols.RootPackage,
+  )
+  checkGlobalSym(
+    Symbols.RootPackage,
+    Descriptor.Package(Names.EmptyPackage.value),
+    Symbols.EmptyPackage,
+  )
+
+  checkLocalSym(0, "local0")
+  checkLocalSym(1, "local1")
+  checkLocalSym(42, "local42")
+  // A local symbol is neither global nor carries a descriptor.
+  checkProp("local isLocal")(Symbols.Local(1).isLocal)
+  checkProp("local !isGlobal")(!Symbols.Local(1).isGlobal)
+
+  // owner drops the trailing descriptor; a top-level symbol's owner is RootPackage; RootPackage has
+  // no owner; and non-global symbols (None / local / multi) have no owner.
+  checkOwner("scala/Int#", "scala/")
+  checkOwner("scala/Predef.x.", "scala/Predef.")
+  checkOwner("scala/Int#foo().", "scala/Int#")
+  checkOwner("scala/", Symbols.RootPackage)
+  checkOwner(Symbols.EmptyPackage, Symbols.RootPackage)
+  checkOwner(Symbols.RootPackage, Symbols.None)
+  checkOwner(Symbols.None, Symbols.None)
+  checkOwner("local1", Symbols.None)
+  checkOwner(";com/A#;org/B#", Symbols.None)
+  checkOwner("com/`a;b`#", "com/")
+  checkOwner("com/`a#b`#", "com/")
+  checkOwner("a/``#", "a/")
+
+  // ownerChain is root-to-self and, for globals, always begins with _root_/ even though _root_/ is
+  // never written into the symbol string.
+  checkOwnerChain("scala/Int#", List(Symbols.RootPackage, "scala/", "scala/Int#"))
+  checkOwnerChain(
+    "scala/Predef.x.",
+    List(Symbols.RootPackage, "scala/", "scala/Predef.", "scala/Predef.x."),
+  )
+  checkOwnerChain(Symbols.RootPackage, List(Symbols.RootPackage))
+  checkOwnerChain(Symbols.EmptyPackage, List(Symbols.RootPackage, Symbols.EmptyPackage))
+  checkOwnerChain(Symbols.None, Nil)
+  checkOwnerChain("local1", List("local1"))
+
+  // desc extracts the trailing descriptor; non-global symbols have Descriptor.None.
+  checkDesc("scala/Int#", Descriptor.Type("Int"))
+  checkDesc("scala/Predef.", Descriptor.Term("Predef"))
+  checkDesc("scala/", Descriptor.Package("scala"))
+  checkDesc("scala/Int#foo().", Descriptor.Method("foo", "()"))
+  checkDesc("scala/Int#foo(+1).", Descriptor.Method("foo", "(+1)"))
+  checkDesc("scala/m().(x)", Descriptor.Parameter("x"))
+  checkDesc("scala/m().[A]", Descriptor.TypeParameter("A"))
+  // Backtick-quoted descriptor values: a ; or # inside backticks is part of the name, not a
+  // delimiter, and an empty identifier is a pair of backticks.
+  checkDesc("com/`a;b`#", Descriptor.Type("a;b"))
+  checkDesc("com/`a#b`#", Descriptor.Type("a#b"))
+  checkDesc("a/``#", Descriptor.Type(""))
+  // Non-global strings are handled gracefully: .desc is None, with no parsing and no error.
+  checkDesc("foo", Descriptor.None)
+  checkDesc("local1", Descriptor.None)
+  checkDesc(Symbols.None, Descriptor.None)
+  checkDesc(";com/A#;org/B#", Descriptor.None)
 
 }


### PR DESCRIPTION
Resolves #1427.

**`SymbolSuite`** (extended) — the `String`-symbol API:
- `Symbols.Global` (including the RootPackage-elision special case) and `Symbols.Local`
- predicates `isNone` / `isRootPackage` / `isEmptyPackage` / `isMulti`, positive and negative
- deconstruction `owner`, `ownerChain`, `desc`, including backtick-quoted names (`;`/`#` inside backticks) and empty identifiers
- root/empty package spec values, construction, and owner chains
- Fixes a latent test bug: `checkMultiRoundtrip` asserted `x.asMulti == x.asMulti` (a tautology that verified nothing); it now checks that `Symbols.Multi(symbols).asMulti` reconstructs the original members.

**`DescriptorSuite`** (new) — the `Descriptor` and `Names` value types:
- `Descriptor` `value` / `name` / predicates and `toString` formatting, with backtick-encoding of awkward names
- `Names.encode` (including Unicode letters and `$`-led identifiers) and the `Names` constants
