### PR TITLE
ScalametaParser: `if` cond in parens can be tuple

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -891,7 +891,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
     makeTupleType(lpPos, body, invalidLiteralUnitType)
   }
 
-  private def inParensOrTupleOrUnitExpr(allowRepeated: Boolean): Term = {
+  private def inParensOrTupleOrUnitExpr(allowRepeated: Boolean = false): Term = {
     val lpPos = currIndex
     val maybeTupleArgs = inParensOnOpenOr(
       commaSeparated(expr(location = PostfixStat, allowRepeated = allowRepeated)),
@@ -1697,13 +1697,13 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
       (cond, None)
     } else {
       val startPos = currIndex
-      val simpleExpr = condExpr()
+      val simpleExpr = inParensOrTupleOrUnitExpr()
       if (acceptIfAfterOptNL[T]) (simpleExpr, None)
       else {
         // let's consider case when something can continue cond or start body
         val argPos = currIndex
         val argsOrInitBody = currToken match {
-          case _: LeftParen => Some(inParensOrTupleOrUnitExpr(allowRepeated = false))
+          case _: LeftParen => Some(inParensOrTupleOrUnitExpr())
           case _: LeftBrace => Some(blockExprOnBrace())
           case _ => None
         }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -4351,4 +4351,22 @@ class ControlSyntaxSuite extends BaseDottySuite {
     runTestAssert[Stat](code)(tree)
   }
 
+  test("#4664 if") {
+    val code = "if (a, b) == pair then ???"
+    val error =
+      """|<input>:1: error: `)` expected but `,` found
+         |if (a, b) == pair then ???
+         |     ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
+  test("#4664 while") {
+    val code = "while (a, b) == pair do ???"
+    val error =
+      """|<input>:1: error: `)` expected but `,` found
+         |while (a, b) == pair do ???
+         |        ^""".stripMargin
+    runTestError[Stat](code, error)
+  }
+
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -4353,20 +4353,16 @@ class ControlSyntaxSuite extends BaseDottySuite {
 
   test("#4664 if") {
     val code = "if (a, b) == pair then ???"
-    val error =
-      """|<input>:1: error: `)` expected but `,` found
-         |if (a, b) == pair then ???
-         |     ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "if ((a, b) == pair) ???"
+    val tree = Term.If(tinfix(Term.Tuple(List("a", "b")), "==", "pair"), "???", Lit.Unit(), Nil)
+    runTestAssert[Stat](code, layout)(tree)
   }
 
   test("#4664 while") {
     val code = "while (a, b) == pair do ???"
-    val error =
-      """|<input>:1: error: `)` expected but `,` found
-         |while (a, b) == pair do ???
-         |        ^""".stripMargin
-    runTestError[Stat](code, error)
+    val layout = "while ((a, b) == pair) ???"
+    val tree = Term.While(tinfix(Term.Tuple(List("a", "b")), "==", "pair"), "???")
+    runTestAssert[Stat](code, layout)(tree)
   }
 
 }


### PR DESCRIPTION
Fixes #4664.