### PR TITLE
trees: allow an existential with an empty body

### DIFF
--- a/scalameta/trees2/shared/src/main/scala/scala/meta/Trees.scala
+++ b/scalameta/trees2/shared/src/main/scala/scala/meta/Trees.scala
@@ -784,7 +784,7 @@ object Type {
     override final def stats: List[Stat] = body.stats
   }
   @ast
-  class Existential(tpe: Type, body: Stat.Block @nonEmpty) extends Type with Tree.WithStatsBlock {
+  class Existential(tpe: Type, body: Stat.Block) extends Type with Tree.WithStatsBlock {
     checkField(body, body.stats.forall(_.isExistentialStat))
     @replacedField("4.9.9")
     override final def stats: List[Stat] = body.stats

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TypeSuite.scala
@@ -1,7 +1,6 @@
 package scala.meta.tests
 package parsers
 
-import org.scalameta.invariants.InvariantFailedException
 import scala.meta._
 import scala.meta.parsers.ParseException
 
@@ -73,10 +72,7 @@ class TypeSuite extends ParseSuite {
     Existential(pselect("a", "T"), Decl.Val(Nil, patvar("a") :: Nil, "A") :: Nil),
   ))
 
-  test("F[T] forSome {}") {
-    val err = intercept[InvariantFailedException](tpe("F[T] forSome {}")).getMessage
-    assert(err.contains("body should be non-empty"), err)
-  }
+  test("F[T] forSome {}")(assertTpe("F[T] forSome {}")(Existential(papply("F", "T"), Nil)))
 
   test("A | B is not a special type")(assertTpe("A | B")(pinfix("A", "|", "B")))
 

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/TypeSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/TypeSuite.scala
@@ -1,6 +1,7 @@
 package scala.meta.tests
 package parsers
 
+import org.scalameta.invariants.InvariantFailedException
 import scala.meta._
 import scala.meta.parsers.ParseException
 
@@ -71,6 +72,11 @@ class TypeSuite extends ParseSuite {
   test("a.T forSome { val a: A }")(assertTpe("a.T forSome { val a: A }")(
     Existential(pselect("a", "T"), Decl.Val(Nil, patvar("a") :: Nil, "A") :: Nil),
   ))
+
+  test("F[T] forSome {}") {
+    val err = intercept[InvariantFailedException](tpe("F[T] forSome {}")).getMessage
+    assert(err.contains("body should be non-empty"), err)
+  }
 
   test("A | B is not a special type")(assertTpe("A | B")(pinfix("A", "|", "B")))
 


### PR DESCRIPTION
`T forSome {}` parses unambiguously, and Type.Refine already accepts an empty body; whether the empty clause is legal is for the compiler.