### PR TITLE
transversers: add the transform and transformNode

### DIFF
--- a/scala3-tree-lifts/macro/src/main/scala/org/scalameta/adt/TransversersGenerate.scala
+++ b/scala3-tree-lifts/macro/src/main/scala/org/scalameta/adt/TransversersGenerate.scala
@@ -78,7 +78,7 @@ class TransversersGenerateMacros(val c: Context) extends GenerateHelper with Ast
       val fname = f.name.toString
       val code = f.tpe match {
         case tpe @ TreeTpe() =>
-          s"""|          val to = apply(original)
+          s"""|          val to = transformChild(original)
               |          to match {
               |            case to: ${getTpeName(tpe)} =>
               |              if (original ne to) same = false
@@ -90,7 +90,7 @@ class TransversersGenerateMacros(val c: Context) extends GenerateHelper with Ast
         case OptionTreeTpe(tpe) =>
           s"""|          original match {
               |            case Some(from) =>
-              |              apply(from) match {
+              |              transformChild(from) match {
               |                case to: ${getTpeName(tpe)} =>
               |                  if (from eq to) original
               |                  else { same = false; Some(to) }
@@ -105,7 +105,7 @@ class TransversersGenerateMacros(val c: Context) extends GenerateHelper with Ast
           s"""|          var samelist = true
               |          val tolist = List.newBuilder[$elemType]
               |          original.foreach { from =>
-              |            apply(from) match {
+              |            transformChild(from) match {
               |              case to: $elemType =>
               |                if (from ne to) samelist = false
               |                tolist += to
@@ -143,8 +143,8 @@ class TransversersGenerateMacros(val c: Context) extends GenerateHelper with Ast
       s"""|package scala.meta
           |package transversers
           |
-          |abstract class Transformer {
-          |  def apply(tree: scala.meta.Tree): scala.meta.Tree = {
+          |abstract class Transformer extends scala.meta.transversers.TransformerBase {
+          |  protected def apply(tree: scala.meta.Tree): scala.meta.Tree = {
           |    tree match {
           |      case t: scala.meta.Term => applyTerm(t)
           |      case t: scala.meta.Type => applyType(t)

--- a/scalameta/common2/shared/src/main/scala/scala/meta/internal/transversers/transformer.scala
+++ b/scalameta/common2/shared/src/main/scala/scala/meta/internal/transversers/transformer.scala
@@ -13,13 +13,15 @@ class transformer extends StaticAnnotation {
 class TransformerMacros(val c: Context) extends TransverserMacros {
   import c.universe._
 
+  override def applyModifiers: Modifiers = Modifiers(Flag.PROTECTED)
+
   def transformField(treeName: TermName)(f: Field): ValDef = {
     def treeTransformer(input: Tree, tpe: Type): Tree = {
       val from = c.freshName(TermName("from"))
       val to = c.freshName(TermName("to"))
       q"""
           val $from = $input
-          val $to = apply($from)
+          val $to = transformChild($from)
           $to match {
             case $to: ${hygienicRef(tpe.typeSymbol)} =>
               if ($from ne $to) same = false

--- a/scalameta/common2/shared/src/main/scala/scala/meta/internal/transversers/transverser.scala
+++ b/scalameta/common2/shared/src/main/scala/scala/meta/internal/transversers/transverser.scala
@@ -28,6 +28,10 @@ trait TransverserMacros extends MacroHelpers with AstReflection {
   def leafHandler(l: Leaf, treeName: TermName): Tree
   def leafHandlerType(): Tree
   def generatedMethods(): Tree
+  // Access of the generated primary `apply`. Public by default (Traverser); the
+  // transformer overrides it to `protected` so `apply` can only be reached via
+  // `transform`.
+  def applyModifiers: Modifiers = Modifiers()
 
   def impl(annottees: Tree*): Tree = annottees.transformAnnottees {
     new ImplTransformer {
@@ -83,7 +87,7 @@ trait TransverserMacros extends MacroHelpers with AstReflection {
     val restTree = getSecondaryApply("Rest", restBuilder.result())()
 
     q"""
-      def apply(tree: $TreeClass): ${leafHandlerType()} = {
+      $applyModifiers def apply(tree: $TreeClass): ${leafHandlerType()} = {
         tree match {
           case t: ${hygienicRef(TermAdt.sym)} => applyTerm(t)
           case t: ${hygienicRef(TypeAdt.sym)} => applyType(t)

--- a/scalameta/transversers/shared/src/main/scala/scala/meta/transversers/Api.scala
+++ b/scalameta/transversers/shared/src/main/scala/scala/meta/transversers/Api.scala
@@ -4,12 +4,9 @@ package transversers
 private[meta] trait Api extends VersionSpecificApis {
   implicit class XtensionCollectionLikeUI(tree: Tree) {
     // legacy calls
-    def transform(fn: PartialFunction[Tree, Tree]): Tree = {
-      object transformer extends Transformer {
-        override def apply(tree: Tree): Tree = super.apply(fn.applyOrElse(tree, identity[Tree]))
-      }
-      transformer(tree)
-    }
+    def transform(fn: PartialFunction[Tree, Tree]): Tree = new Transformer {
+      override protected def transformNode(tree: Tree): Tree = fn.applyOrElse(tree, identity[Tree])
+    }.transform(tree)
     def traverse(f: PartialFunction[Tree, Unit]): Unit = tree.dfs(f.applyOrElse(_, (_: Tree) => ()))
     def collect[A](f: PartialFunction[Tree, A]): List[A] = tree.dfsCollect(f)
   }

--- a/scalameta/transversers/shared/src/main/scala/scala/meta/transversers/TransformerBase.scala
+++ b/scalameta/transversers/shared/src/main/scala/scala/meta/transversers/TransformerBase.scala
@@ -1,0 +1,21 @@
+package scala.meta
+package transversers
+
+/**
+ * Base of the generated [[Transformer]].
+ *
+ * Override `transformNode` to map a node; `transform` applies it across the tree and rebuilds each
+ * node through the generated (protected) `apply`, which pulls each transformed child via
+ * `transformChild`.
+ */
+private[meta] abstract class TransformerBase {
+
+  protected def transformNode(node: Tree): Tree = node
+
+  protected def apply(tree: Tree): Tree
+
+  protected final def transformChild(tree: Tree): Tree = apply(transformNode(tree))
+
+  final def transform(root: Tree): Tree = transformChild(root)
+
+}

--- a/scalameta/transversers2/shared/src/main/scala/scala/meta/transversers/Transformer.scala
+++ b/scalameta/transversers2/shared/src/main/scala/scala/meta/transversers/Transformer.scala
@@ -2,4 +2,4 @@ package scala.meta
 package transversers
 
 @scala.meta.internal.transversers.transformer
-abstract class Transformer
+abstract class Transformer extends TransformerBase

--- a/tests/shared/src/test/scala/scala/meta/tests/transversers/TransformerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/transversers/TransformerSuite.scala
@@ -13,14 +13,10 @@ class TransformerSuite extends TreeSuiteBase {
         def bar(x: x) = ???
       }
     """
-    object transformer extends Transformer {
-      override def apply(tree: Tree): Tree = tree match {
-        case Term.Name("x") => Term.Name("y")
-        case Type.Name("x") => Type.Name("y")
-        case _ => super.apply(tree)
-      }
+    val tree1 = tree0.transform {
+      case Term.Name("x") => Term.Name("y")
+      case Type.Name("x") => Type.Name("y")
     }
-    val tree1 = transformer(tree0)
     assertEquals(
       tree1.toString,
       """|{
@@ -38,10 +34,7 @@ class TransformerSuite extends TreeSuiteBase {
         def bar(x: x) = ???
       }
     """
-    object transformer extends Transformer {
-      override def apply(tree: Tree): Tree = if (tree.toString == "x") q"y" else super.apply(tree)
-    }
-    intercept[UnsupportedOperationException](transformer(tree0))
+    intercept[UnsupportedOperationException](tree0.transform { case t if t.toString == "x" => q"y" })
   }
 
   test("Tree.transform") {


### PR DESCRIPTION
Introduce `transform` (the entry point) and `transformNode` (a per-node hook, default identity) on TransformerBase, and route the generated reconstruction's children through `transformChild`. Since the generated `apply` is protected, callers go through `transform` and customize by overriding `transformNode` rather than `apply`. Helps with #2509.