### PR TITLE
bench: repair the semanticdb benchmarks

### DIFF
--- a/bench/corpus/scalap/scalax/rules/SeqRule.scala
+++ b/bench/corpus/scalap/scalax/rules/SeqRule.scala
@@ -84,13 +84,13 @@ class SeqRule[S, +A, +X](rule: Rule[S, S, A, X]) {
 
   /** Repeats this rule num times */
   def times(num: Int): Rule[S, S, Seq[A], X] = from[S] {
-    val result = new scala.collection.mutable.ArraySeq[A](num)
+    val result = new scala.collection.mutable.ArrayBuffer[A](num)
     // more compact using HoF but written this way so it's tail-recursive
     def rep(i: Int, in: S): Result[S, Seq[A], X] = {
-      if (i == num) Success(in, result)
+      if (i == num) Success(in, result.toSeq)
       else rule(in) match {
        case Success(out, a) => {
-         result(i) = a
+         result += a
          rep(i + 1, out)
        }
        case Failure => Failure

--- a/bench/semanticdb/src/main/scala/scala/meta/internal/bench/Scalameta.scala
+++ b/bench/semanticdb/src/main/scala/scala/meta/internal/bench/Scalameta.scala
@@ -57,8 +57,7 @@ class ScalametaBaseline extends Scalameta {
   override def mkSettings(bs: BenchmarkState): Settings = {
     val settings = super.mkSettings(bs)
     settings.pluginOptions.value ::= s"semanticdb:text:off"
-    settings.pluginOptions.value ::= s"semanticdb:symbols:on"
-    settings.pluginOptions.value ::= s"semanticdb:occurrences:on"
+    settings.pluginOptions.value ::= s"semanticdb:symbols:all"
     settings.pluginOptions.value ::= s"semanticdb:diagnostics:on"
     settings.pluginOptions.value ::= s"semanticdb:synthetics:off"
     settings

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -11,11 +11,10 @@ object Build extends AutoPlugin {
   import autoImport._
   object autoImport {
     trait BenchSemanticdbSuite {
-      def initCommands: List[String] =
-        List("benchSemanticdb/clean", "wow " + Versions.LatestScala212)
+      def initCommands: List[String] = List("benchSemanticdb/clean")
 
       private def toCommands(benches: Seq[String]): List[String] =
-        if (benches.isEmpty) Nil else List(benches.mkString("benchSemanticdb/jmh:run ", " ", ""))
+        if (benches.isEmpty) Nil else List(benches.mkString("benchSemanticdb/Jmh/run ", " ", ""))
 
       def metacpBenches: List[String]
       def metacpCommands: List[String] = toCommands(metacpBenches)


### PR DESCRIPTION
- sbt command "wow <version>" doesn't exit
- sbt command "jmh:run" is no longer valid in sbt2
- semanticdb setting `semanticdb:occurrences:on` was removed earlier
- semanticdb setting `symbols:on` is also no longer valid
- scalap corpus for benchmarking had a trivial syntax problem which does not compile in 2.13, so fix it