### PR TITLE
trees: add Option-free parentOrNull/parentOrNoTree accessors + NoTree…

### DIFF
--- a/scalameta/trees2/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees2/shared/src/main/scala/scala/meta/Trees.scala
@@ -24,6 +24,19 @@ trait Tree extends InternalTree {
 }
 
 object Tree extends InternalTreeXtensions {
+
+  /**
+   * A canonical empty-`Tree` singleton, used as a non-`null` sentinel for "no tree" / "no parent".
+   *
+   * It is an ordinary, unattached node, so its `parent` is `None` and it is distinguishable from
+   * every real tree by reference identity (`eq`; `Tree.equals` is `eq`). We reuse [[MultiSource]]
+   * rather than introducing a new node type: it extends only `Tree`, so unlike most leaf nodes
+   * (e.g. `Lit.Unit` is-a `Term`/`Pat`/`Type`) it answers `false` to every `.is[Term]`/`.is[Stat]`/
+   * ... classifier and so can't be mistaken for a real node in a parent walk. Treat it as opaque:
+   * compare with `eq Tree.NoTree`, never inspect its type or contents.
+   */
+  val NoTree: Tree = MultiSource(Nil)
+
   @tailrec
   /** 0th ancestor is the parent */
   private def ancestorImpl(level: Int)(obj: Tree): Option[Tree] = obj.parent match {
@@ -31,8 +44,44 @@ object Tree extends InternalTreeXtensions {
     case pOpt => pOpt
   }
 
+  /** 0th ancestor is the parent */
+  private def ancestorOr(level: Int, obj: Tree, or: Tree): Tree = {
+    var tree = obj
+    while (tree.parent match {
+        case Some(p) =>
+          tree = p
+          level > 0
+        case _ =>
+          tree = or
+          false
+      }) {}
+    tree
+  }
+
   implicit class ImplicitTree[A <: Tree](private val obj: A) extends AnyVal {
     def ancestor(level: Int): Option[Tree] = ancestorImpl(level)(obj)
+
+    def ancestorOrNull(level: Int): Tree = ancestorOr(level, obj, null)
+    def ancestorOrNoTree(level: Int): Tree = ancestorOr(level, obj, NoTree)
+
+    /** The parent `Tree`, or `null` if there is none (also `null` for a `null` receiver). */
+    def parentOrNull: Tree =
+      if (obj eq null) null
+      else obj.parent match {
+        case Some(p) => p
+        case _ => null
+      }
+
+    /**
+     * The parent `Tree`, or the [[NoTree]] sentinel if there is none; never `null`. Since
+     * `NoTree.parentOrNoTree eq NoTree`, walking a chain needs no `null` checks and terminates at
+     * the `NoTree` fixed point. Unlike [[parentOrNull]] it does not guard a `null` receiver: it
+     * never yields `null`, so a chain never calls it on one — do not call it on a literal `null`.
+     */
+    def parentOrNoTree: Tree = obj.parent match {
+      case Some(p) => p
+      case _ => NoTree
+    }
   }
 
   implicit class ImplicitOptionTree[A <: Tree](private val obj: Option[A]) extends AnyVal {

--- a/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -246,9 +246,13 @@ class SurfaceSuite extends FunSuite {
          |* (scala.meta.inputs.Input, scala.meta.Dialect).parse(implicit scala.meta.parsers.Parse[U]): scala.meta.parsers.Parsed[U]
          |* (scala.meta.inputs.Input, scala.meta.Dialect).tokenize(implicit scala.meta.tokenizers.Tokenize): scala.meta.tokenizers.Tokenized
          |* A.ancestor(Int): Option[scala.meta.Tree]
+         |* A.ancestorOrNoTree(Int): scala.meta.Tree
+         |* A.ancestorOrNull(Int): scala.meta.Tree
          |* A.equals(Any): Boolean
          |* A.hashCode(): Int
          |* A.maybeParse(implicit scala.meta.Dialect, scala.meta.parsers.Parse[A]): scala.meta.package.Parsed[A]
+         |* A.parentOrNoTree: scala.meta.Tree
+         |* A.parentOrNull: scala.meta.Tree
          |* Option[A].ancestor(Int): Option[scala.meta.Tree]
          |* Option[A].equals(Any): Boolean
          |* Option[A].hashCode(): Int

--- a/tests/shared/src/test/scala/scala/meta/tests/trees/TreeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/trees/TreeSuite.scala
@@ -47,6 +47,30 @@ class TreeSuite extends TreeSuiteBase {
 
   test(s"Unary opMap size")(assertEquals(Unary.opMap.size, 4))
 
+  test("parentOrNull/parentOrNoTree walk the parent chain without Option") {
+    val tree = dialects.Scala213("val x = y").parse[Stat].get
+    val name = tree.collect { case n: Term.Name => n }.find(_.value == "y").get
+    // one step up reaches the enclosing tree, matching the Option-based parent
+    assertEquals(name.parentOrNull, name.parent.get)
+    assertEquals(name.parentOrNoTree, name.parent.get)
+    // `y`'s parent is the root `Defn.Val`, whose own parent is missing
+    assert(name.parentOrNull ne null)
+    assertEquals(name.parentOrNull.parentOrNull, null: Tree)
+    assertEquals(name.parentOrNoTree.parentOrNoTree, Tree.NoTree)
+    assertEquals(tree.parentOrNull, null: Tree)
+    assertEquals(tree.parentOrNoTree, Tree.NoTree)
+  }
+
+  test("parentOrNull is null-safe; both bottom out correctly at the root/NoTree fixed point") {
+    // parentOrNull guards a null receiver (its chain can yield null); parentOrNoTree does not
+    assertEquals((null: Tree).parentOrNull, null: Tree)
+    assertEquals(Tree.NoTree.parentOrNull, null: Tree)
+    assertEquals(Tree.NoTree.parentOrNoTree, Tree.NoTree)
+    // the sentinel is inert: it is not any real node category
+    assert(!Tree.NoTree.is[Term])
+    assert(!Tree.NoTree.is[Stat])
+  }
+
   test("#4351 copy preserves dialect: scala3-specific tree with inline") {
     implicit val dialect: Dialect = dialects.Scala3
     val tree = Defn


### PR DESCRIPTION
… sentinel

Tree-ancestor walks (esp. scalafmt's) step `parent` once per upward hop and wrap/deconstruct an `Option` per step. The stored `parent` is already an alloc-free cached `Some`, so the overhead is on the consumer side; expose a raw-`Tree` accessor so walks can drop the `Option` layer entirely.

In `object Tree`:
- `val NoTree: Tree = MultiSource(Nil)` — public non-null "no parent"/"no tree" sentinel. Strict val (static final, JIT-hoistable; not lazy). Reuses `MultiSource` (extends only `Tree`, so it's inert to every `.is[T]` classifier and can't be mistaken for a real node); compared by `eq`.
- extensions:
  - `parentOrNull` — parent or null; null-safe on the receiver (its chain yields null at the root).
  - `parentOrNoTree` — parent or the `NoTree` fixed point; no receiver null-guard (it never yields null, so a chain never calls it on one). Both use an explicit `match` on the stored `Option` rather than `getOrElse`/`orNull`, avoiding the by-name `Function0` thunk.
