### PR TITLE
trees: add allocation-free foreachChild/childrenCount

### DIFF
--- a/scalameta/common2/shared/src/main/scala/scala/meta/internal/trees/TyperMacros.scala
+++ b/scalameta/common2/shared/src/main/scala/scala/meta/internal/trees/TyperMacros.scala
@@ -16,7 +16,8 @@ object CommonTyperMacros {
   def storeField[T](f: T, v: T, s: String): Unit = macro CommonTyperMacrosBundle.storeField
   def initField[T](f: T): T = macro CommonTyperMacrosBundle.initField
   def initParam[T](f: T): T = macro CommonTyperMacrosBundle.initField
-  def children[T, U]: List[U] = macro CommonTyperMacrosBundle.children[T]
+  def childrenCount[T]: Int = macro CommonTyperMacrosBundle.childrenCount[T]
+  def foreachChild[T, U](f: U => Unit): Unit = macro CommonTyperMacrosBundle.foreachChild[T]
 }
 
 class CommonTyperMacrosBundle(val c: Context) extends AdtReflection with MacroHelpers {
@@ -86,29 +87,35 @@ class CommonTyperMacrosBundle(val c: Context) extends AdtReflection with MacroHe
     case tpe => c.abort(c.enclosingPosition, s"unsupported field type $tpe")
   }
 
-  def children[T](implicit T: c.WeakTypeTag[T]): c.Tree = {
-    var streak = List[Tree]()
-    def flushStreak(acc: Tree): Tree = {
-      val result = if (acc.isEmpty) q"$streak" else q"$acc ++ $streak"
-      streak = Nil
-      result
-    }
-    val leaf = T.tpe.typeSymbol.asLeaf
-    val allAnalyzedFields = leaf.fields
-    val acc = allAnalyzedFields.foldLeft(q"": Tree)((acc, f) =>
+  // Sum of: one per single-Tree field (folded into a constant), plus `.size`
+  // for each Option[Tree] field and `.length` for each List[Tree] field. No
+  // collection is materialized -- lets a caller pre-size before foreachChild.
+  def childrenCount[T](implicit T: c.WeakTypeTag[T]): c.Tree = {
+    var base = 0
+    val terms = T.tpe.typeSymbol.asLeaf.fields.flatMap(f =>
       f.tpe match {
         case TreeTpe() =>
-          streak :+= q"this.${f.sym}"
-          acc
-        case OptionTreeTpe(_) =>
-          val acc1 = flushStreak(acc)
-          q"$acc1 ++ this.${f.sym}.toList"
-        case ListTreeTpe(_) =>
-          val acc1 = flushStreak(acc)
-          q"$acc1 ++ this.${f.sym}"
-        case _ => acc
+          base += 1
+          None
+        case OptionTreeTpe(_) => Some(q"this.${f.sym}.size")
+        case ListTreeTpe(_) => Some(q"this.${f.sym}.length")
+        case _ => None
       },
     )
-    flushStreak(acc)
+    terms.foldLeft(q"$base": Tree)((acc, t) => q"$acc + $t")
+  }
+
+  // Applies `f` to each child in field order, visiting Option/List fields
+  // in place -- allocation-free (no intermediate List, unlike `children`).
+  def foreachChild[T](f: c.Tree)(implicit T: c.WeakTypeTag[T]): c.Tree = {
+    val stmts = T.tpe.typeSymbol.asLeaf.fields.flatMap(field =>
+      field.tpe match {
+        case TreeTpe() => Some(q"$f.apply(this.${field.sym})")
+        case OptionTreeTpe(_) => Some(q"this.${field.sym}.foreach($f)")
+        case ListTreeTpe(_) => Some(q"this.${field.sym}.foreach($f)")
+        case _ => None
+      },
+    )
+    q"{ ..$stmts; () }"
   }
 }

--- a/scalameta/common2/shared/src/main/scala/scala/meta/internal/trees/ast.scala
+++ b/scalameta/common2/shared/src/main/scala/scala/meta/internal/trees/ast.scala
@@ -393,9 +393,13 @@ class AstNamerMacros(val c: Context) extends Reflection with CommonNamerMacros {
             q"final override def toString: $StringClass = scala.meta.internal.prettyprinters.TreeToString(this)"
         }
 
-        // step 8: create the children method
+        // step 8: implement foreachChild (allocation-free); `children` and
+        // `childrenCount` derive from it in the base trait (childrenCount is
+        // overridden here to avoid the builder).
         stats1 +=
-          q"def children: $ListClass[$TreeClass] = $CommonTyperMacrosModule.children[$iname, $TreeClass]"
+          q"override def foreachChild(f: $TreeClass => _root_.scala.Unit): _root_.scala.Unit = $CommonTyperMacrosModule.foreachChild[$iname, $TreeClass](f)"
+        stats1 +=
+          q"override def childrenCount: $IntClass = $CommonTyperMacrosModule.childrenCount[$iname]"
 
         // step 9: generate boilerplate required by the @ast infrastructure
         ianns1 += q"new $AstMetadataModule.astClass"

--- a/scalameta/trees2/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees2/shared/src/main/scala/scala/meta/Trees.scala
@@ -15,8 +15,6 @@ import scala.{meta => sm}
 
 @root
 trait Tree extends InternalTree {
-  def children: List[Tree]
-
   override def canEqual(that: Any): Boolean = that.isInstanceOf[Tree]
   override def equals(that: Any): Boolean = this eq that.asInstanceOf[AnyRef]
   override def hashCode: Int = System.identityHashCode(this)

--- a/scalameta/trees2/shared/src/main/scala/scala/meta/internal/trees/InternalTrees.scala
+++ b/scalameta/trees2/shared/src/main/scala/scala/meta/internal/trees/InternalTrees.scala
@@ -36,6 +36,22 @@ trait InternalTree extends Product {
   private[meta] def loadFieldForParent(parent: Tree): Tree
   private[meta] def storeFieldInParent(parent: Tree, destination: String): Tree
 
+  /**
+   * Applies `f` to each direct child tree, in field order. Implemented per `@ast` node
+   * (allocation-free); `children`/`childrenCount` derive from it.
+   */
+  def foreachChild(f: Tree => Unit): Unit
+  def children: List[Tree] = {
+    val buf = List.newBuilder[Tree]
+    foreachChild(buf += _)
+    buf.result()
+  }
+
+  /**
+   * Number of direct child trees; overridden per `@ast` node to avoid the `children` builder.
+   */
+  def childrenCount: Int = children.length
+
   // NOTE: InternalTree inherits traditional productXXX methods from Product
   // and also adds a new method called productFields.
   // def productPrefix: String

--- a/scalameta/trees2/shared/src/main/scala/scala/meta/trees/Origin.scala
+++ b/scalameta/trees2/shared/src/main/scala/scala/meta/trees/Origin.scala
@@ -24,6 +24,7 @@ object Origin {
   object None extends Origin {
     val position: Position = Position.None
     val dialectOpt: Option[Dialect] = scala.None
+    override def isEmpty: Boolean = true
     private[meta] val inputOpt: Option[Input] = scala.None
     private[meta] val textOpt: Option[String] = scala.None
     private[meta] val tokensOpt: Option[Tokens] = scala.None


### PR DESCRIPTION
`children` built a fresh List per call via `++` chains (each copying the left operand), `List(...)` streaks and `Option.toList`, so any consumer that just wants to visit or count children paid for a materialized list.

Add two per-node members on InternalTree (alongside `parent`), macro-generated for every @ast node:
  - foreachChild(f: Tree => Unit): visits each child field in order in place (f(treeField); optField.foreach(f); listField.foreach(f)) -- no collection.
  - childrenCount: constant count of single-Tree fields + optField.size + listField.length, so a caller can pre-size before foreachChild.

`children` is now defined once on InternalTree as a builder over `foreachChild` (removing the per-node `children` macro and the now-dead `CommonTyperMacros.children`). Child order is unchanged (same field order), so `children` is behaviorally identical for all nodes, including Quasi.

Non-@ast trees inherit the InternalTree defaults; @ast nodes override foreachChild (and childrenCount) with the straight-line generated versions.