### PR TITLE
tests: make ParseSuite abstract

### DIFF
--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
@@ -7,7 +7,7 @@ import scala.meta.internal.parsers._
 
 import scala.language.implicitConversions
 
-class ParseSuite extends TreeSuiteBase with CommonTrees {
+abstract class ParseSuite extends TreeSuiteBase with CommonTrees {
   import MoreHelpers._
 
   val escapedEOL = if (EOL == "\n") """\n""" else """\r\n"""


### PR DESCRIPTION
ParseSuite is a base for the real parser suites and defines no tests of its own. As a concrete class, sbt instantiated and "ran" it as an empty suite, which munit reports as a spurious `1 failed, 1 ignored, 0 total` marker (harmless -- the aggregate is 0 failed -- but confusing). Making it abstract stops it from being discovered as a runnable suite.