### PR TITLE
metac: order companion object declarations by source position

### DIFF
--- a/semanticdb/integration/src/main/scala/example/Issue1544.scala
+++ b/semanticdb/integration/src/main/scala/example/Issue1544.scala
@@ -1,0 +1,8 @@
+// See https://github.com/scalameta/scalameta/issues/1544
+package example
+
+object Issue1544 {
+  case class A()
+  class B
+  object A
+}

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/scalacp/SymbolOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/scalacp/SymbolOps.scala
@@ -97,6 +97,8 @@ trait SymbolOps {
       case NoSymbol => d.None
     }
     def semanticdbDecls: SemanticdbDecls = {
+      // ScalaSig has no source positions, so declarations keep symbol-table order: a companion
+      // eagerly created after its class stays there even if declared later (#1544); metac reorders.
       val decls = sym.children.filter(decl => decl.isUseful && !decl.isTypeParam)
       SemanticdbDecls(decls.toList)
     }

--- a/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SymbolOps.scala
+++ b/semanticdb/scalac/library/src/main/scala/scala/meta/internal/semanticdb/scalac/SymbolOps.scala
@@ -100,7 +100,7 @@ trait SymbolOps {
             val gbuf = List.newBuilder[g.Symbol]
             gdecls.sorted.filter(_.isUsefulSymbolInformation).foreach(gbuf.+=)
             if (sym.isJavaDefined) sym.companionModule.info.decls.filter(_.isUseful).foreach(gbuf.+=)
-            SemanticdbDecls(gbuf.result())
+            SemanticdbDecls(inSourceOrder(gbuf.result()))
           case _ => SemanticdbDecls(Nil)
         }
         loop(sym.info)
@@ -212,6 +212,28 @@ trait SymbolOps {
     def isDefaultParameter: Boolean = sym.hasFlag(gf.DEFAULTPARAM) && sym.hasFlag(gf.PARAM)
     def isDefaultMethod: Boolean = sym.isJavaDefined && sym.owner.isInterface && !sym.isDeferred &&
       !sym.isStatic
+  }
+
+  // Reorder companion objects to their source position (#1544): the namer enters an eagerly-
+  // created companion right after its class, so an explicit `object` declared later keeps that
+  // early slot. Only these modules move; other members keep scalac's scope order.
+  private def inSourceOrder(gsyms: List[g.Symbol]): List[g.Symbol] = {
+    def isReorderable(sym: g.Symbol): Boolean = sym.isModule && !sym.isSynthetic &&
+      !sym.isJavaDefined && sym.pos.isDefined
+    if (!gsyms.exists(isReorderable)) gsyms
+    else {
+      // merge the modules into the other members by source offset
+      val (modules, rest) = gsyms.partition(isReorderable)
+      val others = rest.iterator.buffered
+      val result = List.newBuilder[g.Symbol]
+      modules.sortBy(_.pos.start).foreach { module =>
+        def precedes(other: g.Symbol) = !other.pos.isDefined || other.pos.start <= module.pos.start
+        while (others.hasNext && precedes(others.head)) result += others.next()
+        result += module
+      }
+      result ++= others
+      result.result()
+    }
   }
 
   private lazy val idCache = new mutable.HashMap[String, Int]

--- a/tests-semanticdb/src/test/resources/example/Issue1544.scala
+++ b/tests-semanticdb/src/test/resources/example/Issue1544.scala
@@ -1,0 +1,8 @@
+// See https://github.com/scalameta/scalameta/issues/1544
+package example
+
+object Issue1544/*<=example.Issue1544.*/ {
+  case class A/*<=example.Issue1544.A#*/()
+  class B/*<=example.Issue1544.B#*/
+  object A/*<=example.Issue1544.A.*/
+}

--- a/tests-semanticdb/src/test/resources/metac-metacp.diff_2.12
+++ b/tests-semanticdb/src/test/resources/metac-metacp.diff_2.12
@@ -514,6 +514,82 @@ example/InstrumentTyper#existential().
                          display_name: "T"
 
 
+===============================
+example/Issue1544.A#canEqual().
+===============================
+--- metac
++++ metacp
+   public_access {
+-overridden_symbols: "scala/Equals#canEqual()."
+
+
+=============================
+example/Issue1544.A#equals().
+=============================
+--- metac
++++ metacp
+   public_access {
+-overridden_symbols: "scala/Equals#equals()."
+-overridden_symbols: "java/lang/Object#equals()."
+-overridden_symbols: "scala/Any#equals()."
+
+
+===============================
+example/Issue1544.A#hashCode().
+===============================
+--- metac
++++ metacp
+   public_access {
+-overridden_symbols: "java/lang/Object#hashCode()."
+-overridden_symbols: "scala/Any#hashCode()."
+
+
+===================================
+example/Issue1544.A#productArity().
+===================================
+--- metac
++++ metacp
+   public_access {
+-overridden_symbols: "scala/Product#productArity()."
+
+
+=====================================
+example/Issue1544.A#productElement().
+=====================================
+--- metac
++++ metacp
+   public_access {
+-overridden_symbols: "scala/Product#productElement()."
+
+
+======================================
+example/Issue1544.A#productIterator().
+======================================
+--- metac
++++ metacp
+   public_access {
+-overridden_symbols: "scala/Product#productIterator()."
+
+
+====================================
+example/Issue1544.A#productPrefix().
+====================================
+--- metac
++++ metacp
+   public_access {
+-overridden_symbols: "scala/Product#productPrefix()."
+
+
+===============================
+example/Issue1544.A#toString().
+===============================
+--- metac
++++ metacp
+   public_access {
+-overridden_symbols: "java/lang/Object#toString()."
+-overridden_symbols: "scala/Any#toString()."
+
+
 ======================
 example/Issue1872.x$1.
 ======================

--- a/tests-semanticdb/src/test/resources/metac-metacp.diff_2.12
+++ b/tests-semanticdb/src/test/resources/metac-metacp.diff_2.12
@@ -514,6 +514,18 @@ example/InstrumentTyper#existential().
                          display_name: "T"
 
 
+==================
+example/Issue1544.
+==================
+--- metac
++++ metacp
+     declarations {
+       symlinks: "example/Issue1544.A#"
+-      symlinks: "example/Issue1544.B#"
+       symlinks: "example/Issue1544.A."
++      symlinks: "example/Issue1544.B#"
+
+
 ===============================
 example/Issue1544.A#canEqual().
 ===============================

--- a/tests-semanticdb/src/test/resources/metac-metacp.diff_2.13
+++ b/tests-semanticdb/src/test/resources/metac-metacp.diff_2.13
@@ -585,6 +585,18 @@ example/InstrumentTyper#existential().
                      display_name: "T"
 
 
+==================
+example/Issue1544.
+==================
+--- metac
++++ metacp
+     declarations {
+       symlinks: "example/Issue1544.A#"
+-      symlinks: "example/Issue1544.B#"
+       symlinks: "example/Issue1544.A."
++      symlinks: "example/Issue1544.B#"
+
+
 ===============================
 example/Issue1544.A#canEqual().
 ===============================

--- a/tests-semanticdb/src/test/resources/metac-metacp.diff_2.13
+++ b/tests-semanticdb/src/test/resources/metac-metacp.diff_2.13
@@ -585,6 +585,91 @@ example/InstrumentTyper#existential().
                      display_name: "T"
 
 
+===============================
+example/Issue1544.A#canEqual().
+===============================
+--- metac
++++ metacp
+   public_access {
+-overridden_symbols: "scala/Equals#canEqual()."
+
+
+=============================
+example/Issue1544.A#equals().
+=============================
+--- metac
++++ metacp
+   public_access {
+-overridden_symbols: "scala/Equals#equals()."
+-overridden_symbols: "java/lang/Object#equals()."
+-overridden_symbols: "scala/Any#equals()."
+
+
+===============================
+example/Issue1544.A#hashCode().
+===============================
+--- metac
++++ metacp
+   public_access {
+-overridden_symbols: "java/lang/Object#hashCode()."
+-overridden_symbols: "scala/Any#hashCode()."
+
+
+===================================
+example/Issue1544.A#productArity().
+===================================
+--- metac
++++ metacp
+   public_access {
+-overridden_symbols: "scala/Product#productArity()."
+
+
+=====================================
+example/Issue1544.A#productElement().
+=====================================
+--- metac
++++ metacp
+   public_access {
+-overridden_symbols: "scala/Product#productElement()."
+
+
+=========================================
+example/Issue1544.A#productElementName().
+=========================================
+--- metac
++++ metacp
+   public_access {
+-overridden_symbols: "scala/Product#productElementName()."
+
+
+======================================
+example/Issue1544.A#productIterator().
+======================================
+--- metac
++++ metacp
+   public_access {
+-overridden_symbols: "scala/Product#productIterator()."
+
+
+====================================
+example/Issue1544.A#productPrefix().
+====================================
+--- metac
++++ metacp
+   public_access {
+-overridden_symbols: "scala/Product#productPrefix()."
+
+
+===============================
+example/Issue1544.A#toString().
+===============================
+--- metac
++++ metacp
+   public_access {
+-overridden_symbols: "java/lang/Object#toString()."
+-overridden_symbols: "scala/Any#toString()."
+
+
 ======================
 example/Issue1872.x$1.
 ======================

--- a/tests-semanticdb/src/test/resources/metac.expect_2.12
+++ b/tests-semanticdb/src/test/resources/metac.expect_2.12
@@ -2108,6 +2108,82 @@ Synthetics:
   apply => scala/collection/immutable/List.apply().
   Any => scala/Any#
 
+semanticdb/integration/src/main/scala/example/Issue1544.scala
+-------------------------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => semanticdb/integration/src/main/scala/example/Issue1544.scala
+Text => non-empty
+Language => Scala
+Symbols => 22 entries
+Occurrences => 7 entries
+
+Symbols:
+example/Issue1544. => final object Issue1544 extends AnyRef { +3 decls }
+  AnyRef => scala/AnyRef#
+example/Issue1544.A# => case class A extends AnyRef with Product with Serializable { +10 decls }
+  AnyRef => scala/AnyRef#
+  Product => scala/Product#
+  Serializable => scala/Serializable#
+example/Issue1544.A#`<init>`(). => primary ctor <init>()
+example/Issue1544.A#canEqual(). => synthetic method canEqual(x$1: Any): Boolean <: scala/Equals#canEqual().
+  x$1 => example/Issue1544.A#canEqual().(x$1)
+  Any => scala/Any#
+  Boolean => scala/Boolean#
+example/Issue1544.A#canEqual().(x$1) => synthetic param x$1: Any
+  Any => scala/Any#
+example/Issue1544.A#copy(). => synthetic method copy(): A
+  A => example/Issue1544.A#
+example/Issue1544.A#equals(). => synthetic method equals(x$1: Any): Boolean <: scala/Equals#equals()., java/lang/Object#equals()., scala/Any#equals().
+  x$1 => example/Issue1544.A#equals().(x$1)
+  Any => scala/Any#
+  Boolean => scala/Boolean#
+example/Issue1544.A#equals().(x$1) => synthetic param x$1: Any
+  Any => scala/Any#
+example/Issue1544.A#hashCode(). => synthetic method hashCode(): Int <: java/lang/Object#hashCode()., scala/Any#hashCode().
+  Int => scala/Int#
+example/Issue1544.A#productArity(). => synthetic method productArity: Int <: scala/Product#productArity().
+  Int => scala/Int#
+example/Issue1544.A#productElement(). => synthetic method productElement(x$1: Int): Any <: scala/Product#productElement().
+  x$1 => example/Issue1544.A#productElement().(x$1)
+  Int => scala/Int#
+  Any => scala/Any#
+example/Issue1544.A#productElement().(x$1) => synthetic param x$1: Int
+  Int => scala/Int#
+example/Issue1544.A#productIterator(). => synthetic method productIterator: Iterator[Any] <: scala/Product#productIterator().
+  Iterator => scala/collection/Iterator#
+  Any => scala/Any#
+example/Issue1544.A#productPrefix(). => synthetic method productPrefix: String <: scala/Product#productPrefix().
+  String => java/lang/String#
+example/Issue1544.A#toString(). => synthetic method toString(): String <: java/lang/Object#toString()., scala/Any#toString().
+  String => java/lang/String#
+example/Issue1544.A. => final object A extends AnyRef with Serializable { +3 decls }
+  AnyRef => scala/AnyRef#
+  Serializable => scala/Serializable#
+example/Issue1544.A.apply(). => synthetic method apply(): A
+  A => example/Issue1544.A#
+example/Issue1544.A.readResolve(). => private synthetic method readResolve(): Object
+  Object => java/lang/Object#
+example/Issue1544.A.unapply(). => synthetic method unapply(x$0: A): Boolean
+  x$0 => example/Issue1544.A.unapply().(x$0)
+  A => example/Issue1544.A#
+  Boolean => scala/Boolean#
+example/Issue1544.A.unapply().(x$0) => synthetic param x$0: A
+  A => example/Issue1544.A#
+example/Issue1544.B# => class B extends AnyRef { +1 decls }
+  AnyRef => scala/AnyRef#
+example/Issue1544.B#`<init>`(). => primary ctor <init>()
+
+Occurrences:
+[1:8..1:15): example <= example/
+[3:7..3:16): Issue1544 <= example/Issue1544.
+[4:13..4:14): A <= example/Issue1544.A#
+[4:14..4:14):  <= example/Issue1544.A#`<init>`().
+[5:8..5:9): B <= example/Issue1544.B#
+[5:9..5:9):  <= example/Issue1544.B#`<init>`().
+[6:9..6:10): A <= example/Issue1544.A.
+
 semanticdb/integration/src/main/scala/example/Issue1749.scala
 -------------------------------------------------------------
 

--- a/tests-semanticdb/src/test/resources/metac.expect_2.13
+++ b/tests-semanticdb/src/test/resources/metac.expect_2.13
@@ -2242,6 +2242,88 @@ Synthetics:
   apply => scala/collection/IterableFactory#apply().
   Any => scala/Any#
 
+semanticdb/integration/src/main/scala/example/Issue1544.scala
+-------------------------------------------------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => semanticdb/integration/src/main/scala/example/Issue1544.scala
+Text => non-empty
+Language => Scala
+Symbols => 24 entries
+Occurrences => 7 entries
+
+Symbols:
+example/Issue1544. => final object Issue1544 extends AnyRef { +3 decls }
+  AnyRef => scala/AnyRef#
+example/Issue1544.A# => case class A extends AnyRef with Product with Serializable { +11 decls }
+  AnyRef => scala/AnyRef#
+  Product => scala/Product#
+  Serializable => scala/package.Serializable#
+example/Issue1544.A#`<init>`(). => primary ctor <init>()
+example/Issue1544.A#canEqual(). => synthetic method canEqual(x$1: Any): Boolean <: scala/Equals#canEqual().
+  x$1 => example/Issue1544.A#canEqual().(x$1)
+  Any => scala/Any#
+  Boolean => scala/Boolean#
+example/Issue1544.A#canEqual().(x$1) => synthetic param x$1: Any
+  Any => scala/Any#
+example/Issue1544.A#copy(). => synthetic method copy(): A
+  A => example/Issue1544.A#
+example/Issue1544.A#equals(). => synthetic method equals(x$1: Any): Boolean <: scala/Equals#equals()., java/lang/Object#equals()., scala/Any#equals().
+  x$1 => example/Issue1544.A#equals().(x$1)
+  Any => scala/Any#
+  Boolean => scala/Boolean#
+example/Issue1544.A#equals().(x$1) => synthetic param x$1: Any
+  Any => scala/Any#
+example/Issue1544.A#hashCode(). => synthetic method hashCode(): Int <: java/lang/Object#hashCode()., scala/Any#hashCode().
+  Int => scala/Int#
+example/Issue1544.A#productArity(). => synthetic method productArity: Int <: scala/Product#productArity().
+  Int => scala/Int#
+example/Issue1544.A#productElement(). => synthetic method productElement(x$1: Int): Any <: scala/Product#productElement().
+  x$1 => example/Issue1544.A#productElement().(x$1)
+  Int => scala/Int#
+  Any => scala/Any#
+example/Issue1544.A#productElement().(x$1) => synthetic param x$1: Int
+  Int => scala/Int#
+example/Issue1544.A#productElementName(). => synthetic method productElementName(x$1: Int): String <: scala/Product#productElementName().
+  x$1 => example/Issue1544.A#productElementName().(x$1)
+  Int => scala/Int#
+  String => java/lang/String#
+example/Issue1544.A#productElementName().(x$1) => synthetic param x$1: Int
+  Int => scala/Int#
+example/Issue1544.A#productIterator(). => synthetic method productIterator: Iterator[Any] <: scala/Product#productIterator().
+  Iterator => scala/collection/Iterator#
+  Any => scala/Any#
+example/Issue1544.A#productPrefix(). => synthetic method productPrefix: String <: scala/Product#productPrefix().
+  String => java/lang/String#
+example/Issue1544.A#toString(). => synthetic method toString(): String <: java/lang/Object#toString()., scala/Any#toString().
+  String => java/lang/String#
+example/Issue1544.A. => final object A extends AnyRef with Serializable { +3 decls }
+  AnyRef => scala/AnyRef#
+  Serializable => java/io/Serializable#
+example/Issue1544.A.apply(). => synthetic method apply(): A
+  A => example/Issue1544.A#
+example/Issue1544.A.unapply(). => synthetic method unapply(x$0: A): Boolean
+  x$0 => example/Issue1544.A.unapply().(x$0)
+  A => example/Issue1544.A#
+  Boolean => scala/Boolean#
+example/Issue1544.A.unapply().(x$0) => synthetic param x$0: A
+  A => example/Issue1544.A#
+example/Issue1544.A.writeReplace(). => private synthetic method writeReplace(): Object
+  Object => java/lang/Object#
+example/Issue1544.B# => class B extends AnyRef { +1 decls }
+  AnyRef => scala/AnyRef#
+example/Issue1544.B#`<init>`(). => primary ctor <init>()
+
+Occurrences:
+[1:8..1:15): example <= example/
+[3:7..3:16): Issue1544 <= example/Issue1544.
+[4:13..4:14): A <= example/Issue1544.A#
+[4:14..4:14):  <= example/Issue1544.A#`<init>`().
+[5:8..5:9): B <= example/Issue1544.B#
+[5:9..5:9):  <= example/Issue1544.B#`<init>`().
+[6:9..6:10): A <= example/Issue1544.A.
+
 semanticdb/integration/src/main/scala/example/Issue1749.scala
 -------------------------------------------------------------
 

--- a/tests-semanticdb/src/test/resources/metacp.expect_2.12
+++ b/tests-semanticdb/src/test/resources/metacp.expect_2.12
@@ -1988,6 +1988,72 @@ example/InstrumentTyper#singletonType(). => method singletonType(x: Predef.type)
 example/InstrumentTyper#singletonType().(x) => param x: Predef.type
   Predef => scala/Predef.
 
+example/Issue1544.class
+-----------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => example/Issue1544.class
+Text => empty
+Language => Scala
+Symbols => 22 entries
+
+Symbols:
+example/Issue1544. => final object Issue1544 extends AnyRef { +3 decls }
+  AnyRef => scala/AnyRef#
+example/Issue1544.A# => case class A extends AnyRef with Product with Serializable { +10 decls }
+  AnyRef => scala/AnyRef#
+  Product => scala/Product#
+  Serializable => scala/Serializable#
+example/Issue1544.A#`<init>`(). => primary ctor <init>()
+example/Issue1544.A#canEqual(). => synthetic method canEqual(x$1: Any): Boolean
+  x$1 => example/Issue1544.A#canEqual().(x$1)
+  Any => scala/Any#
+  Boolean => scala/Boolean#
+example/Issue1544.A#canEqual().(x$1) => synthetic param x$1: Any
+  Any => scala/Any#
+example/Issue1544.A#copy(). => synthetic method copy(): A
+  A => example/Issue1544.A#
+example/Issue1544.A#equals(). => synthetic method equals(x$1: Any): Boolean
+  x$1 => example/Issue1544.A#equals().(x$1)
+  Any => scala/Any#
+  Boolean => scala/Boolean#
+example/Issue1544.A#equals().(x$1) => synthetic param x$1: Any
+  Any => scala/Any#
+example/Issue1544.A#hashCode(). => synthetic method hashCode(): Int
+  Int => scala/Int#
+example/Issue1544.A#productArity(). => synthetic method productArity: Int
+  Int => scala/Int#
+example/Issue1544.A#productElement(). => synthetic method productElement(x$1: Int): Any
+  x$1 => example/Issue1544.A#productElement().(x$1)
+  Int => scala/Int#
+  Any => scala/Any#
+example/Issue1544.A#productElement().(x$1) => synthetic param x$1: Int
+  Int => scala/Int#
+example/Issue1544.A#productIterator(). => synthetic method productIterator: Iterator[Any]
+  Iterator => scala/collection/Iterator#
+  Any => scala/Any#
+example/Issue1544.A#productPrefix(). => synthetic method productPrefix: String
+  String => java/lang/String#
+example/Issue1544.A#toString(). => synthetic method toString(): String
+  String => java/lang/String#
+example/Issue1544.A. => final object A extends AnyRef with Serializable { +3 decls }
+  AnyRef => scala/AnyRef#
+  Serializable => scala/Serializable#
+example/Issue1544.A.apply(). => synthetic method apply(): A
+  A => example/Issue1544.A#
+example/Issue1544.A.readResolve(). => private synthetic method readResolve(): Object
+  Object => java/lang/Object#
+example/Issue1544.A.unapply(). => synthetic method unapply(x$0: A): Boolean
+  x$0 => example/Issue1544.A.unapply().(x$0)
+  A => example/Issue1544.A#
+  Boolean => scala/Boolean#
+example/Issue1544.A.unapply().(x$0) => synthetic param x$0: A
+  A => example/Issue1544.A#
+example/Issue1544.B# => class B extends AnyRef { +1 decls }
+  AnyRef => scala/AnyRef#
+example/Issue1544.B#`<init>`(). => primary ctor <init>()
+
 example/Issue1749.class
 -----------------------
 

--- a/tests-semanticdb/src/test/resources/metacp.expect_2.13
+++ b/tests-semanticdb/src/test/resources/metacp.expect_2.13
@@ -2004,6 +2004,78 @@ example/InstrumentTyper#singletonType(). => method singletonType(x: Predef.type)
 example/InstrumentTyper#singletonType().(x) => param x: Predef.type
   Predef => scala/Predef.
 
+example/Issue1544.class
+-----------------------
+
+Summary:
+Schema => SemanticDB v4
+Uri => example/Issue1544.class
+Text => empty
+Language => Scala
+Symbols => 24 entries
+
+Symbols:
+example/Issue1544. => final object Issue1544 extends AnyRef { +3 decls }
+  AnyRef => scala/AnyRef#
+example/Issue1544.A# => case class A extends AnyRef with Product with Serializable { +11 decls }
+  AnyRef => scala/AnyRef#
+  Product => scala/Product#
+  Serializable => scala/package.Serializable#
+example/Issue1544.A#`<init>`(). => primary ctor <init>()
+example/Issue1544.A#canEqual(). => synthetic method canEqual(x$1: Any): Boolean
+  x$1 => example/Issue1544.A#canEqual().(x$1)
+  Any => scala/Any#
+  Boolean => scala/Boolean#
+example/Issue1544.A#canEqual().(x$1) => synthetic param x$1: Any
+  Any => scala/Any#
+example/Issue1544.A#copy(). => synthetic method copy(): A
+  A => example/Issue1544.A#
+example/Issue1544.A#equals(). => synthetic method equals(x$1: Any): Boolean
+  x$1 => example/Issue1544.A#equals().(x$1)
+  Any => scala/Any#
+  Boolean => scala/Boolean#
+example/Issue1544.A#equals().(x$1) => synthetic param x$1: Any
+  Any => scala/Any#
+example/Issue1544.A#hashCode(). => synthetic method hashCode(): Int
+  Int => scala/Int#
+example/Issue1544.A#productArity(). => synthetic method productArity: Int
+  Int => scala/Int#
+example/Issue1544.A#productElement(). => synthetic method productElement(x$1: Int): Any
+  x$1 => example/Issue1544.A#productElement().(x$1)
+  Int => scala/Int#
+  Any => scala/Any#
+example/Issue1544.A#productElement().(x$1) => synthetic param x$1: Int
+  Int => scala/Int#
+example/Issue1544.A#productElementName(). => synthetic method productElementName(x$1: Int): String
+  x$1 => example/Issue1544.A#productElementName().(x$1)
+  Int => scala/Int#
+  String => java/lang/String#
+example/Issue1544.A#productElementName().(x$1) => synthetic param x$1: Int
+  Int => scala/Int#
+example/Issue1544.A#productIterator(). => synthetic method productIterator: Iterator[Any]
+  Iterator => scala/collection/Iterator#
+  Any => scala/Any#
+example/Issue1544.A#productPrefix(). => synthetic method productPrefix: String
+  String => java/lang/String#
+example/Issue1544.A#toString(). => synthetic method toString(): String
+  String => java/lang/String#
+example/Issue1544.A. => final object A extends AnyRef with Serializable { +3 decls }
+  AnyRef => scala/AnyRef#
+  Serializable => java/io/Serializable#
+example/Issue1544.A.apply(). => synthetic method apply(): A
+  A => example/Issue1544.A#
+example/Issue1544.A.unapply(). => synthetic method unapply(x$0: A): Boolean
+  x$0 => example/Issue1544.A.unapply().(x$0)
+  A => example/Issue1544.A#
+  Boolean => scala/Boolean#
+example/Issue1544.A.unapply().(x$0) => synthetic param x$0: A
+  A => example/Issue1544.A#
+example/Issue1544.A.writeReplace(). => private synthetic method writeReplace(): Object
+  Object => java/lang/Object#
+example/Issue1544.B# => class B extends AnyRef { +1 decls }
+  AnyRef => scala/AnyRef#
+example/Issue1544.B#`<init>`(). => primary ctor <init>()
+
 example/Issue1749.class
 -----------------------
 

--- a/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/DeclarationOrderSuite.scala
+++ b/tests-semanticdb/src/test/scala/scala/meta/tests/semanticdb/DeclarationOrderSuite.scala
@@ -1,0 +1,149 @@
+package scala.meta.tests
+package semanticdb
+
+import scala.meta.internal.{semanticdb => s}
+
+// Tests for https://github.com/scalameta/scalameta/issues/1544:
+// ClassSignature.declarations must list declared members in source order, even though
+// scalac's namer enters a case class's eagerly-created companion module into the owner
+// scope right after the class rather than at its source position.
+class DeclarationOrderSuite extends SemanticdbSuite {
+
+  private def declarations(doc: s.TextDocument, symbol: String): List[String] = {
+    val info = doc.symbols.find(_.symbol == symbol)
+    assert(info.nonEmpty, s"no symbol information for $symbol")
+    info.get.signature match {
+      case sig: s.ClassSignature => sig.declarations.toList.flatMap(_.symlinks)
+      case sig => fail(s"expected ClassSignature for $symbol, obtained $sig")
+    }
+  }
+
+  // Positive: an explicit companion of a case class declared later and non-adjacently
+  // must appear at its source position, not in the scope slot the namer created for it.
+  targeted(
+    """|package do1
+       |object <<X>> {
+       |  case class A()
+       |  class B
+       |  object A
+       |}
+       |""".stripMargin,
+    (doc, x) => assertEquals(declarations(doc, x), List("do1/X.A#", "do1/X.B#", "do1/X.A.")),
+  )
+
+  // Positive: same with a non-class member between the case class and its companion.
+  targeted(
+    """|package do2
+       |object <<X>> {
+       |  case class A()
+       |  def m: Int = 1
+       |  object A
+       |}
+       |""".stripMargin,
+    (doc, x) => assertEquals(declarations(doc, x), List("do2/X.A#", "do2/X.m().", "do2/X.A.")),
+  )
+
+  // Negative: an adjacent explicit companion is already in source order and must not move.
+  targeted(
+    """|package do3
+       |object <<X>> {
+       |  case class A()
+       |  object A
+       |  class B
+       |}
+       |""".stripMargin,
+    (doc, x) => assertEquals(declarations(doc, x), List("do3/X.A#", "do3/X.A.", "do3/X.B#")),
+  )
+
+  // Negative: a synthetic companion has no explicit source declaration and keeps its slot.
+  targeted(
+    """|package do4
+       |object <<X>> {
+       |  case class A()
+       |  class B
+       |}
+       |""".stripMargin,
+    (doc, x) => assertEquals(declarations(doc, x), List("do4/X.A#", "do4/X.A.", "do4/X.B#")),
+  )
+
+  // Negative: plain (non-case) classes never had the bug; order must stay source order.
+  targeted(
+    """|package do5
+       |object <<X>> {
+       |  class A
+       |  class B
+       |  object A
+       |}
+       |""".stripMargin,
+    (doc, x) => assertEquals(declarations(doc, x), List("do5/X.A#", "do5/X.B#", "do5/X.A.")),
+  )
+
+  // Negative: a companion declared before its case class stays first (source order).
+  targeted(
+    """|package do6
+       |object <<X>> {
+       |  object A
+       |  case class A()
+       |  class B
+       |}
+       |""".stripMargin,
+    (doc, x) => assertEquals(declarations(doc, x), List("do6/X.A.", "do6/X.A#", "do6/X.B#")),
+  )
+
+  // Positive: eager companion creation is not case-class specific — a class with default
+  // constructor parameters also gets an eagerly-entered companion (to hold the default getters),
+  // so an explicit companion declared later must float just the same.
+  targeted(
+    """|package do8
+       |object <<X>> {
+       |  class A(x: Int = 1)
+       |  class B
+       |  object A
+       |}
+       |""".stripMargin,
+    (doc, x) => assertEquals(declarations(doc, x), List("do8/X.A#", "do8/X.B#", "do8/X.A.")),
+  )
+
+  // Positive: two companions whose objects are declared in the reverse order of their classes
+  // must each land at their own source position, not merely follow their class.
+  targeted(
+    """|package do9
+       |object <<X>> {
+       |  case class A()
+       |  case class B()
+       |  object B
+       |  object A
+       |}
+       |""".stripMargin,
+    (doc, x) =>
+      assertEquals(declarations(doc, x), List("do9/X.A#", "do9/X.B#", "do9/X.B.", "do9/X.A.")),
+  )
+
+  // Negative: the spec layout for a template with ctor params — param fields/getters/setters
+  // first, then the primary ctor, then body members in source order — is untouched.
+  targeted(
+    """|package do7
+       |class <<K>>(val p1: Int, var p2: String) {
+       |  def m1: Int = 1
+       |  val v1: Int = 2
+       |  var v2: Int = 3
+       |  def m2: Int = 4
+       |}
+       |""".stripMargin,
+    (doc, k) =>
+      assertEquals(
+        declarations(doc, k),
+        List(
+          "do7/K#p1.",
+          "do7/K#p2().",
+          "do7/K#`p2_=`().",
+          "do7/K#`<init>`().",
+          "do7/K#m1().",
+          "do7/K#v1.",
+          "do7/K#v2().",
+          "do7/K#`v2_=`().",
+          "do7/K#m2().",
+        ),
+      ),
+  )
+}


### PR DESCRIPTION
## Problem

metac emitted `ClassSignature.declarations` with an explicit companion `object` in the wrong place. The namer puts it in an eager scope slot instead of its source position. So declared members came out of source order (#1544).

## Root cause

For a case class, or a class with default constructor parameters, `Namer.ensureCompanionObject` enters a companion right after the class. An explicit companion declared later reuses that early slot. The plugin read declaration order straight from `Scope.sorted`, so it kept the wrong order.

## Why only modules

The first attempt sorted all positioned declarations by source position. That regressed Java overload disambiguators. Java declaration order is non-normative, and reordering it desyncs metac from metacp. It also reordered late-entered annotated fields. The bug is specific to companion modules. So the fix floats only those, and leaves every other member in scope order.

## Scope: metac only

metacp reads Scala 2 pickles, which have no source positions. It cannot recover source order, so it still emits the old order. The divergence is recorded in `metac-metacp.diff`. The metacp half stays open. Part of #1544.
