### PR TITLE
Mima: detect private[meta] nested classes

### DIFF
--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -11,7 +11,7 @@ object Mima {
   val languageAgnosticCompatibilityPolicy: ProblemFilter = {
     case problem: TemplateProblem =>
       val ref = problem.ref
-      isPublicAndNotExcluded(ref.fullName, ref.isPublic && ref.scopedPrivateSuff.isEmpty)
+      isPublicAndNotExcluded(ref.fullName, ScalametaMimaUtils.isPublic(ref, null))
     case problem: MemberProblem =>
       val ref = problem.ref
       val accessible = ScalametaMimaUtils.isPublic(ref) &&


### PR DESCRIPTION
TemplateProblem filtered on the class's own access only, so a class nested in a private[meta] scope leaked through; route it through ScalametaMimaUtils.isPublic like the MemberProblem branch already does.