### PR TITLE
Native: build at its own patch, like Scala.js

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,9 +143,9 @@ jobs:
       - *jdk
       - *sbt
       - if: ${{ !cancelled() }}
-        run: sbt ++${{ env.scala212 }} testsNative/test || sbt ++${{ env.scala212 }} testsNative/test
+        run: sbt ++${{ env.scala212_3 }} testsNative/test || sbt ++${{ env.scala212_3 }} testsNative/test
       - if: ${{ !cancelled() }}
-        run: sbt ++${{ env.scala213 }} testsNative/test || sbt ++${{ env.scala213 }} testsNative/test
+        run: sbt ++${{ env.scala213_3 }} testsNative/test || sbt ++${{ env.scala213_3 }} testsNative/test
       - if: ${{ !cancelled() }}
         run: sbt ++${{ env.scala33 }} testsNative/test || sbt ++${{ env.scala33 }} testsNative/test
       - if: ${{ !cancelled() }}

--- a/project/Extensions.scala
+++ b/project/Extensions.scala
@@ -68,6 +68,15 @@ object Extensions {
 
   lazy val nativeSettings = Seq(
     platformAxis := Platforms.Native,
+    crossScalaVersions := crossScalaVersions.value.flatMap(v =>
+      CrossVersion.binaryScalaVersion(v) match {
+        case "2.12" => Some(PublishedScala212ForNative)
+        case "2.13" => Some(PublishedScala213ForNative)
+        case "3" => Some(v)
+        case _ => None
+      },
+    ).distinct,
+    scalaVersion := PublishedScala213ForNative,
     bspEnabled := false,
     nativeConfig ~= {
       _.withMode(Mode.releaseFast)

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -19,15 +19,22 @@ object Versions {
   val PublishedScalaVersions = PublishedScala2 :+ Scala3LTS
 
   /**
-   * A JVM build takes the oldest patch of a Scala 2 line. A JS build takes the newest one, because
-   * Scala.js publishes its compiler plugin for each full Scala version, and a JS build can use only
-   * a patch Scala.js published for. Name the previous patch here when Scala.js has not published
-   * for a new one yet. Scala.js did that after 2.13.16 came out.
+   * Scala.js publishes a compiler plugin for each full Scala version. Scala Native publishes a
+   * compiler plugin and a standard library. A JS build and a Native build can therefore use only a
+   * patch those projects published for.
    *
-   * Scala 3 needs no plugin, because the Scala 3 compiler writes JS itself.
+   * A JVM build takes the oldest patch of a Scala 2 line. A Native build takes the same patch, the
+   * one it publishes from. A JS build takes the newest patch, because Scala.js publishes for recent
+   * patches only. Name the previous patch here when either project has not published for a new one
+   * yet. Scala.js did that after 2.13.16 came out.
+   *
+   * Scala 3 needs no plugin for JS, because the Scala 3 compiler writes JS itself. A Scala 3 build
+   * keeps its own version.
    */
   val PublishedScala212ForJS = LatestScala212
   val PublishedScala213ForJS = LatestScala213
+  val PublishedScala212ForNative = PublishedScala212
+  val PublishedScala213ForNative = PublishedScala213
 
   val AllScala2Versions = Scala213Versions ++ Scala212Versions
   val AllScalaVersions = AllScala2Versions :+ Scala3LTS :+ Scala3Next


### PR DESCRIPTION
Scala Native publishes the compiler plugin and the standard library for each full Scala version, and for releases only. A Native build can therefore use only a patch Scala Native published for. Scala.js has the same constraint, and the JS settings already rewrite crossScalaVersions for it. The Native settings now do the same, and keep the patch Native publishes from.

The workflow's Native steps name that patch. A step that named a patch outside the list would skip the project and pass.

Native already used both patches, so nothing else changes.