### PR TITLE
Versions: give versions semantic meaning

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -104,10 +104,10 @@ lazy val semanticdbShared = crossProject(allPlatforms: _*).in(file("semanticdb/s
     moduleName := "semanticdb-shared",
     sharedSettings,
     libraryDependencies += {
-      val ver = if (isScala3.value) EarliestScala213 else scalaVersion.value
+      val ver = if (isScala3.value) PublishedScala213 else scalaVersion.value
       "org.scala-lang" % "scalap" % ver
     },
-    crossScalaVersions := EarliestScalaVersions,
+    crossScalaVersions := PublishedScalaVersions,
     protobufSettings,
     description := "Library defining SemanticDB data structures",
   ).dependsOn(scalameta).crossAll.published
@@ -192,7 +192,7 @@ lazy val common2 = crossProject(allPlatforms: _*).in(file("scalameta/common2")).
   enableMacros,
   buildInfoPackage := "scala.meta.internal",
   buildInfoKeys := Seq[BuildInfoKey](version),
-  crossScalaVersions := EarliestScala2Versions,
+  crossScalaVersions := PublishedScala2,
 ).crossAll.published.enablePlugins(BuildInfoPlugin)
 
 lazy val common = crossProject(allPlatforms: _*).in(file("scalameta/common")).settings(
@@ -201,20 +201,20 @@ lazy val common = crossProject(allPlatforms: _*).in(file("scalameta/common")).se
   libraryDependencies += "com.lihaoyi" %%% "sourcecode" % "0.4.4",
   description := "Bag of private and public helpers used in scalameta APIs and implementations",
   enableMacros,
-  crossScalaVersions := EarliestScalaVersions,
+  crossScalaVersions := PublishedScalaVersions,
 ).crossAll.published.enablePlugins(BuildInfoPlugin).dependsOn(common2)
 
 lazy val io = crossProject(allPlatforms: _*).in(file("scalameta/io")).settings(
   moduleName := "io",
   sharedSettings,
   description := "Scalameta IO abstractions",
-  crossScalaVersions := EarliestScala2Versions,
+  crossScalaVersions := PublishedScala2,
 ).crossAll.published
 
 lazy val trees2 = crossProject(allPlatforms: _*).in(file("scalameta/trees2")).settings(
   moduleName := "trees2",
   sharedSettings,
-  crossScalaVersions := EarliestScala2Versions,
+  crossScalaVersions := PublishedScala2,
   // NOTE: uncomment this to update ast.md
   // scalacOptions += "-Xprint:typer",
   enableHardcoreMacros,
@@ -229,7 +229,7 @@ lazy val trees = crossProject(allPlatforms: _*).in(file("scalameta/trees")).sett
   moduleName := "trees",
   sharedSettings,
   description := "Scalameta abstract syntax trees",
-  crossScalaVersions := EarliestScalaVersions,
+  crossScalaVersions := PublishedScalaVersions,
   enableHardcoreMacros,
   libraryDependencies ++= {
     val fastparseVersion =
@@ -265,7 +265,7 @@ lazy val parsers = crossProject(allPlatforms: _*).in(file("scalameta/parsers")).
   sharedSettings,
   description := "Scalameta APIs for parsing and their baseline implementation",
   enableHardcoreMacros,
-  crossScalaVersions := EarliestScalaVersions,
+  crossScalaVersions := PublishedScalaVersions,
   mergedModule(
     base => List(base / "scalameta" / "quasiquotes", base / "scalameta" / "transversers"),
     base => List(base / "scalameta" / "transversers2"),
@@ -314,7 +314,7 @@ lazy val scalameta = crossProject(allPlatforms: _*).in(file("scalameta/scalameta
   moduleName := "scalameta",
   sharedSettings,
   description := "Scalameta umbrella module that includes all public APIs",
-  crossScalaVersions := EarliestScalaVersions,
+  crossScalaVersions := PublishedScalaVersions,
   mergedModule(base => List(base / "scalameta" / "contrib")),
 ).crossAll.published.shaded.dependsOn(parsers)
 
@@ -371,7 +371,7 @@ lazy val semanticdbIntegrationMacros = project.in(file("semanticdb/integration-m
 lazy val testkit = crossProject(allPlatforms: _*).in(file("scalameta/testkit")).settings(
   moduleName := "testkit",
   sharedSettings,
-  crossScalaVersions := EarliestScalaVersions,
+  crossScalaVersions := PublishedScalaVersions,
   hasLargeIntegrationTests,
   description := "Testing utilities for scalameta APIs",
 ).dependsOn(scalameta, io).published
@@ -457,14 +457,14 @@ lazy val testSettings = Def.settings(
 )
 
 lazy val communitytest = project.in(file("community-test"))
-  .settings(sharedTestSettings, jvmPlatformSettings, crossScalaVersions := LatestScala2Versions)
+  .settings(sharedTestSettings, jvmPlatformSettings, crossScalaVersions := LatestScala2)
   .dependsOn(scalameta.jvm)
 
 /* ======================== BENCHES ======================== */
 lazy val benchSemanticdb = project.in(file("bench/semanticdb")).enablePlugins(BuildInfoPlugin)
   .enablePlugins(JmhPlugin).settings(
     sharedJvmSettings,
-    crossScalaVersions := LatestScala2Versions,
+    crossScalaVersions := LatestScala2,
     nonPublishableSettings,
     libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value,
     buildInfoKeys := Seq[BuildInfoKey]("sourceroot" -> (ThisBuild / baseDirectory).value),
@@ -485,7 +485,7 @@ lazy val benchSemanticdb = project.in(file("bench/semanticdb")).enablePlugins(Bu
 lazy val benchScalameta = project.in(file("bench/scalameta")).enablePlugins(BuildInfoPlugin)
   .enablePlugins(JmhPlugin).settings(
     sharedJvmSettings,
-    crossScalaVersions := LatestScala2Versions,
+    crossScalaVersions := LatestScala2,
     nonPublishableSettings,
     buildInfoKeys := Seq[BuildInfoKey]("sourceroot" -> (ThisBuild / baseDirectory).value),
     buildInfoPackage := "scala.meta.internal.bench",

--- a/project/Extensions.scala
+++ b/project/Extensions.scala
@@ -46,13 +46,13 @@ object Extensions {
     platformAxis := Platforms.JS,
     crossScalaVersions := crossScalaVersions.value.flatMap(v =>
       CrossVersion.binaryScalaVersion(v) match {
-        case "2.12" => Some(LatestScala212)
-        case "2.13" => Some(LatestScala213ForJS)
+        case "2.12" => Some(PublishedScala212ForJS)
+        case "2.13" => Some(PublishedScala213ForJS)
         case "3" => Some(v)
         case _ => None
       },
     ).distinct,
-    scalaVersion := LatestScala213ForJS,
+    scalaVersion := PublishedScala213ForJS,
     bspEnabled := false,
     scalaJSLinkerConfig := StandardConfig().withBatchMode(true),
     scalacOptions ++= {

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -4,38 +4,41 @@ package build
 object Versions {
   val Scala212Versions = getVersions2(12, 18 to 21)
   val Scala213Versions = getVersions2(13, 15 to 18)
-  val Scala3Versions = getVersions3(3 -> 8, 8 -> 4)
-  val Scala2ReleaseCandidates = getReleaseCandidates(2)
-  val Scala3ReleaseCandidates = getReleaseCandidates(3)
-  val LatestScala212 = Scala212Versions.head
-  val LatestScala213 = Scala213Versions.head
-  val LatestScala213ForJS = LatestScala213
-  val EarliestScala212 = Scala212Versions.last
-  val EarliestScala213 = Scala213Versions.last
-  val EarliestScala3 = Scala3Versions.last
-  val AllScala2Versions = Scala213Versions ++ Scala212Versions ++ Scala2ReleaseCandidates
-  val AllScalaVersions = AllScala2Versions ++ Scala3Versions ++ Scala3ReleaseCandidates
-  val EarliestScala2Versions = Seq(EarliestScala213, EarliestScala212) ++ Scala2ReleaseCandidates
-  val EarliestScalaVersions = (EarliestScala2Versions :+ EarliestScala3) ++ Scala3ReleaseCandidates
-  val LatestScala2Versions = Seq(LatestScala213, LatestScala212)
 
-  private def getVersions[A](prefix: String, suffixes: Seq[A]) = {
-    if (suffixes.length > 4)
-      throw new Exception(s"Too many versions for scala-$prefix: ${suffixes.length} > 4")
-    suffixes.map(x => s"$prefix.$x")
+  val Scala3LTS = "3.3.8"
+  val Scala3Next = "3.8.4"
+
+  val LatestScala212 = Scala212Versions.last
+  val LatestScala213 = Scala213Versions.last
+  val LatestScala2 = Seq(LatestScala212, LatestScala213)
+
+  val PublishedScala212 = Scala212Versions.head
+  val PublishedScala213 = Scala213Versions.head
+  val PublishedScala2 = Seq(PublishedScala212, PublishedScala213)
+  // a module publishes only if it builds one of these patches, one per binary version
+  val PublishedScalaVersions = PublishedScala2 :+ Scala3LTS
+
+  /**
+   * A JVM build takes the oldest patch of a Scala 2 line. A JS build takes the newest one, because
+   * Scala.js publishes its compiler plugin for each full Scala version, and a JS build can use only
+   * a patch Scala.js published for. Name the previous patch here when Scala.js has not published
+   * for a new one yet. Scala.js did that after 2.13.16 came out.
+   *
+   * Scala 3 needs no plugin, because the Scala 3 compiler writes JS itself.
+   */
+  val PublishedScala212ForJS = LatestScala212
+  val PublishedScala213ForJS = LatestScala213
+
+  val AllScala2Versions = Scala213Versions ++ Scala212Versions
+  val AllScalaVersions = AllScala2Versions :+ Scala3LTS :+ Scala3Next
+
+  // returns versions from oldest to newest
+  private def getVersions2(minor: Int, range: Range) = {
+    val prefix = s"2.$minor."
+    if (range.length > 4)
+      throw new Exception(s"Too many versions for scala-${prefix}x: ${range.length} > 4")
+    val ordered = if (range.step > 0) range else range.reverse
+    ordered.map(x => s"$prefix$x")
   }
-
-  // returns versions from newest to oldest
-  private def getVersions2(minor: Int, range: Range) =
-    getVersions(s"2.$minor", if (range.step > 0) range.reverse else range)
-
-  // returns versions from newest to oldest
-  private def getVersions3(versions: (Int, Int)*) = {
-    val ordering = implicitly[Ordering[(Int, Int)]].reverse
-    getVersions("3", versions.sorted(ordering).map { case (minor, patch) => s"$minor.$patch" })
-  }
-
-  private def getReleaseCandidates(major: Int, versions: (Int, Int, String)*) =
-    getVersions(major.toString, versions.map { case (minor, patch, rc) => s"$minor.$patch-$rc" })
 
 }


### PR DESCRIPTION
Earliest* said which patch a module uses. It did not say why, thus we rename them as Published (a module publishes from the oldest patch of a binary version, so that a user on any later patch can use the artifact). The two Scala 3 versions are also named as Scala3LTS and Scala3Next. For now, drop support for release candidates.