### PR TITLE
sbt-scalajs: bump to 1.22.0 for munit 1.3.4

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,7 +23,7 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % crossProje
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % crossProjectV)
 
 addSbtPlugin("org.scala-debugger" % "sbt-jdi-tools"    % "1.1.1")
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"      % "1.21.0")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"      % "1.22.0")
 addSbtPlugin("org.scala-native"   % "sbt-scala-native" % "0.5.12")
 addSbtPlugin("org.scalameta"      % "sbt-mdoc"         % "2.9.0")
 addSbtPlugin("org.scalameta"      % "sbt-munit"        % "1.3.4")


### PR DESCRIPTION
munit 1.3.4 ships Scala.js artifacts compiled with Scala.js 1.22, whose IR the 1.21 linker cannot deserialize:

  IRVersionNotSupportedException: Failed to deserialize a file
  compiled with Scala.js 1.22 (supported up to: 1.21)

This broke every JS-linking CI job (testLatestScala, Windows tests) while JVM-only jobs stayed green. Align the linker with the IR version munit now emits.