### PR TITLE
trees: load lazy fields iteratively, not recursively

### DIFF
--- a/scalameta/common2/shared/src/main/scala/scala/meta/internal/trees/TyperMacros.scala
+++ b/scalameta/common2/shared/src/main/scala/scala/meta/internal/trees/TyperMacros.scala
@@ -40,17 +40,28 @@ class CommonTyperMacrosBundle(val c: Context) extends AdtReflection with MacroHe
 
   def loadField(f: c.Tree, s: c.Tree): c.Tree = {
     def lazyLoad(fn: c.Tree => c.Tree) = {
-      val q"this.$finternalName" = f
+      val q"$self.$finternalName" = f
+      val selfTpe = self.tpe
       val ownerName = c.internal.enclosingOwner.owner.name
       val externalName = AdtHelpers.getterName(finternalName.toString)
       val assertionMessage = s"internal error when initializing $ownerName.$externalName"
+      val proto = c.freshName(TermName("proto"))
+      // Walk the privatePrototype chain iteratively to the nearest ancestor whose
+      // field is already materialized, then reparent that value directly onto
+      // `this`. Recursing through the chain instead (via each prototype's getter)
+      // both overflows the stack and rebuilds progressively deeper lazy chains,
+      // making a full traversal O(n^2). The chain is walked via the base-typed
+      // `privatePrototype`, casting to this node's type to reach the field.
       q"""
         if ($f == null) {
           // there's not much sense in using org.scalameta.invariants.require here
           // because when the assertion trips, the tree is most likely in inconsistent state
           // which will either lead to useless printouts or maybe even worse errors
           _root_.scala.Predef.require(this.privatePrototype != null, $assertionMessage)
-          $f = ${fn(q"this.privatePrototype.${TermName(externalName)}")}
+          var $proto: $selfTpe = this
+          do $proto = $proto.privatePrototype.asInstanceOf[$selfTpe]
+          while ($proto.$finternalName == null)
+          $f = ${fn(q"$proto.$finternalName")}
         }
       """
     }

--- a/scalameta/testkit/jvm/src/main/scala/scala/meta/testkit/Corpus.scala
+++ b/scalameta/testkit/jvm/src/main/scala/scala/meta/testkit/Corpus.scala
@@ -72,8 +72,6 @@ object Corpus {
         "target/repos/scala/src/scaladoc/scala/tools/nsc/doc/html/page/Entity.scala",
         "target/repos/scala/src/scaladoc/scala/tools/nsc/doc/html/HtmlPage.scala",
         "target/repos/scala/src/scaladoc/scala/tools/nsc/doc/html/page/Template.scala",
-        // transformer fails with StackOverflow - https://github.com/scalameta/scalameta/issues/2509
-        "target/repos/kafka/core/src/main/scala/kafka/server/KafkaConfig.scala",
       ).exists(x.startsWith),
   )
 

--- a/tests/jvm/src/test/scala/scala/meta/tests/StackSafetySuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/StackSafetySuite.scala
@@ -39,6 +39,20 @@ class StackSafetySuite extends FunSuite {
     assert(renamed ne tree) // the spine was actually rebuilt
   }
 
+  // Unlike the others, this can't be captured upfront: before this fix its
+  // failure is an OutOfMemoryError (the O(n^2) reparenting copies exhaust the
+  // heap) that isn't cleanly catchable, so it is introduced as a positive test.
+  test("deeply nested tree - transform then structural equality") {
+    // EqualProps pattern: transform, then compare the outputs. The
+    // outputs are lazily materialized; traversing them (as isEqual does) must
+    // not overflow or blow up superlinearly.
+    val tree = TestHelpers.deepTree(depth)
+    val rename: PartialFunction[Tree, Tree] = { case Term.Name("f") => Term.Name("g") }
+    def load() = (tree.transform(rename), tree.transform(rename))
+    val (a, b) = load()
+    assert(a.isEqual(b))
+  }
+
   test("deeply nested tree - structure") {
     // build the structure Result rather than rendering it: a deep tree's
     // `.structure` string is O(depth^2) and would exhaust the heap. This


### PR DESCRIPTION
A tree's field getter materializes a lazy field with
```
      _field = privatePrototype.field.loadFieldForParent(this)
```
where `privatePrototype.field` calls the prototype's getter. On a deeply nested tree whose nodes form a long privatePrototype chain, this could overflow the stack; worse, it reparents through every level, rebuilding progressively deeper lazy chains.

Walk the chain iteratively instead to the nearest already-materialized ancestor, and reparent that value directly onto `this`. Helps with #2509.