### PR TITLE
Test that enum SYNTHETIC detection rejects same-named overloads

### DIFF
--- a/semanticdb/integration/src/main/java/com/javacp/EnumOverloads.java
+++ b/semanticdb/integration/src/main/java/com/javacp/EnumOverloads.java
@@ -1,0 +1,11 @@
+package com.javacp;
+
+// #1492: the JLS-mandated `values()`/`valueOf(String)` are compiler-synthesized and must be
+// SYNTHETIC, while same-named user overloads with a different signature must NOT be. This fixture
+// exercises the signature comparison in javacp (see Javacp.sproperties / isSyntheticEnumMethod).
+public enum EnumOverloads {
+  ONE;
+
+  public static EnumOverloads valueOf(int ordinal) { return ONE; }
+  public static int values(String name) { return 0; }
+}

--- a/tests-semanticdb/src/test/resources/metacp.expect_2.12
+++ b/tests-semanticdb/src/test/resources/metacp.expect_2.12
@@ -1111,6 +1111,45 @@ com/javacp/Coin#values(). => synthetic static method values(): Array[Coin]
   Array => scala/Array#
   Coin => com/javacp/Coin#
 
+com/javacp/EnumOverloads.class
+------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => com/javacp/EnumOverloads.class
+Text => empty
+Language => Java
+Symbols => 10 entries
+
+Symbols:
+com/javacp/EnumOverloads# => final enum class EnumOverloads extends Enum[EnumOverloads] { +6 decls }
+  Enum => java/lang/Enum#
+  EnumOverloads => com/javacp/EnumOverloads#
+com/javacp/EnumOverloads#ONE. => final static enum field ONE: EnumOverloads
+  EnumOverloads => com/javacp/EnumOverloads#
+com/javacp/EnumOverloads#`<init>`(). => private ctor <init>()
+com/javacp/EnumOverloads#valueOf(). => synthetic static method valueOf(name: String): EnumOverloads
+  name => com/javacp/EnumOverloads#valueOf().(name)
+  String => java/lang/String#
+  EnumOverloads => com/javacp/EnumOverloads#
+com/javacp/EnumOverloads#valueOf().(name) => param name: String
+  String => java/lang/String#
+com/javacp/EnumOverloads#valueOf(+1). => static method valueOf(ordinal: Int): EnumOverloads
+  ordinal => com/javacp/EnumOverloads#valueOf(+1).(ordinal)
+  Int => scala/Int#
+  EnumOverloads => com/javacp/EnumOverloads#
+com/javacp/EnumOverloads#valueOf(+1).(ordinal) => param ordinal: Int
+  Int => scala/Int#
+com/javacp/EnumOverloads#values(). => synthetic static method values(): Array[EnumOverloads]
+  Array => scala/Array#
+  EnumOverloads => com/javacp/EnumOverloads#
+com/javacp/EnumOverloads#values(+1). => static method values(name: String): Int
+  name => com/javacp/EnumOverloads#values(+1).(name)
+  String => java/lang/String#
+  Int => scala/Int#
+com/javacp/EnumOverloads#values(+1).(name) => param name: String
+  String => java/lang/String#
+
 com/javacp/Interface.class
 --------------------------
 

--- a/tests-semanticdb/src/test/resources/metacp.expect_2.13
+++ b/tests-semanticdb/src/test/resources/metacp.expect_2.13
@@ -1128,6 +1128,45 @@ com/javacp/Coin#values(). => synthetic static method values(): Array[Coin]
   Array => scala/Array#
   Coin => com/javacp/Coin#
 
+com/javacp/EnumOverloads.class
+------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => com/javacp/EnumOverloads.class
+Text => empty
+Language => Java
+Symbols => 10 entries
+
+Symbols:
+com/javacp/EnumOverloads# => final enum class EnumOverloads extends Enum[EnumOverloads] { +6 decls }
+  Enum => java/lang/Enum#
+  EnumOverloads => com/javacp/EnumOverloads#
+com/javacp/EnumOverloads#ONE. => final static enum field ONE: EnumOverloads
+  EnumOverloads => com/javacp/EnumOverloads#
+com/javacp/EnumOverloads#`<init>`(). => private ctor <init>()
+com/javacp/EnumOverloads#valueOf(). => synthetic static method valueOf(name: String): EnumOverloads
+  name => com/javacp/EnumOverloads#valueOf().(name)
+  String => java/lang/String#
+  EnumOverloads => com/javacp/EnumOverloads#
+com/javacp/EnumOverloads#valueOf().(name) => param name: String
+  String => java/lang/String#
+com/javacp/EnumOverloads#valueOf(+1). => static method valueOf(ordinal: Int): EnumOverloads
+  ordinal => com/javacp/EnumOverloads#valueOf(+1).(ordinal)
+  Int => scala/Int#
+  EnumOverloads => com/javacp/EnumOverloads#
+com/javacp/EnumOverloads#valueOf(+1).(ordinal) => param ordinal: Int
+  Int => scala/Int#
+com/javacp/EnumOverloads#values(). => synthetic static method values(): Array[EnumOverloads]
+  Array => scala/Array#
+  EnumOverloads => com/javacp/EnumOverloads#
+com/javacp/EnumOverloads#values(+1). => static method values(name: String): Int
+  name => com/javacp/EnumOverloads#values(+1).(name)
+  String => java/lang/String#
+  Int => scala/Int#
+com/javacp/EnumOverloads#values(+1).(name) => param name: String
+  String => java/lang/String#
+
 com/javacp/Interface.class
 --------------------------
 

--- a/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/JavacpSuiteBase.scala
+++ b/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/JavacpSuiteBase.scala
@@ -35,4 +35,20 @@ abstract class JavacpSuiteBase extends FunSuite {
     expected = false,
   )
 
+  // #1492: detection matches the JLS-mandated *signature*, not just the name — a same-named user
+  // overload with a different signature must NOT be synthetic. (Fixture: EnumOverloads, which adds
+  // `valueOf(int)` and `values(String)` overloads alongside the generated `valueOf(String)`/`values()`.)
+  checkSynthetic("enum valueOf(String) is synthetic", "com/javacp/EnumOverloads#valueOf().", true)
+  checkSynthetic("enum values() is synthetic", "com/javacp/EnumOverloads#values().", true)
+  checkSynthetic(
+    "valueOf(int) overload not synthetic",
+    "com/javacp/EnumOverloads#valueOf(+1).",
+    false,
+  )
+  checkSynthetic(
+    "values(String) overload not synthetic",
+    "com/javacp/EnumOverloads#values(+1).",
+    false,
+  )
+
 }


### PR DESCRIPTION
Follow-up to #4658