### PR TITLE
contrib: make structural equality stack-safe

### DIFF
--- a/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/equality/Structurally.scala
+++ b/scalameta/contrib/shared/src/main/scala/scala/meta/contrib/equality/Structurally.scala
@@ -26,18 +26,40 @@ object Structurally {
 
   def equal(a: Tree, b: Tree): Boolean = loopStructure(a, b)
 
-  private def loopStructure(x: Any, y: Any): Boolean = (x, y) match {
-    case (x, y) if x == null || y == null => x == null && y == null
-    case (Some(x), Some(y)) => loopStructure(x, y)
-    case (None, None) => true
-    case (xs: List[_], ys: List[_]) =>
-      xs.length == ys.length && xs.zip(ys).forall { case (x, y) => loopStructure(x, y) }
-    case (x: Tree, y: Tree) =>
-      def sameStructure = x.productPrefix == y.productPrefix &&
-        loopStructure(x.productIterator.toList, y.productIterator.toList)
-
-      sameStructure
-    case _ => x == y
+  // Iterative (deeply nested trees would otherwise overflow the stack).
+  // Children are pushed
+  // onto an explicit worklist instead of recursing; comparison short-circuits
+  // on the first mismatch.
+  private def loopStructure(x0: Any, y0: Any): Boolean = {
+    // Push directly onto `stack` (rather than via a helper def) so it stays a
+    // local var; capturing it in a nested def would lift it to a heap ObjectRef.
+    var stack: List[(Any, Any)] = (x0, y0) :: Nil
+    while (stack.nonEmpty) {
+      val (x, y) = stack.head
+      stack = stack.tail
+      (x, y) match {
+        case (x, y) if x == null || y == null => if (x != null || y != null) return false
+        case (x: Tree, y: Tree) =>
+          if (x.productPrefix != y.productPrefix) return false
+          val xl = x.productArity
+          if (xl != y.productArity) return false
+          var i = 0
+          while (i < xl) {
+            stack = (x.productElement(i), y.productElement(i)) :: stack
+            i += 1
+          }
+        case (Some(x), Some(y)) => stack = (x, y) :: stack
+        case (None, None) =>
+        case (xs: Iterable[_], ys: Iterable[_]) =>
+          val xi = xs.iterator
+          val yi = ys.iterator
+          while (xi.hasNext)
+            if (yi.hasNext) stack = (xi.next(), yi.next()) :: stack else return false
+          if (yi.hasNext) return false
+        case _ => if (x != y) return false
+      }
+    }
+    true
   }
 
   implicit def StructuralEq[A <: Tree]: Equal[Structurally[A]] = new Equal[Structurally[A]] {

--- a/tests/jvm/src/test/scala/scala/meta/tests/StackSafetySuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/StackSafetySuite.scala
@@ -1,0 +1,55 @@
+package scala.meta.tests
+
+import scala.meta._
+import scala.meta.contrib._
+
+import munit.FunSuite
+
+/**
+ * Deeply nested trees must not overflow the stack in any core tree algorithm. See
+ * https://github.com/scalameta/scalameta/issues/2509.
+ *
+ * These cases assert the current behavior -- overflow -- and later commits make each algorithm
+ * stack-safe and flip the assertions to expect success. `intercept`/`interceptMessage` use
+ * `NonFatal`, which does not catch `StackOverflowError`, so the overflow cases use an explicit
+ * `try`/`catch`.
+ */
+class StackSafetySuite extends FunSuite {
+
+  private val depth = 20000
+
+  private def expectStackOverflow(load: => Any): Unit =
+    try {
+      load
+      fail("expected StackOverflowError")
+    } catch { case _: StackOverflowError => }
+
+  test("deeply nested tree - structural equality") {
+    val a = TestHelpers.deepTree(depth)
+    val b = TestHelpers.deepTree(depth)
+    def load() = a.isEqual(b)
+    expectStackOverflow(load())
+  }
+
+  test("deeply nested tree - transform") {
+    val tree = TestHelpers.deepTree(depth)
+    def load() = tree.transform { case Term.Name("x") => Term.Name("y") }
+    expectStackOverflow(load())
+  }
+
+  test("deeply nested tree - structure") {
+    // build the structure Result rather than rendering it: a deep tree's
+    // `.structure` string is O(depth^2) and would exhaust the heap. This
+    // exercises the construction; the render is covered by the syntax case.
+    val tree = TestHelpers.deepTree(depth)
+    def load() = implicitly[Structure[Tree]].apply(tree)
+    expectStackOverflow(load())
+  }
+
+  test("deeply nested tree - syntax") {
+    val tree = TestHelpers.deepTree(depth)
+    def load() = tree.printSyntaxFor(scala.meta.dialects.Scala213)
+    expectStackOverflow(load())
+  }
+
+}

--- a/tests/jvm/src/test/scala/scala/meta/tests/StackSafetySuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/StackSafetySuite.scala
@@ -28,7 +28,7 @@ class StackSafetySuite extends FunSuite {
     val a = TestHelpers.deepTree(depth)
     val b = TestHelpers.deepTree(depth)
     def load() = a.isEqual(b)
-    expectStackOverflow(load())
+    assert(load())
   }
 
   test("deeply nested tree - transform") {

--- a/tests/shared/src/test/scala/scala/meta/tests/TestHelpers.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/TestHelpers.scala
@@ -41,4 +41,19 @@ object TestHelpers {
 
   case class TestCase[A](obj: A)(implicit val loc: munit.Location)
 
+  /**
+   * A left-leaning `f.f.….f.x` spine of the given depth. Mirrors the pathological chained
+   * `Select`/`Apply` structure (e.g. Kafka's `KafkaConfig`) that overflows recursive tree
+   * algorithms. Built with a loop, so constructing it is itself stack-safe.
+   */
+  def deepTree(depth: Int): Term = {
+    var t: Term = Term.Name("x")
+    var i = 0
+    while (i < depth) {
+      t = Term.Select(t, Term.Name("f"))
+      i += 1
+    }
+    t
+  }
+
 }


### PR DESCRIPTION
Structurally.loopStructure recursed through the tree, overflowing the stack on deeply nested inputs. Replace the recursion with an explicit worklist of (x, y) pairs; comparison still short-circuits on the first mismatch. Helps with #2509.