### PR TITLE
CI: disable the sbt 2 disk cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
           cache: 'sbt'
       - &sbt
         uses: sbt/setup-sbt@v1
+        with:
+          # a restored disk cache hung sbt before its first task
+          disk-cache: false
       - &testjvm212
         if: ${{ !cancelled() }}
         run: sbt tests2_12_latest

--- a/.github/workflows/release-custom.yml
+++ b/.github/workflows/release-custom.yml
@@ -33,6 +33,8 @@ jobs:
           distribution: 'temurin'
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
+        with:
+          disk-cache: false
       - name: Publish ${{ github.event.inputs.project }} to Sonatype
         run: sbt -Dbackport.release=1 ci-release
         env:

--- a/.github/workflows/release-js.yml
+++ b/.github/workflows/release-js.yml
@@ -20,6 +20,8 @@ jobs:
           distribution: 'temurin'
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
+        with:
+          disk-cache: false
       - name: Publish
         run: sbt parsersJS/npmPackagePublish
         env:

--- a/.github/workflows/release-semanticdb.yml
+++ b/.github/workflows/release-semanticdb.yml
@@ -27,6 +27,8 @@ jobs:
           distribution: 'temurin'
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
+        with:
+          disk-cache: false
       - name: Publish ${{ github.event.inputs.project }} to Sonatype
         run: sbt -Dbackport.release=1 "ci-release"
         env:

--- a/.github/workflows/release-website.yml
+++ b/.github/workflows/release-website.yml
@@ -16,6 +16,8 @@ jobs:
           distribution: 'temurin'
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
+        with:
+          disk-cache: false
       - name: Publish website
         run: sbt docs/docusaurusPublishGhpages
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,8 @@ jobs:
           distribution: 'temurin'
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
+        with:
+          disk-cache: false
       - name: Publish to Sonatype
         run: sbt ci-release
         env:


### PR DESCRIPTION
sbt/setup-sbt restores the cache by default. In run 32668607902 one job restored it and then hung: sbt printed "set current project" and nothing more for 30 minutes. Four jobs in the same run restored the same cache and passed, so the cache is not the whole trigger. It saved one meta-build compile here, so the loss is small.