### PR TITLE
fastparse: pass the parser context explicitly

### DIFF
--- a/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
+++ b/scalameta/tokenizers/shared/src/main/scala/scala/meta/internal/tokenizers/LegacyScanner.scala
@@ -881,12 +881,12 @@ private[meta] class LegacyScanner(input: Input, dialect: Dialect) {
 
   private def getXml(): Boolean = {
     // 1. Collect positions of scala expressions inside this xml literal.
-    import fastparse.Parsed
     val start = offset
     val xmlParser = new XmlParser(dialect)
-    val result: Int = fastparse.parse(input.text, xmlParser.XmlExpr(_), startIndex = start) match {
-      case x: Parsed.Success[_] => x.index
-      case x: Parsed.Failure =>
+    val parsed = fastparse.parse(input.text, xmlParser.XmlExpr(using _), startIndex = start)
+    val result: Int = parsed match {
+      case x: fastparse.Parsed.Success[_] => x.index
+      case x: fastparse.Parsed.Failure =>
         val err = "malformed xml literal, expected:" + EOL + x.extra.trace().terminalsMsg
         setInvalidToken(curr, x.index)(err)
         return false

--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
@@ -315,7 +315,7 @@ object ScaladocParser {
     if (!isScaladoc) None
     else {
       val text = stripTrailingSpaces(CharBuffer.wrap(comment, 3, comment.length - 2))
-      fastparse.parse(text, parser(_)) match {
+      fastparse.parse(text, parser(using _)) match {
         case p: Parsed.Success[Scaladoc] => Some(p.value)
         case _ => None
       }


### PR DESCRIPTION
Scala 3 Next rejects a context parameter passed by position and requires explicit `using`. Apparently, recent versions of scala 2 allow this keyword for compatibility.