### PR TITLE
SBT: generate protobuf without an external plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -687,30 +687,28 @@ lazy val mergeSettings = Def.settings(
   mimaCurrentClassfiles := fileOf.value((Compile / Keys.`package`).value),
 )
 
+// for SIP-51, the newest ScalaPB built against the earliest Scala 2.13.x we support
+def scalapbVersion = Def.setting(if (scalaVersion.value == "2.13.15") "0.11.17" else "0.11.20")
+
 lazy val protobufSettings = Def.settings(
   // sbt 2 puts managed sources in the sources jar already, and adding them duplicates the entries
-  Compile / PB.targets := Seq(protocbridge.Target(
-    generator = PB.gens.plugin("scala"),
-    outputPath = (Compile / sourceManaged).value / "protobuf",
-    // what scalapb.gen(flatPackage = true) passes to protoc; spelled out so the meta-build needs
-    // no scalapb compilerplugin, whose Scala 3 build wants a different protoc-bridge than sbt-protoc
-    options = Seq("flat_package"),
-  )),
+  Compile / PB.targets := Seq {
+    /* sbt-protoc loads the generator in a classloader of its own, so the meta-build needs no
+     * scalapb compilerplugin, whose Scala 3 build wants another protoc-bridge than sbt-protoc */
+    val artifact = protocbridge
+      .Artifact("com.thesamet.scalapb", "compilerplugin_2.13", scalapbVersion.value)
+    protocbridge.Target(
+      generator = protocbridge.SandboxedJvmGenerator
+        .forModule("scala", artifact, "scalapb.ScalaPbCodeGenerator$", Nil),
+      outputPath = (Compile / sourceManaged).value / "protobuf",
+      options = Seq("flat_package"), // what scalapb.gen(flatPackage = true) passes to protoc
+    )
+  },
   Compile / PB.protoSources := Seq(file("semanticdb/semanticdb/shared/src/main/proto")),
   PB.additionalDependencies := Nil,
   libraryDependencies ++= {
-    val scalapbVersion =
-      // for SIP-51, freeze version to the latest ScalaPB built against the earliest Scala 2.13.x version we support
-      if (scalaVersion.value == "2.13.15") "0.11.17" else "0.11.20"
-    Seq(
-      "com.thesamet.scalapb" %% "scalapb-runtime" % scalapbVersion,
-      "com.thesamet.scalapb" %% "scalapb-runtime" % scalapbVersion % "protobuf",
-      ("com.thesamet.scalapb" % "protoc-gen-scala" % scalapbVersion % "protobuf").artifacts(
-        if (scala.util.Properties.isWin)
-          Artifact("protoc-gen-scala", PB.ProtocPlugin, "bat", "windows")
-        else Artifact("protoc-gen-scala", PB.ProtocPlugin, "sh", "unix"),
-      ),
-    )
+    val pbruntime = "com.thesamet.scalapb" %% "scalapb-runtime" % scalapbVersion.value
+    Seq(pbruntime, pbruntime % "protobuf")
   },
 )
 


### PR DESCRIPTION
Previously PB.targets named PB.gens.plugin("scala"), so protoc ran the published protoc-gen-scala launcher. Windows gets it as a .bat, which runs `java -jar %JAVA_OPTS% "%~dpnx0" %*`. On the CI runner java got no jar to run, so it printed its usage and protoc reported exit code 1.

Now SandboxedJvmGenerator loads scalapb's ScalaPbCodeGenerator from compilerplugin_2.13 into a classloader of its own. No child process runs, and the launcher artifact is gone.