### PR TITLE
SBT: make the semanticdb bench a matrix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -554,18 +554,20 @@ def runJmhMain(extraArgs: Def.Initialize[Task[String]] = Def.task("")) = Def.inp
   }
 }
 
-lazy val benchSemanticdb = project.in(file("bench/semanticdb")).enablePlugins(BuildInfoPlugin)
+lazy val benchSemanticdb = projectMatrix.in(file("bench/semanticdb")).enablePlugins(BuildInfoPlugin)
   .enablePlugins(JmhPlugin).settings(
-    sharedJvmSettings,
-    crossScalaVersions := LatestScala2,
+    sharedSettings,
     nonPublishableSettings,
     libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value,
     buildInfoKeys := Seq[BuildInfoKey]("sourceroot" -> (ThisBuild / baseDirectory).value),
     buildInfoPackage := "scala.meta.internal.bench",
-    Jmh / run := runJmhMain(
-      Def.task(s" -p semanticdbScalacJar=${semanticdbScalacPluginPackage(LatestScala213).value}"),
-    ).evaluated,
-  ).dependsOn(testsSemanticdb.jvm(LatestScala213))
+    Jmh / run := runJmhMain(Def.taskDyn {
+      // a hoisted .value cannot read a local, so the version reaches the task as a parameter
+      def arg(v: String) = Def
+        .task(s" -p semanticdbScalacJar=${semanticdbScalacPluginPackage(v).value}")
+      arg(getForScalaBinaryVersion(scalaBinaryVersion.value, LatestScala2))
+    }).evaluated,
+  ).crossJvm(LatestScala2).dependsOn(testsSemanticdb)
 
 lazy val benchScalameta = project.in(file("bench/scalameta")).enablePlugins(BuildInfoPlugin)
   .enablePlugins(JmhPlugin).settings(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -11,10 +11,10 @@ object Build extends AutoPlugin {
   import autoImport._
   object autoImport {
     trait BenchSemanticdbSuite {
-      def initCommands: List[String] = List("benchSemanticdb/clean")
+      def initCommands: List[String] = List("benchSemanticdb2_13/clean")
 
       private def toCommands(benches: Seq[String]): List[String] =
-        if (benches.isEmpty) Nil else List(benches.mkString("benchSemanticdb/Jmh/run ", " ", ""))
+        if (benches.isEmpty) Nil else List(benches.mkString("benchSemanticdb2_13/Jmh/run ", " ", ""))
 
       def metacpBenches: List[String]
       def metacpCommands: List[String] = toCommands(metacpBenches)


### PR DESCRIPTION
The project listed both latest Scala 2 versions. The run passed the 2.13 semanticdb-scalac plugin for both. Each row now passes the plugin built for its own version.
