### PR TITLE
SBT: give semanticdb a row per patch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,5 +177,5 @@ jobs:
         run: sbt testsJS2_13/testFull
         shell: bash
       - if: ${{ !cancelled() }}
-        run: sbt testsSemanticdb/testFull
+        run: sbt testsSemanticdb2_13
         shell: bash

--- a/.github/workflows/release-semanticdb.yml
+++ b/.github/workflows/release-semanticdb.yml
@@ -33,7 +33,7 @@ jobs:
         run: sbt -Dbackport.release=1 "ci-release"
         env:
           CI_COMMIT_TAG: ${{ github.event.inputs.commit }} // ci-release uses this to detect non-snapshot releases
-          CI_RELEASE: ${{ github.event.inputs.scala != '' && format('++{0}! ', github.event.inputs.scala) || '+' }}; semanticdbScalacCore/publishSigned; semanticdbScalacPlugin/publishSigned; semanticdbMetac/publishSigned; semanticdbMetap/publishSigned
+          CI_RELEASE: ${{ github.event.inputs.scala != '' && format('releaseSemanticdbFor {0}', github.event.inputs.scala) || 'releaseSemanticdb' }}
           SCALAMETA_PLATFORM: ${{ github.event.inputs.platform }}
           GIT_USER: scalameta@scalameta.org
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -77,9 +77,7 @@ You can also do it manually. The local flow is:
 
 - run `set every version := "4.5.9"` - replace `4.5.9` with the specific version you are releasing for
 
-- run `++2.12.17` or another Scala version you need
-
-- run `semanticdbShared2_13/publishSigned`, `semanticdbScalacCore/publishSigned`, `semanticdbScalacPlugin/publishSigned` and `semanticdbMetac/publishSigned`
+- run `semanticdbShared2_13/publishSigned` and `releaseSemanticdbFor 2.12.21`, replacing `2.12.21` with the Scala version you need. It must be one project/Versions.scala lists
 
 - make sure that everything is properly generated to `target/sonatype-staging` directory
 

--- a/bin/publish-semanticdb-scalac.sh
+++ b/bin/publish-semanticdb-scalac.sh
@@ -2,8 +2,11 @@
 set -eux
 
 version=$1
+scala=$2
 
+# semanticdb has a row per Scala patch, and releaseSemanticdbFor names the rows of one patch
 sbt \
   "set every version := \"$version\"" \
-  ++2.12.7 semanticdbShared/publishSigned semanticdbScalacPlugin/publishSigned semanticdbScalacCore/publishSigned  \
+  semanticdbShared2_13/publishSigned \
+  "releaseSemanticdbFor $scala" \
   sonatypeReleaseAll

--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ def testAliasesFor(patches: Seq[String]*) = patches.flatten
     res ++= addCommandAlias(s"tests" + other, forVersions(s"tests$ver/testFull", unpublished))
 
     // testsSemanticdb has a row per patch, so a step names the row and switches nothing
-    def semanticdb(vs: Seq[String]) = forVersions("testsSemanticdb/testFull", vs)
+    def semanticdb(vs: Seq[String]) = all(vs.map(v => s"${testsSemanticdb.jvm(v).id}/testFull"))
     res ++= addCommandAlias(s"testsSemanticdb" + other, semanticdb(unpublished))
     if (published.nonEmpty) res ++= addCommandAlias("testsSemanticdb" + ver, semanticdb(published))
 
@@ -90,15 +90,18 @@ def rootSettings = Def.settings(
   addCommandAlias("mima2_13", "mimaPublished " + PublishedScala213),
   addCommandAlias("mima2_12", "mimaPublished " + PublishedScala212),
   addCommandAlias("mima3_lts", "mimaPublished " + Scala3Published),
-  commands += Command.command("releaseSemanticdb")(s =>
-    List(
-      "semanticdbShared2_13",
-      "semanticdbScalacPlugin",
-      "semanticdbMetac",
-      "semanticdbMetap",
-      "semanticdbMetacp",
-      "semanticdbScalacCore",
-    ).map(s => s + "/publishSigned") ::: s,
+  commands += Command.command("releaseSemanticdb") { s =>
+    val rows = AllScala2Versions.flatMap(semanticdbRows(s))
+    ("semanticdbShared2_13" +: rows).map(_ + "/publishSigned").toList ::: s
+  },
+  /* A backport release names one patch, and every semanticdb artifact carries the full version. */
+  commands += Command.single("releaseSemanticdbFor")((s, version) =>
+    if (AllScala2Versions.contains(version)) semanticdbRows(s)(version).map(_ + "/publishSigned")
+      .toList ::: s
+    else {
+      s.log.error(s"$version is not a version this build validates")
+      s.fail
+    },
   ),
   commands += Command.command("mima")(s => "mimaReportBinaryIssues" :: s),
   commands += Command.command("download-scala-library") { s =>
@@ -110,9 +113,11 @@ def rootSettings = Def.settings(
   },
   commands += Command.command("save-expect")(s =>
     LatestScala2.foldLeft(s) { case (s, version) =>
-      s"++$version" :: "semanticdbScalacPlugin/compile" :: "semanticdbIntegration/clean" ::
-        "semanticdbIntegration/compile" ::
-        "testsSemanticdb/Test/runMain scala.meta.tests.semanticdb.SaveExpectTest" :: s
+      s"${semanticdbScalacPlugin.jvm(version).id}/compile" ::
+        s"${semanticdbIntegration.jvm(version).id}/clean" ::
+        s"${semanticdbIntegration.jvm(version).id}/compile" ::
+        s"${testsSemanticdb.jvm(version).id}/Test/runMain scala.meta.tests.semanticdb.SaveExpectTest" ::
+        s
     },
   ),
   commands += Command.command("save-manifest")(s =>
@@ -136,7 +141,7 @@ def rootSettings = Def.settings(
   Test / test / aggregate := false,
   packagedArtifacts := Def.uncached(Map.empty),
   ScalaUnidoc / unidoc / unidocProjectFilter := inAnyProject,
-  console := (scalameta.jvm(PublishedScala213) / Compile / console).value,
+  console := (scalameta.jvmCompile(PublishedScala213) / console).value,
 )
 
 lazy val scalametaRoot = rootProject.withId("scalameta-root").autoAggregate
@@ -146,9 +151,9 @@ Global / resolvers +=
   "scala-integration".at("https://scala-ci.typesafe.com/artifactory/scala-integration/")
 
 /* ======================== SEMANTICDB ======================== */
-lazy val semanticdbScalacCore = project.in(file("semanticdb/scalac/library")).settings(
+lazy val semanticdbScalacCore = projectMatrix.in(file("semanticdb/scalac/library")).settings(
   moduleName := "semanticdb-scalac-core",
-  sharedJvmSettings,
+  sharedSettings,
   publishJvmSettings,
   fullCrossVersionSettings,
   mimaPreviousArtifacts := Set.empty,
@@ -165,8 +170,7 @@ lazy val semanticdbScalacCore = project.in(file("semanticdb/scalac/library")).se
   // SIP-51 on the earliest cross-built Scala versions.
   libraryDependencies +=
     ("com.lihaoyi" %% "unroll-annotation" % "0.3.0").exclude("org.scala-lang", "scala-library"),
-).dependsOn(semanticdbShared.jvm(PublishedScala213), io.jvm(PublishedScala213))
-  .enablePlugins(BuildInfoPlugin)
+).crossFullJvm(AllScala2Versions, deps = Seq(semanticdbShared, io)).enablePlugins(BuildInfoPlugin)
 
 def semanticdbSharedSettings = Def.settings(
   moduleName := "semanticdb-shared",
@@ -183,10 +187,10 @@ lazy val semanticdbShared = projectMatrix.in(file("semanticdb/semanticdb"))
   .settings(semanticdbSharedSettings).dependsOn(scalameta)
   .crossAllPublished(TestedScalaVersions, PublishedScalaVersions)
 
-lazy val semanticdbScalacPlugin = project.in(file("semanticdb/scalac/plugin")).settings(
+lazy val semanticdbScalacPlugin = projectMatrix.in(file("semanticdb/scalac/plugin")).settings(
   moduleName := "semanticdb-scalac",
   description := "Scalac 2.x compiler plugin that generates SemanticDB on compile",
-  sharedJvmSettings,
+  sharedSettings,
   publishJvmSettings,
   mimaPreviousArtifacts := Set.empty,
   mergeSettings,
@@ -206,38 +210,38 @@ lazy val semanticdbScalacPlugin = project.in(file("semanticdb/scalac/plugin")).s
       }
     }).transform(node).head
   },
-).dependsOn(semanticdbScalacCore)
+).crossFullJvm(AllScala2Versions).dependsOn(semanticdbScalacCore)
 
-lazy val semanticdbMetac = project.in(file("semanticdb/metac")).settings(
+lazy val semanticdbMetac = projectMatrix.in(file("semanticdb/metac")).settings(
   moduleName := "metac", // that was name chosen originally, must keep it
-  sharedJvmSettings,
+  sharedSettings,
   publishJvmSettings,
   fullCrossVersionSettings,
   mimaPreviousArtifacts := Set.empty,
   description := "Scalac 2.x launcher that generates SemanticDB on compile",
   libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value,
   mainClass := Some("scala.meta.cli.Metac"),
-).dependsOn(semanticdbScalacPlugin)
+).crossFullJvm(AllScala2Versions).dependsOn(semanticdbScalacPlugin)
 
-lazy val semanticdbMetap = project.in(file("semanticdb/metap")).settings(
+lazy val semanticdbMetap = projectMatrix.in(file("semanticdb/metap")).settings(
   moduleName := "semanticdb-metap",
-  sharedJvmSettings,
+  sharedSettings,
   publishJvmSettings,
   fullCrossVersionSettings,
   mimaPreviousArtifacts := Set.empty,
   description := "Prints SemanticDB files",
   mainClass := Some("scala.meta.cli.Metap"),
-).dependsOn(semanticdbShared.jvm(PublishedScala213))
+).crossFullJvm(AllScala2Versions, deps = Seq(semanticdbShared))
 
-lazy val semanticdbMetacp = project.in(file("semanticdb/metacp")).settings(
+lazy val semanticdbMetacp = projectMatrix.in(file("semanticdb/metacp")).settings(
   moduleName := "semanticdb-metacp",
-  sharedJvmSettings,
+  sharedSettings,
   publishJvmSettings,
   fullCrossVersionSettings,
   mimaPreviousArtifacts := Set.empty,
   description := "Generates SemanticDB files for a classpath",
   mainClass := Some("scala.meta.cli.Metacp"),
-).dependsOn(semanticdbScalacCore)
+).crossFullJvm(AllScala2Versions).dependsOn(semanticdbScalacCore)
 
 /* ============== CODEGEN FOR SCALA 3 QUASIQUOTES, TRANSVERSERS ============= */
 lazy val scala3TreeLiftsMacro = project.in(file("scala3-tree-lifts/macro")).settings(
@@ -383,10 +387,9 @@ lazy val scalameta = projectMatrix.in(file("scalameta/scalameta")).settings(
 ).crossAllPublished(TestedScalaVersions, PublishedScalaVersions).dependsOn(parsers)
 
 /* ======================== TESTS ======================== */
-lazy val semanticdbIntegration = project.in(file("semanticdb/integration")).settings(
+lazy val semanticdbIntegration = projectMatrix.in(file("semanticdb/integration")).settings(
   description := "Sources to compile to build SemanticDB for tests.",
-  sharedJvmSettings,
-  crossScalaVersions := AllScala2Versions,
+  sharedSettings,
   nonPublishableSettings,
   // the sources in this project intentionally produce warnings to test the
   // diagnostics pipeline in semanticdb-scalac.
@@ -401,7 +404,6 @@ lazy val semanticdbIntegration = project.in(file("semanticdb/integration")).sett
     else Nil
   },
   scalacOptions ++= Seq(
-    s"-Xplugin:${semanticdbScalacPluginPackage.value}",
     "-Xplugin-require:semanticdb",
     if (isScala213.value) "-Wunused:imports" else "-Ywarn-unused-import",
     "-Yrangepos",
@@ -419,14 +421,13 @@ lazy val semanticdbIntegration = project.in(file("semanticdb/integration")).sett
     Some(actualHome)
   },
   javacOptions += "-parameters",
+).crossFullJvm(
+  AllScala2Versions,
+  v => Seq(scalacOptions += s"-Xplugin:${semanticdbScalacPluginPackage(v).value}"),
 ).dependsOn(semanticdbIntegrationMacros, semanticdbScalacPlugin)
 
-lazy val semanticdbIntegrationMacros = project.in(file("semanticdb/integration-macros")).settings(
-  sharedJvmSettings,
-  crossScalaVersions := AllScala2Versions,
-  nonPublishableSettings,
-  enableMacros,
-)
+lazy val semanticdbIntegrationMacros = projectMatrix.in(file("semanticdb/integration-macros"))
+  .settings(sharedSettings, nonPublishableSettings, enableMacros).crossFullJvm(AllScala2Versions)
 
 lazy val testkit = projectMatrix.in(file("scalameta/testkit")).settings(
   moduleName := "testkit",
@@ -480,21 +481,17 @@ lazy val tests = projectMatrix.in(file("tests")).settings(testsSettings)
   .crossNative(TestedScalaVersions, testsNativeSettings).enablePlugins(BuildInfoPlugin)
   .dependsOn(scalameta, testkit)
 
-def testsSemanticdbSettings = Def.settings(
+def testsSemanticdbSettings(version: String) = Def.settings(
   Test / exportJars := false,
-  crossScalaVersions := AllScala2Versions,
   testSettings,
   // only the suites in tests-semanticdb read these
   buildInfoKeys ++= Seq[BuildInfoKey](
-    "classDirectories" -> Seq(
-      (common2.jvm(PublishedScala213) / Compile / classDirectory).value.getAbsolutePath,
-      (common.jvm(PublishedScala213) / Compile / classDirectory).value.getAbsolutePath,
-    ),
-    "databaseClasspath" -> (semanticdbIntegration / Compile / classDirectory).value.getAbsolutePath,
-    "integrationSourceDirectories" -> (semanticdbIntegration / Compile / sourceDirectories).value,
+    "classDirectories" ->
+      Seq(common2.publishedClassDir(version).value, common.publishedClassDir(version).value),
+    "databaseClasspath" -> semanticdbIntegration.classDir(version).value,
+    "integrationSourceDirectories" -> (semanticdbIntegration.jvmCompile(version) / sourceDirectories)
+      .value,
   ),
-  jvmPlatformSettings,
-  scalaVersion := LatestScala213,
   dependencyOverrides ++= // project switches to older scala library, so pin these artifacts
     Seq("scala-library", "scala-compiler", "scalap").map("org.scala-lang" % _ % scalaVersion.value),
   /* only this project uses coursier. On a Scala.js row sbt 2's %% asks for the Scala.js build of
@@ -502,22 +499,21 @@ def testsSemanticdbSettings = Def.settings(
   libraryDependencies += "io.get-coursier" %% "coursier" % "2.1.24" cross CrossVersion.for3Use2_13,
   Test / fullClasspath := Def.uncached {
     sys.props("sbt.paths.semanticdb-scalac-plugin.compile.jar") =
-      semanticdbScalacPluginPackage.value
+      semanticdbScalacPluginPackage(version).value
     (Test / fullClasspath).value
   },
   // Needed because some tests rely on the --usejavacp option
   Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,
 )
 
-lazy val testsSemanticdb = project.in(file("tests-semanticdb")).dependsOn(
-  scalameta.jvm(PublishedScala213),
-  testkit.jvm(PublishedScala213),
+lazy val testsSemanticdb = projectMatrix.in(file("tests-semanticdb")).dependsOn(
   semanticdbScalacPlugin,
   semanticdbMetac,
   semanticdbMetacp,
   semanticdbMetap,
   semanticdbIntegration,
-).settings(testsSemanticdbSettings).enablePlugins(BuildInfoPlugin)
+).crossFullJvm(AllScala2Versions, v => Seq(testsSemanticdbSettings(v)), Seq(scalameta, testkit))
+  .enablePlugins(BuildInfoPlugin)
 
 lazy val sharedTestSettings = Def.settings(
   sharedSettings,
@@ -566,22 +562,22 @@ lazy val benchSemanticdb = project.in(file("bench/semanticdb")).enablePlugins(Bu
       buf += "org.openjdk.jmh.Main"
       buf ++= args
       buf += "-p"
-      buf += s"semanticdbScalacJar=${semanticdbScalacPluginPackage.value}"
+      buf += s"semanticdbScalacJar=${semanticdbScalacPluginPackage(LatestScala213).value}"
       (Jmh / runMain).toTask(s"  ${buf.result().mkString(" ")}")
     }.evaluated,
-  ).dependsOn(testsSemanticdb)
+  ).dependsOn(testsSemanticdb.jvm(LatestScala213))
 
 lazy val benchScalameta = project.in(file("bench/scalameta")).enablePlugins(BuildInfoPlugin)
   .enablePlugins(JmhPlugin).settings(
     sharedJvmSettings,
-    crossScalaVersions := LatestScala2,
+    crossScalaVersions := Seq(LatestScala213),
     nonPublishableSettings,
     buildInfoKeys := Seq[BuildInfoKey]("sourceroot" -> (ThisBuild / baseDirectory).value),
     buildInfoPackage := "scala.meta.internal.bench",
     Jmh / resourceDirectory := (Compile / resourceDirectory).value,
     // two Append instances match a bare Classpath, so name the type
     Jmh / fullClasspath ++=
-      { (scalameta.jvm(PublishedScala213) / Compile / fullClasspath).value: Classpath },
+      { (scalameta.jvmCompile(PublishedScala213) / fullClasspath).value: Classpath },
     Jmh / run := Def.inputTaskDyn {
       val buf = List.newBuilder[String]
       buf += "org.openjdk.jmh.Main"
@@ -647,7 +643,7 @@ def copyAssemblyJar = Def.task {
 }
 
 lazy val mergeSettings = Def.settings(
-  sharedJvmSettings,
+  sharedSettings,
   // sbt-assembly's shade rules fail on an exported jar
   exportJars := false,
   assembly / test := TestResult.Passed,
@@ -723,7 +719,6 @@ def compatibilityPolicyViolation(ticket: String) = Seq(mimaPreviousArtifacts := 
 
 lazy val fullCrossVersionSettings = Seq(
   crossVersion := CrossVersion.full,
-  crossScalaVersions := AllScala2Versions,
   Compile / unmanagedSourceDirectories += {
     // NOTE: sbt 0.13.8 provides cross-version support for Scala sources
     // (http://www.scala-sbt.org/0.13/docs/sbt-0.13-Tech-Previews.html#Cross-version+support+for+Scala+sources).
@@ -800,5 +795,15 @@ lazy val docs = project.in(file("scalameta-docs")).settings(
 
 def fileOf = Def.task(fileConverter.value.toPath(_: xsbti.HashedVirtualFileRef).toFile)
 
-def semanticdbScalacPluginPackage = Def
-  .task(fileOf.value((semanticdbScalacPlugin / Compile / Keys.`package`).value).getAbsolutePath)
+/** The rows that publish one artifact per full Scala version. */
+def semanticdbRows(state: State)(version: String) = {
+  val extracted = Project.extract(state)
+  extracted.structure.allProjectRefs.filter(ref =>
+    extracted.getOpt(ref / crossVersion).contains(CrossVersion.full) &&
+      extracted.getOpt(ref / scalaVersion).contains(version),
+  ).map(_.project)
+}
+
+def semanticdbScalacPluginPackage(version: String) = Def.task(
+  fileOf.value((semanticdbScalacPlugin.jvmCompile(version) / Keys.`package`).value).getAbsolutePath,
+)

--- a/project/Extensions.scala
+++ b/project/Extensions.scala
@@ -2,6 +2,7 @@ package org.scalameta
 package build
 
 import sbt.Keys._
+import sbt.ProjectExtra.given
 import sbt._
 
 import scala.scalanative.build.Mode
@@ -251,6 +252,26 @@ object Extensions {
       scala3.foldLeft(proj) { case (m, (v, axis, ss)) => m.jvmPlatform(v, axis, settings ++ ss) }
     }
 
+    /* semanticdb publishes one artifact per full Scala version, so each patch gets a row of its
+     * own. The row id carries the patch, because two rows of one binary version would collide. */
+    def crossFullJvm(
+        versions: Seq[String],
+        ss: String => Seq[Def.SettingsDefinition] = _ => Nil,
+        deps: Seq[ProjectMatrix] = Nil,
+    ): ProjectMatrix = versions.foldLeft(self.defaultAxes(fullAxes *)) { (matrix, v) =>
+      val pv = getPublishedForScalaVersion(v)
+      /* customRow hands each row its own Project, so a row states the dependency for its own
+       * version. A module published per binary version has one row a full-cross row can name. */
+      val conv = (p: Project) =>
+        p.settings(rowSettings("jvm", jvmPlatformSettings, ss(v))).dependsOn(deps.map(_.jvm(pv)) *)
+      matrix.customRow(
+        autoScalaLibrary = true,
+        scalaVersions = Seq(v),
+        axisValues = Seq(VirtualAxis.jvm, VirtualAxis.ScalaVersionAxis(v, v.replace('.', '_'))),
+        process = conv,
+      )
+    }
+
     def crossJs(versions: Seq[String], ss: Def.SettingsDefinition*): ProjectMatrix = {
       val (scala2, scala3) = splitScala3(versions)
       val settings = rowSettings("js", commonJsSettings, ss)
@@ -308,6 +329,10 @@ object Extensions {
         ss: Seq[Def.SettingsDefinition],
     ): Seq[Setting[?]] = platform ++ roots("shared", dir) ++ ss.flatMap(_.settings)
 
+    def jvmCompile(v: String) = self.jvm(v) / Compile
+    def classDir(v: String) = Def.setting((jvmCompile(v) / classDirectory).value.getAbsolutePath)
+    def publishedClassDir(v: String) = classDir(getPublishedForScalaVersion(v))
+
   }
 
   /**
@@ -319,6 +344,16 @@ object Extensions {
     /* projectMatrix leaves out an axis whose value a default repeats, and it counts two axes as
      * equal by version — so this default names the binary version and no real one. */
     VirtualAxis.scalaVersionAxis("3", "3"),
+  )
+
+  /**
+   * projectMatrix adds an axis naming the binary version, and a default swallows an axis of the
+   * same value. These name no real version, so a row keeps the axis that names its patch.
+   */
+  private def fullAxes: Seq[VirtualAxis] = Seq(
+    VirtualAxis.jvm,
+    VirtualAxis.scalaVersionAxis("2.12", "2.12"),
+    VirtualAxis.scalaVersionAxis("2.13", "2.13"),
   )
 
   /**

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -33,6 +33,12 @@ object Versions {
   val PublishedScalaVersions = PublishedScala2 :+ Scala3Published
   val TestedScalaVersions = PublishedScalaVersions ++ Scala3Rows.tail.map(_._1)
 
+  def getPublishedForScalaVersion(v: String): String = {
+    val prefix = s"${sbt.CrossVersion.binaryScalaVersion(v)}."
+    PublishedScalaVersions.find(_.startsWith(prefix))
+      .getOrElse(throw new Exception(s"No published version for Scala version $v"))
+  }
+
   /**
    * Scala.js and Native republish the standard library per full version, and for releases only. A
    * JS row takes the newest release, because scalajs-library depends on that scala-library.


### PR DESCRIPTION
The semanticdb modules publish one artifact per full Scala version, but were
cross-built as plain projects: each listed `crossScalaVersions`, so a CI step had
to force a version onto every project, and that switch outlives the step because
the steps of one job share the sbt server. Each patch now has a row of its own.

Rows name their dependencies explicitly, and `semanticdb-shared`, `io`,
`scalameta` and `testkit` publish per *binary* version — so each row resolves the
patch its own binary version publishes from. Pointing every row at the 2.13 patch
is what breaks the release today: `ci-release` fails on `main` with
`Scala version mismatch: semanticdbScalacCore (Scala 2.12.18) depends on
semanticdbShared2_13`, reproducible as
`sbt "; ++2.12.18; semanticdbScalacCore/publishLocal"`.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
