### PR TITLE
Release: build on JDK 17, pin Scala 2 JVM to Java 8

### DIFF
--- a/.github/workflows/release-custom.yml
+++ b/.github/workflows/release-custom.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up JVM
         uses: actions/setup-java@v5
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1

--- a/.github/workflows/release-js.yml
+++ b/.github/workflows/release-js.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up JVM
         uses: actions/setup-java@v5
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up JVM
         uses: actions/setup-java@v5
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1

--- a/build.sbt
+++ b/build.sbt
@@ -595,6 +595,11 @@ lazy val sharedSettings = Def.settings(
     else Nil
   },
   scalacOptions ++= Seq("-feature", "-unchecked"),
+  // Target Java 8 bytecode for Scala 2 JVM artifacts regardless of the
+  // build JDK, so releases built on newer JDKs still run on JDK 8. Scala 3
+  // (3.8+) is built with JDK 17 and needs no -release flag.
+  scalacOptions ++=
+    { if (!isScala3.value && isPlatform(JVMPlatform).value) Seq("-release", "8") else Nil },
   Compile / doc / scalacOptions ++=
     { if (!isScala3.value) Seq("-implicits", "-implicits-hide:.", "-groups") else Seq("-groups") },
   Test / parallelExecution := false, // hello, reflection sync!!


### PR DESCRIPTION
The release workflows compiled JS/Native on JDK 8, which the toolchain no longer supports (17+), and JDK 8 could not build the published Scala 3 (3.8.4, needs JDK 17). Bump release.yml, release-js.yml and release-custom.yml to JDK 17.

Nothing pinned the bytecode target before — JVM artifacts were Java 8 only because they were compiled on JDK 8. Add -release:8 for Scala 2 JVM so a JDK 17 build still emits Java 8 bytecode (verified: major version 52). Scala 3 (3.8+) targets JDK 17 and needs no flag; JS/Native have no JVM target.