### PR TITLE
Look up the tokenizer where there is no ServiceLoader

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -263,6 +263,7 @@ lazy val trees2 = crossProject(allPlatforms: _*).in(file("scalameta/trees2")).se
     val scalameta = base / "scalameta"
     List("tokenizers2", "tokens2", "dialects2", "inputs2").map(scalameta / _)
   }),
+  libraryDependencies += "org.portable-scala" %%% "portable-scala-reflect" % "1.1.3",
 ).configureCross(crossPlatformPublishSettings, crossPlatformShading).jsSettings(commonJsSettings)
   .nativeSettings(nativeSettings).dependsOn(common2, io)
 
@@ -450,8 +451,8 @@ lazy val testsSemanticdb = project.in(file("tests-semanticdb")).settings(
   crossScalaVersions := AllScala2Versions,
   testSettings,
   Test / fullClasspath := {
-    val semanticdbScalacJar = (semanticdbScalacPlugin / Compile / Keys.`package`).value
-      .getAbsolutePath
+    val semanticdbScalacJar =
+      (semanticdbScalacPlugin / Compile / Keys.`package`).value.getAbsolutePath
     sys.props("sbt.paths.semanticdb-scalac-plugin.compile.jar") = semanticdbScalacJar
     (Test / fullClasspath).value
   },
@@ -515,8 +516,8 @@ lazy val benchSemanticdb = project.in(file("bench/semanticdb")).enablePlugins(Bu
     buildInfoPackage := "scala.meta.internal.bench",
     Jmh / run := Def.inputTaskDyn {
       val args = spaceDelimited("<arg>").parsed
-      val semanticdbScalacJar = (semanticdbScalacPlugin / Compile / Keys.`package`).value
-        .getAbsolutePath
+      val semanticdbScalacJar =
+        (semanticdbScalacPlugin / Compile / Keys.`package`).value.getAbsolutePath
       val buf = List.newBuilder[String]
       buf += "org.openjdk.jmh.Main"
       buf ++= args

--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/ScalametaTokenizer.scala
@@ -11,6 +11,8 @@ import java.{util => ju}
 
 import scala.annotation.tailrec
 
+import org.portablescala.reflect.annotation.EnableReflectiveInstantiation
+
 class ScalametaTokenizer(input: Input, dialect: Dialect)(implicit options: TokenizerOptions) {
   import LegacyToken._
 
@@ -327,6 +329,7 @@ class ScalametaTokenizer(input: Input, dialect: Dialect)(implicit options: Token
 
 object ScalametaTokenizer {
 
+  @EnableReflectiveInstantiation
   object AsTokenize extends Tokenize {
     def apply(input: Input, dialect: Dialect): Tokenized = {
       def tokenize = {

--- a/scalameta/tokenizers2/shared/src/main/scala/scala/meta/tokenizers/Tokenize.scala
+++ b/scalameta/tokenizers2/shared/src/main/scala/scala/meta/tokenizers/Tokenize.scala
@@ -32,4 +32,9 @@ object Tokenize {
       throw new UnsupportedOperationException("No implementation of Tokenize service is provided")
   }
 
+  private[tokenizers] def loadScalametaTokenizer: Option[Tokenize] = org.portablescala.reflect
+    .Reflect
+    .lookupLoadableModuleClass("scala.meta.internal.tokenizers.ScalametaTokenizer$AsTokenize$")
+    .map(_.loadModule().asInstanceOf[Tokenize])
+
 }

--- a/scalameta/trees2/js/src/main/scala/scala/meta/tokenizers/PlatformCompat.scala
+++ b/scalameta/trees2/js/src/main/scala/scala/meta/tokenizers/PlatformCompat.scala
@@ -2,8 +2,7 @@ package scala.meta.tokenizers
 
 object PlatformCompat {
 
-  def loadTokenize(cl: ClassLoader): Option[Tokenize] = None
-
-  val loadTokenize: Option[Tokenize] = None
+  def loadTokenize(cl: ClassLoader): Option[Tokenize] = loadTokenize
+  lazy val loadTokenize: Option[Tokenize] = Tokenize.loadScalametaTokenizer
 
 }

--- a/scalameta/trees2/native/src/main/scala/scala/meta/tokenizers/PlatformCompat.scala
+++ b/scalameta/trees2/native/src/main/scala/scala/meta/tokenizers/PlatformCompat.scala
@@ -2,8 +2,7 @@ package scala.meta.tokenizers
 
 object PlatformCompat {
 
-  def loadTokenize(cl: ClassLoader): Option[Tokenize] = None
-
-  val loadTokenize: Option[Tokenize] = None
+  def loadTokenize(cl: ClassLoader): Option[Tokenize] = loadTokenize
+  lazy val loadTokenize: Option[Tokenize] = Tokenize.loadScalametaTokenizer
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizeServiceSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/tokenizers/TokenizeServiceSuite.scala
@@ -1,0 +1,15 @@
+package scala.meta.tests
+package tokenizers
+
+import scala.meta._
+
+import munit.FunSuite
+
+class TokenizeServiceSuite extends FunSuite {
+
+  test("a tree tokenizes without the parser having run") {
+    val tree = Term.ApplyInfix(Term.Name("a"), Term.Name("+"), Nil, List(Term.Name("b")))
+    assertEquals(tree.tokens.structure.isEmpty, false)
+  }
+
+}


### PR DESCRIPTION
The JVM finds it through the service file in trees; JS and Native found nothing and left Tokenize undefined, so a tree tokenized only if the parser had run first and registered it. portable-scala-reflect looks the module up by the name that file carries.