### PR TITLE
CI: name intentions, not versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,24 +9,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# Every Scala version lives here — bump in ONE place and all jobs follow.
-# Upgrade:
-#  - replace the previous oldest (scalaX_Y) with the previous latest (scalaX)
-#  - replace the previous latest (scalaX) with the new version
-#  - don't need to reorder scalaX_Y, they are not designed to be monotonic
-env:
-  scala33: '3.3.8'
-  scala38: '3.8.4'
-  # 2.13
-  scala213: '2.13.18'
-  scala213_1: '2.13.17'
-  scala213_2: '2.13.16'
-  scala213_3: '2.13.15'
-  # 2.12
-  scala212: '2.12.21'
-  scala212_1: '2.12.20'
-  scala212_2: '2.12.19'
-  scala212_3: '2.12.18'
+# This file names no Scala version. project/Versions.scala lists them, and a
+# step asks the build for what it needs: the newest patch of 2.12 or 2.13
+# (tests2_13_latest), all the older patches (tests2_12_older), the patch a
+# platform builds at (testsNative2_12), or a Scala 3 version by the label
+# Scala3Rows gives it (tests3_lts, tests3_next). Add or bump a version there
+# and this file stays as it is. `sbt alias` lists what CI can ask for.
 
 # Pre-merge gate (pr-* jobs): only the most critical checks, packed into a
 # few equal-length workers so it finishes about as fast as the work allows.
@@ -56,22 +44,22 @@ jobs:
         uses: sbt/setup-sbt@v1
       - &testjvm212
         if: ${{ !cancelled() }}
-        run: sbt ++${{ env.scala212 }} testsJVM/test
+        run: sbt tests2_12_latest
       - &testsem212
         if: ${{ !cancelled() }}
-        run: sbt ++${{ env.scala212 }} testsSemanticdb/test
+        run: sbt testsSemanticdb2_12_latest
       - &testjvm213
         if: ${{ !cancelled() }}
-        run: sbt ++${{ env.scala213 }} testsJVM/test
+        run: sbt tests2_13_latest
       - &testsem213
         if: ${{ !cancelled() }}
-        run: sbt ++${{ env.scala213 }} testsSemanticdb/test
+        run: sbt testsSemanticdb2_13_latest
       - &testjvm33
         if: ${{ !cancelled() }}
-        run: sbt ++${{ env.scala33 }} testsJVM/test
+        run: sbt tests3_lts
       - &testjvm38
         if: ${{ !cancelled() }}
-        run: sbt ++${{ env.scala38 }} testsJVM/test
+        run: sbt tests3_next
 
   # ===== PR gate: 5 balanced JDK-17 workers, run on PR *and* push (~8 min) =====
   pr-mima: # MiMa binary-compatibility (the single heaviest atom)
@@ -92,7 +80,7 @@ jobs:
       - *testjvm212
       - *testsem212
       - if: ${{ !cancelled() }}
-        run: sbt ++${{ env.scala38 }} testsJS/test
+        run: sbt testsJS3_next
 
   pr-jvm213-js33-other: # latest 2.13 parser + 3.3 JS + scala-library download
     runs-on: ubuntu-latest
@@ -102,9 +90,9 @@ jobs:
       - *sbt
       - *testjvm213
       - if: ${{ !cancelled() }}
-        run: sbt ++${{ env.scala33 }} testsJS/test
+        run: sbt testsJS3_lts
       - if: ${{ !cancelled() }}
-        run: sbt '++${{ env.scala213 }}; download-scala-library'
+        run: sbt download-scala-library
   
   pr-jvm33-sem213-other: # 3.3 parser + 2.13 semanticdb + community + scalafmt
     runs-on: ubuntu-latest
@@ -127,9 +115,9 @@ jobs:
       - *sbt
       - *testjvm38
       - if: ${{ !cancelled() }}
-        run: sbt ++${{ env.scala212 }} testsJS/test
+        run: sbt testsJS2_12
       - if: ${{ !cancelled() }}
-        run: sbt ++${{ env.scala213 }} testsJS/test
+        run: sbt testsJS2_13
 
   # ===== post-merge superset: deferred axes, added only on push to main =====
   post-native: # flaky Native leg — deferred off the PR gate, retried once
@@ -143,33 +131,29 @@ jobs:
       - *jdk
       - *sbt
       - if: ${{ !cancelled() }}
-        run: sbt ++${{ env.scala212_3 }} testsNative/test || sbt ++${{ env.scala212_3 }} testsNative/test
+        run: sbt testsNative2_12 || sbt testsNative2_12
       - if: ${{ !cancelled() }}
-        run: sbt ++${{ env.scala213_3 }} testsNative/test || sbt ++${{ env.scala213_3 }} testsNative/test
+        run: sbt testsNative2_13 || sbt testsNative2_13
       - if: ${{ !cancelled() }}
-        run: sbt ++${{ env.scala33 }} testsNative/test || sbt ++${{ env.scala33 }} testsNative/test
+        run: sbt testsNative3_lts || sbt testsNative3_lts
       - if: ${{ !cancelled() }}
-        run: sbt ++${{ env.scala38 }} testsNative/test || sbt ++${{ env.scala38 }} testsNative/test
+        run: sbt testsNative3_next || sbt testsNative3_next
 
-  post-older-scala: # older patches — one leg per slot index (2.12_N + 2.13_N)
+  post-older-scala: # every patch but the newest, one leg per binary version
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        idx: [ '1', '2', '3' ]
+        binary: [ '2_13', '2_12' ]
     steps:
       - *checkout
       - *jdk
       - *sbt
       - if: ${{ !cancelled() }}
-        run: "sbt '++${{ env[format('scala212_{0}', matrix.idx)] }}!; testsJVM/test'"
+        run: sbt tests${{ matrix.binary }}_older
       - if: ${{ !cancelled() }}
-        run: "sbt ++${{ env[format('scala212_{0}', matrix.idx)] }} testsSemanticdb/test"
-      - if: ${{ !cancelled() }}
-        run: "sbt '++${{ env[format('scala213_{0}', matrix.idx)] }}!; testsJVM/test'"
-      - if: ${{ !cancelled() }}
-        run: "sbt ++${{ env[format('scala213_{0}', matrix.idx)] }} testsSemanticdb/test"
+        run: sbt testsSemanticdb${{ matrix.binary }}_older
 
   post-windows: # Windows parser/JS/semanticdb (line-ending sensitivity)
     if: ${{ github.event_name == 'push' }}
@@ -178,7 +162,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: olafurpg/setup-scala@v14
-      - run: sbtx testsJVM/test
+      - run: sbtx tests/test
         shell: bash
       - run: sbtx testsJS/test
         shell: bash

--- a/build.sbt
+++ b/build.sbt
@@ -14,9 +14,32 @@ import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
 def isCI = System.getenv("CI") != null
 
+/**
+ * Generates the aliases CI calls: tests2_12_older, testsSemanticdb2_13_latest. A step names a
+ * binary version, 2.12 or 2.13, and asks for its newest patch or for all the older ones.
+ * project/Versions.scala lists the patches, so a new patch changes no workflow file.
+ */
+def patchAliases(patches: Seq[String], forceOlder: Boolean = false)(tasks: (String, String)*) = {
+  val tag = CrossVersion.binaryScalaVersion(patches.head).replace('.', '_')
+  def aliases(which: String, force: Boolean, versions: Seq[String]) = tasks
+    .flatMap { case (name, task) =>
+      val bang = if (force) "!" else ""
+      val cmd = versions.map(v => s"++$v$bang; $task").mkString("; ", "; ", "")
+      addCommandAlias(s"$name${tag}_$which", cmd)
+    }
+  // the older patches run newest first, because that patch is the one most projects use
+  val latest = getLatest(patches)
+  aliases("latest", force = false, Seq(latest)) ++
+    aliases("older", forceOlder, patches.filterNot(_ == latest).reverse)
+}
+
+/** Generates an alias that runs one task at one version: a platform's patch, or a Scala 3 one. */
+def versionAliases(entries: (String, String, String)*) = entries
+  .flatMap { case (name, version, task) => addCommandAlias(name, s"; ++$version; $task") }
+
 def helloContributor(): Unit = println(
   """|Welcome to the Scalameta build! You probably don't want to run `sbt test` since
-     |that will take a long time to complete.  More likely, you want to run `testsJVM/test`.
+     |that will take a long time to complete.  More likely, you want to run `tests/test`.
      |For more productivity tips, please read CONTRIBUTING.md.
      |""".stripMargin,
 )
@@ -36,6 +59,23 @@ def rootSettings = Def.settings(
   addCommandAlias("benchAll", benchAll.command),
   addCommandAlias("benchLSP", benchLSP.command),
   addCommandAlias("benchQuick", benchQuick.command),
+  // a module builds at the patch it publishes from, so an alias forces an older patch onto it.
+  // semanticdb-scalac cross-builds at every patch, so a plain switch reaches it.
+  patchAliases(Scala213Versions, forceOlder = true)("tests" -> "tests/test"),
+  patchAliases(Scala212Versions, forceOlder = true)("tests" -> "tests/test"),
+  patchAliases(Scala213Versions)("testsSemanticdb" -> "testsSemanticdb/test"),
+  patchAliases(Scala212Versions)("testsSemanticdb" -> "testsSemanticdb/test"),
+  versionAliases(
+    ("testsJS2_13", PublishedScala213ForJS, "testsJS/test"),
+    ("testsJS2_12", PublishedScala212ForJS, "testsJS/test"),
+    ("testsNative2_13", PublishedScala213ForNative, "testsNative/test"),
+    ("testsNative2_12", PublishedScala212ForNative, "testsNative/test"),
+  ), {
+    val names = Seq("tests", "testsJS", "testsNative")
+    versionAliases(Scala3Rows.flatMap { case (ver, label) =>
+      names.map(name => (name + label, ver, name + "/test"))
+    }: _*)
+  },
   commands += Command.command("releaseSemanticdb")(s =>
     List(
       "semanticdbSharedJVM",
@@ -62,7 +102,7 @@ def rootSettings = Def.settings(
     },
   ),
   commands += Command.command("save-manifest")(s =>
-    "testsJVM/test:runMain scala.meta.tests.semanticdb.SaveManifestTest" :: s,
+    "tests/test:runMain scala.meta.tests.semanticdb.SaveManifestTest" :: s,
   ),
   test := helloContributor(),
   test / aggregate := false,
@@ -409,9 +449,9 @@ def testsNativeSettings = Def.settings(nativeConfig ~= {
   _.withMode(scalanative.build.Mode.debug).withLinkStubs(true)
 })
 
-lazy val tests = crossProject(allPlatforms: _*).in(file("tests")).settings(testsSettings)
-  .crossJvm(testsJvmSettings).crossJs(testsJsSettings).crossNative(testsNativeSettings)
-  .enablePlugins(BuildInfoPlugin).dependsOn(scalameta, testkit)
+lazy val tests = crossProject(allPlatforms: _*).withoutSuffixFor(JVMPlatform).in(file("tests"))
+  .settings(testsSettings).crossJvm(testsJvmSettings).crossJs(testsJsSettings)
+  .crossNative(testsNativeSettings).enablePlugins(BuildInfoPlugin).dependsOn(scalameta, testkit)
 
 def testsSemanticdbSettings = Def.settings(
   crossScalaVersions := AllScala2Versions,


### PR DESCRIPTION
The workflow listed every patch of both Scala 2 lines, and each step named one, so adding or bumping a patch meant editing two files that had to agree.

A step now asks the build for what it needs: the newest patch of a line, every older patch, the patch a platform builds at, or a Scala 3 line. The build answers from project/Versions.scala. `sbt alias` lists what CI can ask for.

The commands stay the same. An alias forces an older patch onto a library module, and does not force it onto semanticdb-scalac, which cross-builds at every patch already. One thing changes: a group of patches runs in one sbt session, where each patch used to get a step.