### PR TITLE
TokensToString: replace unquote dollar with {$}

### DIFF
--- a/scalameta/tokens2/shared/src/main/scala/scala/meta/internal/prettyprinters/TokensToString.scala
+++ b/scalameta/tokens2/shared/src/main/scala/scala/meta/internal/prettyprinters/TokensToString.scala
@@ -35,6 +35,7 @@ object TokensToString {
             } else {
               val ch = chars(idx)
               if (Character.isWhitespace(ch)) sb.append(' ') // no newlines
+              else if (ch == '$') sb.append("{$}") // #4711 overzealous linter -Wmacros:after
               else if (ch != '`') sb.append(ch) // no backquotes
               true
             }

--- a/tests/shared/src/test/scala-3/scala/meta/tests/quasiquotes/Scala3SpecificSuccessSuite.scala
+++ b/tests/shared/src/test/scala-3/scala/meta/tests/quasiquotes/Scala3SpecificSuccessSuite.scala
@@ -15,12 +15,12 @@ class Scala3SpecificSuccessSuite extends TreeSuiteBase {
       """
     assertPositions(
       foo(Type.Name("AAA")),
-      """|<?>Defn.Class class AAA { val a: Int = 1 }</?> [0:...class `$name`:...:55)
-         |<tparamClause>Type.ParamClause         class `$name`@@:</tparamClause> [22::22)
-         |<ctor>Ctor.Primary         class `$name`@@:</ctor> [22::22)
-         |<templ>Template { val a: Int = 1 }</templ> [22<:...>48)
-         |<body>Template.Body { val a: Int = 1 }</body> [22<:...>48)
-         |<stats0>Defn.Val val a: Int = 1</stats0> [34:val a: Int = 1:48)
+      """|<?>Defn.Class class AAA { val a: Int = 1 }</?> [0:...class `{$}name`:...:57)
+         |<tparamClause>Type.ParamClause         class `{$}name`@@:</tparamClause> [24::24)
+         |<ctor>Ctor.Primary         class `{$}name`@@:</ctor> [24::24)
+         |<templ>Template { val a: Int = 1 }</templ> [24<:...>50)
+         |<body>Template.Body { val a: Int = 1 }</body> [24<:...>50)
+         |<stats0>Defn.Val val a: Int = 1</stats0> [36:val a: Int = 1:50)
          |""".stripMargin,
       showPosition = true,
       showFieldName = true,
@@ -36,12 +36,12 @@ class Scala3SpecificSuccessSuite extends TreeSuiteBase {
       """
     assertPositions(
       foo(Type.Name("AAA")),
-      """|<?>Defn.Class class AAA { val a: Int = 1 }</?> [0:...class `$name`:...:55)
-         |<tparamClause>Type.ParamClause         class `$name`@@:</tparamClause> [22::22)
-         |<ctor>Ctor.Primary         class `$name`@@:</ctor> [22::22)
-         |<templ>Template { val a: Int = 1 }</templ> [22<:...>48)
-         |<body>Template.Body { val a: Int = 1 }</body> [22<:...>48)
-         |<stats0>Defn.Val val a: Int = 1</stats0> [34:val a: Int = 1:48)
+      """|<?>Defn.Class class AAA { val a: Int = 1 }</?> [0:...class `{$}name`:...:57)
+         |<tparamClause>Type.ParamClause         class `{$}name`@@:</tparamClause> [24::24)
+         |<ctor>Ctor.Primary         class `{$}name`@@:</ctor> [24::24)
+         |<templ>Template { val a: Int = 1 }</templ> [24<:...>50)
+         |<body>Template.Body { val a: Int = 1 }</body> [24<:...>50)
+         |<stats0>Defn.Val val a: Int = 1</stats0> [36:val a: Int = 1:50)
          |""".stripMargin,
       showPosition = true,
       showFieldName = true,
@@ -80,19 +80,19 @@ class Scala3SpecificSuccessSuite extends TreeSuiteBase {
     assertTokensAsStructureLines(
       quoted.tokens,
       """|BOF [0..0)
-         |Ident(${fooTypes(0)}) [0..16)
-         |Semicolon [16..17)
-         |Space [17..18)
-         |Constant.String(any message) [18..31)
-         |EOF [31..31)
+         |Ident({$}{fooTypes(0)}) [0..18)
+         |Semicolon [18..19)
+         |Space [19..20)
+         |Constant.String(any message) [20..33)
+         |EOF [33..33)
          |""".stripMargin,
     )
     val pos = quoted.pos
-    assertNoDiff(pos.toString, """[0,31) in str(`${fooTypes(0)}`; "any message")""")
-    assertNoDiff(pos.text, """`${fooTypes(0)}`; "any message"""")
+    assertNoDiff(pos.toString, """[0,33) in str(`{$}{fooTypes(0)}`; "any message")""")
+    assertNoDiff(pos.text, """`{$}{fooTypes(0)}`; "any message"""")
     assertPositions(
       quoted,
-      """|<stats1>Lit.String "any message"</stats1> [18:"any message":31)
+      """|<stats1>Lit.String "any message"</stats1> [20:"any message":33)
          |""".stripMargin,
       showPosition = true,
       showFieldName = true,

--- a/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/DottySuccessSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/DottySuccessSuite.scala
@@ -193,19 +193,19 @@ class DottySuccessSuite extends TreeSuiteBase {
     assertTokensAsStructureLines(
       quoted.tokens,
       """|BOF [0..0)
-         |Ident(${fooTypes(0)}) [0..16)
-         |Semicolon [16..17)
-         |Space [17..18)
-         |Constant.String(any message) [18..31)
-         |EOF [31..31)
+         |Ident({$}{fooTypes(0)}) [0..18)
+         |Semicolon [18..19)
+         |Space [19..20)
+         |Constant.String(any message) [20..33)
+         |EOF [33..33)
          |""".stripMargin,
     )
     val pos = quoted.pos
-    assertNoDiff(pos.toString, """[0,31) in str(`${fooTypes(0)}`; "any message")""")
-    assertNoDiff(pos.text, """`${fooTypes(0)}`; "any message"""")
+    assertNoDiff(pos.toString, """[0,33) in str(`{$}{fooTypes(0)}`; "any message")""")
+    assertNoDiff(pos.text, """`{$}{fooTypes(0)}`; "any message"""")
     assertPositions(
       quoted,
-      """|<stats1>Lit.String "any message"</stats1> [18:"any message":31)
+      """|<stats1>Lit.String "any message"</stats1> [20:"any message":33)
          |""".stripMargin,
       showPosition = true,
       showFieldName = true,
@@ -232,19 +232,19 @@ class DottySuccessSuite extends TreeSuiteBase {
       quoted.tokens,
       """|BOF [0..0)
          |Comment( .. ) [0..8)
-         |Ident($terms) [8..16)
-         |Semicolon [16..17)
-         |Space [17..18)
-         |Constant.String(any message) [18..31)
-         |EOF [31..31)
+         |Ident({$}terms) [8..18)
+         |Semicolon [18..19)
+         |Space [19..20)
+         |Constant.String(any message) [20..33)
+         |EOF [33..33)
          |""".stripMargin,
     )
     val pos = quoted.pos
-    assertNoDiff(pos.toString, """[0,31) in str(/* .. */`$terms`; "any message")""")
-    assertNoDiff(pos.text, """/* .. */`$terms`; "any message"""")
+    assertNoDiff(pos.toString, """[0,33) in str(/* .. */`{$}terms`; "any message")""")
+    assertNoDiff(pos.text, """/* .. */`{$}terms`; "any message"""")
     assertPositions(
       quoted,
-      """|<stats1>Lit.String "any message"</stats1> [18:"any message":31)
+      """|<stats1>Lit.String "any message"</stats1> [20:"any message":33)
          |""".stripMargin,
       showPosition = true,
       showFieldName = true,

--- a/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -2461,4 +2461,15 @@ class SuccessSuite extends TreeSuiteBase {
     assertNoDiff(quoted.reprint, syntax)
     assertTree(quoted)(blk(tname("Foo"), lit("any message")))
   }
+
+  test("#4711 unquote in generated origin input") {
+    val terms = List(q"a")
+    val x = terms.head
+    def inputText(tree: Tree): String = tree.origin match {
+      case y: Origin.ParsedSpliced => y.input.text
+      case y => fail(s"origin doesn't match: $y")
+    }
+    assertNoDiff(inputText(q"$x.b"), "`$x`.b")
+    assertNoDiff(inputText(q"${terms(0)}.c"), "`${terms(0)}`.c")
+  }
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -2394,19 +2394,19 @@ class SuccessSuite extends TreeSuiteBase {
     assertTokensAsStructureLines(
       quoted.tokens,
       """|BOF [0..0)
-         |Ident(${fooTypes(0)}) [0..16)
-         |Semicolon [16..17)
-         |Space [17..18)
-         |Constant.String(any message) [18..31)
-         |EOF [31..31)
+         |Ident({$}{fooTypes(0)}) [0..18)
+         |Semicolon [18..19)
+         |Space [19..20)
+         |Constant.String(any message) [20..33)
+         |EOF [33..33)
          |""".stripMargin,
     )
     val pos = quoted.pos
-    assertNoDiff(pos.toString, """[0,31) in str(`${fooTypes(0)}`; "any message")""")
-    assertNoDiff(pos.text, """`${fooTypes(0)}`; "any message"""")
+    assertNoDiff(pos.toString, """[0,33) in str(`{$}{fooTypes(0)}`; "any message")""")
+    assertNoDiff(pos.text, """`{$}{fooTypes(0)}`; "any message"""")
     assertPositions(
       quoted,
-      """|<stats1>Lit.String "any message"</stats1> [18:"any message":31)
+      """|<stats1>Lit.String "any message"</stats1> [20:"any message":33)
          |""".stripMargin,
       showPosition = true,
       showFieldName = true,
@@ -2432,19 +2432,19 @@ class SuccessSuite extends TreeSuiteBase {
       quoted.tokens,
       """|BOF [0..0)
          |Comment( .. ) [0..8)
-         |Ident($terms) [8..16)
-         |Semicolon [16..17)
-         |Space [17..18)
-         |Constant.String(any message) [18..31)
-         |EOF [31..31)
+         |Ident({$}terms) [8..18)
+         |Semicolon [18..19)
+         |Space [19..20)
+         |Constant.String(any message) [20..33)
+         |EOF [33..33)
          |""".stripMargin,
     )
     val pos = quoted.pos
-    assertNoDiff(pos.toString, """[0,31) in str(/* .. */`$terms`; "any message")""")
-    assertNoDiff(pos.text, """/* .. */`$terms`; "any message"""")
+    assertNoDiff(pos.toString, """[0,33) in str(/* .. */`{$}terms`; "any message")""")
+    assertNoDiff(pos.text, """/* .. */`{$}terms`; "any message"""")
     assertPositions(
       quoted,
-      """|<stats1>Lit.String "any message"</stats1> [18:"any message":31)
+      """|<stats1>Lit.String "any message"</stats1> [20:"any message":33)
          |""".stripMargin,
       showPosition = true,
       showFieldName = true,
@@ -2469,7 +2469,7 @@ class SuccessSuite extends TreeSuiteBase {
       case y: Origin.ParsedSpliced => y.input.text
       case y => fail(s"origin doesn't match: $y")
     }
-    assertNoDiff(inputText(q"$x.b"), "`$x`.b")
-    assertNoDiff(inputText(q"${terms(0)}.c"), "`${terms(0)}`.c")
+    assertNoDiff(inputText(q"$x.b"), "`{$}x`.b")
+    assertNoDiff(inputText(q"${terms(0)}.c"), "`{$}{terms(0)}`.c")
   }
 }


### PR DESCRIPTION
That synthetic source ends up as a plain string literal in the macro expansion, and a hole's `$name` resolves at the call site by construction, so scalac's missing-interpolator lint flags it under `-Wmacros:after`. Fixes #4711.