### PR TITLE
prettyprinters: build tree printers lazily

### DIFF
--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -11,7 +11,7 @@ object Mima {
   val languageAgnosticCompatibilityPolicy: ProblemFilter = {
     case problem: TemplateProblem =>
       val ref = problem.ref
-      isPublicAndNotExcluded(ref.fullName, ref.isPublic && ref.scopedPrivateSuff.isEmpty)
+      isPublicAndNotExcluded(ref.fullName, ScalametaMimaUtils.isPublic(ref, null))
     case problem: MemberProblem =>
       val ref = problem.ref
       val accessible = ScalametaMimaUtils.isPublic(ref) &&

--- a/scalameta/common2/shared/src/main/scala/scala/meta/prettyprinters/Show.scala
+++ b/scalameta/common2/shared/src/main/scala/scala/meta/prettyprinters/Show.scala
@@ -99,7 +99,7 @@ private[meta] object Show {
           case AsIs(value) => appendAsIs(value)
           case Str(value) => append(value)
           case Blank => blank()
-          case m: Meta => stack = m.res :: stack
+          case m: Deferred => stack = m.res() :: stack
           case Function(fn) => stack = fn(sb) :: stack
           case Newline(res) =>
             nl()
@@ -162,8 +162,12 @@ private[meta] object Show {
   final case class Newline(res: Result) extends Result {
     override def desc: String = s"Newline(r=${res.desc})"
   }
-  final case class Meta(data: Any, res: Result) extends Result {
-    override def desc: String = s"Meta(d=$data, r=${res.desc})"
+  sealed class Deferred(val res: () => Result) extends Result {
+    override def desc: String = s"Deferred(...)"
+  }
+  // `data` can be consulted without materializing `res`
+  final class Meta(val data: Any, res: () => Result) extends Deferred(res) {
+    override def desc: String = s"Meta(d=$data, ...)"
   }
   final case class Wrap(prefix: String, res: Result, suffix: String) extends Result {
     override def desc: String = s"Wrap(p=$prefix, r=${res.desc}, s=$suffix)"
@@ -207,7 +211,11 @@ private[meta] object Show {
   def newline(): Result = Newline(None)
   def newline(res: Result): Result = if (res eq None) None else Newline(res)
 
-  def meta(data: Any, res: Result): Result = if (res eq None) None else Meta(data, res)
+  // body by-name + no eager None-elision: the child render is deferred, and
+  // serialize's `delay` mechanism elides empties dynamically instead.
+  def meta(data: Any, res: => Result): Result = new Meta(data, () => res)
+
+  def defer(res: => Result): Result = new Deferred(() => res)
 
   // wrap if non-empty
   def wrap(x: Result, suffix: => String): Result = if (x eq None) None else sequence(x, suffix)

--- a/scalameta/trees2/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeStructure.scala
+++ b/scalameta/trees2/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeStructure.scala
@@ -14,7 +14,10 @@ object TreeStructure {
 
   private def anyStructure(x: Any): Show.Result = x match {
     case el: String => s(DoubleQuotes(el))
-    case el: Tree => anyTree(el)
+    // Defer the child's structure so it is built lazily, one level at a time,
+    // by the iterative renderer -- a deep tree would otherwise overflow the
+    // stack while constructing the Result.
+    case el: Tree => Show.defer(anyTree(el))
     case None => s("None")
     case Some(el) => s("Some(", i(anyStructure(el)), n(")"))
     case el: List[_] => iterableStructure(el, "List")

--- a/scalameta/trees2/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
+++ b/scalameta/trees2/shared/src/main/scala/scala/meta/internal/prettyprinters/TreeSyntax.scala
@@ -55,7 +55,7 @@ object TreeSyntax {
             case ig: TreeSyntacticGroup => groupNeedsParens(og, ig)
             case _ => false
           })
-        w("(", x.res, ")", needParens)
+        w("(", x, ")", needParens)
       case res => res
     }
 
@@ -989,10 +989,8 @@ object TreeSyntax {
       case t => p(SimpleExpr, t)
     }
 
-    private def printSelect(t: Term.SelectLike, sep: String, bqExpr: Boolean = false) = {
-      val expr = printSelectLhs(t.qual, backquote = bqExpr)
-      m(Path, s(expr, sep, t.name))
-    }
+    private def printSelect(t: Term.SelectLike, sep: String, bqExpr: Boolean = false) =
+      m(Path, s(printSelectLhs(t.qual, backquote = bqExpr), sep, t.name))
 
     private def printMacroExprBody(t: Term, prefix: String) = {
       val body = t match {

--- a/tests/jvm/src/test/scala/scala/meta/tests/StackSafetySuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/StackSafetySuite.scala
@@ -59,13 +59,13 @@ class StackSafetySuite extends FunSuite {
     // exercises the construction; the render is covered by the syntax case.
     val tree = TestHelpers.deepTree(depth)
     def load() = implicitly[Structure[Tree]].apply(tree)
-    expectStackOverflow(load())
+    assert(!load().isEmpty)
   }
 
   test("deeply nested tree - syntax") {
     val tree = TestHelpers.deepTree(depth)
     def load() = tree.printSyntaxFor(scala.meta.dialects.Scala213)
-    expectStackOverflow(load())
+    assert(load().endsWith(".f"))
   }
 
 }


### PR DESCRIPTION
Defer each child behind a thunk (Deferred; Meta adds the paren group) so construction no longer recurses; serialize unfolds it. Fixes #2509.