### PR TITLE
SBT: make the scalameta bench a matrix

### DIFF
--- a/bench/scalameta/src/main/scala/scala/meta/internal/bench/Corpus.scala
+++ b/bench/scalameta/src/main/scala/scala/meta/internal/bench/Corpus.scala
@@ -23,10 +23,10 @@ import org.openjdk.jmh.infra.Blackhole
  *
  * {{{
  * // per-op allocation over the munit corpus:
- * sbt 'benchScalameta/Jmh/run -wi 3 -i 5 -f1 -t1 -prof gc ".*CorpusBenchmark.*"'
+ * sbt 'bench2_13/Jmh/run -wi 3 -i 5 -f1 -t1 -prof gc ".*CorpusBenchmark.*"'
  *
  * // alloc flame graph over a 1500-file spark sample:
- * sbt 'benchScalameta/Jmh/run -wi 3 -i 5 -f1 -t1 -p corpus=spark -p limit=1500 \
+ * sbt 'bench2_13/Jmh/run -wi 3 -i 5 -f1 -t1 -p corpus=spark -p limit=1500 \
  *   -prof "async:libPath=/opt/homebrew/lib/libasyncProfiler.dylib;event=alloc;output=flamegraph;dir=/tmp/ap" \
  *   ".*CorpusBenchmark.parse"'
  * }}}

--- a/bench/scalameta/src/main/scala/scala/meta/internal/bench/Parser.scala
+++ b/bench/scalameta/src/main/scala/scala/meta/internal/bench/Parser.scala
@@ -20,15 +20,15 @@ import org.openjdk.jmh.annotations._
  * Recommended runs:
  * {{{
  * // wall-clock + per-op allocation (gc.alloc.rate.norm is the stable signal):
- * sbt 'benchScalameta/Jmh/run -wi 5 -i 10 -f1 -t1 -prof gc ".*ParserBenchmark.*"'
+ * sbt 'bench2_13/Jmh/run -wi 5 -i 10 -f1 -t1 -prof gc ".*ParserBenchmark.*"'
  *
  * // allocation flame graph via async-profiler (Homebrew v4.x):
- * sbt 'benchScalameta/Jmh/run -wi 5 -i 10 -f1 -t1 \
+ * sbt 'bench2_13/Jmh/run -wi 5 -i 10 -f1 -t1 \
  *   -prof "async:libPath=/opt/homebrew/lib/libasyncProfiler.dylib;event=alloc;output=flamegraph;dir=/tmp/ap" \
  *   ".*ParserBenchmark.parse"'
  *
  * // CPU flame graph (event=cpu):
- * sbt 'benchScalameta/Jmh/run ... -prof "async:...;event=cpu;..." ".*parse"'
+ * sbt 'bench2_13/Jmh/run ... -prof "async:...;event=cpu;..." ".*parse"'
  * }}}
  */
 @State(Scope.Benchmark) @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)

--- a/build.sbt
+++ b/build.sbt
@@ -567,20 +567,17 @@ lazy val benchSemanticdb = project.in(file("bench/semanticdb")).enablePlugins(Bu
     ).evaluated,
   ).dependsOn(testsSemanticdb.jvm(LatestScala213))
 
-lazy val benchScalameta = project.in(file("bench/scalameta")).enablePlugins(BuildInfoPlugin)
+lazy val bench = projectMatrix.in(file("bench/scalameta")).enablePlugins(BuildInfoPlugin)
   .enablePlugins(JmhPlugin).settings(
-    sharedJvmSettings,
-    scalaVersion := PublishedScala213,
-    crossScalaVersions := Seq(PublishedScala213),
+    sharedSettings,
     nonPublishableSettings,
     buildInfoKeys := Seq[BuildInfoKey]("sourceroot" -> (ThisBuild / baseDirectory).value),
     buildInfoPackage := "scala.meta.internal.bench",
     Jmh / resourceDirectory := (Compile / resourceDirectory).value,
     // two Append instances match a bare Classpath, so name the type
-    Jmh / fullClasspath ++=
-      { (scalameta.jvmCompile(PublishedScala213) / fullClasspath).value: Classpath },
+    Jmh / fullClasspath ++= { (Compile / fullClasspath).value: Classpath },
     Jmh / run := runJmhMain().evaluated,
-  ).dependsOn(scalameta.jvm(PublishedScala213))
+  ).crossJvm(PublishedScala2).dependsOn(scalameta)
 
 // ==========================================
 // Settings


### PR DESCRIPTION
The Jmh classpath named the 2.13 row of scalameta, so the benchmark measured 2.13 whatever version the project itself built at. It now has a row per published Scala 2 version.
