### PR TITLE
sbt2 prep: compare MiMa only where a row is published

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,7 @@ val allPlatforms = Seq(JSPlatform, JVMPlatform, NativePlatform)
 lazy val semanticdbScalacCore = project.in(file("semanticdb/scalac/library")).settings(
   moduleName := "semanticdb-scalac-core",
   sharedJvmSettings,
-  publishJVMSettings,
+  publishJvmSettings,
   fullCrossVersionSettings,
   mimaPreviousArtifacts := Set.empty,
   buildInfoPackage := "scala.meta.internal.semanticdb.scalac",
@@ -116,7 +116,7 @@ lazy val semanticdbScalacPlugin = project.in(file("semanticdb/scalac/plugin")).s
   moduleName := "semanticdb-scalac",
   description := "Scalac 2.x compiler plugin that generates SemanticDB on compile",
   sharedJvmSettings,
-  publishJVMSettings,
+  publishJvmSettings,
   mimaPreviousArtifacts := Set.empty,
   mergeSettings,
   fullCrossVersionSettings,
@@ -140,7 +140,7 @@ lazy val semanticdbScalacPlugin = project.in(file("semanticdb/scalac/plugin")).s
 lazy val semanticdbMetac = project.in(file("semanticdb/metac")).settings(
   moduleName := "metac", // that was name chosen originally, must keep it
   sharedJvmSettings,
-  publishJVMSettings,
+  publishJvmSettings,
   fullCrossVersionSettings,
   mimaPreviousArtifacts := Set.empty,
   description := "Scalac 2.x launcher that generates SemanticDB on compile",
@@ -151,7 +151,7 @@ lazy val semanticdbMetac = project.in(file("semanticdb/metac")).settings(
 lazy val semanticdbMetap = project.in(file("semanticdb/metap")).settings(
   moduleName := "semanticdb-metap",
   sharedJvmSettings,
-  publishJVMSettings,
+  publishJvmSettings,
   fullCrossVersionSettings,
   mimaPreviousArtifacts := Set.empty,
   description := "Prints SemanticDB files",
@@ -161,7 +161,7 @@ lazy val semanticdbMetap = project.in(file("semanticdb/metap")).settings(
 lazy val semanticdbMetacp = project.in(file("semanticdb/metacp")).settings(
   moduleName := "semanticdb-metacp",
   sharedJvmSettings,
-  publishJVMSettings,
+  publishJvmSettings,
   fullCrossVersionSettings,
   mimaPreviousArtifacts := Set.empty,
   description := "Generates SemanticDB files for a classpath",

--- a/project/Extensions.scala
+++ b/project/Extensions.scala
@@ -95,19 +95,11 @@ object Extensions {
   lazy val adhocRepoUri = sys.props("scalameta.repository.uri")
   lazy val adhocRepoCredentials = sys.props("scalameta.repository.credentials")
   lazy val isCustomRepository = adhocRepoUri != null && adhocRepoCredentials != null
-  lazy val publishableSettings = Def.settings(
-    credentials ++= {
-      val credentialsFile =
-        if (adhocRepoCredentials != null) new File(adhocRepoCredentials) else null
-      if (credentialsFile != null) List(new FileCredentials(credentialsFile)) else Nil
-    },
-    Compile / publishArtifact := true,
-    Test / publishArtifact := false,
-    publishMavenStyle := true,
-    pomIncludeRepository := { x => false },
-    versionScheme := Some("semver-spec"),
+
+  /** MiMa has predecessors to compare against only on a JVM row that is published. */
+  lazy val jvmMimaSettings = Def.settings {
     mimaPreviousArtifacts := {
-      if (organization.value == "org.scalameta" && isPlatform(Platforms.JVM).value) {
+      if (organization.value == "org.scalameta") {
         val rxVersion = """^(\d+)\.(\d+)\.(\d+)(.+)?$""".r
         val previousVersion = version.value match {
           case rxVersion(major, "0", "0", suffix) if suffix != null =>
@@ -122,7 +114,21 @@ object Extensions {
         previousVersion.map(organization.value % moduleName.value % _ cross crossVersion.value)
           .toSet
       } else Set()
+    }
+  }
+
+  lazy val publishableSettings = Def.settings(
+    mimaPreviousArtifacts := Set.empty,
+    credentials ++= {
+      val credentialsFile =
+        if (adhocRepoCredentials != null) new File(adhocRepoCredentials) else null
+      if (credentialsFile != null) List(new FileCredentials(credentialsFile)) else Nil
     },
+    Compile / publishArtifact := true,
+    Test / publishArtifact := false,
+    publishMavenStyle := true,
+    pomIncludeRepository := { x => false },
+    versionScheme := Some("semver-spec"),
     mimaBinaryIssueFilters += Mima.languageAgnosticCompatibilityPolicy,
     mimaBinaryIssueFilters += Mima.scalaSpecificCompatibilityPolicy,
     mimaBinaryIssueFilters ++= Mima.apiCompatibilityExceptions,
@@ -207,7 +213,12 @@ object Extensions {
       val settings = platformPublishSettings(platform)
       if (settings.isEmpty) res else res.configurePlatform(platform)(_.settings(settings))
     }
-  val publishJVMSettings = platformPublishSettings(JVMPlatform)
+
+  /** A published JVM row, cross-built or not. */
+  lazy val publishJvmSettings =
+    if (Platforms.shouldBuildPlatform(Platforms.JVM)) Def
+      .settings(publishableSettings, jvmMimaSettings)
+    else nonPublishableSettings
 
   implicit class CrossProjectExtensions(private val self: CrossProject) extends AnyVal {
 
@@ -224,7 +235,7 @@ object Extensions {
     def crossAll: CrossProject = self.crossJvm().crossJs().crossNative()
 
     /** Per row, publishable or not, as SCALAMETA_PLATFORM selects. */
-    def published: CrossProject = self.jvmSettings(publishJVMSettings)
+    def published: CrossProject = self.jvmSettings(publishJvmSettings)
       .jsSettings(platformPublishSettings(JSPlatform))
       .nativeSettings(platformPublishSettings(NativePlatform))
 


### PR DESCRIPTION
The check sat in publishableSettings and asked whether the row was the JVM one, which every non-cross project also answered yes to. It now comes with the JVM row's publish settings, so a row that publishes nothing has no predecessor to compare against.

The baselines are the same either way today: the projects the old test would have measured set mimaPreviousArtifacts to empty by hand.