### PR TITLE
Fix bincompat of SemanticdbConfig via @unroll

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -127,6 +127,15 @@ lazy val semanticdbScalacCore = project.in(file("semanticdb/scalac/library")).se
   buildInfoKeys := Seq[BuildInfoKey](scalaVersion),
   description := "Library to generate SemanticDB from Scalac 2.x internal data structures",
   libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value,
+  // @unroll keeps SemanticdbConfig's synthetic apply/copy/ctor binary-compatible
+  // when fields are added, so mismatched semanticdb-scalac versions (e.g. scalafix
+  // vs. sbt) don't fail with NoSuchMethodError. See #4640.
+  libraryDependencies +=
+    compilerPlugin("com.lihaoyi" % "unroll-plugin" % "0.3.0" cross CrossVersion.full),
+  // exclude scala-library: the annotation pom pins a newer patch that would trip
+  // SIP-51 on the earliest cross-built Scala versions.
+  libraryDependencies +=
+    ("com.lihaoyi" %% "unroll-annotation" % "0.3.0").exclude("org.scala-lang", "scala-library"),
 ).dependsOn(semanticdbShared.jvm, io.jvm).enablePlugins(BuildInfoPlugin)
 
 lazy val semanticdbShared = crossProject(allPlatforms: _*).in(file("semanticdb/semanticdb"))

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/ConfigOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/ConfigOps.scala
@@ -7,13 +7,14 @@ import scala.reflect.internal.util.NoPosition
 import scala.tools.nsc.reporters.Reporter
 import scala.util.matching.Regex
 
+import com.lihaoyi.unroll
+
 case class SemanticdbConfig(
     failures: FailureMode,
     profiling: BinaryMode,
     fileFilter: FileFilter,
     sourceroot: AbsolutePath,
     targetroot: AbsolutePath,
-    buildTarget: String,
     cleanup: BinaryMode,
     text: BinaryMode,
     md5: BinaryMode,
@@ -21,6 +22,8 @@ case class SemanticdbConfig(
     diagnostics: BinaryMode,
     synthetics: BinaryMode,
     overrides: BinaryMode,
+    @unroll
+    buildTarget: String = "",
 ) {
   private[scalac] lazy val realSourceRoot = sourceroot.toNIO.toRealPath()
 
@@ -53,7 +56,6 @@ object SemanticdbConfig {
     fileFilter = FileFilter.matchEverything,
     sourceroot = PathIO.workingDirectory,
     targetroot = PathIO.workingDirectory,
-    buildTarget = "",
     text = BinaryMode.Off,
     md5 = BinaryMode.On,
     cleanup = BinaryMode.On,
@@ -61,6 +63,7 @@ object SemanticdbConfig {
     diagnostics = BinaryMode.On,
     synthetics = BinaryMode.Off,
     overrides = BinaryMode.On,
+    buildTarget = "",
   )
 
   private val prefix = "-P:semanticdb:"


### PR DESCRIPTION
Adding buildTarget as a case-class field in #4640 broke binary compatibility: it renumbered/retyped the synthetic copy/apply/ctor accessors (copy$default$6 went from BinaryMode to String). When two semanticdb-scalac versions share a classpath (e.g. scalafix vs. sbt), the evicted-to newer jar no longer has the old-arity methods, so older compiled code fails with NoSuchMethodError.

Move buildTarget to the last constructor param with a default and annotate it @unroll, which regenerates the old-arity apply/copy/ctor forwarders. Restores copy$default$6 to BinaryMode and adds a new copy$default$13:String.