### PR TITLE
CI: cancel superseded runs via concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
     branches:
       - main
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   testOther:
     name: ${{ matrix.command }}


### PR DESCRIPTION
Add a concurrency group keyed on workflow + ref with cancel-in-progress, so pushing again to a branch/PR cancels its now-obsolete in-flight run instead of letting stale runs finish.