### PR TITLE
prettyprinters: leading brace from the tree

### DIFF
--- a/scalameta/common2/shared/src/main/scala/scala/meta/prettyprinters/Show.scala
+++ b/scalameta/common2/shared/src/main/scala/scala/meta/prettyprinters/Show.scala
@@ -133,61 +133,47 @@ private[meta] object Show {
       builder.result
     }
     final def isEmpty: Boolean = this eq None
-    def headChar: Option[Char]
   }
 
   final case object None extends Result {
     override def desc: String = "None"
-    def headChar: Option[Char] = Option.empty
   }
   final case class AsIs(value: String) extends Result {
     override def desc: String = s"AsIs($value)"
-    def headChar: Option[Char] = value.headOption
   }
   final case class Str(value: String) extends Result {
     override def desc: String = s"Str($value)"
-    def headChar: Option[Char] = value.headOption
   }
   final case class Sequence(xs: Result*) extends Result {
     override def desc: String = s"Sequence(#${xs.length})"
-    def headChar: Option[Char] = xs.view.flatMap(_.headChar).headOption
   }
   final case class Repeat(xs: Seq[Result], sep: String) extends Result {
     override def desc: String = s"Repeat(#${xs.length}, s=$sep)"
-    def headChar: Option[Char] = xs.view.flatMap(_.headChar).headOption
   }
   final case class Indent(res: Result) extends Result {
     override def desc: String = s"Indent(r=${res.desc})"
-    def headChar: Option[Char] = res.headChar
   }
   final case class Space(res: Result, space: String) extends Result {
     override def desc: String = s"NoSplit(r=${res.desc})"
-    def headChar: Option[Char] = res.headChar
   }
   final case object Blank extends Result {
     override def desc: String = s"Blank()"
-    def headChar: Option[Char] = Option.empty
   }
   final case class Newline(res: Result) extends Result {
     override def desc: String = s"Newline(r=${res.desc})"
-    def headChar: Option[Char] = Option.empty
   }
   final case class Meta(data: Any, res: Result) extends Result {
     override def desc: String = s"Meta(d=$data, r=${res.desc})"
-    def headChar: Option[Char] = res.headChar
   }
   final case class Wrap(prefix: String, res: Result, suffix: String) extends Result {
     override def desc: String = s"Wrap(p=$prefix, r=${res.desc}, s=$suffix)"
-    def headChar: Option[Char] = prefix.headOption.orElse(res.headChar)
   }
   final case class Function(fn: CharSequence => Result) extends Result {
     override def desc: String = s"Function(...)"
-    def headChar: Option[Char] = Option.empty
   }
 
   private final class Run(val run: () => Unit) extends Result {
     override def desc: String = "Run(...)"
-    override def headChar: Option[Char] = Option.empty
   }
 
   def apply[T](f: T => Result): Show[T] = new Show[T] {

--- a/scalameta/trees2/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees2/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -909,14 +909,33 @@ object TreeSyntax {
 
     implicit def syntaxCases: Syntax[Seq[CaseTree]] = Syntax(cases => r(cases.map(i(_))))
 
+    // Does this stat render with a leading `{` (which would misparse as a
+    // continuation of the previous stat)? Walk the leftmost spine -- the tree
+    // analog of the old `showStat.headChar.contains('{')`, which we can no
+    // longer use because the child render is now deferred.
+    @tailrec
+    private def guessLeadingBrace(t: Tree): Boolean = t match {
+      case _: Tree.Block | _: Template.Body | _: Term.PartialFunction => true
+      case t: Term.Select => guessLeadingBrace(t.qual)
+      case t: Term.SelectPostfix => guessLeadingBrace(t.qual)
+      case t: Term.Apply => guessLeadingBrace(t.fun)
+      case t: Term.ApplyUsing => guessLeadingBrace(t.fun)
+      case t: Term.ApplyInfix => guessLeadingBrace(t.lhs)
+      case t: Term.ApplyType => guessLeadingBrace(t.fun)
+      case t: Term.Ascribe => guessLeadingBrace(t.expr)
+      case t: Term.Assign => guessLeadingBrace(t.lhs)
+      case t: Term.Eta => guessLeadingBrace(t.expr)
+      case t: Term.Match => guessLeadingBrace(t.expr)
+      case _ => false
+    }
+
     private def printStats(stats: Seq[Stat]) = r {
       var prevStat: Stat = null
       stats.map { stat =>
         val showStat = i(stat)
         if (showStat.isEmpty) showStat
         else {
-          val needNL = null != prevStat && showStat.headChar.contains('{') &&
-            guessNeedsLineSep(prevStat)
+          val needNL = null != prevStat && guessLeadingBrace(stat) && guessNeedsLineSep(prevStat)
           prevStat = stat
           s(blank(needNL), showStat)
         }


### PR DESCRIPTION
printStats decided whether to line-separate a stat from the previous one by its rendered first char (showStat.headChar.contains('{')). Reading the rendered Result blocks deferring the child render, so compute it from the tree instead: guessLeadingBrace walks the leftmost spine, the analog of the existing guessNeedsLineSep. Drop Show.Result.headChar -- its only reader is gone. Helps with #2509.