### PR TITLE
SBT Mima: test scoped-private flag, not its label

### DIFF
--- a/project/ScalametaMimaUtils.scala
+++ b/project/ScalametaMimaUtils.scala
@@ -2,8 +2,10 @@ package com.typesafe.tools.mima.core
 
 object ScalametaMimaUtils {
 
+  /* scopedPrivatePrefix is what mima prints, not a test: it reads "private[..] " for every member,
+   * so asking whether it is empty said no member is public and dropped every problem. */
   def isPublic(obj: MemberInfo): Boolean = null != obj && !obj.nonAccessible &&
-    obj.scopedPrivatePrefix.isEmpty && isPublic(obj.owner, null)
+    !obj.scopedPrivate && isPublic(obj.owner, null)
 
   def isPublic(obj: ClassInfo, ref: AnyRef): Boolean = obj == ref || NoClass == obj ||
     null != obj && {


### PR DESCRIPTION
scopedPrivatePrefix is what mima prints for a member, and it reads "private[..] " whatever the member is. Alas, the mima checks have been passing without really checking anything.