### PR TITLE
CI: run semanticdb on the newest JDK at the newest patch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,15 +49,13 @@ jobs:
       - &testjvm212
         if: ${{ !cancelled() }}
         run: sbt tests2_12/testFull
-      - &testsem212
-        if: ${{ !cancelled() }}
-        run: sbt testsSemanticdb2_12
+      - if: ${{ !cancelled() }}
+        run: sbt testsSemanticdb2_12_latest
       - &testjvm213
         if: ${{ !cancelled() }}
         run: sbt tests2_13/testFull
-      - &testsem213
-        if: ${{ !cancelled() }}
-        run: sbt testsSemanticdb2_13
+      - if: ${{ !cancelled() }}
+        run: sbt testsSemanticdb2_13_latest
       - &testjvm3lts
         if: ${{ !cancelled() }}
         run: sbt tests3_lts/testFull
@@ -75,7 +73,9 @@ jobs:
       - *testjvm212
       - if: ${{ !cancelled() }}
         run: sbt mima2_12
-      - *testsem212
+      - &testsem212
+        if: ${{ !cancelled() }}
+        run: sbt testsSemanticdb2_12
       - if: ${{ !cancelled() }}
         run: sbt testsJS3_next/testFull
 
@@ -105,7 +105,9 @@ jobs:
       - *testjvm3lts
       - if: ${{ !cancelled() }}
         run: sbt mima3_lts
-      - *testsem213
+      - &testsem213
+        if: ${{ !cancelled() }}
+        run: sbt testsSemanticdb2_13
       - if: ${{ !cancelled() }}
         run: sbt communitytest/testFull
       - if: ${{ !cancelled() }}

--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,9 @@ def testAliasesFor(patches: Seq[String]*) = patches.flatten
     // testsSemanticdb has a row per patch, so a step names the row and switches nothing
     def semanticdb(vs: Seq[String]) = all(vs.map(v => s"${testsSemanticdb.jvm(v).id}/testFull"))
     res ++= addCommandAlias(s"testsSemanticdb" + other, semanticdb(unpublished))
+    /* the newest JDK reads class files the published patch's asm does not, so the job that
+     * names a JDK pairs it with the newest patch rather than the one that publishes */
+    res ++= addCommandAlias(s"testsSemanticdb${ver}_latest", semanticdb(Seq(getLatest(vs))))
     if (published.nonEmpty) res ++= addCommandAlias("testsSemanticdb" + ver, semanticdb(published))
 
     res.result()


### PR DESCRIPTION
post-jvm-other-jdks runs the newest JDK, and its semanticdb steps run the patch that publishes. scalap and metacp read class files with the asm of their own Scala version, and 2.12.18 and 2.13.15 reject major version 69, so both steps fail on JDK 25. That job now names the newest patch, which read them before the gate moved to the published one.

The testsem212 and testsem213 anchors were defined here, so they move to the first gate job that uses each; the gate keeps the published patch.