### PR TITLE
SBT: give the 2.13 rows a suffix of their own

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
       - if: ${{ !cancelled() }}
         run: sbt testsJS2_12/testFull
       - if: ${{ !cancelled() }}
-        run: sbt testsJS/testFull
+        run: sbt testsJS2_13/testFull
 
   # ===== post-merge superset: deferred axes, added only on push to main =====
   post-native: # flaky Native leg — deferred off the PR gate, retried once
@@ -138,7 +138,7 @@ jobs:
       - if: ${{ !cancelled() }}
         run: sbt testsNative2_12/testFull || sbt testsNative2_12/testFull
       - if: ${{ !cancelled() }}
-        run: sbt testsNative/testFull || sbt testsNative/testFull
+        run: sbt testsNative2_13/testFull || sbt testsNative2_13/testFull
       - if: ${{ !cancelled() }}
         run: sbt testsNative3_lts/testFull || sbt testsNative3_lts/testFull
       - if: ${{ !cancelled() }}
@@ -171,10 +171,10 @@ jobs:
       - *sbt
       - *sbt_bootup
       - if: ${{ !cancelled() }}
-        run: sbt tests/testFull
+        run: sbt tests2_13/testFull
         shell: bash
       - if: ${{ !cancelled() }}
-        run: sbt testsJS/testFull
+        run: sbt testsJS2_13/testFull
         shell: bash
       - if: ${{ !cancelled() }}
         run: sbt testsSemanticdb/testFull

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -79,7 +79,7 @@ You can also do it manually. The local flow is:
 
 - run `++2.12.17` or another Scala version you need
 
-- run `semanticdbShared/publishSigned`, `semanticdbScalacCore/publishSigned`, `semanticdbScalacPlugin/publishSigned` and `semanticdbMetac/publishSigned`
+- run `semanticdbShared2_13/publishSigned`, `semanticdbScalacCore/publishSigned`, `semanticdbScalacPlugin/publishSigned` and `semanticdbMetac/publishSigned`
 
 - make sure that everything is properly generated to `target/sonatype-staging` directory
 

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,9 @@ def isCI = System.getenv("CI") != null
 def patchAliases(patches: Seq[String])(tasks: (String, String)*) = {
   val tag = CrossVersion.binaryScalaVersion(patches.head).replace('.', '_')
   def aliases(which: String, versions: Seq[String]) = tasks.flatMap { case (name, task) =>
-    val cmd = versions.map(v => s"++$v!; $task").mkString("; ", "; ", "")
+    /* A forced switch stays in the session, and the steps of one CI job share the sbt server.
+     * reload gives each project its own version back; another ++ sets one for every project. */
+    val cmd = (versions.map(v => s"++$v!; $task") :+ "reload").mkString("; ", "; ", "")
     addCommandAlias(s"$name${tag}_$which", cmd)
   }
   // the older patches run newest first, because that patch is the one most projects use

--- a/build.sbt
+++ b/build.sbt
@@ -78,7 +78,7 @@ def rootSettings = Def.settings(
   addCommandAlias("benchLSP", benchLSP.command),
   addCommandAlias("benchQuick", benchQuick.command),
   patchAliases(Scala213Versions)(
-    "tests" -> "tests/testFull",
+    "tests" -> "tests2_13/testFull",
     "testsSemanticdb" -> "testsSemanticdb/testFull",
   ),
   patchAliases(Scala212Versions)(
@@ -92,7 +92,7 @@ def rootSettings = Def.settings(
   addCommandAlias("mima3_lts", "mimaPublished " + Scala3Published),
   commands += Command.command("releaseSemanticdb")(s =>
     List(
-      "semanticdbShared",
+      "semanticdbShared2_13",
       "semanticdbScalacPlugin",
       "semanticdbMetac",
       "semanticdbMetap",

--- a/project/Extensions.scala
+++ b/project/Extensions.scala
@@ -311,12 +311,11 @@ object Extensions {
   }
 
   /**
-   * Names the row that gets the id without a suffix. sbt 2 would leave the Scala 3 JVM row bare and
-   * rename every id CI and the aliases use.
+   * The default axes. idSuffix leaves a matching axis out of a row id. Only VirtualAxis.jvm
+   * matches, so a JVM row id has no JVM. Every row id still names the version it builds.
    */
   private def bareAxes: Seq[VirtualAxis] = Seq(
     VirtualAxis.jvm,
-    VirtualAxis.scalaABIVersion(LatestScala213),
     /* projectMatrix leaves out an axis whose value a default repeats, and it counts two axes as
      * equal by version — so this default names the binary version and no real one. */
     VirtualAxis.scalaVersionAxis("3", "3"),


### PR DESCRIPTION
Previously bareAxes named the 2.13 ABI, so the row that publishes 2.13 carried no suffix and a step naming it named no version. Now every row says which version it builds, and tests2_13/testOnly works the way tests2_12/testOnly already did.