### PR TITLE
tokens: add alloc-free OrNull siblings for Option[Token] accessors

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -540,7 +540,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
                   endBuf.append(asComment(parts.toList, begIdx, idx + 1))
                   true
                 case _: HSpace => true
-                case _: Comma => tokens.findNot(_.is[HTrivia], idx + 1).exists(_.is[AtEOL])
+                case _: Comma => tokens.findNotOrNull(_.is[HTrivia], idx + 1).is[AtEOL]
                 case _ => false
               }) idx += 1
             if (endBuf eq null) None else asComments(endBuf)

--- a/scalameta/tokens2/shared/src/main/scala/scala/meta/tokens/Tokens.scala
+++ b/scalameta/tokens2/shared/src/main/scala/scala/meta/tokens/Tokens.scala
@@ -47,6 +47,12 @@ class Tokens private (private[meta] val tokens: Array[Token], val start: Int, va
     if (wideIdx >= 0 && wideIdx < tokens.length) Some(tokens(wideIdx)) else None
   }
 
+  /** Like [[getWideOpt]] but returns `null` instead of an `Option`. See [[getOrNull]]. */
+  private[meta] def getWideOrNull(idx: Int): Token = {
+    val wideIdx = start + idx
+    if (wideIdx >= 0 && wideIdx < tokens.length) tokens(wideIdx) else null
+  }
+
   override def slice(from: Int, until: Int): Tokens = {
     val lo = start + from.max(0).min(length)
     val len = 0.max(start + until.min(length) - lo)
@@ -80,8 +86,14 @@ class Tokens private (private[meta] val tokens: Array[Token], val start: Int, va
   override def head: Token = apply(0)
   override def headOption: Option[Token] = if (isEmpty) None else Some(get(0))
 
+  /** Like [[headOption]] but returns `null` instead of an `Option`. See [[getOrNull]]. */
+  private[meta] def headOrNull: Token = if (isEmpty) null else get(0)
+
   override def last: Token = apply(length - 1)
   override def lastOption: Option[Token] = if (isEmpty) None else Some(get(length - 1))
+
+  /** Like [[lastOption]] but returns `null` instead of an `Option`. See [[getOrNull]]. */
+  private[meta] def lastOrNull: Token = if (isEmpty) null else get(length - 1)
 
   override def toString = scala.meta.internal.prettyprinters.TokensToString(this)
 
@@ -105,6 +117,20 @@ class Tokens private (private[meta] val tokens: Array[Token], val start: Int, va
   def rfindWideNot(p: Token => Boolean, rangeBeg: Int): Option[Token] =
     rfindWideNot(p, rangeBeg, Int.MinValue)
 
+  @inline
+  private[meta] def findNotOrNull(p: Token => Boolean, rangeBeg: Int): Token =
+    findNotOrNull(p, rangeBeg, Int.MaxValue)
+  @inline
+  private[meta] def rfindNotOrNull(p: Token => Boolean, rangeBeg: Int): Token =
+    rfindNotOrNull(p, rangeBeg, Int.MinValue)
+
+  @inline
+  private[meta] def findWideNotOrNull(p: Token => Boolean, rangeBeg: Int): Token =
+    findWideNotOrNull(p, rangeBeg, Int.MaxValue)
+  @inline
+  private[meta] def rfindWideNotOrNull(p: Token => Boolean, rangeBeg: Int): Token =
+    rfindWideNotOrNull(p, rangeBeg, Int.MinValue)
+
   /**
    * Find token not satisfying a given predicate.
    * @param rangeBeg
@@ -121,6 +147,22 @@ class Tokens private (private[meta] val tokens: Array[Token], val start: Int, va
     getWideOpt(skipWideIf(p, rangeBeg, rangeEnd))
   def rfindWideNot(p: Token => Boolean, rangeBeg: Int, rangeEnd: Int): Option[Token] =
     getWideOpt(rskipWideIf(p, rangeBeg, rangeEnd))
+
+  /** Like [[findNot]] but returns `null` instead of an `Option`. See [[getOrNull]]. */
+  private[meta] def findNotOrNull(p: Token => Boolean, rangeBeg: Int, rangeEnd: Int): Token =
+    getOrNull(skipIf(p, rangeBeg, rangeEnd))
+
+  /** Like [[rfindNot]] but returns `null` instead of an `Option`. See [[getOrNull]]. */
+  private[meta] def rfindNotOrNull(p: Token => Boolean, rangeBeg: Int, rangeEnd: Int): Token =
+    getOrNull(rskipIf(p, rangeBeg, rangeEnd))
+
+  /** Like [[findWideNot]] but returns `null` instead of an `Option`. See [[getOrNull]]. */
+  private[meta] def findWideNotOrNull(p: Token => Boolean, rangeBeg: Int, rangeEnd: Int): Token =
+    getWideOrNull(skipWideIf(p, rangeBeg, rangeEnd))
+
+  /** Like [[rfindWideNot]] but returns `null` instead of an `Option`. See [[getOrNull]]. */
+  private[meta] def rfindWideNotOrNull(p: Token => Boolean, rangeBeg: Int, rangeEnd: Int): Token =
+    getWideOrNull(rskipWideIf(p, rangeBeg, rangeEnd))
 
   /**
    * Skip tokens satisfying a given predicate.
@@ -199,6 +241,12 @@ class Tokens private (private[meta] val tokens: Array[Token], val start: Int, va
   def findNot(p: Token => Boolean): Option[Token] = {
     val idx = segmentLength(p)
     if (idx < length) Some(get(idx)) else None
+  }
+
+  /** Like [[findNot]] but returns `null` instead of an `Option`. See [[getOrNull]]. */
+  private[meta] def findNotOrNull(p: Token => Boolean): Token = {
+    val idx = segmentLength(p)
+    if (idx < length) get(idx) else null
   }
 
   def foreachWithIndex(f: (Token, Int) => Unit): Unit = {

--- a/scalameta/trees2/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees2/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -686,7 +686,7 @@ object TreeSyntax {
           case Some(p: Defn.Given) =>
             val isNew = givenSigUsesNewSyntax(p.paramClauseGroups)(
               t.inits.forall(_.argClauses.isEmpty) && !t.body.origin.tokensOpt.forall(
-                _.rfindWideNot(_.is[Token.Trivia], -1).is[Token.KwWith], // still old syntax
+                _.rfindWideNotOrNull(_.is[Token.Trivia], -1).is[Token.KwWith], // still old syntax
               ),
             )
             if (isNew) Decl.Given else Defn.Given
@@ -784,7 +784,7 @@ object TreeSyntax {
                 getLine(imp) >= 0 && {
                   val tokens = imp.tokens
                   val idx = tokens.rskipWideIf(_.is[Token.Trivia], -1)
-                  idx < -1 && tokens.getWideOpt(idx).exists(_.is[Token.LeftBrace])
+                  idx < -1 && tokens.getWideOrNull(idx).is[Token.LeftBrace]
                 }
               }
               def rspace: Boolean = {
@@ -792,7 +792,7 @@ object TreeSyntax {
                 getLine(imp) >= 0 && {
                   val tokens = imp.tokens
                   val idx = tokens.skipWideIf(_.is[Token.Trivia], tokens.length)
-                  idx > tokens.length && tokens.getWideOpt(idx).exists(_.is[Token.RightBrace])
+                  idx > tokens.length && tokens.getWideOrNull(idx).is[Token.RightBrace]
                 }
               }
               val space = o(" ", lspace || rspace)
@@ -939,9 +939,9 @@ object TreeSyntax {
       case Nil => s()
       case head :: Nil => s(kw(": "), head)
       case cbs @ x :: _
-          if dialect.allowImprovedTypeClassesSyntax &&
-            x.origin.tokensOpt.exists(_.rfindWideNot(_.is[Token.Trivia], -1).is[Token.LeftBrace]) =>
-        s(kw(": "), "{", r(cbs, ", "), "}")
+          if dialect.allowImprovedTypeClassesSyntax && x.origin.tokensOpt.exists(
+            _.rfindWideNotOrNull(_.is[Token.Trivia], -1).is[Token.LeftBrace],
+          ) => s(kw(": "), "{", r(cbs, ", "), "}")
       case cbs => s(kw(": "), r(cbs, ": "))
     }
 

--- a/tests/shared/src/test/scala/scala/meta/tests/tokens/TokensSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokens/TokensSuite.scala
@@ -172,7 +172,9 @@ class TokensApiSuite extends FunSuite {
     val beforeLbeg = tokens.length - beforeLlen
     assertEquals(beforeL.rskipWideIf(notIdent, beforeLbeg, -1), beforeLlen)
     assertEquals(beforeL.getWideOpt(beforeLlen).orNull, afterL.head)
+    assertEquals(beforeL.getWideOrNull(beforeLlen), afterL.head)
     assertEquals(beforeL.rfindWideNot(notIdent, beforeLbeg, -1), Some(afterL.head))
+    assertEquals(beforeL.rfindWideNotOrNull(notIdent, beforeLbeg, -1), afterL.head)
 
     val afterLlen = afterL.length
     val afterLbeg = afterLlen - tokens.length
@@ -186,7 +188,9 @@ class TokensApiSuite extends FunSuite {
     val afterRbeg = afterRlen - tokens.length
     assertEquals(afterR.skipWideIf(notIdent, afterRbeg, tokens.length), -1)
     assertEquals(afterR.getWideOpt(-1).orNull, afterL.head)
+    assertEquals(afterR.getWideOrNull(-1), afterL.head)
     assertEquals(afterR.findWideNot(notIdent, afterRbeg), Some(afterL.head))
+    assertEquals(afterR.findWideNotOrNull(notIdent, afterRbeg), afterL.head)
 
     var lastidx = -1
     tokens.foreachWithIndex { (t, i) =>
@@ -196,6 +200,50 @@ class TokensApiSuite extends FunSuite {
       else if (i == 3) assertEquals(t.text, "foo")
       else if (i == 5) assertEquals(t.text, "=")
     }
+  }
+
+  test("Tokens OrNull accessors match their Option counterparts") {
+    def notIdent(t: Token): Boolean = t.name != "identifier"
+    val tokens = tokenize("val foo = 0")
+
+    // element access, in range and out of range
+    for (i <- -1 to tokens.length) {
+      assertEquals(tokens.getOrNull(i), tokens.getOpt(i).orNull)
+      assertEquals(tokens.getWideOrNull(i), tokens.getWideOpt(i).orNull)
+    }
+
+    assertEquals(tokens.headOrNull, tokens.headOption.orNull)
+    assertEquals(tokens.lastOrNull, tokens.lastOption.orNull)
+
+    // find, both when a match exists and when it does not
+    assertEquals(tokens.findNotOrNull(notIdent), tokens.findNot(notIdent).orNull)
+    assertEquals(tokens.findNotOrNull(_ => true), tokens.findNot(_ => true).orNull)
+    for (beg <- 0 to tokens.length) {
+      assertEquals(tokens.findNotOrNull(notIdent, beg), tokens.findNot(notIdent, beg).orNull)
+      assertEquals(tokens.rfindNotOrNull(notIdent, beg), tokens.rfindNot(notIdent, beg).orNull)
+      assertEquals(tokens.findWideNotOrNull(notIdent, beg), tokens.findWideNot(notIdent, beg).orNull)
+      assertEquals(
+        tokens.rfindWideNotOrNull(notIdent, beg),
+        tokens.rfindWideNot(notIdent, beg).orNull,
+      )
+    }
+  }
+
+  test("Tokens OrNull accessors return null when absent") {
+    val tokens = tokenize("val foo = 0")
+    val empty = tokens.take(0)
+
+    assert(tokens.getOrNull(-1) eq null)
+    assert(tokens.getOrNull(tokens.length) eq null)
+    assert(tokens.getWideOrNull(-tokens.length - 1) eq null)
+
+    assert(empty.headOrNull eq null)
+    assert(empty.lastOrNull eq null)
+
+    // predicate never fails, so nothing is found
+    assert(tokens.findNotOrNull(_ => true) eq null)
+    assert(tokens.findNotOrNull(_ => true, 0) eq null)
+    assert(tokens.rfindNotOrNull(_ => true, tokens.length - 1) eq null)
   }
 
 }


### PR DESCRIPTION
Add getWideOrNull/headOrNull/lastOrNull and the findNot/rfindNot/ findWideNot/rfindWideNot OrNull variants alongside the existing Option- returning methods (mirroring the pre-existing getOrNull), so hot paths that immediately deconstruct the result avoid a Some allocation.

Switch the internal call sites that only do `.exists(_.is[...])` / `.is[...]` on the result to the OrNull variants; token classifiers use `isInstanceOf`, which is null-safe.