### PR TITLE
Build: honor SCALAMETA_PLATFORM for semanticdb-shared

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -142,7 +142,6 @@ lazy val semanticdbShared = crossProject(allPlatforms: _*).in(file("semanticdb/s
   .settings(
     moduleName := "semanticdb-shared",
     sharedSettings,
-    publishJVMSettings,
     libraryDependencies += {
       val ver = if (isScala3.value) EarliestScala213 else scalaVersion.value
       "org.scala-lang" % "scalap" % ver
@@ -151,6 +150,7 @@ lazy val semanticdbShared = crossProject(allPlatforms: _*).in(file("semanticdb/s
     protobufSettings,
     description := "Library defining SemanticDB data structures",
   ).dependsOn(scalameta).nativeSettings(nativeSettings).jsSettings(commonJsSettings)
+  .configureCross(crossPlatformPublishSettings)
 
 lazy val semanticdbScalacPlugin = project.in(file("semanticdb/scalac/plugin")).settings(
   moduleName := "semanticdb-scalac",


### PR DESCRIPTION
semanticdbShared is a crossProject(allPlatforms) but applied publishJVMSettings in its shared settings. That setting keys the publish/non-publish decision off whether *JVM* should build and applies it to all three variants, so the JS/Native variants ignored the per-platform filter: with SCALAMETA_PLATFORM=JVM they published anyway (and with =JS/=Native none of semanticdbShared published in that leg).

Wire it through crossPlatformPublishSettings like the other crossProjects so each variant follows its own platform. Verified: a JVM-only publishM2 now emits no JS/Native jars, and publish/skip is false only under the matching SCALAMETA_PLATFORM.