### PR TITLE
bugfix: Prevent double shading

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -630,6 +630,8 @@ lazy val mergeSettings = Def.settings(
       ShadeRule.rename(
         s"$pkg.SemanticdbPlugin" -> s"$pkg.SemanticdbPlugin",
         s"$pkg.SemanticdbPlugin$$" -> s"$pkg.SemanticdbPlugin$$",
+        // Prevent double-shading: if classes are already in the shaded package, keep them as-is.
+        s"$pkg.shaded_v$ver.**" -> s"$pkg.shaded_v$ver.@1",
         s"$pkg.**" -> s"$pkg.shaded_v$ver.@1",
       ).inAll,
     )


### PR DESCRIPTION
I was getting an error in Metals:
```
[error] /Users/tgodzik/Documents/metals/metals-bench/src/main/scala/bench/MetalsBench.scala:157:29: Symbol 'type scala.meta.internal.semanticdb.scalac.shaded_v4_17_2.shaded_v4_17_2.VersionCompilerOps' is missing from the classpath.
```
