### PR TITLE
Scala 3: take a list of versions, not two

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,14 +1,20 @@
 package org.scalameta
 package build
 
+import scala.collection.mutable
+
 object Versions {
   val Scala2ReleaseCandidate = "" // type the entire RC version here, e.g. "2.13.19-RC1"
   val Scala212Versions = getVersions2(12, 18 to 21)
   val Scala213Versions = getVersions2(13, 15 to 18)
 
-  // put any Scala 3 RC under one of these two
-  val Scala3LTS = "3.3.8"
-  val Scala3Next = "3.8.4"
+  val Scala3Rows = Seq(
+    // version to build label; only the first one is published; others are tested
+    "3.3.8" -> "3_lts",
+    "3.8.4" -> "3_next",
+    // you can add an RC here, e.g. "3.9.0-RC1" -> "3_rc"
+  )
+  val Scala3Published = Scala3Rows.head._1
 
   // returns the RC when this line lists one, and the newest patch otherwise
   def getLatest(v: Seq[String]) = if (v.head == Scala2ReleaseCandidate) v.head else v.last
@@ -19,8 +25,8 @@ object Versions {
   val PublishedScala212 = Scala212Versions.head
   val PublishedScala213 = Scala213Versions.head
   val PublishedScala2 = Seq(PublishedScala212, PublishedScala213)
-  // a module publishes only if it builds one of these patches, one per binary version
-  val PublishedScalaVersions = PublishedScala2 :+ Scala3LTS
+  // a row publishes only if it builds one of these patches, one per binary version
+  val PublishedScalaVersions = PublishedScala2 :+ Scala3Published
 
   /**
    * Scala.js publishes a compiler plugin for each full Scala version. Scala Native publishes a
@@ -43,10 +49,10 @@ object Versions {
 
   val AllScala2Versions = Scala213Versions ++ Scala212Versions
   require(
-    AllScala2Versions.contains(Scala2ReleaseCandidate) || Scala2ReleaseCandidate.isEmpty,
+    Scala2ReleaseCandidate.isEmpty || AllScala2Versions.contains(Scala2ReleaseCandidate),
     s"$Scala2ReleaseCandidate is not used, perhaps its minor is not yet listed",
   )
-  val AllScalaVersions = AllScala2Versions :+ Scala3LTS :+ Scala3Next
+  val AllScalaVersions = AllScala2Versions ++ Scala3Rows.map(_._1)
 
   // returns versions from oldest to newest
   private def getVersions2(minor: Int, range: Range) = {
@@ -58,6 +64,23 @@ object Versions {
     // the RC comes first, in place of the patch its line publishes from. A JVM build then compiles
     // and tests every module with it. A plain switch reaches the test sources only.
     if (Scala2ReleaseCandidate.startsWith(prefix)) Scala2ReleaseCandidate +: prod else prod
+  }
+
+  /**
+   * Every Scala 3 version has binary version 3, so a build keyed by the binary version alone holds
+   * one version and drops the rest. Each version carries a label instead, and CI steps name those
+   * labels: an RC put in the list above keeps the label its place in the list gives it.
+   */
+  val Scala3RowIds: Map[String, String] = {
+    val versions = new mutable.HashSet[String]()
+    val labels = new mutable.HashSet[String]()
+    val builder = Map.newBuilder[String, String]
+    Scala3Rows.foreach { case (ver, label) =>
+      if (!versions.add(ver)) throw new Exception(s"Scala 3 version $ver is listed twice")
+      if (!labels.add(label)) throw new Exception(s"Scala 3 label $label is listed twice")
+      builder += ver -> label
+    }
+    builder.result()
   }
 
 }


### PR DESCRIPTION
Scala 3 ships more than one version at a time, and a second LTS is coming, so the build stops naming exactly two. Scala3Rows pairs every Scala 3 version with the id of its rows, and Scala3Published names the one version this build publishes from. Adding a version is a val and an entry.

A row id names the part a version plays, not the version itself, because CI steps name these ids and a version moves from one part to another.

The build refuses a version or an id listed twice, and a Scala3Published that Scala3Rows does not list.