### PR TITLE
parsers: support scala 3 match sub-cases

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -2715,9 +2715,24 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
         else if (forceSingleExpr) expr(location = BlockStat, allowRepeated = false)
         else blockOnOther()
       }
-      @inline
-      def guard(): Option[Term] = if (at[KwIf]) Some(guardOnIf()) else None
-      Case(pattern(), guard(), caseBody())
+      val pat = pattern()
+      if (!at[KwIf]) Case(pat, None, caseBody())
+      else {
+        // Scala 3 sub-cases: the guard is parsed normally (a trailing `match` becomes a
+        // match-as-operator expression), then disambiguated by what follows -- a second
+        // `if`, or the absence of `=>`, marks the guard `match` as a sub-match. A guard
+        // followed by `=>` stays an ordinary boolean guard (which may itself be a match).
+        def asSubMatch(t: Term.Match) = copyPos(t)(Term.SubMatch(t.expr, t.casesBlock, t.mods))
+        val firstGuard = guardOnIf()
+        if (at[KwIf]) guardOnIf() match {
+          case t: Term.Match => Case(pat, Some(firstGuard), asSubMatch(t))
+          case t => syntaxError("`match` expected", at = t)
+        }
+        else firstGuard match {
+          case t: Term.Match if !at[RightArrow] => Case(pat, None, asSubMatch(t))
+          case _ => Case(pat, Some(firstGuard), caseBody())
+        }
+      }
     }
   }
 

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -456,7 +456,18 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
         case _: KwCase // case follows catch on same line
             if dialect.allowSignificantIndentation && curr.pos.endLine == next.pos.startLine =>
           val regions = markRegions()
-          val nextRegions = RegionIndent(findIndent(sepRegions)) :: regions
+          // Scala 3 sub-cases: a `match` in a case guard yields a single sub-case that
+          // must collapse at the enclosing level (no same-level body-line leniency),
+          // unlike the catch/match-body single-liner; use a deeper indent for it. The
+          // guard region may sit under `RegionIf`s from a chain of boolean `if` guards.
+          @tailrec
+          def getExtraIndent(rs: List[SepRegion]): Int = rs match {
+            case (_: RegionCaseExprGuard) :: _ => 1
+            case (_: RegionIf | _: RegionLine) :: tail => getExtraIndent(tail)
+            case _ => 0
+          }
+          val indent = findIndent(sepRegions) + getExtraIndent(sepRegions)
+          val nextRegions = RegionIndent(indent) :: regions
           currAndNextRef(regions, mkIndent(currPos, nextPos, nextRegions))
         case _: KwCase | _: LeftBrace => currRef(markRegions())
         case _ => currRef(sepRegions)

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SepRegion.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/SepRegion.scala
@@ -33,7 +33,7 @@ case class RegionBracket(override val indent: Int) extends RegionDelimNonIndente
 case class RegionBrace(override val indent: Int) extends RegionDelimNonIndented with CanProduceLF
 
 case object RegionCaseMark extends RegionNonDelimNonIndented
-sealed trait RegionCaseExpr extends SepRegionNonIndented
+sealed trait RegionCaseExpr extends RegionNonDelimNonIndented
 final class RegionCaseExprPat(override val indent: Int) extends RegionCaseExpr
 final class RegionCaseExprGuard(override val indent: Int) extends RegionCaseExpr
 final class RegionCaseBody(override val indent: Int, val arrow: Token)

--- a/scalameta/trees2/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees2/shared/src/main/scala/scala/meta/Trees.scala
@@ -535,6 +535,11 @@ object Term {
   }
   @ast
   class SelectMatch(expr: Term, casesBlock: CasesBlock, mods: List[Mod] = Nil) extends MatchLike
+  // Scala 3 sub-cases: a `match` in a case guard, `case p if e match ...`,
+  // whose sub-cases fall through to the enclosing match when none apply.
+  // https://docs.scala-lang.org/scala3/reference/experimental/sub-cases.html
+  @ast
+  class SubMatch(expr: Term, casesBlock: CasesBlock, mods: List[Mod] = Nil) extends MatchLike
   @branch
   trait TryClause extends Term {
     def expr: Term

--- a/scalameta/trees2/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees2/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -808,20 +808,23 @@ object TreeSyntax {
       case t: Case =>
         val ppat = p(Pattern, t.pat)
         val pcond = t.cond.fold(s())(cond => s(" ", kw("if"), " ", p(PostfixExpr, cond)))
-        def isOneLiner(t: Case) = t.stats match {
-          case Nil => true
-          case (_: Lit | _: Term.Name) :: Nil => true
-          case _ => false
+        val prest = t.body match {
+          // Scala 3 sub-cases: the body is a `match` in the guard, printed as
+          // `case p [if cond] if e match ...`, with no `=>`.
+          case b: Term.SubMatch => s(kw("if"), " ", b)
+          case b: Term.Block => s(kw("=>"), b.stats)
+          case b =>
+            def isOneLiner(body: Tree) = body match {
+              case _: Lit | _: Term.Name | Term.Block(Nil) => true
+              case _ => false
+            }
+            def allOneLiner = t.parent match {
+              case Some(p: Term.CasesBlock) => p.cases.forall(x => isOneLiner(x.body))
+              case _ => isOneLiner(b)
+            }
+            s(kw("=>"), if (allOneLiner) s(" ", b) else i(b))
         }
-        def allOneLiner = t.parent match {
-          case Some(p: Term.CasesBlock) => p.cases.forall(isOneLiner)
-          case _ => isOneLiner(t)
-        }
-        val pbody = t.stats match {
-          case stat :: Nil if allOneLiner => s(" ", stat)
-          case stats => s(stats)
-        }
-        s("case ", ppat, pcond, " ", kw("=>"), pbody)
+        s("case ", ppat, pcond, " ", prest)
 
       case t: TypeCase => s("case ", t.pat, " ", kw("=>"), " ", t.body)
 

--- a/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
+++ b/tests-semanticdb/src/test/scala-2.13/scala/meta/tests/api/SurfaceSuite.scala
@@ -535,6 +535,7 @@ class SurfaceSuite extends FunSuite {
          |scala.meta.Term.SplicedMacroExpr
          |scala.meta.Term.SplicedMacroLike
          |scala.meta.Term.SplicedMacroPat
+         |scala.meta.Term.SubMatch
          |scala.meta.Term.Super
          |scala.meta.Term.This
          |scala.meta.Term.Throw

--- a/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
+++ b/tests/jvm/src/test/scala-2.13/scala/meta/tests/trees/ReflectionSuite.scala
@@ -24,7 +24,7 @@ class ReflectionSuite extends TreeSuiteBase {
     val sym = symbolOf[scala.meta.Tree]
     assert(sym.isRoot)
     val root = sym.asRoot
-    assertEquals((root.allBranches.length, root.allLeafs.length), (77, 491))
+    assertEquals((root.allBranches.length, root.allLeafs.length), (77, 493))
   }
 
   test("If") {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/CommonTrees.scala
@@ -152,6 +152,7 @@ trait CommonTrees extends CommonTrees.LowPriorityDefinitions {
   final def tmatch(lt: Term, cases: Case*): Term.Match = tmatch()(lt, cases: _*)
   final def tselectmatch(lt: Term, cases: Case*): Term.SelectMatch = Term
     .SelectMatch(lt, cases.toList)
+  final def tsubmatch(lt: Term, cases: Case*): Term.SubMatch = Term.SubMatch(lt, cases.toList)
   final def tfunc(params: Term.Param*)(body: Term): Term.Function = Term
     .Function(params.toList, body)
   final def tctxfunc(params: Term.Param*)(body: Term): Term.ContextFunction = Term

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ControlSyntaxSuite.scala
@@ -2349,6 +2349,258 @@ class ControlSyntaxSuite extends BaseDottySuite {
     ))
   }
 
+  // Plain nested matches (via case bodies), braceless: a single dedent from the
+  // innermost match closes several indent regions, and the outer `case _` belongs to
+  // the outer match.
+  test("match-nested multi-level dedent") {
+    val code =
+      """|x match
+         |  case a =>
+         |    b match
+         |      case c =>
+         |        d match
+         |          case e => 1
+         |  case _ => 2
+         |""".stripMargin
+    val layout =
+      """|x match {
+         |  case a =>
+         |    b match {
+         |      case c =>
+         |        d match {
+         |          case e => 1
+         |        }
+         |    }
+         |  case _ =>
+         |    2
+         |}
+         |""".stripMargin
+    runTestAssert[Stat](code, layout)(tmatch(
+      tname("x"),
+      Case(
+        patvar("a"),
+        None,
+        tmatch(tname("b"), Case(patvar("c"), None, tmatch(tname("d"), Case(patvar("e"), None, lit(1))))),
+      ),
+      Case(patwildcard, None, lit(2)),
+    ))
+  }
+
+  // --------------------------
+  // MATCH SUB-CASES
+  // https://docs.scala-lang.org/scala3/reference/experimental/sub-cases.html
+  // --------------------------
+
+  // The reported issue: outer match in braces, single sub-case inline.
+  test("sub-case: single inline in braces") {
+    val code =
+      """|d match {
+         |  case Some(m) if m.content match case c: T => 1
+         |  case _ => 2
+         |}
+         |""".stripMargin
+    val layout =
+      """|d match {
+         |  case Some(m) if m.content match {
+         |    case c: T => 1
+         |  }
+         |  case _ =>
+         |    2
+         |}
+         |""".stripMargin
+    runTestAssert[Stat](code, layout)(tmatch(
+      tname("d"),
+      Case(
+        patextract(tname("Some"), patvar("m")),
+        None,
+        tsubmatch(tselect("m", "content"), Case(Pat.Typed(patvar("c"), pname("T")), None, lit(1))),
+      ),
+      Case(patwildcard, None, lit(2)),
+    ))
+  }
+
+  // Same as above but braceless outer match: the single inline sub-case is delimited
+  // and the dedented `case _` belongs to the outer match.
+  test("sub-case: single inline, braceless outer") {
+    val code =
+      """|d match
+         |  case Some(m) if m.content match case c: T => 1
+         |  case _ => 2
+         |""".stripMargin
+    val layout =
+      """|d match {
+         |  case Some(m) if m.content match {
+         |    case c: T => 1
+         |  }
+         |  case _ =>
+         |    2
+         |}
+         |""".stripMargin
+    runTestAssert[Stat](code, layout)(tmatch(
+      tname("d"),
+      Case(
+        patextract(tname("Some"), patvar("m")),
+        None,
+        tsubmatch(tselect("m", "content"), Case(Pat.Typed(patvar("c"), pname("T")), None, lit(1))),
+      ),
+      Case(patwildcard, None, lit(2)),
+    ))
+  }
+
+  test("sub-case: boolean guard then sub-match in braces") {
+    val code =
+      """|d match {
+         |  case Some(m) if cond if m.content match case c: T => 1
+         |  case _ => 2
+         |}
+         |""".stripMargin
+    val layout =
+      """|d match {
+         |  case Some(m) if cond if m.content match {
+         |    case c: T => 1
+         |  }
+         |  case _ =>
+         |    2
+         |}
+         |""".stripMargin
+    runTestAssert[Stat](code, layout)(tmatch(
+      tname("d"),
+      Case(
+        patextract(tname("Some"), patvar("m")),
+        Some(tname("cond")),
+        tsubmatch(tselect("m", "content"), Case(Pat.Typed(patvar("c"), pname("T")), None, lit(1))),
+      ),
+      Case(patwildcard, None, lit(2)),
+    ))
+  }
+
+  test("sub-case: indented multi sub-case") {
+    val code =
+      """|d match
+         |  case Some(x) if x.version match
+         |    case Stable(m, n) if m > 2 => 1
+         |    case Legacy => 2
+         |  case _ => 3
+         |""".stripMargin
+    val layout =
+      """|d match {
+         |  case Some(x) if x.version match {
+         |    case Stable(m, n) if m > 2 => 1
+         |    case Legacy => 2
+         |  }
+         |  case _ =>
+         |    3
+         |}
+         |""".stripMargin
+    runTestAssert[Stat](code, layout)(tmatch(
+      tname("d"),
+      Case(
+        patextract(tname("Some"), patvar("x")),
+        None,
+        tsubmatch(
+          tselect("x", "version"),
+          Case(
+            patextract(tname("Stable"), patvar("m"), patvar("n")),
+            Some(tinfix(tname("m"), ">", lit(2))),
+            lit(1),
+          ),
+          Case(tname("Legacy"), None, lit(2)),
+        ),
+      ),
+      Case(patwildcard, None, lit(3)),
+    ))
+  }
+
+  test("sub-case: nested sub-sub-match") {
+    val code =
+      """|x match {
+         |  case a if b match {
+         |    case c if d match {
+         |      case e => 1
+         |    }
+         |  }
+         |  case _ => 2
+         |}
+         |""".stripMargin
+    val layout =
+      """|x match {
+         |  case a if b match {
+         |    case c if d match {
+         |      case e => 1
+         |    }
+         |  }
+         |  case _ =>
+         |    2
+         |}
+         |""".stripMargin
+    runTestAssert[Stat](code, layout)(tmatch(
+      tname("x"),
+      Case(
+        patvar("a"),
+        None,
+        tsubmatch(
+          tname("b"),
+          Case(patvar("c"), None, tsubmatch(tname("d"), Case(patvar("e"), None, lit(1)))),
+        ),
+      ),
+      Case(patwildcard, None, lit(2)),
+    ))
+  }
+
+  // A match-as-operator expression is still a valid boolean guard when followed by
+  // `=>`; sub-cases must not change that (only a missing `=>`, or a second `if`, turns
+  // the guard `match` into a sub-match). The reprint parenthesizes the guard match.
+  test("sub-case: match-as-operator guard with => stays a guard") {
+    val code = "x match { case foo if bar match { case baz => true } => 1 }"
+    val layout =
+      """|x match {
+         |  case foo if (bar match {
+         |    case baz => true
+         |  }) => 1
+         |}
+         |""".stripMargin
+    runTestAssert[Stat](code, layout)(tmatch(
+      tname("x"),
+      Case(patvar("foo"), Some(tmatch(tname("bar"), Case(patvar("baz"), None, lit(true)))), lit(1)),
+    ))
+  }
+
+  // Braceless nested sub-sub-match: a single dedent from the innermost sub-match to the
+  // outer level closes several sub-match indent regions at once, so the outer `case _`
+  // belongs to the outer match.
+  test("sub-case: nested sub-sub-match, braceless") {
+    val code =
+      """|x match
+         |  case a if b match
+         |    case c if d match
+         |      case e => 1
+         |  case _ => 2
+         |""".stripMargin
+    val layout =
+      """|x match {
+         |  case a if b match {
+         |    case c if d match {
+         |      case e => 1
+         |    }
+         |  }
+         |  case _ =>
+         |    2
+         |}
+         |""".stripMargin
+    runTestAssert[Stat](code, layout)(tmatch(
+      tname("x"),
+      Case(
+        patvar("a"),
+        None,
+        tsubmatch(
+          tname("b"),
+          Case(patvar("c"), None, tsubmatch(tname("d"), Case(patvar("e"), None, lit(1)))),
+        ),
+      ),
+      Case(patwildcard, None, lit(2)),
+    ))
+  }
+
   test("if-then-else with parens in cond and leading infix") {
     runTestAssert[Stat](
       """|def foo =


### PR DESCRIPTION
Parse Scala 3 sub-cases: a `match` in a case guard whose sub-cases fall through to the enclosing match, e.g.
`case Some(m) if m.content match case c: T => ...`.

Mirrors dotty's representation: `Case(pat, cond, body)` is unchanged; the sub-match is a new `Term.SubMatch` node (a MatchLike sibling of Match/SelectMatch) held in `body`. It is distinct from a plain `Term.Match` body because it has different syntax (`if e match`, no `=>`) and semantics (falls through rather than throwing when no sub-case matches).

No dialect flag: the guard is parsed normally (a trailing `match` becomes a match-as-operator expression), then disambiguated by what follows -- a second `if`, or the absence of `=>`, reinterprets the guard `match` as a sub-match; a guard followed by `=>` stays an ordinary boolean guard (which may itself be a match). Both new forms were previously syntax errors, so this is unambiguous and additive.

Scanner changes:
- getCaseIntro: when a same-line `case` follows a `match` sitting in a case guard, give the synthetic indent region a deeper indent so the single sub-case collapses at the enclosing level instead of absorbing the following outer case (the catch/match-body single-liner keeps its same-level leniency).
- RegionCaseExpr now extends RegionNonDelimNonIndented (it is a non-delimiter, non-indented region), so getOutdentInfo unwinds through a lingering case-guard region left on a sub-match indent (a sub-case has no `=>` to convert the guard region to a body). Without this, a braceless nested sub-sub-match's single multi-level dedent stopped short and absorbed the outer case.

Fixes #4673.