### PR TITLE
sbt2 prep: give the build its own platform axis

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,6 @@ import org.scalajs.linker.interface.StandardConfig
 
 import complete.DefaultParsers._
 import sbtcrossproject.CrossPlugin.autoImport.crossProject
-import sbtcrossproject.Platform
 
 def isCI = System.getenv("CI") != null
 
@@ -77,7 +76,15 @@ console := (scalameta.jvm / Compile / console).value
 Global / resolvers +=
   "scala-integration".at("https://scala-ci.typesafe.com/artifactory/scala-integration/")
 
+/**
+ * Which row a setting is being evaluated in. Only the source roots of a merged module need to name
+ * it; everything else gets its platform's settings handed to it directly.
+ */
+val platformAxis = settingKey[Platforms.Platform]("platform this project builds for")
+ThisBuild / platformAxis := Platforms.JVM
+
 val commonJsSettings = Seq(
+  platformAxis := Platforms.JS,
   crossScalaVersions := crossScalaVersions.value.flatMap(v =>
     CrossVersion.binaryScalaVersion(v) match {
       case "2.12" => Some(LatestScala212)
@@ -91,7 +98,7 @@ val commonJsSettings = Seq(
   scalaJSLinkerConfig := StandardConfig().withBatchMode(true),
   scalacOptions ++= {
     // scala3 specifically will invoke scala3TreeLiftsCodeGen which is a JVM project
-    if (isSnapshot.value || !isPlatform(JSPlatform).value) Seq.empty
+    if (isSnapshot.value || !isPlatform(Platforms.JS).value) Seq.empty
     else {
       val localDir = (ThisBuild / baseDirectory).value.toURI.toString
       val githubDir = "https://raw.githubusercontent.com/scalameta/scalameta"
@@ -102,6 +109,7 @@ val commonJsSettings = Seq(
 )
 
 lazy val nativeSettings = Seq(
+  platformAxis := Platforms.Native,
   bspEnabled := false,
   nativeConfig ~= {
     _.withMode(scalanative.build.Mode.releaseFast)
@@ -348,7 +356,7 @@ def mergedModule(
       res += project / "shared" / "src" / "main" / scalaBinary
       res += project / "shared" / "src" / "main" / scalaMajor
       res += project / "shared" / "src" / "main" / "scala"
-      res += project / crossProjectPlatform.value.identifier / "src" / "main" / "scala"
+      res += project / platformAxis.value.id / "src" / "main" / "scala"
     }
     res.result()
   }
@@ -556,14 +564,7 @@ lazy val isScala213 = isScalaBinaryVersion("2.13")
 lazy val isScala3 = isScalaBinaryVersion("3")
 def isScala213or3 = Def.setting(isScala213.value || isScala3.value)
 
-// NOTE: Here's what I'd like to do, but I can't because of deprecations:
-//   val isJVM = crossPlatform.value == JVMPlatform
-// Here's my second best guess, but it doesn't work due to some reason:
-//   val isJVM = platformDepsCrossVersion.value == CrossVersion.binary
-def isPlatform(platform: Platform) = Def.settingDyn(
-  if (crossProjectPlatform.?.value.isEmpty) Def.setting(platform == JVMPlatform)
-  else Def.setting(crossProjectPlatform.value == platform),
-)
+def isPlatform(platform: Platforms.Platform) = Def.setting(platformAxis.value == platform)
 
 lazy val sharedSettings = Def.settings(
   // version is set dynamically by sbt-dynver, but let's adjust it
@@ -603,7 +604,7 @@ lazy val sharedSettings = Def.settings(
   // build JDK, so releases built on newer JDKs still run on JDK 8. Scala 3
   // (3.8+) is built with JDK 17 and needs no -release flag.
   scalacOptions ++=
-    { if (!isScala3.value && isPlatform(JVMPlatform).value) Seq("-release", "8") else Nil },
+    { if (!isScala3.value && isPlatform(Platforms.JVM).value) Seq("-release", "8") else Nil },
   Compile / doc / scalacOptions ++=
     { if (!isScala3.value) Seq("-implicits", "-implicits-hide:.", "-groups") else Seq("-groups") },
   Test / parallelExecution := false, // hello, reflection sync!!
@@ -711,7 +712,7 @@ lazy val publishableSettings = Def.settings(
   pomIncludeRepository := { x => false },
   versionScheme := Some("semver-spec"),
   mimaPreviousArtifacts := {
-    if (organization.value == "org.scalameta" && isPlatform(JVMPlatform).value) {
+    if (organization.value == "org.scalameta" && isPlatform(Platforms.JVM).value) {
       val rxVersion = """^(\d+)\.(\d+)\.(\d+)(.+)?$""".r
       val previousVersion = version.value match {
         case rxVersion(major, "0", "0", suffix) if suffix != null =>
@@ -889,7 +890,8 @@ lazy val shadingSettings = Def.settings(
 )
 
 def platformPublishSettings(platform: sbtcrossproject.Platform) =
-  if (Platforms.shouldBuildPlatform(platform)) publishableSettings else nonPublishableSettings
+  if (Platforms.shouldBuildPlatform(Platforms(platform.identifier))) publishableSettings
+  else nonPublishableSettings
 
 def crossPlatformPublishSettings(project: sbtcrossproject.CrossProject) = project.projects.keys
   .foldLeft(project) { case (res, platform) =>

--- a/project/Platforms.scala
+++ b/project/Platforms.scala
@@ -2,18 +2,23 @@ object Platforms {
 
   private val envPlatform = "SCALAMETA_PLATFORM"
 
-  private val platforms: Map[String, sbtcrossproject.Platform] = Map(
-    "jvm" -> sbtcrossproject.JVMPlatform,
-    "js" -> scalajscrossproject.JSPlatform,
-    "native" -> scalanativecrossproject.NativePlatform,
-  )
+  /** The build's own platform axis. */
+  sealed abstract class Platform(val id: String) {
+    override def toString: String = id
+  }
 
-  private val platformOpt = Option(System.getenv(envPlatform)).map(_.trim.toLowerCase)
-    .filter(_.nonEmpty).map(x =>
-      platforms.get(x).getOrElse(throw new NoSuchElementException(s"Platform '$x' is unknown'")),
-    )
+  object JVM extends Platform("jvm")
+  object JS extends Platform("js")
+  object Native extends Platform("native")
 
-  def shouldBuildPlatform(platform: sbtcrossproject.Platform): Boolean = platformOpt.isEmpty ||
-    platformOpt.contains(platform)
+  val all: Seq[Platform] = Seq(JVM, JS, Native)
+
+  def apply(id: String): Platform = all.find(_.id == id)
+    .getOrElse(throw new NoSuchElementException(s"Platform '$id' is unknown"))
+
+  private val selected: Option[Platform] = Option(System.getenv(envPlatform)).map(_.trim.toLowerCase)
+    .filter(_.nonEmpty).map(apply)
+
+  def shouldBuildPlatform(platform: Platform): Boolean = selected.forall(_ == platform)
 
 }


### PR DESCRIPTION
isPlatform asked sbt-crossproject, via crossProjectPlatform, which row a setting was being evaluated in. projectMatrix has no such key, and the question would have degraded silently to "always JVM": JS and Native rows would have picked up -release 8 and been measured by MiMa.

So the axis becomes the build's own. Platforms gains a Platform type that owes nothing to sbt-crossproject, a platformAxis setting carries it, and each row declares itself through the settings every row of that platform already receives. ThisBuild defaults it to JVM, which is what isPlatform answered for non-cross projects.