### PR TITLE
CI: 5 balanced PR workers, full matrix post-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,164 +9,190 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Every Scala version lives here — bump in ONE place and all jobs follow.
+# Upgrade:
+#  - replace the previous oldest (scalaX_Y) with the previous latest (scalaX)
+#  - replace the previous latest (scalaX) with the new version
+#  - don't need to reorder scalaX_Y, they are not designed to be monotonic
+env:
+  scala33: '3.3.8'
+  scala38: '3.8.4'
+  # 2.13
+  scala213: '2.13.18'
+  scala213_1: '2.13.17'
+  scala213_2: '2.13.16'
+  scala213_3: '2.13.15'
+  # 2.12
+  scala212: '2.12.21'
+  scala212_1: '2.12.20'
+  scala212_2: '2.12.19'
+  scala212_3: '2.12.18'
+
+# Pre-merge gate (pr-* jobs): only the most critical checks, packed into a
+# few equal-length workers so it finishes about as fast as the work allows.
+# No event guard, so they run post-merge too, where the post-* jobs
+# (if: push) add everything else — one definition, no drift.
+
 jobs:
-  testOther:
-    name: ${{ matrix.command }}
+  post-jvm-other-jdks:
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        command:
-          - "++2.13.18; download-scala-library"
-          - "communitytest/test"
-          - "mima"
+        java: [ '25' ]
     steps:
-      - uses: actions/checkout@v7
+      - &checkout
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - name: Set up JVM
+      - &jdk
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
+          java-version: ${{ matrix.java || '17' }}
           distribution: 'temurin'
           cache: 'sbt'
-      - uses: sbt/setup-sbt@v1
-      - run: sbt '${{ matrix.command }}'
-  testLatestScala2OnJVM:
+      - &sbt
+        uses: sbt/setup-sbt@v1
+      - &testjvm212
+        if: ${{ !cancelled() }}
+        run: sbt ++${{ env.scala212 }} testsJVM/test
+      - &testsem212
+        if: ${{ !cancelled() }}
+        run: sbt ++${{ env.scala212 }} testsSemanticdb/test
+      - &testjvm213
+        if: ${{ !cancelled() }}
+        run: sbt ++${{ env.scala213 }} testsJVM/test
+      - &testsem213
+        if: ${{ !cancelled() }}
+        run: sbt ++${{ env.scala213 }} testsSemanticdb/test
+      - &testjvm33
+        if: ${{ !cancelled() }}
+        run: sbt ++${{ env.scala33 }} testsJVM/test
+      - &testjvm38
+        if: ${{ !cancelled() }}
+        run: sbt ++${{ env.scala38 }} testsJVM/test
+
+  # ===== PR gate: 5 balanced JDK-17 workers, run on PR *and* push (~8 min) =====
+  pr-mima: # MiMa binary-compatibility (the single heaviest atom)
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        scala:
-          - '2.12.21'
-          - '2.13.18'
-        java:
-          - '17'
-          - '25'
     steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - name: Set up JVM
-        uses: actions/setup-java@v5
-        with:
-          java-version: ${{ matrix.java }}
-          distribution: 'temurin'
-          cache: 'sbt'
-      - uses: sbt/setup-sbt@v1
-      - name: Test Parser on ${{ matrix.scala }} using JVM
-        run: sbt ++${{ matrix.scala }} testsJVM/test
-      - name: Test Semanticdb on ${{ matrix.scala }}
-        run: sbt ++${{ matrix.scala }} testsSemanticdb/test
-  testLatestScala3OnJVM:
+      - *checkout
+      - *jdk
+      - *sbt
+      - if: ${{ !cancelled() }}
+        run: sbt mima
+
+  pr-jvm212-sem212-js38: # latest 2.12 parser+semanticdb + latest-3 JS
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        scala:
-          - '3.3.8'
-          - '3.8.4'
-        java:
-          - '17'
-          - '25'
     steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - name: Set up JVM
-        uses: actions/setup-java@v5
-        with:
-          java-version: ${{ matrix.java }}
-          distribution: 'temurin'
-          cache: 'sbt'
-      - uses: sbt/setup-sbt@v1
-      - name: Test Parser on ${{ matrix.scala }} using JVM
-        run: sbt ++${{ matrix.scala }} testsJVM/test
-  testJsNative:
-    # JS/Native output is independent of the toolchain JDK (JS runs on
-    # Node, Native emits a binary), so we don't matrix the JDK here — one
-    # modern LTS suffices, and it must be 17+ (older JDKs warn/fail).
+      - *checkout
+      - *jdk
+      - *sbt
+      - *testjvm212
+      - *testsem212
+      - if: ${{ !cancelled() }}
+        run: sbt ++${{ env.scala38 }} testsJS/test
+
+  pr-jvm213-js33-other: # latest 2.13 parser + 3.3 JS + scala-library download
     runs-on: ubuntu-latest
-    # Scala Native's multithreaded GC uses trap-based (signal/page-fault)
-    # yieldpoints by default, which intermittently time out on CI runners
-    # and make the Native leg flaky. Disabling them at build time falls
-    # back to conditional yieldpoints; no-op for the JS leg.
+    steps:
+      - *checkout
+      - *jdk
+      - *sbt
+      - *testjvm213
+      - if: ${{ !cancelled() }}
+        run: sbt ++${{ env.scala33 }} testsJS/test
+      - if: ${{ !cancelled() }}
+        run: sbt '++${{ env.scala213 }}; download-scala-library'
+  
+  pr-jvm33-sem213-other: # 3.3 parser + 2.13 semanticdb + community + scalafmt
+    runs-on: ubuntu-latest
+    steps:
+      - *checkout
+      - *jdk
+      - *sbt
+      - *testjvm33
+      - *testsem213
+      - if: ${{ !cancelled() }}
+        run: sbt communitytest/test
+      - if: ${{ !cancelled() }}
+        run: ./bin/scalafmt --test
+
+  pr-jvm38-js2: # latest-3 parser + JS on both Scala 2 lines
+    runs-on: ubuntu-latest
+    steps:
+      - *checkout
+      - *jdk
+      - *sbt
+      - *testjvm38
+      - if: ${{ !cancelled() }}
+        run: sbt ++${{ env.scala212 }} testsJS/test
+      - if: ${{ !cancelled() }}
+        run: sbt ++${{ env.scala213 }} testsJS/test
+
+  # ===== post-merge superset: deferred axes, added only on push to main =====
+  post-native: # flaky Native leg — deferred off the PR gate, retried once
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    # Scala Native's trap-based GC yieldpoints intermittently time out on CI.
     env:
       SCALANATIVE_GC_TRAP_BASED_YIELDPOINTS: '0'
-    strategy:
-      fail-fast: false
-      matrix:
-        scala:
-          - '2.12.21'
-          - '2.13.18'
-          - '3.3.8'
-          - '3.8.4'
     steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - name: Set up JVM
-        uses: actions/setup-java@v5
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'sbt'
-      - uses: sbt/setup-sbt@v1
-      - name: Test Parser on ${{ matrix.scala }} using JS
-        run: sbt ++${{ matrix.scala }} testsJS/test
-      - name: Test Parser on ${{ matrix.scala }} using Native
-        run: sbt ++${{ matrix.scala }} testsNative/test
-  testOlderScalaOnJVM:
+      - *checkout
+      - *jdk
+      - *sbt
+      - if: ${{ !cancelled() }}
+        run: sbt ++${{ env.scala212 }} testsNative/test || sbt ++${{ env.scala212 }} testsNative/test
+      - if: ${{ !cancelled() }}
+        run: sbt ++${{ env.scala213 }} testsNative/test || sbt ++${{ env.scala213 }} testsNative/test
+      - if: ${{ !cancelled() }}
+        run: sbt ++${{ env.scala33 }} testsNative/test || sbt ++${{ env.scala33 }} testsNative/test
+      - if: ${{ !cancelled() }}
+        run: sbt ++${{ env.scala38 }} testsNative/test || sbt ++${{ env.scala38 }} testsNative/test
+
+  post-older-scala: # older 2.12/2.13 patches — parser + semanticdb
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        scala:
-          - '2.12.18'
-          - '2.12.19'
-          - '2.12.20'
-          - '2.13.15'
-          - '2.13.16'
-          - '2.13.17'
     steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-      - name: Set up JVM
-        uses: actions/setup-java@v5
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'sbt'
-      - uses: sbt/setup-sbt@v1
-      - name: Test Parser on ${{ matrix.scala }} using JVM
-        run: sbt '++${{ matrix.scala }}!; testsJVM/test'
-      - name: Test Semanticdb on ${{ matrix.scala }}
-        run: sbt ++${{ matrix.scala }} testsSemanticdb/test
-  windows:
+      - *checkout
+      - *jdk
+      - *sbt
+      - if: ${{ !cancelled() }}
+        run: sbt '++${{ env.scala213_1 }}!; testsJVM/test'
+      - if: ${{ !cancelled() }}
+        run: sbt ++${{ env.scala213_1 }} testsSemanticdb/test
+      - if: ${{ !cancelled() }}
+        run: sbt '++${{ env.scala213_2 }}!; testsJVM/test'
+      - if: ${{ !cancelled() }}
+        run: sbt ++${{ env.scala213_2 }} testsSemanticdb/test
+      - if: ${{ !cancelled() }}
+        run: sbt '++${{ env.scala213_3 }}!; testsJVM/test'
+      - if: ${{ !cancelled() }}
+        run: sbt ++${{ env.scala213_3 }} testsSemanticdb/test
+      - if: ${{ !cancelled() }}
+        run: sbt '++${{ env.scala212_1 }}!; testsJVM/test'
+      - if: ${{ !cancelled() }}
+        run: sbt ++${{ env.scala212_1 }} testsSemanticdb/test
+      - if: ${{ !cancelled() }}
+        run: sbt '++${{ env.scala212_2 }}!; testsJVM/test'
+      - if: ${{ !cancelled() }}
+        run: sbt ++${{ env.scala212_2 }} testsSemanticdb/test
+      - if: ${{ !cancelled() }}
+        run: sbt '++${{ env.scala212_3 }}!; testsJVM/test'
+      - if: ${{ !cancelled() }}
+        run: sbt ++${{ env.scala212_3 }} testsSemanticdb/test
+
+  post-windows: # Windows parser/JS/semanticdb (line-ending sensitivity)
+    if: ${{ github.event_name == 'push' }}
     name: Windows tests
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v7
       - uses: olafurpg/setup-scala@v14
-      - name: Test Parser on Windows using JVM
-        run: sbtx testsJVM/test
+      - run: sbtx testsJVM/test
         shell: bash
-      - name: Test Parser on Windows using JS
-        run: sbtx testsJS/test
+      - run: sbtx testsJS/test
         shell: bash
-      - name: Test Semanticdb on Windows
-        run: sbtx testsSemanticdb/test
+      - run: sbtx testsSemanticdb/test
         shell: bash
-  checks:
-    name: Scalafmt
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-      - name: Set up JVM
-        uses: actions/setup-java@v5
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'sbt'
-      - run: ./bin/scalafmt --test


### PR DESCRIPTION
A PR fired 25 jobs against the shared ~20-slot pool, so during dependabot/scala-steward storms they queued for hours (median ~2h wait) though the actual compute is only ~7 min. The enemy is the number of slot-requests, not per-job duration.

The PR gate is now 5 balanced ~8-min ubuntu/JDK-17 workers. They run on PR and push alike (no event guard); post-merge merely ADDS post-* jobs for the deferred axes -- other JDKs, the older Scala patches, the flaky Native leg (retried once), and Windows.