### PR TITLE
Restrict legacy tokenizer internals to the scala.meta namespace

### DIFF
--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/CharArrayReader.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/CharArrayReader.scala
@@ -94,7 +94,7 @@ private[meta] case class CharArrayReader(
 
 }
 
-object CharArrayReader {
+private[meta] object CharArrayReader {
 
   case class NextChar(ch: Int, end: Int)
 

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/Errors.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/Errors.scala
@@ -1,3 +1,3 @@
 package scala.meta.internal.tokenizers
 
-class UnexpectedInputEndException(val ltd: LegacyTokenData) extends Exception
+private[meta] class UnexpectedInputEndException(val ltd: LegacyTokenData) extends Exception

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
@@ -10,7 +10,7 @@ import scala.meta.internal.tokens.Chars._
 import scala.annotation.{switch, tailrec}
 import scala.collection.mutable
 
-class LegacyScanner(input: Input, dialect: Dialect) {
+private[meta] class LegacyScanner(input: Input, dialect: Dialect) {
 
   import LegacyToken._
 

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyToken.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyToken.scala
@@ -5,7 +5,7 @@ package tokenizers
 // NOTE: moved to the package object
 // type LegacyToken = Int
 
-object LegacyToken {
+private[meta] object LegacyToken {
   def isIdentifier(code: LegacyToken) = code == IDENTIFIER // used by ide
   def isLiteral(code: LegacyToken) = code >= CHARLIT && code <= INTERPOLATIONID
 

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyTokenData.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyTokenData.scala
@@ -6,7 +6,7 @@ import scala.meta.tokens.Token
 
 import java.math.{MathContext, RoundingMode}
 
-class LegacyTokenData {
+private[meta] class LegacyTokenData {
 
   import LegacyToken._
 
@@ -116,7 +116,7 @@ class LegacyTokenData {
 
 }
 
-object LegacyTokenData {
+private[meta] object LegacyTokenData {
   // add a bit more, JS doesn't handle it well
   private val bigDecimalMaxFloat = BigDecimal
     .binary(Float.MaxValue, new MathContext(8, RoundingMode.UP))

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/XmlParser.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/XmlParser.scala
@@ -13,7 +13,7 @@ import fastparse._
  * [[https://github.com/scalameta/fastparse/pull/1#issuecomment-244940542]] and adapted to more
  * closely match scala-xml and then adapted to fastparse 2.3.1
  */
-class XmlParser(dialect: Dialect) {
+private[meta] class XmlParser(dialect: Dialect) {
 
   val blockParser = new ScalaExprPositionParser(dialect)
 
@@ -130,7 +130,7 @@ class XmlParser(dialect: Dialect) {
  *
  * Doesn't really parse scala expressions, only reads until the curly brace balance hits 0.
  */
-class ScalaExprPositionParser(dialect: Dialect) {
+private[meta] class ScalaExprPositionParser(dialect: Dialect) {
   case class XmlTokenRange(from: Int, to: Int) // from is inclusive, to is exclusive
   private val _splicePositions = List.newBuilder[XmlTokenRange]
   def splicePositions: List[XmlTokenRange] = _splicePositions.result()

--- a/scalameta/tokenizers2/shared/src/main/scala/scala/meta/internal/tokenizers/package.scala
+++ b/scalameta/tokenizers2/shared/src/main/scala/scala/meta/internal/tokenizers/package.scala
@@ -3,7 +3,7 @@ package internal
 
 package object tokenizers {
   type Offset = Int
-  type LegacyToken = Int
+  private[meta] type LegacyToken = Int
 
   private val baseKeywords = Set(
     "abstract",

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/BaseTokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/BaseTokenizerSuite.scala
@@ -3,8 +3,6 @@ package scala.meta.tests.tokenizers
 import scala.meta._
 import scala.meta.tests.{TestHelpers, TreeSuiteBase}
 
-import munit.Location
-
 abstract class BaseTokenizerSuite extends TreeSuiteBase {
 
   protected val dialect: Dialect = dialects.Scala211
@@ -19,26 +17,6 @@ abstract class BaseTokenizerSuite extends TreeSuiteBase {
     implicit val implicitDialect = dialect
     val obtained = tokenize(code)
     expected.lift(obtained).getOrElse(fail("Got unexpected tokens: " + obtained))
-  }
-
-  def assertLegacyScannedAsStringLines(
-      code: String,
-      expected: String,
-      dialect: Dialect = this.dialect,
-  )(implicit loc: Location): Unit = {
-    import scala.meta.internal.tokenizers._
-    import scala.meta.tests.parsers.MoreHelpers._
-
-    val input = code.asInput
-    val scanner = new LegacyScanner(input = input, dialect = dialect)
-    scanner.initialize()
-    val sb = new StringBuilder
-    while ({
-      val ltd = scanner.nextTokenOrEof()
-      sb.append(ltd).append('\n')
-      ltd.ok
-    }) {}
-    assertEquals(sb.result(), expected)
   }
 
   protected def testTokenizedStructLines(

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/BaseTokenizerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/BaseTokenizerSuite.scala
@@ -3,6 +3,8 @@ package scala.meta.tests.tokenizers
 import scala.meta._
 import scala.meta.tests.{TestHelpers, TreeSuiteBase}
 
+import munit.Location
+
 abstract class BaseTokenizerSuite extends TreeSuiteBase {
 
   protected val dialect: Dialect = dialects.Scala211
@@ -17,6 +19,26 @@ abstract class BaseTokenizerSuite extends TreeSuiteBase {
     implicit val implicitDialect = dialect
     val obtained = tokenize(code)
     expected.lift(obtained).getOrElse(fail("Got unexpected tokens: " + obtained))
+  }
+
+  def assertLegacyScannedAsStringLines(
+      code: String,
+      expected: String,
+      dialect: Dialect = this.dialect,
+  )(implicit loc: Location): Unit = {
+    import scala.meta.internal.tokenizers._
+    import scala.meta.tests.parsers.MoreHelpers._
+
+    val input = code.asInput
+    val scanner = new LegacyScanner(input = input, dialect = dialect)
+    scanner.initialize()
+    val sb = new StringBuilder
+    while ({
+      val ltd = scanner.nextTokenOrEof()
+      sb.append(ltd).append('\n')
+      ltd.ok
+    }) {}
+    assertEquals(sb.result(), expected)
   }
 
   protected def testTokenizedStructLines(


### PR DESCRIPTION
Marks the legacy lexer internals (`LegacyScanner`, `LegacyTokenData`, `LegacyToken`, `XmlParser`, `UnexpectedInputEndException`, the `CharArrayReader` companion) `private[meta]`, per the `CharArrayReader` precedent (#3295): Metals keeps compiling, everything outside `scala.meta` is fenced out.
