### PR TITLE
CI: start the sbt server in a step of its own

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,11 @@ jobs:
         with:
           # a restored disk cache hung sbt before its first task
           disk-cache: false
+      # a cold boot downloads sbt and Scala; that failing is not a test failing
+      - &sbt_bootup
+        name: start the sbt server
+        run: sbt whoami
+        shell: bash
       - &testjvm212
         if: ${{ !cancelled() }}
         run: sbt tests2_12_latest
@@ -129,6 +134,7 @@ jobs:
       - *checkout
       - *jdk
       - *sbt
+      - *sbt_bootup
       - if: ${{ !cancelled() }}
         run: sbt testsNative2_12/testFull || sbt testsNative2_12/testFull
       - if: ${{ !cancelled() }}
@@ -149,6 +155,7 @@ jobs:
       - *checkout
       - *jdk
       - *sbt
+      - *sbt_bootup
       - if: ${{ !cancelled() }}
         run: sbt tests${{ matrix.binary }}_other
       - if: ${{ !cancelled() && startsWith(matrix.binary, '2_') }} # semanticdb is Scala 2 only

--- a/build.sbt
+++ b/build.sbt
@@ -69,10 +69,7 @@ def helloContributor(): Unit = println(
 
 def rootSettings = Def.settings(
   sharedSettings,
-  name := {
-    println(s"[info] Welcome to scalameta ${version.value}")
-    "scalametaRoot"
-  },
+  name := "scalametaRoot",
   nonPublishableSettings,
   crossScalaVersions := Nil,
   addCommandAlias("benchAll", benchAll.command),
@@ -119,6 +116,11 @@ def rootSettings = Def.settings(
   commands += Command.command("save-manifest")(s =>
     "tests/Test/runMain scala.meta.tests.semanticdb.SaveManifestTest" :: s,
   ),
+  // can also be used to ensure sbt server has started
+  commands += Command.command("whoami") { s =>
+    s.log.info(s"Welcome to scalameta ${Project.extract(s).get(version)}")
+    s
+  },
   // `sbt test` at the root would take hours, so print advice instead of running it
   Test / test := {
     helloContributor()


### PR DESCRIPTION
Previously the first test step paid the cold boot: sbt downloads itself and Scala, then loads the build. A boot failure was reported as a failure of that suite, and in run 32748616241 the message named the wrong thing, "failed to connect to server", after five minutes.

Now a boot step precedes the suites and leaves the server running, so they attach to it. A failure there names the boot, and each suite's duration is its own work rather than the boot plus its own work.

The step is an anchor beside *sbt, so the pre-merge jobs need *boot too once the gate is back in this file.