### PR TITLE
sbt2: switch to 2.0.7 and projectMatrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# This file names no Scala version. project/Versions.scala lists them, and a
-# step asks the build for what it needs: the newest patch of 2.12 or 2.13
-# (tests2_13_latest), all the older patches (tests2_12_older), the patch a
-# platform builds at (testsNative2_12), or a Scala 3 version by the label
-# Scala3Rows gives it (tests3_lts, tests3_next). Add or bump a version there
-# and this file stays as it is. `sbt alias` lists what CI can ask for.
+# This file names no Scala version (all listed in project/Versions.scala).
+# `sbt alias` lists what CI can ask for.
 
 # Pre-merge gate (pr-* jobs): only the most critical checks, packed into a
 # few equal-length workers so it finishes about as fast as the work allows.
@@ -56,10 +52,10 @@ jobs:
         run: sbt testsSemanticdb2_13_latest
       - &testjvm33
         if: ${{ !cancelled() }}
-        run: sbt tests3_lts
+        run: sbt tests3_lts/testFull
       - &testjvm38
         if: ${{ !cancelled() }}
-        run: sbt tests3_next
+        run: sbt tests3_next/testFull
 
   # ===== PR gate: 5 balanced JDK-17 workers, run on PR *and* push (~8 min) =====
   pr-mima: # MiMa binary-compatibility (the single heaviest atom)
@@ -80,7 +76,7 @@ jobs:
       - *testjvm212
       - *testsem212
       - if: ${{ !cancelled() }}
-        run: sbt testsJS3_next
+        run: sbt testsJS3_next/testFull
 
   pr-jvm213-js33-other: # latest 2.13 parser + 3.3 JS + scala-library download
     runs-on: ubuntu-latest
@@ -90,7 +86,7 @@ jobs:
       - *sbt
       - *testjvm213
       - if: ${{ !cancelled() }}
-        run: sbt testsJS3_lts
+        run: sbt testsJS3_lts/testFull
       - if: ${{ !cancelled() }}
         run: sbt download-scala-library
   
@@ -103,7 +99,7 @@ jobs:
       - *testjvm33
       - *testsem213
       - if: ${{ !cancelled() }}
-        run: sbt communitytest/test
+        run: sbt communitytest/testFull
       - if: ${{ !cancelled() }}
         run: ./bin/scalafmt --test
 
@@ -115,9 +111,9 @@ jobs:
       - *sbt
       - *testjvm38
       - if: ${{ !cancelled() }}
-        run: sbt testsJS2_12
+        run: sbt testsJS2_12/testFull
       - if: ${{ !cancelled() }}
-        run: sbt testsJS2_13
+        run: sbt testsJS/testFull
 
   # ===== post-merge superset: deferred axes, added only on push to main =====
   post-native: # flaky Native leg — deferred off the PR gate, retried once
@@ -131,13 +127,13 @@ jobs:
       - *jdk
       - *sbt
       - if: ${{ !cancelled() }}
-        run: sbt testsNative2_12 || sbt testsNative2_12
+        run: sbt testsNative2_12/testFull || sbt testsNative2_12/testFull
       - if: ${{ !cancelled() }}
-        run: sbt testsNative2_13 || sbt testsNative2_13
+        run: sbt testsNative/testFull || sbt testsNative/testFull
       - if: ${{ !cancelled() }}
-        run: sbt testsNative3_lts || sbt testsNative3_lts
+        run: sbt testsNative3_lts/testFull || sbt testsNative3_lts/testFull
       - if: ${{ !cancelled() }}
-        run: sbt testsNative3_next || sbt testsNative3_next
+        run: sbt testsNative3_next/testFull || sbt testsNative3_next/testFull
 
   post-older-scala: # every patch but the newest, one leg per binary version
     if: ${{ github.event_name == 'push' }}
@@ -162,9 +158,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: olafurpg/setup-scala@v14
-      - run: sbtx tests/test
+      - run: sbtx tests/testFull
         shell: bash
-      - run: sbtx testsJS/test
+      - run: sbtx testsJS/testFull
         shell: bash
-      - run: sbtx testsSemanticdb/test
+      - run: sbtx testsSemanticdb/testFull
         shell: bash

--- a/.jvmopts
+++ b/.jvmopts
@@ -3,5 +3,4 @@
 -Xmx8G
 -XX:ReservedCodeCacheSize=1024m
 -XX:+TieredCompilation
--Dsbt.server.autostart=false
 -Dsbt.io.implicit.relative.glob.conversion=allow

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,6 @@ import scala.xml.transform.{RewriteRule, RuleTransformer}
 import scala.xml.{Node => XmlNode, NodeSeq => XmlNodeSeq, _}
 
 import complete.DefaultParsers._
-import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
 def isCI = System.getenv("CI") != null
 
@@ -18,24 +17,20 @@ def isCI = System.getenv("CI") != null
  * Generates the aliases CI calls: tests2_12_older, testsSemanticdb2_13_latest. A step names a
  * binary version, 2.12 or 2.13, and asks for its newest patch or for all the older ones.
  * project/Versions.scala lists the patches, so a new patch changes no workflow file.
+ *
+ * A JVM row builds at the patch it publishes from, so an alias forces the version onto it. A JS or
+ * Native step needs no alias, because every row of those graphs builds at one patch.
  */
-def patchAliases(patches: Seq[String], forceOlder: Boolean = false)(tasks: (String, String)*) = {
+def patchAliases(patches: Seq[String])(tasks: (String, String)*) = {
   val tag = CrossVersion.binaryScalaVersion(patches.head).replace('.', '_')
-  def aliases(which: String, force: Boolean, versions: Seq[String]) = tasks
-    .flatMap { case (name, task) =>
-      val bang = if (force) "!" else ""
-      val cmd = versions.map(v => s"++$v$bang; $task").mkString("; ", "; ", "")
-      addCommandAlias(s"$name${tag}_$which", cmd)
-    }
+  def aliases(which: String, versions: Seq[String]) = tasks.flatMap { case (name, task) =>
+    val cmd = versions.map(v => s"++$v!; $task").mkString("; ", "; ", "")
+    addCommandAlias(s"$name${tag}_$which", cmd)
+  }
   // the older patches run newest first, because that patch is the one most projects use
   val latest = getLatest(patches)
-  aliases("latest", force = false, Seq(latest)) ++
-    aliases("older", forceOlder, patches.filterNot(_ == latest).reverse)
+  aliases("latest", Seq(latest)) ++ aliases("older", patches.filterNot(_ == latest).reverse)
 }
-
-/** Generates an alias that runs one task at one version: a platform's patch, or a Scala 3 one. */
-def versionAliases(entries: (String, String, String)*) = entries
-  .flatMap { case (name, version, task) => addCommandAlias(name, s"; ++$version; $task") }
 
 def helloContributor(): Unit = println(
   """|Welcome to the Scalameta build! You probably don't want to run `sbt test` since
@@ -59,26 +54,17 @@ def rootSettings = Def.settings(
   addCommandAlias("benchAll", benchAll.command),
   addCommandAlias("benchLSP", benchLSP.command),
   addCommandAlias("benchQuick", benchQuick.command),
-  // a module builds at the patch it publishes from, so an alias forces an older patch onto it.
-  // semanticdb-scalac cross-builds at every patch, so a plain switch reaches it.
-  patchAliases(Scala213Versions, forceOlder = true)("tests" -> "tests/test"),
-  patchAliases(Scala212Versions, forceOlder = true)("tests" -> "tests/test"),
-  patchAliases(Scala213Versions)("testsSemanticdb" -> "testsSemanticdb/test"),
-  patchAliases(Scala212Versions)("testsSemanticdb" -> "testsSemanticdb/test"),
-  versionAliases(
-    ("testsJS2_13", PublishedScala213ForJS, "testsJS/test"),
-    ("testsJS2_12", PublishedScala212ForJS, "testsJS/test"),
-    ("testsNative2_13", PublishedScala213ForNative, "testsNative/test"),
-    ("testsNative2_12", PublishedScala212ForNative, "testsNative/test"),
-  ), {
-    val names = Seq("tests", "testsJS", "testsNative")
-    versionAliases(Scala3Rows.flatMap { case (ver, label) =>
-      names.map(name => (name + label, ver, name + "/test"))
-    }: _*)
-  },
+  patchAliases(Scala213Versions)(
+    "tests" -> "tests/testFull",
+    "testsSemanticdb" -> "testsSemanticdb/testFull",
+  ),
+  patchAliases(Scala212Versions)(
+    "tests" -> "tests2_12/testFull",
+    "testsSemanticdb" -> "testsSemanticdb/testFull",
+  ),
   commands += Command.command("releaseSemanticdb")(s =>
     List(
-      "semanticdbSharedJVM",
+      "semanticdbShared",
       "semanticdbScalacPlugin",
       "semanticdbMetac",
       "semanticdbMetap",
@@ -104,21 +90,27 @@ def rootSettings = Def.settings(
   commands += Command.command("save-manifest")(s =>
     "tests/Test/runMain scala.meta.tests.semanticdb.SaveManifestTest" :: s,
   ),
-  test := helloContributor(),
-  test / aggregate := false,
-  testOnly := helloContributor(),
-  testOnly / aggregate := false,
-  packagedArtifacts := Map.empty,
+  // `sbt test` at the root would take hours, so print advice instead of running it
+  Test / test := {
+    helloContributor()
+    TestResult.Passed
+  },
+  Test / testOnly := {
+    helloContributor()
+    TestResult.Passed
+  },
+  Test / testOnly / aggregate := false,
+  Test / test / aggregate := false,
+  packagedArtifacts := Def.uncached(Map.empty),
   ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject,
-  console := (scalameta.jvm / Compile / console).value,
+  console := (scalameta.jvm(PublishedScala213) / Compile / console).value,
 )
 
-rootSettings
-enablePlugins(ScalaUnidocPlugin)
+lazy val scalametaRoot = rootProject.withId("scalameta-root").autoAggregate
+  .enablePlugins(ScalaUnidocPlugin).settings(rootSettings)
+
 Global / resolvers +=
   "scala-integration".at("https://scala-ci.typesafe.com/artifactory/scala-integration/")
-
-val allPlatforms = Seq(JSPlatform, JVMPlatform, NativePlatform)
 
 /* ======================== SEMANTICDB ======================== */
 lazy val semanticdbScalacCore = project.in(file("semanticdb/scalac/library")).settings(
@@ -140,7 +132,8 @@ lazy val semanticdbScalacCore = project.in(file("semanticdb/scalac/library")).se
   // SIP-51 on the earliest cross-built Scala versions.
   libraryDependencies +=
     ("com.lihaoyi" %% "unroll-annotation" % "0.3.0").exclude("org.scala-lang", "scala-library"),
-).dependsOn(semanticdbShared.jvm, io.jvm).enablePlugins(BuildInfoPlugin)
+).dependsOn(semanticdbShared.jvm(PublishedScala213), io.jvm(PublishedScala213))
+  .enablePlugins(BuildInfoPlugin)
 
 def semanticdbSharedSettings = Def.settings(
   moduleName := "semanticdb-shared",
@@ -149,13 +142,13 @@ def semanticdbSharedSettings = Def.settings(
     val ver = if (isScala3.value) PublishedScala213 else scalaVersion.value
     "org.scala-lang" % "scalap" % ver
   },
-  crossScalaVersions := PublishedScalaVersions,
   protobufSettings,
   description := "Library defining SemanticDB data structures",
 )
 
-lazy val semanticdbShared = crossProject(allPlatforms: _*).in(file("semanticdb/semanticdb"))
-  .settings(semanticdbSharedSettings).dependsOn(scalameta).crossAll.published
+lazy val semanticdbShared = projectMatrix.in(file("semanticdb/semanticdb"))
+  .settings(semanticdbSharedSettings).dependsOn(scalameta)
+  .crossAllPublished(TestedScalaVersions, PublishedScalaVersions)
 
 lazy val semanticdbScalacPlugin = project.in(file("semanticdb/scalac/plugin")).settings(
   moduleName := "semanticdb-scalac",
@@ -201,7 +194,7 @@ lazy val semanticdbMetap = project.in(file("semanticdb/metap")).settings(
   mimaPreviousArtifacts := Set.empty,
   description := "Prints SemanticDB files",
   mainClass := Some("scala.meta.cli.Metap"),
-).dependsOn(semanticdbShared.jvm)
+).dependsOn(semanticdbShared.jvm(PublishedScala213))
 
 lazy val semanticdbMetacp = project.in(file("semanticdb/metacp")).settings(
   moduleName := "semanticdb-metacp",
@@ -220,46 +213,41 @@ lazy val scala3TreeLiftsMacro = project.in(file("scala3-tree-lifts/macro")).sett
   scalaVersion := LatestScala213,
   enableMacros,
   nonPublishableSettings,
-).dependsOn(trees.jvm, common.jvm)
+).dependsOn(trees.jvm(PublishedScala213), common.jvm(PublishedScala213))
 
 lazy val scala3TreeLiftsCodeGen = project.in(file("scala3-tree-lifts/impl")).settings(
   jvmPlatformSettings,
   crossScalaVersions := List(LatestScala213),
   scalaVersion := LatestScala213,
-  libraryDependencies += "com.github.scopt" %%% "scopt" % "4.1.0",
+  libraryDependencies += "com.github.scopt" %% "scopt" % "4.1.0",
   nonPublishableSettings,
 ).dependsOn(scala3TreeLiftsMacro)
 
 /* ======================== SCALAMETA ======================== */
-lazy val common2 = crossProject(allPlatforms: _*).in(file("scalameta/common2")).settings(
+lazy val common2 = projectMatrix.in(file("scalameta/common2")).settings(
   moduleName := "common2",
   sharedSettings,
   enableMacros,
   buildInfoPackage := "scala.meta.internal",
   buildInfoKeys := Seq[BuildInfoKey](version),
-  crossScalaVersions := PublishedScala2,
-).crossAll.published.enablePlugins(BuildInfoPlugin)
+).crossAllPublished(PublishedScala2).enablePlugins(BuildInfoPlugin)
 
-lazy val common = crossProject(allPlatforms: _*).in(file("scalameta/common")).settings(
+lazy val common = projectMatrix.in(file("scalameta/common")).settings(
   moduleName := "common",
   sharedSettings,
-  libraryDependencies += "com.lihaoyi" %%% "sourcecode" % "0.4.4",
+  libraryDependencies += "com.lihaoyi" %% "sourcecode" % "0.4.4",
   description := "Bag of private and public helpers used in scalameta APIs and implementations",
   enableMacros,
-  crossScalaVersions := PublishedScalaVersions,
-).crossAll.published.enablePlugins(BuildInfoPlugin).dependsOn(common2)
+).crossAllPublished(TestedScalaVersions, PublishedScalaVersions).enablePlugins(BuildInfoPlugin)
+  .dependsOn(common2)
 
-lazy val io = crossProject(allPlatforms: _*).in(file("scalameta/io")).settings(
-  moduleName := "io",
-  sharedSettings,
-  description := "Scalameta IO abstractions",
-  crossScalaVersions := PublishedScala2,
-).crossAll.published
+lazy val io = projectMatrix.in(file("scalameta/io"))
+  .settings(moduleName := "io", sharedSettings, description := "Scalameta IO abstractions")
+  .crossAllPublished(PublishedScala2)
 
-lazy val trees2 = crossProject(allPlatforms: _*).in(file("scalameta/trees2")).settings(
+lazy val trees2 = projectMatrix.in(file("scalameta/trees2")).settings(
   moduleName := "trees2",
   sharedSettings,
-  crossScalaVersions := PublishedScala2,
   // NOTE: uncomment this to update ast.md
   // scalacOptions += "-Xprint:typer",
   enableHardcoreMacros,
@@ -267,27 +255,25 @@ lazy val trees2 = crossProject(allPlatforms: _*).in(file("scalameta/trees2")).se
     val scalameta = base / "scalameta"
     List("tokenizers2", "tokens2", "dialects2", "inputs2").map(scalameta / _)
   }),
-  libraryDependencies += "org.portable-scala" %%% "portable-scala-reflect" % "1.1.3",
-).crossAll.published.dependsOn(common2, io)
+  libraryDependencies += "org.portable-scala" %% "portable-scala-reflect" % "1.1.3",
+).crossAllPublished(PublishedScala2).dependsOn(common2, io)
 
-// the only module that shades: its jar moves fastparse and geny under scala.meta.shaded.internal
-lazy val trees = crossProject(allPlatforms: _*).in(file("scalameta/trees")).settings(
+lazy val trees = projectMatrix.in(file("scalameta/trees")).settings(
   moduleName := "trees",
   sharedSettings,
   description := "Scalameta abstract syntax trees",
-  crossScalaVersions := PublishedScalaVersions,
   enableHardcoreMacros,
-  libraryDependencies +=
-    "com.lihaoyi" %%% "fastparse" % { if (isScala212.value) "3.1.0" else "3.1.1" },
+  libraryDependencies += "com.lihaoyi" %% "fastparse" % { if (isScala212.value) "3.1.0" else "3.1.1" },
   mergedModule(projects = { base =>
     val scalameta = base / "scalameta"
     List("tokenizers").map(scalameta / _)
   }),
 ) // NOTE: tokenizers needed for Tree.tokens when Tree.pos.isEmpty
-  .crossAll.published.shaded.dependsOn(common, io, trees2)
+  .crossAllPublished(TestedScalaVersions, PublishedScalaVersions).shaded
+  .dependsOn(common, io, trees2)
 
 def parsersJsSettings = Def.settings(
-  commonJsSettings,
+  publishJsFor(PublishedScalaVersions),
   // has to agree with the "type" NpmPackage writes into package.json
   scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) },
   NpmPackage.settings(
@@ -302,12 +288,11 @@ def parsersJsSettings = Def.settings(
   ),
 )
 
-lazy val parsers = crossProject(allPlatforms: _*).in(file("scalameta/parsers")).settings(
+lazy val parsers = projectMatrix.in(file("scalameta/parsers")).settings(
   moduleName := "parsers",
   sharedSettings,
   description := "Scalameta APIs for parsing and their baseline implementation",
   enableHardcoreMacros,
-  crossScalaVersions := PublishedScalaVersions,
   mergedModule(
     base => List(base / "scalameta" / "quasiquotes", base / "scalameta" / "transversers"),
     base => List(base / "scalameta" / "transversers2"),
@@ -323,6 +308,7 @@ lazy val parsers = crossProject(allPlatforms: _*).in(file("scalameta/parsers")).
       val opts = s"--dir=${outDir.getAbsolutePath}" +: args.map { case (k, v) => s"--$k=$v" }
       val config = scala3TreeLiftsCodeGen / Compile
       Def.task {
+        implicit val conv: xsbti.FileConverter = fileConverter.value
         val cp = (config / fullClasspath).value.files
         // runner waits for the process to finish, whereas Compile / runMain doesn't
         (config / runner).value.run("org.scalameta.adt.Main", cp, opts, streams.value.log).get
@@ -330,7 +316,9 @@ lazy val parsers = crossProject(allPlatforms: _*).in(file("scalameta/parsers")).
       }
     } else Def.task(Seq.empty[File])
   }.taskValue,
-).crossJvm().crossNative().published.crossJs(parsersJsSettings).dependsOn(trees)
+).crossJvm(TestedScalaVersions, publishJvmFor(PublishedScalaVersions))
+  .crossNative(TestedScalaVersions, publishNativeFor(PublishedScalaVersions))
+  .crossJs(TestedScalaVersions, parsersJsSettings).dependsOn(trees)
 
 def mergedModule(
     projects: File => List[File] = _ => Nil,
@@ -354,13 +342,12 @@ def mergedModule(
   }
 }
 
-lazy val scalameta = crossProject(allPlatforms: _*).in(file("scalameta/scalameta")).settings(
+lazy val scalameta = projectMatrix.in(file("scalameta/scalameta")).settings(
   moduleName := "scalameta",
   sharedSettings,
   description := "Scalameta umbrella module that includes all public APIs",
-  crossScalaVersions := PublishedScalaVersions,
   mergedModule(base => List(base / "scalameta" / "contrib")),
-).crossAll.published.dependsOn(parsers)
+).crossAllPublished(TestedScalaVersions, PublishedScalaVersions).dependsOn(parsers)
 
 /* ======================== TESTS ======================== */
 lazy val semanticdbIntegration = project.in(file("semanticdb/integration")).settings(
@@ -408,18 +395,20 @@ lazy val semanticdbIntegrationMacros = project.in(file("semanticdb/integration-m
   enableMacros,
 )
 
-lazy val testkit = crossProject(allPlatforms: _*).in(file("scalameta/testkit")).settings(
+lazy val testkit = projectMatrix.in(file("scalameta/testkit")).settings(
   moduleName := "testkit",
   sharedSettings,
-  crossScalaVersions := PublishedScalaVersions,
   hasLargeIntegrationTests,
   description := "Testing utilities for scalameta APIs",
-).dependsOn(scalameta, io).published
-  .crossJvm(libraryDependencies += "org.rauschig" % "jarchivelib" % "1.2.0").crossJs().crossNative()
+).dependsOn(scalameta, io).crossJvm(
+  TestedScalaVersions,
+  publishJvmFor(PublishedScalaVersions),
+  libraryDependencies += "org.rauschig" % "jarchivelib" % "1.2.0",
+).crossJs(TestedScalaVersions, publishJsFor(PublishedScalaVersions))
+  .crossNative(TestedScalaVersions, publishNativeFor(PublishedScalaVersions))
 
 def testsSettings = Def.settings(
   testSettings,
-  crossScalaVersions := AllScalaVersions,
   scalacOptions ++= {
     if (isScala3.value)
       List("-Wconf:msg=pattern binding uses refutable extractor:s", "-Xcheck-macros")
@@ -428,9 +417,13 @@ def testsSettings = Def.settings(
 )
 
 def testsJvmSettings = Def.settings(
+  /* munit's pom asks for a scala-library newer than this row's patch, and sbt 2 refuses that. Only
+   * this row may pin it: a second pin makes coursier's SameVersion rule reject the graph. */
+  dependencyOverrides ++=
+    { if (isScala3.value) Nil else Seq("org.scala-lang" % "scala-library" % scalaVersion.value) },
   libraryDependencies ++=
     { if (!isScala3.value) List("org.scala-lang" % "scala-reflect" % scalaVersion.value) else Nil },
-  dependencyOverrides += "org.scala-lang.modules" %%% "scala-xml" % "2.4.0",
+  dependencyOverrides += "org.scala-lang.modules" %% "scala-xml" % "2.4.0",
   libraryDependencies ++= {
     if (isScala213.value) List(
       "org.scala-lang" % "scala-compiler" % scalaVersion.value % Test,
@@ -446,24 +439,26 @@ def testsJsSettings = Def.settings( // JS for tests
 
 def testsNativeSettings = Def.settings( // Native for tests
   nativeConfig ~= { _.withMode(scalanative.build.Mode.debug).withLinkStubs(true) },
+  allowUnsafeScalaLibUpgrade := true, // Scala Native needs a newer scala-library
 )
 
-lazy val tests = crossProject(allPlatforms: _*).withoutSuffixFor(JVMPlatform).in(file("tests"))
-  .settings(testsSettings).crossJvm(testsJvmSettings).crossJs(testsJsSettings)
-  .crossNative(testsNativeSettings).enablePlugins(BuildInfoPlugin).dependsOn(scalameta, testkit)
+lazy val tests = projectMatrix.in(file("tests")).settings(testsSettings)
+  .crossJvm(TestedScalaVersions, testsJvmSettings).crossJs(TestedScalaVersions, testsJsSettings)
+  .crossNative(TestedScalaVersions, testsNativeSettings).enablePlugins(BuildInfoPlugin)
+  .dependsOn(scalameta, testkit)
 
 def testsSemanticdbSettings = Def.settings(
-  // a test reads a resource as a Path, and cannot read one from inside a jar
   Test / exportJars := false,
   crossScalaVersions := AllScala2Versions,
   testSettings,
   jvmPlatformSettings,
-  dependencyOverrides ++=
+  scalaVersion := LatestScala213,
+  dependencyOverrides ++= // project switches to older scala library, so pin these artifacts
     Seq("scala-library", "scala-compiler", "scalap").map("org.scala-lang" % _ % scalaVersion.value),
   /* only this project uses coursier. On a Scala.js row sbt 2's %% asks for the Scala.js build of
    * coursier, which puts a second suffix of fastparse, geny and sourcecode on the classpath. */
   libraryDependencies += "io.get-coursier" %% "coursier" % "2.1.24" cross CrossVersion.for3Use2_13,
-  Test / fullClasspath := {
+  Test / fullClasspath := Def.uncached {
     sys.props("sbt.paths.semanticdb-scalac-plugin.compile.jar") =
       semanticdbScalacPluginPackage.value
     (Test / fullClasspath).value
@@ -473,8 +468,8 @@ def testsSemanticdbSettings = Def.settings(
 )
 
 lazy val testsSemanticdb = project.in(file("tests-semanticdb")).dependsOn(
-  scalameta.jvm,
-  testkit.jvm,
+  scalameta.jvm(PublishedScala213),
+  testkit.jvm(PublishedScala213),
   semanticdbScalacPlugin,
   semanticdbMetac,
   semanticdbMetacp,
@@ -486,12 +481,7 @@ lazy val sharedTestSettings = Def.settings(
   sharedSettings,
   nonPublishableSettings,
   testFrameworks := List(TestFrameworks.MUnit),
-  /* munit's pom asks for a newer scala-library than the patch a test project compiles at, and sbt
-   * refuses a scala-library newer than scalaVersion. Every platform needs the pin: JS and Native
-   * compile at a patch of their own. */
-  dependencyOverrides ++=
-    { if (isScala3.value) Nil else Seq("org.scala-lang" % "scala-library" % scalaVersion.value) },
-  libraryDependencies += "org.scalameta" %%% "munit" % munit.sbtmunit.BuildInfo.munitVersion,
+  libraryDependencies += "org.scalameta" %% "munit" % munit.sbtmunit.BuildInfo.munitVersion,
 )
 
 lazy val testSettings = Def.settings(
@@ -509,8 +499,8 @@ lazy val testSettings = Def.settings(
     "databaseSourcepath" -> (ThisBuild / baseDirectory).value.getAbsolutePath,
     "resourcesDirectory" -> (Test / resourceDirectory).value.getAbsolutePath,
     "classDirectories" -> Seq(
-      (common2.jvm / Compile / classDirectory).value.getAbsolutePath,
-      (common.jvm / Compile / classDirectory).value.getAbsolutePath,
+      (common2.jvm(PublishedScala213) / Compile / classDirectory).value.getAbsolutePath,
+      (common.jvm(PublishedScala213) / Compile / classDirectory).value.getAbsolutePath,
     ),
     "databaseClasspath" -> (semanticdbIntegration / Compile / classDirectory).value.getAbsolutePath,
     "integrationSourceDirectories" -> (semanticdbIntegration / Compile / sourceDirectories).value,
@@ -518,9 +508,12 @@ lazy val testSettings = Def.settings(
   buildInfoPackage := "scala.meta.tests",
 )
 
-lazy val communitytest = project.in(file("community-test"))
-  .settings(sharedTestSettings, jvmPlatformSettings, crossScalaVersions := LatestScala2)
-  .dependsOn(scalameta.jvm)
+lazy val communitytest = project.in(file("community-test")).settings(
+  sharedTestSettings,
+  jvmPlatformSettings,
+  scalaVersion := LatestScala213,
+  crossScalaVersions := LatestScala2,
+).dependsOn(scalameta.jvm(PublishedScala213))
 
 /* ======================== BENCHES ======================== */
 lazy val benchSemanticdb = project.in(file("bench/semanticdb")).enablePlugins(BuildInfoPlugin)
@@ -550,20 +543,23 @@ lazy val benchScalameta = project.in(file("bench/scalameta")).enablePlugins(Buil
     buildInfoKeys := Seq[BuildInfoKey]("sourceroot" -> (ThisBuild / baseDirectory).value),
     buildInfoPackage := "scala.meta.internal.bench",
     Jmh / resourceDirectory := (Compile / resourceDirectory).value,
-    Jmh / fullClasspath ++= (scalameta.jvm / Compile / fullClasspath).value,
+    // two Append instances match a bare Classpath, so name the type
+    Jmh / fullClasspath ++=
+      { (scalameta.jvm(PublishedScala213) / Compile / fullClasspath).value: Classpath },
     Jmh / run := Def.inputTaskDyn {
       val buf = List.newBuilder[String]
       buf += "org.openjdk.jmh.Main"
       buf ++= spaceDelimited("<arg>").parsed
       (Jmh / runMain).toTask(s"  ${buf.result().mkString(" ")}")
     }.evaluated,
-  ).dependsOn(scalameta.jvm)
+  ).dependsOn(scalameta.jvm(PublishedScala213))
 
 // ==========================================
 // Settings
 // ==========================================
 
-lazy val sharedJvmSettings = Def.settings(sharedSettings, jvmPlatformSettings)
+lazy val sharedJvmSettings = Def
+  .settings(sharedSettings, jvmPlatformSettings, scalaVersion := LatestScala213)
 
 lazy val sharedSettings = Def.settings(
   // version is set dynamically by sbt-dynver, but let's adjust it
@@ -580,7 +576,6 @@ lazy val sharedSettings = Def.settings(
     dynverGitDescribeOutput.value.mkVersion(dynVer, curVersion)
   },
   isSnapshot := version.value.endsWith("-SNAPSHOT"), // overrides dynver setting
-  scalaVersion := LatestScala213,
   organization := "org.scalameta",
   libraryDependencies ++= {
     if (!isScala212.value) Nil
@@ -606,7 +601,7 @@ lazy val sharedSettings = Def.settings(
   updateOptions := updateOptions.value.withCachedResolution(true),
   ThisBuild / watchTriggeredMessage := Watch.clearScreenOnTrigger,
   evictionErrorLevel := sbt.util.Level.Warn,
-  incOptions := incOptions.value.withLogRecompileOnMacro(false),
+  incOptions := Def.uncached(incOptions.value.withLogRecompileOnMacro(false)),
 )
 
 def copyAssemblyJar = Def.task {
@@ -619,7 +614,7 @@ lazy val mergeSettings = Def.settings(
   sharedJvmSettings,
   // sbt-assembly's shade rules fail on an exported jar
   exportJars := false,
-  assembly / test := {},
+  assembly / test := TestResult.Passed,
   assembly / logLevel := Level.Error,
   assembly / assemblyJarName :=
     name.value + "_" + scalaVersion.value + "-" + version.value + "-assembly.jar",
@@ -643,12 +638,12 @@ lazy val mergeSettings = Def.settings(
       ).inAll,
     )
   },
-  Compile / Keys.`package` := {
+  Compile / Keys.`package` := Def.uncached {
     val slimJar = (Compile / Keys.`package`).value
     copyAssemblyJar.value(slimJar)
     slimJar
   },
-  Compile / packageBin / packagedArtifact := {
+  Compile / packageBin / packagedArtifact := Def.uncached {
     val (art, slimJar) = (Compile / packageBin / packagedArtifact).value
     copyAssemblyJar.value(slimJar)
     (art, slimJar)
@@ -664,11 +659,7 @@ lazy val mergeSettings = Def.settings(
 )
 
 lazy val protobufSettings = Def.settings(
-  Compile / packageSrc / mappings ++= {
-    val base = (Compile / sourceManaged).value
-    val files = (Compile / managedSources).value
-    files.map(f => (f, f.relativeTo(base).get.getPath))
-  },
+  // sbt 2 puts managed sources in the sources jar already, and adding them duplicates the entries
   Compile / PB.targets := Seq(protocbridge.Target(
     generator = PB.gens.plugin("scala"),
     outputPath = (Compile / sourceManaged).value / "protobuf",
@@ -683,8 +674,8 @@ lazy val protobufSettings = Def.settings(
       // for SIP-51, freeze version to the latest ScalaPB built against the earliest Scala 2.13.x version we support
       if (scalaVersion.value == "2.13.15") "0.11.17" else "0.11.20"
     Seq(
-      "com.thesamet.scalapb" %%% "scalapb-runtime" % scalapbVersion,
-      "com.thesamet.scalapb" %%% "scalapb-runtime" % scalapbVersion % "protobuf",
+      "com.thesamet.scalapb" %% "scalapb-runtime" % scalapbVersion,
+      "com.thesamet.scalapb" %% "scalapb-runtime" % scalapbVersion % "protobuf",
       ("com.thesamet.scalapb" % "protoc-gen-scala" % scalapbVersion % "protobuf").artifacts(
         if (scala.util.Properties.isWin)
           Artifact("protoc-gen-scala", PB.ProtocPlugin, "bat", "windows")
@@ -728,10 +719,11 @@ def exposePaths(projectName: String, config: Configuration) = Def.settings {
     System.setProperty(prefix + label, f(value))
     value
   }
-  config / fullClasspath := {
+  config / fullClasspath := Def.uncached {
     setProp("sources", (config / sourceDirectory).value)(_.getAbsolutePath)
     setProp("resources", (config / resourceDirectory).value)(_.getAbsolutePath)
-    setProp("options", (config / scalacOptions).value)(_.mkString(" "))
+    // resolvedScalacOptions expands ${CSR_CACHE} and the other roots to real paths
+    setProp("options", (config / resolvedScalacOptions).value)(_.mkString(" "))
     val toFile = fileOf.value
     setProp("classes", (config / fullClasspath).value)(
       _.map(x => toFile(x.data).getAbsolutePath).mkString(java.io.File.pathSeparator),
@@ -772,7 +764,7 @@ lazy val docs = project.in(file("scalameta-docs")).settings(
   mimaPreviousArtifacts := Set.empty,
 ).enablePlugins(BuildInfoPlugin, DocusaurusPlugin)
 
-def fileOf = Def.task((file: File) => file)
+def fileOf = Def.task(fileConverter.value.toPath(_: xsbti.HashedVirtualFileRef).toFile)
 
 def semanticdbScalacPluginPackage = Def
   .task(fileOf.value((semanticdbScalacPlugin / Compile / Keys.`package`).value).getAbsolutePath)

--- a/project/Extensions.scala
+++ b/project/Extensions.scala
@@ -5,10 +5,11 @@ import sbt.Keys._
 import sbt._
 
 import scala.scalanative.build.Mode
+import scala.scalanative.sbtplugin.ScalaNativeCrossVersion
 import scala.scalanative.sbtplugin.ScalaNativePlugin.autoImport._
 
-import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 import org.scalajs.linker.interface.StandardConfig
+import org.scalajs.sbtplugin.ScalaJSCrossVersion
 import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
 
 import com.jsuereth.sbtpgp.PgpKeys
@@ -16,10 +17,6 @@ import com.typesafe.tools.mima.plugin.MimaPlugin.autoImport._
 
 import coursier.ShadingPlugin
 import coursier.ShadingPlugin.autoImport._
-import sbtcrossproject.CrossPlugin.autoImport._
-import sbtcrossproject.CrossProject
-import scalajscrossproject.ScalaJSCrossPlugin.autoImport._
-import scalanativecrossproject.ScalaNativeCrossPlugin.autoImport._
 
 /**
  * Settings a project gets for the platform it builds for, and the combinators that hand them out.
@@ -44,8 +41,6 @@ object Extensions {
 
   val commonJsSettings = Def.settings(
     platformAxis := Platforms.JS,
-    crossScalaVersions := jsScalaVersions(crossScalaVersions.value),
-    scalaVersion := PublishedScala213ForJS,
     bspEnabled := false,
     scalaJSLinkerConfig := StandardConfig().withBatchMode(true),
     scalacOptions ++= {
@@ -61,8 +56,6 @@ object Extensions {
 
   lazy val nativeSettings = Def.settings(
     platformAxis := Platforms.Native,
-    crossScalaVersions := nativeScalaVersions(crossScalaVersions.value),
-    scalaVersion := PublishedScala213ForNative,
     bspEnabled := false,
     nativeConfig ~= {
       _.withMode(Mode.releaseFast)
@@ -124,7 +117,7 @@ object Extensions {
     mimaBinaryIssueFilters += Mima.languageAgnosticCompatibilityPolicy,
     mimaBinaryIssueFilters += Mima.scalaSpecificCompatibilityPolicy,
     mimaBinaryIssueFilters ++= Mima.apiCompatibilityExceptions,
-    licenses += "BSD" -> url("https://github.com/scalameta/scalameta/blob/main/LICENSE.md"),
+    licenses += License("BSD", uri("https://github.com/scalameta/scalameta/blob/main/LICENSE.md")),
     pomExtra :=
       <url>https://github.com/scalameta/scalameta</url>
       <inceptionYear>2014</inceptionYear>
@@ -187,14 +180,37 @@ object Extensions {
   )
 
   lazy val shadingSettings = Def.settings(
-    shadedDependencies ++= ShadedDependency.all.map(x =>
-      if (x.isPlatformSpecific) x.groupID %%% x.artifactID % "foo"
-      else x.groupID %% x.artifactID % "foo",
-    ).toSet,
+    /* sbt 2 takes the platform from scalaModuleInfo (sbt/sbt#9621), so a CrossVersion that named
+     * the platform here would name it twice */
+    shadedDependencies ++=
+      ShadedDependency.all.map(x => (x.groupID % x.artifactID % "foo").cross(CrossVersion.binary))
+        .toSet,
     shadingRules ++=
       ShadedDependency.all.map(x => ShadingRule.moveUnder(x.namespace, "scala.meta.shaded.internal")),
     validNamespaces ++= Set("org", "scala", "java"),
   )
+
+  /* Two rows of one binary version would write the same artifact name, so only the versions this
+   * build published before the conversion keep the publishing settings. */
+  private def publishFor(platform: Platforms.Platform, versions: Seq[String]): Seq[Setting[?]] =
+    if (!Platforms.shouldBuildPlatform(platform)) nonPublishableSettings
+    else {
+      val keep = Def.setting(versions.contains(scalaVersion.value))
+      Def.settings(
+        publish / skip := !keep.value,
+        publishArtifact := keep.value,
+        publishableSettings,
+        mimaPreviousArtifacts := {
+          if (platform == Platforms.JVM && keep.value) getMimaPreviousArtifacts().value
+          else Set.empty
+        },
+      )
+    }
+
+  def publishJvmFor(versions: Seq[String]) = publishFor(Platforms.JVM, versions)
+  def publishJsFor(versions: Seq[String]) = publishFor(Platforms.JS, jsScalaVersions(versions))
+  def publishNativeFor(versions: Seq[String]) =
+    publishFor(Platforms.Native, nativeScalaVersions(versions))
 
   /** A published JVM row, cross-built or not. */
   lazy val publishJvmSettings =
@@ -203,8 +219,8 @@ object Extensions {
     else nonPublishableSettings
 
   /**
-   * Which patch a Scala.js build uses, given the list a JVM build uses. PublishedScala213ForJS
-   * gives the reason.
+   * Maps the list a JVM row uses to the patch a Scala.js row builds at, see PublishedScala213ForJS.
+   * A row cannot rewrite its own axis, so the build maps it at creation.
    */
   def jsScalaVersions(versions: Seq[String]): Seq[String] = versions.flatMap(v =>
     CrossVersion.binaryScalaVersion(v) match {
@@ -215,7 +231,7 @@ object Extensions {
     },
   ).distinct
 
-  /** The same for a Scala Native build. See PublishedScala213ForNative. */
+  /** Maps the same list to the patch a Native row builds at. See PublishedScala213ForNative. */
   def nativeScalaVersions(versions: Seq[String]): Seq[String] = versions.map(v =>
     CrossVersion.binaryScalaVersion(v) match {
       case "2.12" => PublishedScala212ForNative
@@ -224,32 +240,104 @@ object Extensions {
     },
   ).distinct
 
-  def platformPublishSettings(platform: Platforms.Platform) =
-    if (Platforms.shouldBuildPlatform(platform)) publishableSettings else nonPublishableSettings
+  implicit class ProjectMatrixExtensions(private val self: ProjectMatrix) extends AnyVal {
 
-  implicit class CrossProjectExtensions(private val self: CrossProject) extends AnyVal {
+    def crossJvm(versions: Seq[String], ss: Def.SettingsDefinition*): ProjectMatrix = {
+      val (scala2, scala3) = splitScala3(versions)
+      val settings = rowSettings("jvm", jvmPlatformSettings, ss)
+      val proj = self.defaultAxes(bareAxes *).jvmPlatform(scala2, settings)
+      scala3.foldLeft(proj) { case (m, (v, axis, ss)) => m.jvmPlatform(v, axis, settings ++ ss) }
+    }
 
-    def crossJvm(ss: Def.SettingsDefinition*): CrossProject = self
-      .jvmSettings((jvmPlatformSettings: Def.SettingsDefinition) +: ss: _*)
+    def crossJs(versions: Seq[String], ss: Def.SettingsDefinition*): ProjectMatrix = {
+      val (scala2, scala3) = splitScala3(versions)
+      val settings = rowSettings("js", commonJsSettings, ss)
+      val proj = self.defaultAxes(bareAxes *).jsPlatform(jsScalaVersions(scala2), settings)
+      scala3.foldLeft(proj) { case (m, (v, axis, ss)) => m.jsPlatform(v, axis, settings ++ ss) }
+    }
 
-    def crossJs(ss: Def.SettingsDefinition*): CrossProject = self
-      .jsSettings((commonJsSettings: Def.SettingsDefinition) +: ss: _*)
+    def crossNative(versions: Seq[String], ss: Def.SettingsDefinition*): ProjectMatrix = {
+      val (scala2, scala3) = splitScala3(versions)
+      val settings = rowSettings("native", nativeSettings, ss)
+      val proj = self.defaultAxes(bareAxes *).nativePlatform(nativeScalaVersions(scala2), settings)
+      scala3.foldLeft(proj) { case (m, (v, axis, ss)) => m.nativePlatform(v, axis, settings ++ ss) }
+    }
 
-    def crossNative(ss: Def.SettingsDefinition*): CrossProject = self
-      .nativeSettings((nativeSettings: Def.SettingsDefinition) +: ss: _*)
+    /** Every platform, nothing published. */
+    def crossAll(versions: Seq[String]): ProjectMatrix = self.crossJvm(versions).crossJs(versions)
+      .crossNative(versions)
 
-    /** Every row gets the settings for the platform it is. */
-    def crossAll: CrossProject = self.crossJvm().crossJs().crossNative()
+    /** Every platform, publishing every row it builds. */
+    def crossAllPublished(versions: Seq[String]): ProjectMatrix = self
+      .crossAllPublished(versions, versions)
 
-    /** Per row, publishable or not, as SCALAMETA_PLATFORM selects. */
-    def published: CrossProject = self.jvmSettings(publishJvmSettings)
-      .jsSettings(platformPublishSettings(Platforms.JS))
-      .nativeSettings(platformPublishSettings(Platforms.Native))
+    /** Every platform. SCALAMETA_PLATFORM decides which rows publish. */
+    def crossAllPublished(versions: Seq[String], publish: Seq[String]): ProjectMatrix = self
+      .crossJvm(versions, publishJvmFor(publish)).crossJs(versions, publishJsFor(publish))
+      .crossNative(versions, publishNativeFor(publish))
 
-    def shaded: CrossProject =
+    def shaded: ProjectMatrix =
       if (shadingSettings.isEmpty) self
       else self.enablePlugins(ShadingPlugin).settings(shadingSettings)
 
+    /**
+     * A matrix has one base directory, so each row lists every source directory it reads. An absent
+     * directory is harmless.
+     */
+    private def roots(dirs: String*): Seq[Setting[?]] = {
+      def under(conf: String, leaf: String => Seq[String]) = Def.setting {
+        // a matrix base can be relative, so resolve a source directory against the build root
+        val root = IO.resolve((ThisBuild / baseDirectory).value, self.base)
+        for (dir <- dirs.toList; name <- leaf(scalaBinaryVersion.value)) yield root / dir / "src" /
+          conf / name
+      }
+      def sources(sbv: String) = Seq("scala", "java", s"scala-$sbv", s"scala-${sbv.head}").distinct
+      Def.settings(
+        Compile / unmanagedSourceDirectories ++= under("main", sources).value,
+        Test / unmanagedSourceDirectories ++= under("test", sources).value,
+        Compile / unmanagedResourceDirectories ++= under("main", _ => Seq("resources")).value,
+        Test / unmanagedResourceDirectories ++= under("test", _ => Seq("resources")).value,
+      )
+    }
+
+    private def rowSettings(
+        dir: String,
+        platform: Seq[Setting[?]],
+        ss: Seq[Def.SettingsDefinition],
+    ): Seq[Setting[?]] = platform ++ roots("shared", dir) ++ ss.flatMap(_.settings)
+
+  }
+
+  /**
+   * Names the row that gets the id without a suffix. sbt 2 would leave the Scala 3 JVM row bare and
+   * rename every id CI and the aliases use.
+   */
+  private def bareAxes: Seq[VirtualAxis] = Seq(
+    VirtualAxis.jvm,
+    VirtualAxis.scalaABIVersion(LatestScala213),
+    /* projectMatrix leaves out an axis whose value a default repeats, and it counts two axes as
+     * equal by version — so this default names the binary version and no real one. */
+    VirtualAxis.scalaVersionAxis("3", "3"),
+  )
+
+  /**
+   * Splits a version list into the Scala 2 versions and the Scala 3 ones. Every Scala 3 version
+   * gets a row of its own, keyed by an axis, and only Scala3Published publishes.
+   */
+  private def splitScala3(versions: Seq[String]) = {
+    val s3 = Seq.newBuilder[(Seq[String], Seq[VirtualAxis.ScalaVersionAxis], Seq[Setting[_]])]
+    val s2 = Seq.newBuilder[String]
+    versions.foreach(v =>
+      Scala3RowIds.get(v) match {
+        case Some(id) =>
+          val settings =
+            if (v == Scala3Published) Nil
+            else Def.settings(nonPublishableSettings, allowMismatchScala := true)
+          s3 += ((Seq(v), Seq(VirtualAxis.ScalaVersionAxis(v, id)), settings))
+        case None => s2 += v
+      },
+    )
+    (s2.result(), s3.result())
   }
 
 }

--- a/project/NpmPackage.scala
+++ b/project/NpmPackage.scala
@@ -45,7 +45,8 @@ object NpmPackage {
       pkgKeywords: Seq[String],
       pkgReadme: File,
   ): Seq[Setting[_]] = Seq(
-    npmPackage := {
+    // sbt 2 cannot cache a task returning File
+    npmPackage := Def.uncached {
       val dir = crossTarget.value / "npm-package"
       IO.delete(dir)
       IO.createDirectory(dir)

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -27,19 +27,11 @@ object Versions {
   val PublishedScala2 = Seq(PublishedScala212, PublishedScala213)
   // a row publishes only if it builds one of these patches, one per binary version
   val PublishedScalaVersions = PublishedScala2 :+ Scala3Published
+  val TestedScalaVersions = PublishedScalaVersions ++ Scala3Rows.tail.map(_._1)
 
   /**
-   * Scala.js publishes a compiler plugin for each full Scala version. Scala Native publishes a
-   * compiler plugin and a standard library. Both publish them for releases only, so a JS build and
-   * a Native build keep the release an RC replaces.
-   *
-   * A JVM build takes the oldest release of a Scala 2 line. A Native build takes the same release,
-   * the one it publishes from. A JS build takes the newest release, because Scala.js publishes for
-   * recent patches only. Name the previous release here when either project has not published for a
-   * new patch yet. Scala.js did that after 2.13.16 came out.
-   *
-   * Scala 3 needs no plugin for JS, because the Scala 3 compiler writes JS itself. A Scala 3 build
-   * keeps its own version.
+   * Scala.js and Native republish the standard library per full version, and for releases only. A
+   * JS row takes the newest release, because scalajs-library depends on that scala-library.
    */
   private def releases(versions: Seq[String]) = versions.filterNot(_ == Scala2ReleaseCandidate)
   val PublishedScala212ForJS = releases(Scala212Versions).last
@@ -52,17 +44,15 @@ object Versions {
     Scala2ReleaseCandidate.isEmpty || AllScala2Versions.contains(Scala2ReleaseCandidate),
     s"$Scala2ReleaseCandidate is not used, perhaps its minor is not yet listed",
   )
-  val AllScalaVersions = AllScala2Versions ++ Scala3Rows.map(_._1)
 
   // returns versions from oldest to newest
+  // put RC first, as published, so it's fully tested, not just with semanticdb
   private def getVersions2(minor: Int, range: Range) = {
     val prefix = s"2.$minor."
     if (range.length > 4)
       throw new Exception(s"Too many versions for scala-${prefix}x: ${range.length} > 4")
     val ordered = if (range.step > 0) range else range.reverse
     val prod = ordered.map(x => s"$prefix$x")
-    // the RC comes first, in place of the patch its line publishes from. A JVM build then compiles
-    // and tests every module with it. A plain switch reaches the test sources only.
     if (Scala2ReleaseCandidate.startsWith(prefix)) Scala2ReleaseCandidate +: prod else prod
   }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.15
+sbt.version=2.0.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,5 @@
 // scalafmt: { maxColumn = 100 }
 
-val crossProjectV = "1.3.2"
-
 resolvers += Resolver.sonatypeCentralSnapshots
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.4.1")
@@ -14,9 +12,6 @@ addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.1.0-RC2")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.6")
 
 addSbtPlugin("io.get-coursier" % "sbt-shading" % "2.1.8")
-
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % crossProjectV)
-addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % crossProjectV)
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.22.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.12")


### PR DESCRIPTION
Previously, a 3.8.4 build compiled only the tests but everything else at 3.3.8 (or 2.13 for scala2-only modules). Now the version applies to all scala3-compatible modules.