### PR TITLE
CI: standardize every single-JDK job on JDK 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up JVM
         uses: actions/setup-java@v5
         with:
-          java-version: '25'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
@@ -41,10 +41,6 @@ jobs:
           - '2.12.21'
           - '2.13.18'
         java:
-          # Certify the JVM runtimes we support: oldest (floor) through
-          # newest. JS/Native are certified separately (testJsNative);
-          # their toolchain requires JDK 17+, so they don't belong here.
-          - '8'
           - '17'
           - '25'
     steps:
@@ -112,7 +108,7 @@ jobs:
       - name: Set up JVM
         uses: actions/setup-java@v5
         with:
-          java-version: '25'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
@@ -139,7 +135,7 @@ jobs:
       - name: Set up JVM
         uses: actions/setup-java@v5
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
@@ -170,7 +166,7 @@ jobs:
       - name: Set up JVM
         uses: actions/setup-java@v5
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'sbt'
       - run: ./bin/scalafmt --test

--- a/.github/workflows/release-semanticdb.yml
+++ b/.github/workflows/release-semanticdb.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up JVM
         uses: actions/setup-java@v5
         with:
-          java-version: '8'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1

--- a/.github/workflows/release-website.yml
+++ b/.github/workflows/release-website.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up JVM
         uses: actions/setup-java@v5
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1


### PR DESCRIPTION
This will allow us to re-group some of them, if they share a JDK.