### PR TITLE
Add utility methods to AbsolutePath, RelativePath, Classpath

### DIFF
--- a/scalameta/io/js/src/main/scala/java/io/File.scala
+++ b/scalameta/io/js/src/main/scala/java/io/File.scala
@@ -23,7 +23,9 @@ class File(path: String) {
   def isAbsolute: Boolean = toPath.isAbsolute
   def getAbsoluteFile: File = toPath.toAbsolutePath.toFile
   def getAbsolutePath: String = getAbsoluteFile.toString
-  def getParentFile: File = toPath.getParent.toFile
+  // java.io.File.getParentFile returns null when there is no parent; mirror that now that
+  // NodeNIOPath.getParent can return null.
+  def getParentFile: File = Option(toPath.getParent).map(_.toFile).orNull
   def mkdirs(): Unit =
     throw new UnsupportedOperationException("mkdirs() is not supported in Scala.js")
   def getPath: String = path

--- a/scalameta/io/js/src/main/scala/scala/meta/internal/io/NodeNIOPath.scala
+++ b/scalameta/io/js/src/main/scala/scala/meta/internal/io/NodeNIOPath.scala
@@ -46,9 +46,11 @@ case class NodeNIOPath(filename: String) extends Path {
   // Follow the java.nio.file.Path contract: null when there is no parent, i.e. no name elements
   // (a filesystem root) or a single relative name element (e.g. "foo"). Node's path.parse instead
   // yields the root or the empty path for those, which would break Option(getParent)-based checks.
-  override def getParent: Path =
-    if (parts.length == 0 || parts.length == 1 && parsed.root.isEmpty) null
-    else NodeNIOPath(parsed.dir)
+  override def getParent: Path = parts.length match {
+    case 0 => null
+    case 1 if parsed.root.isEmpty => null
+    case _ => NodeNIOPath(parsed.dir)
+  }
   override def getFileName: Path = NodeNIOPath(parsed.base)
 
   override def isAbsolute: Boolean = parsed.root.nonEmpty

--- a/scalameta/io/js/src/main/scala/scala/meta/internal/io/NodeNIOPath.scala
+++ b/scalameta/io/js/src/main/scala/scala/meta/internal/io/NodeNIOPath.scala
@@ -43,7 +43,12 @@ case class NodeNIOPath(filename: String) extends Path {
   }
 
   override def getRoot: Path = if (parsed.root.isEmpty) null else NodeNIOPath(parsed.root)
-  override def getParent: Path = NodeNIOPath(parsed.dir)
+  // Follow the java.nio.file.Path contract: null when there is no parent, i.e. no name elements
+  // (a filesystem root) or a single relative name element (e.g. "foo"). Node's path.parse instead
+  // yields the root or the empty path for those, which would break Option(getParent)-based checks.
+  override def getParent: Path =
+    if (parts.length == 0 || parts.length == 1 && parsed.root.isEmpty) null
+    else NodeNIOPath(parsed.dir)
   override def getFileName: Path = NodeNIOPath(parsed.base)
 
   override def isAbsolute: Boolean = parsed.root.nonEmpty

--- a/scalameta/io/js/src/main/scala/scala/meta/internal/io/PlatformFileIO.scala
+++ b/scalameta/io/js/src/main/scala/scala/meta/internal/io/PlatformFileIO.scala
@@ -65,6 +65,8 @@ object PlatformFileIO {
 
   def isDirectory(path: AbsolutePath): Boolean = JSIO.isDirectory(path.toString)
 
+  def exists(path: AbsolutePath): Boolean = JSIO.exists(path.toString)
+
   def listAllFilesRecursively(root: AbsolutePath): ListFiles = {
     val builder = List.newBuilder[RelativePath]
     def loop(path: AbsolutePath): Unit =

--- a/scalameta/io/jvm/src/main/scala/scala/meta/internal/io/PlatformFileIO.scala
+++ b/scalameta/io/jvm/src/main/scala/scala/meta/internal/io/PlatformFileIO.scala
@@ -44,6 +44,8 @@ object PlatformFileIO {
 
   def isDirectory(path: AbsolutePath): Boolean = Files.isDirectory(path.toNIO)
 
+  def exists(path: AbsolutePath): Boolean = Files.exists(path.toNIO)
+
   def listAllFilesRecursively(root: AbsolutePath): ListFiles = {
     val relativeFiles = List.newBuilder[RelativePath]
     // FOLLOW_LINKS so a symlink's target attributes are used (symlinked files are listed); note this

--- a/scalameta/io/native/src/main/scala/scala/meta/internal/io/PlatformFileIO.scala
+++ b/scalameta/io/native/src/main/scala/scala/meta/internal/io/PlatformFileIO.scala
@@ -50,6 +50,8 @@ object PlatformFileIO {
 
   def isDirectory(path: AbsolutePath): Boolean = Files.isDirectory(path.toNIO)
 
+  def exists(path: AbsolutePath): Boolean = Files.exists(path.toNIO)
+
   def listAllFilesRecursively(root: AbsolutePath): ListFiles = {
     // NOTE: Some Java stream APIs aren't yet available in Scala Native,
     // so I had to steal the Scala.js implementation from js/.

--- a/scalameta/io/shared/src/main/scala/scala/meta/internal/io/FileIO.scala
+++ b/scalameta/io/shared/src/main/scala/scala/meta/internal/io/FileIO.scala
@@ -23,6 +23,8 @@ object FileIO {
 
   def isDirectory(path: AbsolutePath): Boolean = PlatformFileIO.isDirectory(path)
 
+  def exists(path: AbsolutePath): Boolean = PlatformFileIO.exists(path)
+
   def listAllFilesRecursively(path: AbsolutePath): ListFiles = PlatformFileIO
     .listAllFilesRecursively(path)
 

--- a/scalameta/io/shared/src/main/scala/scala/meta/io/AbsolutePath.scala
+++ b/scalameta/io/shared/src/main/scala/scala/meta/io/AbsolutePath.scala
@@ -41,6 +41,21 @@ sealed abstract case class AbsolutePath(toNIO: nio.Path) {
   def isFile: Boolean = FileIO.isFile(this)
   def isDirectory: Boolean = FileIO.isDirectory(this)
   def readAllBytes: Array[Byte] = FileIO.readAllBytes(this)
+
+  /** True if a file or directory exists at this path. */
+  def exists: Boolean = FileIO.exists(this)
+
+  /** The parent directory, or None if this is a filesystem root. */
+  def parentOpt: Option[AbsolutePath] = Option(toNIO.getParent).map(p => new AbsolutePath(p) {})
+
+  /** The parent directory, or this path unchanged if it is a filesystem root. */
+  def parent: AbsolutePath = parentOpt.getOrElse(this)
+
+  /** The last path segment, or "" if this is a filesystem root. */
+  def fileName: String = {
+    val name = toNIO.getFileName
+    if (name == null) "" else name.toString
+  }
 }
 
 object AbsolutePath {

--- a/scalameta/io/shared/src/main/scala/scala/meta/io/AbsolutePath.scala
+++ b/scalameta/io/shared/src/main/scala/scala/meta/io/AbsolutePath.scala
@@ -52,10 +52,7 @@ sealed abstract case class AbsolutePath(toNIO: nio.Path) {
   def parent: AbsolutePath = parentOpt.getOrElse(this)
 
   /** The last path segment, or "" if this is a filesystem root. */
-  def fileName: String = {
-    val name = toNIO.getFileName
-    if (name == null) "" else name.toString
-  }
+  def fileName: String = Option(toNIO.getFileName).fold("")(_.toString)
 }
 
 object AbsolutePath {

--- a/scalameta/io/shared/src/main/scala/scala/meta/io/Classpath.scala
+++ b/scalameta/io/shared/src/main/scala/scala/meta/io/Classpath.scala
@@ -7,6 +7,9 @@ final case class Classpath(entries: List[AbsolutePath]) {
 
   def ++(other: Classpath): Classpath = Classpath(entries ++ other.entries)
 
+  /** Keep only the entries matching the predicate. */
+  def filter(f: AbsolutePath => Boolean): Classpath = Classpath(entries.filter(f))
+
   @deprecated("Use .entries instead", "4.0.0")
   private[meta] def shallow: List[AbsolutePath] = entries
 

--- a/scalameta/io/shared/src/main/scala/scala/meta/io/RelativePath.scala
+++ b/scalameta/io/shared/src/main/scala/scala/meta/io/RelativePath.scala
@@ -29,16 +29,13 @@ sealed abstract case class RelativePath(toNIO: Path) {
     RelativePath(toNIO.resolveSibling(f(toNIO.getFileName.toString)))
 
   /** The parent directory, or None if there is no parent segment. */
-  def parentOpt: Option[RelativePath] = Option(toNIO.getParent).map(p => RelativePath(p))
+  def parentOpt: Option[RelativePath] = Option(toNIO.getParent).map(RelativePath.apply)
 
   /** The parent directory, or the empty relative path if there is no parent segment. */
   def parent: RelativePath = parentOpt.getOrElse(RelativePath(""))
 
   /** The last path segment, or "" if the path is empty. */
-  def fileName: String = {
-    val name = toNIO.getFileName
-    if (name == null) "" else name.toString
-  }
+  def fileName: String = Option(toNIO.getFileName).fold("")(_.toString)
 }
 
 object RelativePath {

--- a/scalameta/io/shared/src/main/scala/scala/meta/io/RelativePath.scala
+++ b/scalameta/io/shared/src/main/scala/scala/meta/io/RelativePath.scala
@@ -27,6 +27,18 @@ sealed abstract case class RelativePath(toNIO: Path) {
   def resolve(path: String): RelativePath = resolve(Paths.get(path))
   def resolveSibling(f: String => String): RelativePath =
     RelativePath(toNIO.resolveSibling(f(toNIO.getFileName.toString)))
+
+  /** The parent directory, or None if there is no parent segment. */
+  def parentOpt: Option[RelativePath] = Option(toNIO.getParent).map(p => RelativePath(p))
+
+  /** The parent directory, or the empty relative path if there is no parent segment. */
+  def parent: RelativePath = parentOpt.getOrElse(RelativePath(""))
+
+  /** The last path segment, or "" if the path is empty. */
+  def fileName: String = {
+    val name = toNIO.getFileName
+    if (name == null) "" else name.toString
+  }
 }
 
 object RelativePath {

--- a/tests/shared/src/test/scala/scala/meta/tests/io/IOSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/io/IOSuite.scala
@@ -47,4 +47,48 @@ class IOSuite extends FunSuite {
     assertEquals(obtained, customWorkingDirectory.resolve("foo"))
   }
 
+  test("AbsolutePath.exists") {
+    assert(buildSbt.exists) // positive: real file
+    assert(PathIO.workingDirectory.exists) // positive: a directory also exists
+    assert(!buildSbt.resolveSibling(_ + ".does.not.exist").exists) // negative: absent sibling
+  }
+
+  test("AbsolutePath.fileName") {
+    assert(buildSbt.fileName == "build.sbt")
+    assert(AbsolutePath.root.fileName == "") // edge: a filesystem root has no file name
+  }
+
+  test("AbsolutePath.parent") {
+    assert(buildSbt.parent == PathIO.workingDirectory)
+    assert(AbsolutePath.root.parent == AbsolutePath.root) // edge: a root's parent is itself
+  }
+
+  test("AbsolutePath.parentOpt") {
+    assert(buildSbt.parentOpt == Some(PathIO.workingDirectory)) // positive
+    assert(AbsolutePath.root.parentOpt.isEmpty) // negative: a root has no parent
+  }
+
+  test("RelativePath.fileName") {
+    assert(RelativePath("foo/bar.scala").fileName == "bar.scala")
+    assert(RelativePath("").fileName == "") // edge: the empty relative path
+  }
+
+  test("RelativePath.parent") {
+    assert(RelativePath("foo/bar").parent == RelativePath("foo"))
+    assert(RelativePath("foo").parent == RelativePath("")) // edge: single segment
+  }
+
+  test("RelativePath.parentOpt") {
+    assert(RelativePath("foo/bar").parentOpt == Some(RelativePath("foo"))) // positive
+    assert(RelativePath("foo").parentOpt.isEmpty) // negative: single segment has no parent
+  }
+
+  test("Classpath.filter") {
+    val a = buildSbt
+    val b = buildSbt.resolveSibling(_ => "other.sbt")
+    val cp = Classpath(List(a, b))
+    assert(cp.filter(_ == a) == Classpath(List(a))) // positive: keeps the matching entry
+    assert(cp.filter(_ => false) == Classpath(Nil)) // negative: drops everything
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/io/NIOPathTest.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/io/NIOPathTest.scala
@@ -42,7 +42,11 @@ class NIOPathTest extends FunSuite {
     assertEquals(abs.getFileName.toString, "foo")
     assertEquals(nonNormalizedFile.getFileName.toString, "scalafmt")
   }
-  test(".getParent")(assertEquals(abs.getParent.getFileName.toString, "bar"))
+  test(".getParent") {
+    assertEquals(abs.getParent.getFileName.toString, "bar")
+    assertEquals(Paths.get(rootString).getParent, null) // a filesystem root has no parent
+    assertEquals(file.getParent, null) // a single relative segment has no parent
+  }
   test(".getNameCount") {
     assertEquals(Paths.get(rootString).getNameCount, 0, rootString)
     assertEquals(Paths.get("").getNameCount, 1)


### PR DESCRIPTION
Closes #1516.

New methods on the public `scala.meta.io` types:
- `AbsolutePath`: `exists`, `parent`, `parentOpt`, `fileName`
- `RelativePath`: `parent`, `parentOpt`, `fileName`
- `Classpath`: `filter`

`parent`/`fileName` are total (at a root → path unchanged / `""`); `parentOpt` is the `Option` variant (`None` at root). Also fixes the Scala.js `NodeNIOPath.getParent` shim to return `null` per the `java.nio` contract.
