### PR TITLE
SBT: skip mima where nothing was published before

### DIFF
--- a/project/Extensions.scala
+++ b/project/Extensions.scala
@@ -172,6 +172,8 @@ object Extensions {
   lazy val nonPublishableSettings = Seq(
     publish / skip := true,
     mimaPreviousArtifacts := Set.empty,
+    // nothing to compare, and the default task would compile the row to find that out
+    mimaReportBinaryIssues := {},
     Compile / packageDoc / publishArtifact := false,
     Compile / doc / sources := Seq.empty,
     publishArtifact := false,


### PR DESCRIPTION
Previously mima ran for every row, and 93 of them reported an empty mimaPreviousArtifacts after compiling the row to find that out. Now a non-publishable row reports nothing and compiles nothing for mima.