### PR TITLE
sbt2 prep: drop two unused plugins

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,6 @@ val crossProjectV = "1.3.2"
 resolvers += Resolver.sonatypeCentralSnapshots
 
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.20"
-libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.4.1")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
@@ -22,7 +21,6 @@ addSbtPlugin("io.get-coursier" % "sbt-shading" % "2.1.7")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % crossProjectV)
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % crossProjectV)
 
-addSbtPlugin("org.scala-debugger" % "sbt-jdi-tools" % "1.1.1")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.22.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.12")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "2.9.1")


### PR DESCRIPTION
sbt-jdi-tools only ever added tools.jar, which no JDK past 8 has, and nothing enables it. scripted-plugin arrived with the scalahost sbt plugin in #683 and outlived it; there is no sbt-test tree and nothing enables ScriptedPlugin. Neither has an sbt 2 build, so they would have had to go at the switch regardless.