### PR TITLE
CI: run every Scala 3 row from one step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,10 @@ jobs:
       - &testsem213
         if: ${{ !cancelled() }}
         run: sbt testsSemanticdb2_13_latest
-      - &testjvm33
+      - &testjvm3lts
         if: ${{ !cancelled() }}
         run: sbt tests3_lts/testFull
-      - &testjvm38
+      - &testjvm3next
         if: ${{ !cancelled() }}
         run: sbt tests3_next/testFull
 
@@ -96,7 +96,7 @@ jobs:
       - *checkout
       - *jdk
       - *sbt
-      - *testjvm33
+      - *testjvm3lts
       - *testsem213
       - if: ${{ !cancelled() }}
         run: sbt communitytest/testFull
@@ -109,7 +109,7 @@ jobs:
       - *checkout
       - *jdk
       - *sbt
-      - *testjvm38
+      - *testjvm3next
       - if: ${{ !cancelled() }}
         run: sbt testsJS2_12/testFull
       - if: ${{ !cancelled() }}
@@ -135,21 +135,21 @@ jobs:
       - if: ${{ !cancelled() }}
         run: sbt testsNative3_next/testFull || sbt testsNative3_next/testFull
 
-  post-older-scala: # every patch but the newest, one leg per binary version
+  post-other-scala: # what the gate leaves out: an older 2.x patch, a further Scala 3 row
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        binary: [ '2_13', '2_12' ]
+        binary: [ '2_13', '2_12', '3' ]
     steps:
       - *checkout
       - *jdk
       - *sbt
       - if: ${{ !cancelled() }}
-        run: sbt tests${{ matrix.binary }}_older
-      - if: ${{ !cancelled() }}
-        run: sbt testsSemanticdb${{ matrix.binary }}_older
+        run: sbt tests${{ matrix.binary }}_other
+      - if: ${{ !cancelled() && startsWith(matrix.binary, '2_') }} # semanticdb is Scala 2 only
+        run: sbt testsSemanticdb${{ matrix.binary }}_other
 
   post-windows: # Windows parser/JS/semanticdb (line-ending sensitivity)
     if: ${{ github.event_name == 'push' }}

--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,19 @@ def patchAliases(patches: Seq[String])(tasks: (String, String)*) = {
   }
   // the older patches run newest first, because that patch is the one most projects use
   val latest = getLatest(patches)
-  aliases("latest", Seq(latest)) ++ aliases("older", patches.filterNot(_ == latest).reverse)
+  aliases("latest", Seq(latest)) ++ aliases("other", patches.filterNot(_ == latest).reverse)
+}
+
+/**
+ * Generates two aliases per graph: one runs every Scala 3 row, the other runs the rows past the
+ * pre-merge pair. A version added to Scala3Rows lands in both, so it changes no workflow file.
+ */
+def scala3Aliases(names: String*) = names.flatMap { name =>
+  def testEach(rows: Iterable[(String, String)]) = rows.map { case (_, label) =>
+    s"$name$label/testFull"
+  }.mkString("; ", "; ", "")
+  addCommandAlias(s"${name}3", testEach(Scala3Rows)) ++
+    addCommandAlias(s"${name}3_other", testEach(Scala3PostMerge))
 }
 
 def helloContributor(): Unit = println(
@@ -62,6 +74,7 @@ def rootSettings = Def.settings(
     "tests" -> "tests2_12/testFull",
     "testsSemanticdb" -> "testsSemanticdb/testFull",
   ),
+  scala3Aliases("tests", "testsJS", "testsNative"),
   commands += Command.command("releaseSemanticdb")(s =>
     List(
       "semanticdbShared",

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -9,11 +9,15 @@ object Versions {
   val Scala213Versions = getVersions2(13, 15 to 18)
 
   val Scala3Rows = Seq(
-    // version to build label; only the first one is published; others are tested
+    // version to build label mapping; if you change a build label, adjust build.sbt and CI
+    // the first row is published and checked for mima
+    // the first two are tested in pre-merge for JVM and JS, and in post-merge for Native
+    // NB: use one of these two lines for RC testing, as long as it's not merged
     "3.3.8" -> "3_lts",
     "3.8.4" -> "3_next",
-    // you can add an RC here, e.g. "3.9.0-RC1" -> "3_rc"
+    // lines below will only be tested for JVM in post-merge CI
   )
+  val Scala3PostMerge = Scala3Rows.drop(2)
   val Scala3Published = Scala3Rows.head._1
 
   // returns the RC when this line lists one, and the newest patch otherwise


### PR DESCRIPTION
Previously a step named 3_lts and 3_next, so a version added to Scala3Rows built rows that nothing tested. Now tests3, testsJS3 and testsNative3 run every row of their graph.