### PR TITLE
Add hierarchy-aware SymbolTable.overloads(tpe, name)

### DIFF
--- a/scalameta/common/shared/src/main/scala-2.12/org/scalameta/collections/Conversions.scala
+++ b/scalameta/common/shared/src/main/scala-2.12/org/scalameta/collections/Conversions.scala
@@ -32,6 +32,10 @@ private[collections] trait Conversions {
   implicit class XtensionJavaEnumeration[T](obj: ju.Enumeration[T]) {
     def toScala: Iterator[T] = obj.asScala
   }
+
+  implicit class XtensionIterator[T](private val obj: Iterator[T]) {
+    def nextOption(): Option[T] = if (obj.hasNext) Some(obj.next()) else None
+  }
 }
 
 object Conversions extends Conversions

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/symtab/SymbolTable.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/symtab/SymbolTable.scala
@@ -36,17 +36,11 @@ trait SymbolTable {
     else if (symbol.isGlobal) {
       val (desc, owner) = DescriptorParser(symbol)
       desc match {
-        case d.Method(name, _) => info(owner).map(_.signature) match {
-            case Some(c: ClassSignature) =>
-              // keep only members that really are same-named methods of this owner, so a symbol
-              // that merely parses like one (but isn't declared here) isn't fabricated into the set
-              val sameName = c.declarations.symbols.filter(_.desc match {
-                case d.Method(`name`, _) => true
-                case _ => false
-              })
-              if (sameName.contains(symbol)) sameName else Nil
-            case _ => Nil
-          }
+        case d.Method(name, _) =>
+          // keep `owner`'s same-name methods only if `symbol` is actually one of them, so a symbol
+          // that merely parses like a method of `owner` (but isn't declared there) isn't fabricated
+          val sameName = membersNamed(owner, name)
+          if (sameName.contains(symbol)) sameName else Nil
         case _ => Nil
       }
     } else Nil
@@ -81,12 +75,10 @@ trait SymbolTable {
     // constructors are not inherited, so do not walk parents for the `<init>` name
     val bases = if (name == "<init>") List(tpe -> Map.empty[String, String]) else linearization(tpe)
     val seenSignatures = mutable.Set.empty[List[String]]
-    bases.flatMap { case (owner, env) => membersNamed(owner, name).map(_ -> env) }.filter {
-      case (method, env) => erasedSignature(method, env) match {
-          case Some(signature) => seenSignatures.add(signature)
-          case None => true // unresolved parameter types: keep rather than risk a wrong merge
-        }
-    }.map(_._1)
+    bases.flatMap { case (owner, env) =>
+      // an unresolved erased signature (None) keeps the method rather than risk a wrong merge
+      membersNamed(owner, name).filter(erasedSignature(_, env).forall(seenSignatures.add))
+    }
   }
 
   /**
@@ -117,28 +109,34 @@ trait SymbolTable {
     loop(child)
   }
 
-  private def parentSymbols(sinfo: SymbolInformation): Iterator[String] = sinfo.signature match {
-    case cs: ClassSignature => typeSymbolsFlatten(cs.parents)
-    case ts: TypeSignature => typeSymbols(ts.upperBound) // follow type-alias upper bound
-    case _ => Iterator.empty
-  }
+  // Parent (symbol, type-arguments) pairs from a class signature, or the alias target for a type.
+  private def parentRefs(sinfo: SymbolInformation): Iterator[(String, Seq[Type])] =
+    sinfo.signature match {
+      case cs: ClassSignature => typeRefsFlatten(cs.parents)
+      case ts: TypeSignature => typeRefs(ts.upperBound) // follow type-alias upper bound
+      case _ => Iterator.empty
+    }
 
   @tailrec
-  private def typeSymbols(tpe: Type): Iterator[String] = tpe match {
-    case TypeRef(_, symbol, _) => Iterator(symbol)
-    case WithType(types) => typeSymbolsFlatten(types)
-    case IntersectionType(types) => typeSymbolsFlatten(types)
+  private def typeRefs(tpe: Type): Iterator[(String, Seq[Type])] = tpe match {
+    case TypeRef(_, symbol, args) => Iterator(symbol -> args)
+    case WithType(types) => typeRefsFlatten(types)
+    case IntersectionType(types) => typeRefsFlatten(types)
     // unwrap type wrappers to the underlying type(s); e.g. a refined parent is encoded as
     // StructuralType(WithType(...)) (see scalacp/TypeOps.scala).
-    case StructuralType(t, _) => typeSymbols(t)
-    case AnnotatedType(_, t) => typeSymbols(t)
-    case ExistentialType(t, _) => typeSymbols(t)
-    case UniversalType(_, t) => typeSymbols(t)
+    case StructuralType(t, _) => typeRefs(t)
+    case AnnotatedType(_, t) => typeRefs(t)
+    case ExistentialType(t, _) => typeRefs(t)
+    case UniversalType(_, t) => typeRefs(t)
     case _ => Iterator.empty
   }
 
-  private def typeSymbolsFlatten(types: Iterable[Type]): Iterator[String] = types.iterator
-    .flatMap(typeSymbols)
+  private def typeRefsFlatten(types: Iterable[Type]): Iterator[(String, Seq[Type])] = types.iterator
+    .flatMap(typeRefs)
+
+  // symbol-only views, used where type arguments aren't needed (e.g. `isSubtypeOf`)
+  private def parentSymbols(sinfo: SymbolInformation): Iterator[String] = parentRefs(sinfo).map(_._1)
+  private def typeSymbols(tpe: Type): Iterator[String] = typeRefs(tpe).map(_._1)
 
   // `tpe` plus its transitive parents, most-derived first and cycle-safe, each paired with the
   // substitution of its type parameters to erased symbols (so generic overrides compare correctly).
@@ -153,25 +151,6 @@ trait SymbolTable {
     }
     loop(tpe, Map.empty)
     seen.toList
-  }
-
-  // Parent (symbol, type-arguments) pairs from a class signature, or the alias target for a type.
-  private def parentRefs(sinfo: SymbolInformation): Iterator[(String, Seq[Type])] =
-    sinfo.signature match {
-      case cs: ClassSignature => cs.parents.iterator.flatMap(typeRefs)
-      case ts: TypeSignature => typeRefs(ts.upperBound)
-      case _ => Iterator.empty
-    }
-
-  private def typeRefs(tpe: Type): Iterator[(String, Seq[Type])] = tpe match {
-    case TypeRef(_, symbol, args) => Iterator(symbol -> args)
-    case WithType(types) => types.iterator.flatMap(typeRefs)
-    case IntersectionType(types) => types.iterator.flatMap(typeRefs)
-    case StructuralType(t, _) => typeRefs(t)
-    case AnnotatedType(_, t) => typeRefs(t)
-    case ExistentialType(t, _) => typeRefs(t)
-    case UniversalType(_, t) => typeRefs(t)
-    case _ => Iterator.empty
   }
 
   // Map `owner`'s type parameters to the erased symbols of `args` (resolved through the caller's
@@ -217,25 +196,25 @@ trait SymbolTable {
   // Reduce a type to its erased head symbol: unwrap by-name/repeated wrappers, then resolve a type
   // parameter through `env` (substitution) or, failing that, follow its alias/upper bound.
   private def headSymbol(tpe: Type, env: Map[String, String]): Option[String] = {
+    // resolve a type parameter through `env` (substitution), else follow its alias/upper bound;
+    // `seen` guards against alias/type-parameter cycles.
     @tailrec
-    def resolve(sym: String, fuel: Int): String = env.get(sym) match {
+    def resolve(sym: String, seen: Set[String]): String = env.get(sym) match {
       case Some(bound) => bound
-      case None if fuel > 0 =>
-        info(sym).map(_.signature) match {
+      case None => info(sym).map(_.signature) match {
           case Some(ts: TypeSignature) => typeSymbols(ts.upperBound).toList.headOption match {
-              case Some(next) if next != sym => resolve(next, fuel - 1)
+              case Some(next) if !seen(next) => resolve(next, seen + next)
               case _ => sym
             }
           case _ => sym
         }
-      case None => sym
     }
     def head(t: Type): Option[String] = t match {
       case ByNameType(u) => head(u)
       case RepeatedType(u) => head(u)
       case _ => typeSymbols(t).toList.headOption
     }
-    head(tpe).map(resolve(_, 16))
+    head(tpe).map(resolve(_, Set.empty))
   }
 
 }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/symtab/SymbolTable.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/symtab/SymbolTable.scala
@@ -143,9 +143,10 @@ trait SymbolTable {
   // A type always precedes its own ancestors, so dedup-by-first-seen keeps the most-derived method.
   private def linearization(tpe: String): List[(String, Map[String, String])] = {
     val seen = mutable.LinkedHashMap.empty[String, Map[String, String]]
-    def loop(sym: String, env: Map[String, String]): Unit = if (!seen.contains(sym)) {
-      seen(sym) = env
-      info(sym).foreach(parentRefs(_).foreach { case (parent, args) =>
+    def loop(sym: String, env: Map[String, String]): Unit = {
+      val size = seen.size
+      seen.getOrElseUpdate(sym, env) // first env wins; recurse only when this was a new entry
+      if (seen.size != size) info(sym).foreach(parentRefs(_).foreach { case (parent, args) =>
         loop(parent, bindTypeParams(parent, args, env))
       })
     }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/symtab/SymbolTable.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/symtab/SymbolTable.scala
@@ -52,6 +52,44 @@ trait SymbolTable {
     } else Nil
 
   /**
+   * Returns all overloads of `name` visible on type `tpe` — its own declarations plus those
+   * inherited across its supertypes — override-deduplicated, most-derived first. `Nil` if `tpe` is
+   * not a resolvable class-like symbol or has no such method.
+   *
+   * This is the hierarchy-aware companion to the single-argument `overloads`: a resolved method
+   * symbol only exposes its own owner's overloads, but the complete candidate set at a call site
+   * spans the receiver type's supertypes (e.g. `trait T { def foo(x: A) }` and
+   * `class C extends T { def foo(x: B) }` — both are candidates on `C`). `tpe` is the receiver type
+   * symbol (e.g. `C#`), which the caller supplies; see
+   * https://github.com/scalameta/scalameta/issues/1298.
+   *
+   * Dedup is by erased parameter signature: an override has the same erased signature as the method
+   * it overrides, so the most-derived one is kept while genuine overloads (different signatures)
+   * all survive. Parent type arguments are substituted before erasing, so a generic override
+   * deduplicates correctly (`trait Base[A] { def foo(a: A) }`, `class Sub extends Base[String] {
+   * override def foo(a: String) }` collapse to one `foo`). A method whose parameter types cannot be
+   * resolved is conservatively kept rather than risk a wrong merge.
+   *
+   * Constructors are not inherited, so for `name == "<init>"` only `tpe`'s own constructors are
+   * returned, not its parents'.
+   *
+   * Caveats: the walk is a simple most-derived-first parent traversal, not full Scala linearization
+   * (enough for override dedup, not for exact resolution order); erasure is symbol-level; and
+   * accessibility/applicability is not applied — final overload resolution is the compiler's job.
+   */
+  def overloads(tpe: String, name: String): List[String] = {
+    // constructors are not inherited, so do not walk parents for the `<init>` name
+    val bases = if (name == "<init>") List(tpe -> Map.empty[String, String]) else linearization(tpe)
+    val seenSignatures = mutable.Set.empty[List[String]]
+    bases.flatMap { case (owner, env) => membersNamed(owner, name).map(_ -> env) }.filter {
+      case (method, env) => erasedSignature(method, env) match {
+          case Some(signature) => seenSignatures.add(signature)
+          case None => true // unresolved parameter types: keep rather than risk a wrong merge
+        }
+    }.map(_._1)
+  }
+
+  /**
    * Tests whether `child` is an erased subtype of `parent`.
    *
    * "Erased" means only symbols are compared and type arguments are ignored — the semantics of
@@ -101,5 +139,103 @@ trait SymbolTable {
 
   private def typeSymbolsFlatten(types: Iterable[Type]): Iterator[String] = types.iterator
     .flatMap(typeSymbols)
+
+  // `tpe` plus its transitive parents, most-derived first and cycle-safe, each paired with the
+  // substitution of its type parameters to erased symbols (so generic overrides compare correctly).
+  // A type always precedes its own ancestors, so dedup-by-first-seen keeps the most-derived method.
+  private def linearization(tpe: String): List[(String, Map[String, String])] = {
+    val seen = mutable.LinkedHashMap.empty[String, Map[String, String]]
+    def loop(sym: String, env: Map[String, String]): Unit = if (!seen.contains(sym)) {
+      seen(sym) = env
+      info(sym).foreach(parentRefs(_).foreach { case (parent, args) =>
+        loop(parent, bindTypeParams(parent, args, env))
+      })
+    }
+    loop(tpe, Map.empty)
+    seen.toList
+  }
+
+  // Parent (symbol, type-arguments) pairs from a class signature, or the alias target for a type.
+  private def parentRefs(sinfo: SymbolInformation): Iterator[(String, Seq[Type])] =
+    sinfo.signature match {
+      case cs: ClassSignature => cs.parents.iterator.flatMap(typeRefs)
+      case ts: TypeSignature => typeRefs(ts.upperBound)
+      case _ => Iterator.empty
+    }
+
+  private def typeRefs(tpe: Type): Iterator[(String, Seq[Type])] = tpe match {
+    case TypeRef(_, symbol, args) => Iterator(symbol -> args)
+    case WithType(types) => types.iterator.flatMap(typeRefs)
+    case IntersectionType(types) => types.iterator.flatMap(typeRefs)
+    case StructuralType(t, _) => typeRefs(t)
+    case AnnotatedType(_, t) => typeRefs(t)
+    case ExistentialType(t, _) => typeRefs(t)
+    case UniversalType(_, t) => typeRefs(t)
+    case _ => Iterator.empty
+  }
+
+  // Map `owner`'s type parameters to the erased symbols of `args` (resolved through the caller's
+  // `env`); unbound when args are missing (raw type), so such parameters erase to their upper bound.
+  private def bindTypeParams(
+      owner: String,
+      args: Seq[Type],
+      env: Map[String, String],
+  ): Map[String, String] =
+    if (args.isEmpty) Map.empty
+    else info(owner).map(_.signature) match {
+      case Some(c: ClassSignature) => c.typeParameters.symbols.iterator.zip(args.iterator)
+          .flatMap { case (param, arg) => headSymbol(arg, env).map(param -> _) }.toMap
+      case _ => Map.empty
+    }
+
+  private def membersNamed(owner: String, name: String): List[String] =
+    info(owner).map(_.signature) match {
+      case Some(c: ClassSignature) => c.declarations.symbols.filter(_.desc match {
+          case d.Method(`name`, _) => true
+          case _ => false
+        })
+      case _ => Nil
+    }
+
+  // The erased parameter-type symbols of `method` under substitution `env`, or None when it is not a
+  // resolvable method or a parameter type can't be reduced (so callers don't merge what they can't
+  // compare).
+  private def erasedSignature(method: String, env: Map[String, String]): Option[List[String]] =
+    info(method).map(_.signature) match {
+      case Some(m: MethodSignature) =>
+        val types = m.parameterLists.iterator.flatMap(paramInfos).map(_.signature match {
+          case v: ValueSignature => headSymbol(v.tpe, env)
+          case _ => None
+        }).toList
+        if (types.forall(_.isDefined)) Some(types.flatten) else None
+      case _ => None
+    }
+
+  private def paramInfos(scope: Scope): Iterator[SymbolInformation] =
+    if (scope.symlinks.nonEmpty) scope.symlinks.iterator.flatMap(info) else scope.hardlinks.iterator
+
+  // Reduce a type to its erased head symbol: unwrap by-name/repeated wrappers, then resolve a type
+  // parameter through `env` (substitution) or, failing that, follow its alias/upper bound.
+  private def headSymbol(tpe: Type, env: Map[String, String]): Option[String] = {
+    @tailrec
+    def resolve(sym: String, fuel: Int): String = env.get(sym) match {
+      case Some(bound) => bound
+      case None if fuel > 0 =>
+        info(sym).map(_.signature) match {
+          case Some(ts: TypeSignature) => typeSymbols(ts.upperBound).toList.headOption match {
+              case Some(next) if next != sym => resolve(next, fuel - 1)
+              case _ => sym
+            }
+          case _ => sym
+        }
+      case None => sym
+    }
+    def head(t: Type): Option[String] = t match {
+      case ByNameType(u) => head(u)
+      case RepeatedType(u) => head(u)
+      case _ => typeSymbols(t).toList.headOption
+    }
+    head(tpe).map(resolve(_, 16))
+  }
 
 }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/symtab/SymbolTable.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/symtab/SymbolTable.scala
@@ -199,14 +199,17 @@ trait SymbolTable {
   private def headSymbol(tpe: Type, env: Map[String, String]): Option[String] = {
     // resolve a type parameter through `env` (substitution), else follow its alias/upper bound;
     // `seen` guards against alias/type-parameter cycles.
+    val seen = mutable.Set.empty[String]
     @tailrec
-    def resolve(sym: String, seen: Set[String]): String = env.get(sym) match {
+    def resolve(sym: String): String = env.get(sym) match {
       case Some(bound) => bound
       case None => info(sym).map(_.signature) match {
-          case Some(ts: TypeSignature) => firstSymbol(typeSymbols(ts.upperBound)) match {
-              case Some(next) if !seen(next) => resolve(next, seen + next)
-              case _ => sym
-            }
+          case Some(ts: TypeSignature) =>
+            val bounds = typeSymbols(ts.upperBound)
+            if (bounds.hasNext) {
+              val next = bounds.next()
+              if (seen.add(next)) resolve(next) else sym
+            } else sym
           case _ => sym
         }
     }
@@ -214,13 +217,11 @@ trait SymbolTable {
     def head(t: Type): Option[String] = t match {
       case ByNameType(u) => head(u)
       case RepeatedType(u) => head(u)
-      case _ => firstSymbol(typeSymbols(t))
+      case _ =>
+        val symbols = typeSymbols(t)
+        if (symbols.hasNext) Some(resolve(symbols.next())) else None
     }
-    head(tpe).map(resolve(_, Set.empty))
+    head(tpe)
   }
-
-  // Iterator has no cross-version `headOption`/`nextOption` (the latter is 2.13-only)
-  private def firstSymbol(symbols: Iterator[String]): Option[String] =
-    if (symbols.hasNext) Some(symbols.next()) else None
 
 }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/symtab/SymbolTable.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/symtab/SymbolTable.scala
@@ -6,6 +6,7 @@ import scala.meta.internal.semanticdb._
 
 import scala.annotation.tailrec
 import scala.collection.mutable
+import scala.reflect.ClassTag
 
 trait SymbolTable {
 
@@ -165,33 +166,28 @@ trait SymbolTable {
       env: Map[String, String],
   ): Map[String, String] =
     if (args.isEmpty) Map.empty
-    else info(owner).map(_.signature) match {
-      case Some(c: ClassSignature) => c.typeParameters.symbols.iterator.zip(args.iterator)
-          .flatMap { case (param, arg) => headSymbol(arg, env).map(param -> _) }.toMap
-      case _ => Map.empty
-    }
+    else owner.signature[ClassSignature].map(c =>
+      c.typeParameters.symbols.iterator.zip(args.iterator).flatMap { case (param, arg) =>
+        headSymbol(arg, env).map(param -> _)
+      }.toMap,
+    ).getOrElse(Map.empty)
 
-  private def membersNamed(owner: String, name: String): List[String] =
-    info(owner).map(_.signature) match {
-      case Some(c: ClassSignature) => c.declarations.symbols.filter(_.desc match {
-          case d.Method(`name`, _) => true
-          case _ => false
-        })
-      case _ => Nil
-    }
+  private def membersNamed(owner: String, name: String): List[String] = owner
+    .signature[ClassSignature].map(_.declarations.symbols.filter(_.desc match {
+      case d.Method(`name`, _) => true
+      case _ => false
+    })).getOrElse(Nil)
 
   // The erased parameter-type symbols of `method` under substitution `env`, or None when it is not a
   // resolvable method or a parameter type can't be reduced (so callers don't merge what they can't
   // compare).
   private def erasedSignature(method: String, env: Map[String, String]): Option[List[String]] =
-    info(method).map(_.signature) match {
-      case Some(m: MethodSignature) =>
-        val types = m.parameterLists.iterator.flatMap(paramInfos).map(_.signature match {
-          case v: ValueSignature => headSymbol(v.tpe, env)
-          case _ => None
-        }).toList
-        if (types.forall(_.isDefined)) Some(types.flatten) else None
-      case _ => None
+    method.signature[MethodSignature].flatMap { m =>
+      val types = m.parameterLists.iterator.flatMap(paramInfos).map(_.signature match {
+        case v: ValueSignature => headSymbol(v.tpe, env)
+        case _ => None
+      }).toList
+      if (types.forall(_.isDefined)) Some(types.flatten) else None
     }
 
   private def paramInfos(scope: Scope): Iterator[SymbolInformation] =
@@ -207,14 +203,21 @@ trait SymbolTable {
     @tailrec
     def resolve(sym: String): String = env.get(sym) match {
       case Some(bound) => bound
-      case None =>
-        info(sym).map(_.signature).collect { case x: TypeSignature => head(x.upperBound) }
-          .flatten match {
+      case None => sym.signature[TypeSignature].flatMap(x => head(x.upperBound)) match {
           case Some(next) if seen.add(next) => resolve(next)
           case _ => sym
         }
     }
     head(tpe).map(resolve)
+  }
+
+  implicit class XtensionOptionSymbolInformation(private val obj: Option[SymbolInformation]) {
+    def signature[T <: Signature](implicit classTag: ClassTag[T]): Option[T] = obj.map(_.signature)
+      .flatMap(classTag.unapply)
+  }
+
+  implicit class XtensionSymbol(private val symbol: String) {
+    def signature[T <: Signature: ClassTag]: Option[T] = info(symbol).signature[T]
   }
 
 }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/symtab/SymbolTable.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/symtab/SymbolTable.scala
@@ -1,5 +1,6 @@
 package scala.meta.internal.symtab
 
+import org.scalameta.collections.Conversions._
 import scala.meta.internal.semanticdb.Scala.{Descriptor => d, _}
 import scala.meta.internal.semanticdb._
 
@@ -203,13 +204,10 @@ trait SymbolTable {
     @tailrec
     def resolve(sym: String): String = env.get(sym) match {
       case Some(bound) => bound
-      case None => info(sym).map(_.signature) match {
-          case Some(ts: TypeSignature) =>
-            val bounds = typeSymbols(ts.upperBound)
-            if (bounds.hasNext) {
-              val next = bounds.next()
-              if (seen.add(next)) resolve(next) else sym
-            } else sym
+      case None => info(sym).map(_.signature).collect { case ts: TypeSignature =>
+          typeSymbols(ts.upperBound).nextOption()
+        }.flatten match {
+          case Some(next) if seen.add(next) => resolve(next)
           case _ => sym
         }
     }
@@ -217,9 +215,7 @@ trait SymbolTable {
     def head(t: Type): Option[String] = t match {
       case ByNameType(u) => head(u)
       case RepeatedType(u) => head(u)
-      case _ =>
-        val symbols = typeSymbols(t)
-        if (symbols.hasNext) Some(resolve(symbols.next())) else None
+      case _ => typeSymbols(t).nextOption().map(resolve)
     }
     head(tpe)
   }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/symtab/SymbolTable.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/symtab/SymbolTable.scala
@@ -129,6 +129,8 @@ trait SymbolTable {
     case AnnotatedType(_, t) => typeRefs(t)
     case ExistentialType(t, _) => typeRefs(t)
     case UniversalType(_, t) => typeRefs(t)
+    case ByNameType(t) => typeRefs(t)
+    case RepeatedType(t) => typeRefs(t)
     case _ => Iterator.empty
   }
 
@@ -201,23 +203,18 @@ trait SymbolTable {
     // resolve a type parameter through `env` (substitution), else follow its alias/upper bound;
     // `seen` guards against alias/type-parameter cycles.
     val seen = mutable.Set.empty[String]
+    def head(t: Type): Option[String] = typeSymbols(t).nextOption()
     @tailrec
     def resolve(sym: String): String = env.get(sym) match {
       case Some(bound) => bound
-      case None => info(sym).map(_.signature).collect { case ts: TypeSignature =>
-          typeSymbols(ts.upperBound).nextOption()
-        }.flatten match {
+      case None =>
+        info(sym).map(_.signature).collect { case x: TypeSignature => head(x.upperBound) }
+          .flatten match {
           case Some(next) if seen.add(next) => resolve(next)
           case _ => sym
         }
     }
-    @tailrec
-    def head(t: Type): Option[String] = t match {
-      case ByNameType(u) => head(u)
-      case RepeatedType(u) => head(u)
-      case _ => typeSymbols(t).nextOption().map(resolve)
-    }
-    head(tpe)
+    head(tpe).map(resolve)
   }
 
 }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/symtab/SymbolTable.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/symtab/SymbolTable.scala
@@ -203,19 +203,24 @@ trait SymbolTable {
     def resolve(sym: String, seen: Set[String]): String = env.get(sym) match {
       case Some(bound) => bound
       case None => info(sym).map(_.signature) match {
-          case Some(ts: TypeSignature) => typeSymbols(ts.upperBound).toList.headOption match {
+          case Some(ts: TypeSignature) => firstSymbol(typeSymbols(ts.upperBound)) match {
               case Some(next) if !seen(next) => resolve(next, seen + next)
               case _ => sym
             }
           case _ => sym
         }
     }
+    @tailrec
     def head(t: Type): Option[String] = t match {
       case ByNameType(u) => head(u)
       case RepeatedType(u) => head(u)
-      case _ => typeSymbols(t).toList.headOption
+      case _ => firstSymbol(typeSymbols(t))
     }
     head(tpe).map(resolve(_, Set.empty))
   }
+
+  // Iterator has no cross-version `headOption`/`nextOption` (the latter is 2.13-only)
+  private def firstSymbol(symbols: Iterator[String]): Option[String] =
+    if (symbols.hasNext) Some(symbols.next()) else None
 
 }

--- a/tests-semanticdb/src/test/scala/scala/meta/tests/symtab/SymbolTableSuite.scala
+++ b/tests-semanticdb/src/test/scala/scala/meta/tests/symtab/SymbolTableSuite.scala
@@ -301,10 +301,11 @@ class SymbolTableSuite extends FunSuite {
   )
 
   test("overloads(tpe, name): a generic hierarchy keeps genuine overloads")(
-    // Sub#foo(Int) is a real overload of Base#foo(String-after-substitution), so both survive
+    // Sub#foo(Int) is a real overload of Base#foo(String-after-substitution), so both survive,
+    // most-derived first
     assertEquals(
-      genericHierarchy("scala/Int#").overloads("_empty_/Sub#", "foo").toSet,
-      Set("_empty_/Sub#foo().", "_empty_/Base#foo()."),
+      genericHierarchy("scala/Int#").overloads("_empty_/Sub#", "foo"),
+      List("_empty_/Sub#foo().", "_empty_/Base#foo()."),
     ),
   )
 

--- a/tests-semanticdb/src/test/scala/scala/meta/tests/symtab/SymbolTableSuite.scala
+++ b/tests-semanticdb/src/test/scala/scala/meta/tests/symtab/SymbolTableSuite.scala
@@ -162,4 +162,160 @@ class SymbolTableSuite extends FunSuite {
     assert(ctors.contains("scala/collection/mutable/StringBuilder#`<init>`()."), ctors.toString)
   }
 
+  // ---- hierarchy-aware overloads(tpe, name) ----
+
+  // a class `sym` extending `parents`, declaring (symlinks to) the methods `decls`
+  private def synthClass(sym: String, parents: List[String], decls: List[String]) = s
+    .SymbolInformation(
+      symbol = sym,
+      kind = s.SymbolInformation.Kind.CLASS,
+      signature = s.ClassSignature(
+        parents = parents.map(p => s.TypeRef(symbol = p)),
+        declarations = Some(s.Scope(symlinks = decls)),
+      ),
+    )
+
+  // a one-parameter method `sym` whose parameter has type `paramType` (carried inline as a hardlink)
+  private def synthMethod(sym: String, paramType: String) = s.SymbolInformation(
+    symbol = sym,
+    kind = s.SymbolInformation.Kind.METHOD,
+    signature = s.MethodSignature(parameterLists =
+      List(s.Scope(hardlinks =
+        List(s.SymbolInformation(
+          symbol = sym + "(x)",
+          kind = s.SymbolInformation.Kind.PARAMETER,
+          signature = s.ValueSignature(s.TypeRef(symbol = paramType)),
+        )),
+      )),
+    ),
+  )
+
+  test("overloads(tpe, name): inherited and own overloads are both returned, most-derived first") {
+    val symtab = LocalSymbolTable(List(
+      synthClass("_empty_/T#", Nil, List("_empty_/T#foo().")),
+      synthMethod("_empty_/T#foo().", "_empty_/A#"),
+      synthClass("_empty_/C#", List("_empty_/T#"), List("_empty_/C#foo().")),
+      synthMethod("_empty_/C#foo().", "_empty_/B#"),
+    ))
+    assertEquals(symtab.overloads("_empty_/C#", "foo"), List("_empty_/C#foo().", "_empty_/T#foo()."))
+  }
+
+  test("overloads(tpe, name): an override is deduplicated to the most-derived method") {
+    val symtab = LocalSymbolTable(List(
+      synthClass("_empty_/Base#", Nil, List("_empty_/Base#f().")),
+      synthMethod("_empty_/Base#f().", "scala/Int#"),
+      synthClass("_empty_/Sub#", List("_empty_/Base#"), List("_empty_/Sub#f().")),
+      synthMethod("_empty_/Sub#f().", "scala/Int#"), // same erased signature -> override
+    ))
+    assertEquals(symtab.overloads("_empty_/Sub#", "f"), List("_empty_/Sub#f()."))
+  }
+
+  test("overloads(tpe, name): a diamond ancestor is not double-counted") {
+    val symtab = LocalSymbolTable(List(
+      synthClass("_empty_/Top#", Nil, List("_empty_/Top#f().")),
+      synthMethod("_empty_/Top#f().", "scala/Int#"),
+      synthClass("_empty_/L#", List("_empty_/Top#"), Nil),
+      synthClass("_empty_/R#", List("_empty_/Top#"), Nil),
+      synthClass("_empty_/D#", List("_empty_/L#", "_empty_/R#"), Nil),
+    ))
+    assertEquals(symtab.overloads("_empty_/D#", "f"), List("_empty_/Top#f()."))
+  }
+
+  test("overloads(tpe, name): cyclic parents terminate") {
+    val symtab = LocalSymbolTable(List(
+      synthClass("_empty_/A#", List("_empty_/B#"), List("_empty_/A#f().")),
+      synthMethod("_empty_/A#f().", "scala/Int#"),
+      synthClass("_empty_/B#", List("_empty_/A#"), Nil),
+    ))
+    assertEquals(symtab.overloads("_empty_/A#", "f"), List("_empty_/A#f()."))
+  }
+
+  test("overloads(tpe, name): unknown or non-class type is Nil") {
+    assertEquals(globalSymtab.overloads("does/not/T#", "foo"), Nil)
+    // a method symbol is not a type
+    assertEquals(globalSymtab.overloads("scala/Predef.assert().", "assert"), Nil)
+  }
+
+  test("overloads(tpe, name): resolves overloads on a real classpath type")(
+    // exercises the GlobalSymbolTable path end to end (object module-class signature, parameter
+    // symbols resolved via symlinks, erased-signature dedup not wrongly merging the two asserts)
+    assertEquals(
+      globalSymtab.overloads("scala/Predef.", "assert"),
+      List("scala/Predef.assert().", "scala/Predef.assert(+1)."),
+    ),
+  )
+
+  // `trait Base[A] { def foo(a: A) }; class Sub extends Base[String] { def foo(a: subParam) }`
+  private def genericHierarchy(subParam: String) = {
+    def method(sym: String, paramType: String) = s.SymbolInformation(
+      symbol = sym,
+      kind = s.SymbolInformation.Kind.METHOD,
+      signature = s.MethodSignature(parameterLists =
+        List(s.Scope(hardlinks =
+          List(s.SymbolInformation(
+            symbol = sym + "(a)",
+            kind = s.SymbolInformation.Kind.PARAMETER,
+            signature = s.ValueSignature(s.TypeRef(symbol = paramType)),
+          )),
+        )),
+      ),
+    )
+    LocalSymbolTable {
+      List(
+        s.SymbolInformation(
+          symbol = "_empty_/Base#",
+          kind = s.SymbolInformation.Kind.TRAIT,
+          signature = s.ClassSignature(
+            typeParameters = Some(s.Scope(symlinks = List("_empty_/Base#[A]"))),
+            declarations = Some(s.Scope(symlinks = List("_empty_/Base#foo()."))),
+          ),
+        ),
+        s.SymbolInformation(
+          symbol = "_empty_/Base#[A]",
+          kind = s.SymbolInformation.Kind.TYPE_PARAMETER,
+          signature = s.TypeSignature(upperBound = s.TypeRef(symbol = "scala/Any#")),
+        ),
+        method("_empty_/Base#foo().", "_empty_/Base#[A]"), // parameter typed by the type parameter A
+        s.SymbolInformation(
+          symbol = "_empty_/Sub#",
+          kind = s.SymbolInformation.Kind.CLASS,
+          signature = s.ClassSignature(
+            parents = List(s.TypeRef(
+              symbol = "_empty_/Base#",
+              typeArguments = List(s.TypeRef(symbol = "scala/Predef.String#")),
+            )),
+            declarations = Some(s.Scope(symlinks = List("_empty_/Sub#foo()."))),
+          ),
+        ),
+        method("_empty_/Sub#foo().", subParam),
+      )
+    }
+  }
+
+  test("overloads(tpe, name): a generic override is deduplicated via type-argument substitution")(
+    // Sub#foo(String) overrides Base#foo(A) with A := String, so only the most-derived survives
+    assertEquals(
+      genericHierarchy("scala/Predef.String#").overloads("_empty_/Sub#", "foo"),
+      List("_empty_/Sub#foo()."),
+    ),
+  )
+
+  test("overloads(tpe, name): a generic hierarchy keeps genuine overloads")(
+    // Sub#foo(Int) is a real overload of Base#foo(String-after-substitution), so both survive
+    assertEquals(
+      genericHierarchy("scala/Int#").overloads("_empty_/Sub#", "foo").toSet,
+      Set("_empty_/Sub#foo().", "_empty_/Base#foo()."),
+    ),
+  )
+
+  test("overloads(tpe, name): constructors are not inherited") {
+    val symtab = LocalSymbolTable(List(
+      synthClass("_empty_/P#", Nil, List("_empty_/P#`<init>`().")),
+      synthMethod("_empty_/P#`<init>`().", "scala/Int#"),
+      synthClass("_empty_/Q#", List("_empty_/P#"), List("_empty_/Q#`<init>`().")),
+      synthMethod("_empty_/Q#`<init>`().", "scala/Long#"),
+    ))
+    assertEquals(symtab.overloads("_empty_/Q#", "<init>"), List("_empty_/Q#`<init>`()."))
+  }
+
 }


### PR DESCRIPTION
Partial fix for #1298, follow-up to #4639.

#4639's `overloads(symbol)` only finds overloads declared in a method's own owner. This adds the hierarchy-aware `SymbolTable.overloads(tpe, name)`: given a receiver type symbol and a method name, it walks `tpe`'s linearization, collects every same-named method (own + inherited), and override-deduplicates by erased parameter signature — substituting parent type arguments first, so a generic override (`Base[A]` / `Sub extends Base[String]`) collapses to one while genuine overloads survive. Constructors aren't inherited, so `<init>` stays on the receiver type.

Reuses the type-hierarchy walk shape from #4639's `isSubtypeOf` (left untouched); the contract and caveats live in the method's scaladoc. Internal (`scala.meta.internal.symtab`) → MiMa-exempt.

The remaining piece — extracting the static receiver type at the call site — is Scalafix-side.
