### PR TITLE
CI: check mima beside the tests of the same row

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,27 +61,20 @@ jobs:
         run: sbt tests3_next/testFull
 
   # ===== PR gate: 5 balanced JDK-17 workers, run on PR *and* push (~8 min) =====
-  pr-mima: # MiMa binary-compatibility (the single heaviest atom)
-    runs-on: ubuntu-latest
-    steps:
-      - *checkout
-      - *jdk
-      - *sbt
-      - if: ${{ !cancelled() }}
-        run: sbt mima
-
-  pr-jvm212-sem212-js38: # latest 2.12 parser+semanticdb + latest-3 JS
+  pr-jvm212-sem212-js38: # 2.12 parser and mima + semanticdb + latest-3 JS
     runs-on: ubuntu-latest
     steps:
       - *checkout
       - *jdk
       - *sbt
       - *testjvm212
+      - if: ${{ !cancelled() }}
+        run: sbt mima2_12
       - *testsem212
       - if: ${{ !cancelled() }}
         run: sbt testsJS3_next/testFull
 
-  pr-jvm213-js33-other: # latest 2.13 parser + 3.3 JS + scala-library download
+  pr-jvm213-js33-other: # 2.13 parser and mima + 3.3 JS + scala-library download
     runs-on: ubuntu-latest
     steps:
       - *checkout
@@ -89,17 +82,24 @@ jobs:
       - *sbt
       - *testjvm213
       - if: ${{ !cancelled() }}
+        run: sbt mima2_13
+      - if: ${{ !cancelled() }}
         run: sbt testsJS3_lts/testFull
       - if: ${{ !cancelled() }}
         run: sbt download-scala-library
+      # the shortest worker of the gate, and it already builds the 2.13 rows scaladoc documents
+      - if: ${{ !cancelled() && github.event_name == 'push' }}
+        run: sbt doc
   
-  pr-jvm33-sem213-other: # 3.3 parser + 2.13 semanticdb + community + scalafmt
+  pr-jvm33-sem213-other: # 3.3 parser and mima + 2.13 semanticdb + community + scalafmt
     runs-on: ubuntu-latest
     steps:
       - *checkout
       - *jdk
       - *sbt
       - *testjvm3lts
+      - if: ${{ !cancelled() }}
+        run: sbt mima3_lts
       - *testsem213
       - if: ${{ !cancelled() }}
         run: sbt communitytest/testFull

--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,18 @@ def scala3Aliases(names: String*) = names.flatMap { name =>
     addCommandAlias(s"${name}3_other", testEach(Scala3PostMerge))
 }
 
+/* Runs mima for every row that builds this version and has a release to compare against. Only a
+ * published JVM row gets a baseline, so the build knows the rows and no list here can go stale. */
+def mimaPublished = Command.single("mimaPublished") { (state, version) =>
+  val extracted = Project.extract(state)
+  val rows = extracted.structure.allProjectRefs.filter(ref =>
+    extracted.getOpt(ref / mimaPreviousArtifacts).exists(_.nonEmpty) &&
+      extracted.getOpt(ref / scalaVersion).contains(version),
+  )
+  state.log.info(s"mima checks ${rows.map(_.project).mkString(", ")}")
+  rows.map(ref => s"${ref.project}/mimaReportBinaryIssues").toList ::: state
+}
+
 def helloContributor(): Unit = println(
   """|Welcome to the Scalameta build! You probably don't want to run `sbt test` since
      |that will take a long time to complete.  More likely, you want to run `tests/test`.
@@ -75,6 +87,10 @@ def rootSettings = Def.settings(
     "testsSemanticdb" -> "testsSemanticdb/testFull",
   ),
   scala3Aliases("tests", "testsJS", "testsNative"),
+  commands += mimaPublished,
+  addCommandAlias("mima2_13", "mimaPublished " + PublishedScala213),
+  addCommandAlias("mima2_12", "mimaPublished " + PublishedScala212),
+  addCommandAlias("mima3_lts", "mimaPublished " + Scala3Published),
   commands += Command.command("releaseSemanticdb")(s =>
     List(
       "semanticdbShared",
@@ -85,7 +101,7 @@ def rootSettings = Def.settings(
       "semanticdbScalacCore",
     ).map(s => s + "/publishSigned") ::: s,
   ),
-  commands += Command.command("mima")(s => "mimaReportBinaryIssues" :: "doc" :: s),
+  commands += Command.command("mima")(s => "mimaReportBinaryIssues" :: s),
   commands += Command.command("download-scala-library") { s =>
     val out = file("target/scala-library")
     val arc = uri(s"https://github.com/scala/scala/archive/v$LatestScala213.zip").toURL


### PR DESCRIPTION
Previously the gate forced the newest patch onto the row that publishes, so pr-mima compiled the library a second time at the published patch and was the longest job. Now a JVM parser step tests the row as it publishes and mima runs beside it, and scaladoc runs after a merge in the worker with the most room.