### PR TITLE
npm: inline the packaging, drop sbt-npm-package

### DIFF
--- a/.github/workflows/release-js.yml
+++ b/.github/workflows/release-js.yml
@@ -21,7 +21,7 @@ jobs:
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
       - name: Publish
-        run: sbt "parsersJS/npmPackageNpmrc; parsersJS/npmPackagePublish"
+        run: sbt parsersJS/npmPackagePublish
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/build.sbt
+++ b/build.sbt
@@ -287,6 +287,22 @@ lazy val trees = crossProject(allPlatforms: _*).in(file("scalameta/trees")).sett
   .configureCross(crossPlatformPublishSettings, crossPlatformShading).jsSettings(commonJsSettings)
   .nativeSettings(nativeSettings).dependsOn(common, io, trees2)
 
+def parsersJsSettings = Def.settings(
+  commonJsSettings,
+  // has to agree with the "type" NpmPackage writes into package.json
+  scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
+  NpmPackage.settings(
+    pkgName = "scalameta-parsers",
+    pkgDescription = "Library to parse Scala programs",
+    pkgRepository = "https://github.com/scalameta/scalameta",
+    pkgAuthor = "scalameta",
+    pkgLicense = "BSD-3-Clause",
+    pkgKeywords = Seq("scala", "parser"),
+    pkgHomepage = "https://scalameta.org/",
+    pkgReadme = file("README.npm.md"),
+  ),
+)
+
 lazy val parsers = crossProject(allPlatforms: _*).in(file("scalameta/parsers")).settings(
   moduleName := "parsers",
   sharedSettings,
@@ -313,21 +329,8 @@ lazy val parsers = crossProject(allPlatforms: _*).in(file("scalameta/parsers")).
       }
     } else Def.task(Seq.empty[File])
   }.taskValue,
-).configureCross(crossPlatformPublishSettings, crossPlatformShading)
-  .jsConfigure(_.enablePlugins(NpmPackagePlugin)).jsSettings(
-    commonJsSettings,
-    scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
-    npmPackageName := "scalameta-parsers",
-    npmPackageDescription := "Library to parse Scala programs",
-    npmPackageRepository := Some("https://github.com/scalameta/scalameta"),
-    npmPackageAuthor := "scalameta",
-    npmPackageLicense := Some("BSD-3-Clause"),
-    npmPackageKeywords := Seq("scala", "parser"),
-    npmPackageStage := org.scalajs.sbtplugin.Stage.FullOpt,
-    npmPackageAdditionalNpmConfig :=
-      Map("homepage" -> _root_.io.circe.Json.fromString("https://scalameta.org/")),
-    npmPackageREADME := Some(file("README.npm.md")),
-  ).nativeSettings(nativeSettings).dependsOn(trees)
+).configureCross(crossPlatformPublishSettings, crossPlatformShading).jsSettings(parsersJsSettings)
+  .nativeSettings(nativeSettings).dependsOn(trees)
 
 def mergedModule(
     projects: File => List[File] = _ => Nil,
@@ -451,8 +454,8 @@ lazy val testsSemanticdb = project.in(file("tests-semanticdb")).settings(
   crossScalaVersions := AllScala2Versions,
   testSettings,
   Test / fullClasspath := {
-    val semanticdbScalacJar =
-      (semanticdbScalacPlugin / Compile / Keys.`package`).value.getAbsolutePath
+    val semanticdbScalacJar = (semanticdbScalacPlugin / Compile / Keys.`package`).value
+      .getAbsolutePath
     sys.props("sbt.paths.semanticdb-scalac-plugin.compile.jar") = semanticdbScalacJar
     (Test / fullClasspath).value
   },
@@ -516,8 +519,8 @@ lazy val benchSemanticdb = project.in(file("bench/semanticdb")).enablePlugins(Bu
     buildInfoPackage := "scala.meta.internal.bench",
     Jmh / run := Def.inputTaskDyn {
       val args = spaceDelimited("<arg>").parsed
-      val semanticdbScalacJar =
-        (semanticdbScalacPlugin / Compile / Keys.`package`).value.getAbsolutePath
+      val semanticdbScalacJar = (semanticdbScalacPlugin / Compile / Keys.`package`).value
+        .getAbsolutePath
       val buf = List.newBuilder[String]
       buf += "org.openjdk.jmh.Main"
       buf ++= args

--- a/project/NpmPackage.scala
+++ b/project/NpmPackage.scala
@@ -1,0 +1,109 @@
+package org.scalameta
+package build
+
+import sbt.Keys._
+import sbt._
+
+import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
+
+/**
+ * Packaging for the one npm artifact this build publishes, scalameta-parsers.
+ *
+ * Replaces io.chrisdavenport:sbt-npm-package, which has no sbt 2 build. All it did for us was
+ * assemble four files and call `npm publish`.
+ */
+object NpmPackage {
+
+  val npmPackage = taskKey[File]("Assemble the npm package under target; returns its directory")
+  val npmPackagePublish = taskKey[Unit]("Publish the assembled npm package to the registry")
+
+  /* TODO(esm): should this package ship ES modules rather than CommonJS?
+   *
+   * Two settings have to agree, and both say CommonJS today. The linker's ModuleKind, set on the JS
+   * row in build.sbt, decides whether main.js speaks `require`/`module.exports` or
+   * `import`/`export`; package.json's "type" below tells Node which of the two to expect.
+   *
+   * Going ESM means ModuleKind.ESModule, "type": "module", and probably an "exports" map in place
+   * of the bare "main". The old objection was that CommonJS consumers then could not load the
+   * package at all. That is largely gone: require() of an ESM package is unflagged and stable in
+   * Node 20.19+ and 22.12+. What is left to weigh is older Node (the release workflow still pins
+   * 18, which cannot), bundlers that resolve "main" only, and whether to ship both formats from one
+   * package and route by "exports" condition.
+   *
+   * Left alone deliberately. It changes what consumers of scalameta-parsers receive, so it is a
+   * decision about the published package, not about the build.
+   */
+  private val packageType = "commonjs"
+
+  def settings(
+      pkgName: String,
+      pkgDescription: String,
+      pkgHomepage: String,
+      pkgRepository: String,
+      pkgAuthor: String,
+      pkgLicense: String,
+      pkgKeywords: Seq[String],
+      pkgReadme: File,
+  ): Seq[Setting[_]] = Seq(
+    npmPackage := {
+      val dir = crossTarget.value / "npm-package"
+      IO.delete(dir)
+      IO.createDirectory(dir)
+      // the linker already emits main.js and a main.js.map next to it
+      IO.copyDirectory((Compile / fullLinkJSOutput).value, dir)
+      IO.copyFile(pkgReadme, dir / "README.md")
+      IO.write(
+        dir / "package.json",
+        packageJson(
+          Seq(
+            "name" -> pkgName,
+            "version" -> version.value,
+            "description" -> pkgDescription,
+            "main" -> "main.js",
+            "type" -> packageType,
+            "homepage" -> pkgHomepage,
+            "repository" -> pkgRepository,
+            "author" -> pkgAuthor,
+            "license" -> pkgLicense,
+          ),
+          pkgKeywords,
+        ),
+      )
+      streams.value.log.info(s"assembled npm package $pkgName in $dir")
+      dir
+    },
+    npmPackagePublish := {
+      val dir = npmPackage.value
+      // npm expands ${NPM_TOKEN} when it reads this, so the token never reaches disk
+      IO.write(dir / ".npmrc", "//registry.npmjs.org/:_authToken=${NPM_TOKEN}\n")
+      npm(dir, streams.value.log, "publish")
+    },
+  )
+
+  private def packageJson(fields: Seq[(String, String)], keywords: Seq[String]): String = {
+    val entries = fields.map { case (k, v) => s"  ${quote(k)}: ${quote(v)}" } :+
+      s"  ${quote("keywords")}: [${keywords.map(quote).mkString(", ")}]"
+    entries.mkString("{\n", ",\n", "\n}\n")
+  }
+
+  private def quote(str: String): String = {
+    val sb = new StringBuilder("\"")
+    str.foreach {
+      case '"' => sb ++= "\\\""
+      case '\\' => sb ++= "\\\\"
+      case '\n' => sb ++= "\\n"
+      case c if c < ' ' => sb ++= f"\\u$c%04x"
+      case c => sb += c
+    }
+    sb.append('"').toString
+  }
+
+  private def npm(dir: File, log: Logger, args: String*): Unit = {
+    val exe =
+      if (sys.props("os.name").toLowerCase.contains("win")) Seq("cmd", "/c", "npm") else Seq("npm")
+    val logger = scala.sys.process.ProcessLogger(log.info(_), log.error(_))
+    val code = scala.sys.process.Process(exe ++ args, dir).!(logger)
+    if (code != 0) sys.error(s"npm ${args.mkString(" ")} failed with exit code $code")
+  }
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,7 +16,6 @@ addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.12.0")
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.8")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.6")
 
-addSbtPlugin("io.chrisdavenport" %% "sbt-npm-package" % "0.2.0")
 addSbtPlugin("io.get-coursier" % "sbt-shading" % "2.1.7")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % crossProjectV)


### PR DESCRIPTION
The plugin has no sbt 2 build, and no functional commit since December
2023. All it did here was assemble four files (main.js, its source map, README, package.json) and run `npm publish`, so that now lives in project/NpmPackage.scala.

It reads the linker's fullLinkJS output directory instead of fullOptJS. That directory already names the file main.js, so the rename and the source-map rewriting the plugin did are both gone. The publish task writes .npmrc itself, leaving the workflow one command instead of two.