### PR TITLE
mdoc: upgrade to v2.9.1

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -25,7 +25,7 @@ addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % crossProje
 addSbtPlugin("org.scala-debugger" % "sbt-jdi-tools"    % "1.1.1")
 addSbtPlugin("org.scala-js"       % "sbt-scalajs"      % "1.22.0")
 addSbtPlugin("org.scala-native"   % "sbt-scala-native" % "0.5.12")
-addSbtPlugin("org.scalameta"      % "sbt-mdoc"         % "2.9.0")
+addSbtPlugin("org.scalameta"      % "sbt-mdoc"         % "2.9.1")
 addSbtPlugin("org.scalameta"      % "sbt-munit"        % "1.3.4")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.8")

--- a/website/package.json
+++ b/website/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "start": "docusaurus start",
     "build": "docusaurus build",
-    "publish-gh-pages": "docusaurus deploy",
+    "deploy": "docusaurus deploy",
     "docusaurus": "docusaurus",
     "serve": "docusaurus serve",
     "swizzle": "docusaurus swizzle"


### PR DESCRIPTION
sbt-mdoc 2.9.1 defaults docusaurusVersion to V3, which publishes via `yarn deploy` (2.9.0 used `yarn publish-gh-pages`). Rename the website publish script to `deploy` to match; still `docusaurus deploy` underneath.