### PR TITLE
CI: give the Windows job the shared toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,11 @@ jobs:
         with:
           # a restored disk cache hung sbt before its first task
           disk-cache: false
+      # a cold boot downloads sbt and Scala; that failing is not a test failing
+      - &sbt_bootup
+        name: start the sbt server
+        run: sbt whoami
+        shell: bash
       - &testjvm212
         if: ${{ !cancelled() }}
         run: sbt tests2_12_latest
@@ -129,6 +134,7 @@ jobs:
       - *checkout
       - *jdk
       - *sbt
+      - *sbt_bootup
       - if: ${{ !cancelled() }}
         run: sbt testsNative2_12/testFull || sbt testsNative2_12/testFull
       - if: ${{ !cancelled() }}
@@ -149,6 +155,7 @@ jobs:
       - *checkout
       - *jdk
       - *sbt
+      - *sbt_bootup
       - if: ${{ !cancelled() }}
         run: sbt tests${{ matrix.binary }}_other
       - if: ${{ !cancelled() && startsWith(matrix.binary, '2_') }} # semanticdb is Scala 2 only

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,64 +65,6 @@ jobs:
         if: ${{ !cancelled() }}
         run: sbt tests3_next/testFull
 
-  # ===== PR gate: 5 balanced JDK-17 workers, run on PR *and* push (~8 min) =====
-  pr-jvm212-sem212-js38: # 2.12 parser and mima + semanticdb + latest-3 JS
-    runs-on: ubuntu-latest
-    steps:
-      - *checkout
-      - *jdk
-      - *sbt
-      - *testjvm212
-      - if: ${{ !cancelled() }}
-        run: sbt mima2_12
-      - *testsem212
-      - if: ${{ !cancelled() }}
-        run: sbt testsJS3_next/testFull
-
-  pr-jvm213-js33-other: # 2.13 parser and mima + 3.3 JS + scala-library download
-    runs-on: ubuntu-latest
-    steps:
-      - *checkout
-      - *jdk
-      - *sbt
-      - *testjvm213
-      - if: ${{ !cancelled() }}
-        run: sbt mima2_13
-      - if: ${{ !cancelled() }}
-        run: sbt testsJS3_lts/testFull
-      - if: ${{ !cancelled() }}
-        run: sbt download-scala-library
-      # the shortest worker of the gate, and it already builds the 2.13 rows scaladoc documents
-      - if: ${{ !cancelled() && github.event_name == 'push' }}
-        run: sbt doc
-  
-  pr-jvm33-sem213-other: # 3.3 parser and mima + 2.13 semanticdb + community + scalafmt
-    runs-on: ubuntu-latest
-    steps:
-      - *checkout
-      - *jdk
-      - *sbt
-      - *testjvm3lts
-      - if: ${{ !cancelled() }}
-        run: sbt mima3_lts
-      - *testsem213
-      - if: ${{ !cancelled() }}
-        run: sbt communitytest/testFull
-      - if: ${{ !cancelled() }}
-        run: ./bin/scalafmt --test
-
-  pr-jvm38-js2: # latest-3 parser + JS on both Scala 2 lines
-    runs-on: ubuntu-latest
-    steps:
-      - *checkout
-      - *jdk
-      - *sbt
-      - *testjvm3next
-      - if: ${{ !cancelled() }}
-        run: sbt testsJS2_12/testFull
-      - if: ${{ !cancelled() }}
-        run: sbt testsJS/testFull
-
   # ===== post-merge superset: deferred axes, added only on push to main =====
   post-native: # flaky Native leg — deferred off the PR gate, retried once
     if: ${{ github.event_name == 'push' }}
@@ -162,7 +104,6 @@ jobs:
         run: sbt testsSemanticdb${{ matrix.binary }}_other
 
   post-windows: # Windows parser/JS/semanticdb (line-ending sensitivity)
-    if: ${{ github.event_name == 'push' }}
     name: Windows tests
     runs-on: windows-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,10 +108,15 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: olafurpg/setup-scala@v14
-      - run: sbtx tests/testFull
+      - *jdk
+      - *sbt
+      - *sbt_bootup
+      - if: ${{ !cancelled() }}
+        run: sbt tests/testFull
         shell: bash
-      - run: sbtx testsJS/testFull
+      - if: ${{ !cancelled() }}
+        run: sbt testsJS/testFull
         shell: bash
-      - run: sbtx testsSemanticdb/testFull
+      - if: ${{ !cancelled() }}
+        run: sbt testsSemanticdb/testFull
         shell: bash

--- a/build.sbt
+++ b/build.sbt
@@ -69,10 +69,7 @@ def helloContributor(): Unit = println(
 
 def rootSettings = Def.settings(
   sharedSettings,
-  name := {
-    println(s"[info] Welcome to scalameta ${version.value}")
-    "scalametaRoot"
-  },
+  name := "scalametaRoot",
   nonPublishableSettings,
   crossScalaVersions := Nil,
   addCommandAlias("benchAll", benchAll.command),
@@ -119,6 +116,11 @@ def rootSettings = Def.settings(
   commands += Command.command("save-manifest")(s =>
     "tests/Test/runMain scala.meta.tests.semanticdb.SaveManifestTest" :: s,
   ),
+  // can also be used to ensure sbt server has started
+  commands += Command.command("whoami") { s =>
+    s.log.info(s"Welcome to scalameta ${Project.extract(s).get(version)}")
+    s
+  },
   // `sbt test` at the root would take hours, so print advice instead of running it
   Test / test := {
     helloContributor()

--- a/build.sbt
+++ b/build.sbt
@@ -689,30 +689,28 @@ lazy val mergeSettings = Def.settings(
   mimaCurrentClassfiles := fileOf.value((Compile / Keys.`package`).value),
 )
 
+// for SIP-51, the newest ScalaPB built against the earliest Scala 2.13.x we support
+def scalapbVersion = Def.setting(if (scalaVersion.value == "2.13.15") "0.11.17" else "0.11.20")
+
 lazy val protobufSettings = Def.settings(
   // sbt 2 puts managed sources in the sources jar already, and adding them duplicates the entries
-  Compile / PB.targets := Seq(protocbridge.Target(
-    generator = PB.gens.plugin("scala"),
-    outputPath = (Compile / sourceManaged).value / "protobuf",
-    // what scalapb.gen(flatPackage = true) passes to protoc; spelled out so the meta-build needs
-    // no scalapb compilerplugin, whose Scala 3 build wants a different protoc-bridge than sbt-protoc
-    options = Seq("flat_package"),
-  )),
+  Compile / PB.targets := Seq {
+    /* sbt-protoc loads the generator in a classloader of its own, so the meta-build needs no
+     * scalapb compilerplugin, whose Scala 3 build wants another protoc-bridge than sbt-protoc */
+    val artifact = protocbridge
+      .Artifact("com.thesamet.scalapb", "compilerplugin_2.13", scalapbVersion.value)
+    protocbridge.Target(
+      generator = protocbridge.SandboxedJvmGenerator
+        .forModule("scala", artifact, "scalapb.ScalaPbCodeGenerator$", Nil),
+      outputPath = (Compile / sourceManaged).value / "protobuf",
+      options = Seq("flat_package"), // what scalapb.gen(flatPackage = true) passes to protoc
+    )
+  },
   Compile / PB.protoSources := Seq(file("semanticdb/semanticdb/shared/src/main/proto")),
   PB.additionalDependencies := Nil,
   libraryDependencies ++= {
-    val scalapbVersion =
-      // for SIP-51, freeze version to the latest ScalaPB built against the earliest Scala 2.13.x version we support
-      if (scalaVersion.value == "2.13.15") "0.11.17" else "0.11.20"
-    Seq(
-      "com.thesamet.scalapb" %% "scalapb-runtime" % scalapbVersion,
-      "com.thesamet.scalapb" %% "scalapb-runtime" % scalapbVersion % "protobuf",
-      ("com.thesamet.scalapb" % "protoc-gen-scala" % scalapbVersion % "protobuf").artifacts(
-        if (scala.util.Properties.isWin)
-          Artifact("protoc-gen-scala", PB.ProtocPlugin, "bat", "windows")
-        else Artifact("protoc-gen-scala", PB.ProtocPlugin, "sh", "unix"),
-      ),
-    )
+    val pbruntime = "com.thesamet.scalapb" %% "scalapb-runtime" % scalapbVersion.value
+    Seq(pbruntime, pbruntime % "protobuf")
   },
 )
 


### PR DESCRIPTION
Previously post-windows installed its own toolchain with olafurpg/setup-scala@v14, and that action defaults to adopt@1.8. sbt 2 ships a scala-library compiled for Java 17. So the launcher stopped with UnsupportedClassVersionError before it read the build, and every push since the sbt 2 switch failed there.

Now the job takes the jdk and sbt anchors, like the other jobs, and calls sbt instead of the sbtx that action supplied.
