### PR TITLE
Spell out what scalapb's compilerplugin provided

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -609,16 +609,16 @@ lazy val protobufSettings = Def.settings(
   Compile / PB.targets := Seq(protocbridge.Target(
     generator = PB.gens.plugin("scala"),
     outputPath = (Compile / sourceManaged).value / "protobuf",
-    options = scalapb.gen(flatPackage =
-      true, // Don't append filename to package
-    )._2,
+    // what scalapb.gen(flatPackage = true) passes to protoc; spelled out so the meta-build needs
+    // no scalapb compilerplugin, whose Scala 3 build wants a different protoc-bridge than sbt-protoc
+    options = Seq("flat_package"),
   )),
   Compile / PB.protoSources := Seq(file("semanticdb/semanticdb/shared/src/main/proto")),
   PB.additionalDependencies := Nil,
   libraryDependencies ++= {
     val scalapbVersion =
       // for SIP-51, freeze version to the latest ScalaPB built against the earliest Scala 2.13.x version we support
-      if (scalaVersion.value == "2.13.15") "0.11.17" else scalapb.compiler.Version.scalapbVersion
+      if (scalaVersion.value == "2.13.15") "0.11.17" else "0.11.20"
     Seq(
       "com.thesamet.scalapb" %%% "scalapb-runtime" % scalapbVersion,
       "com.thesamet.scalapb" %%% "scalapb-runtime" % scalapbVersion % "protobuf",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,8 +4,6 @@ val crossProjectV = "1.3.2"
 
 resolvers += Resolver.sonatypeCentralSnapshots
 
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.20"
-
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.4.1")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
 


### PR DESCRIPTION
The meta-build took it for one protoc option and one version. Its Scala 3 build wants a different protoc-bridge than sbt-protoc does, and the two cannot share a classpath.