### PR TITLE
CI: document each axis where it is built

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
       - *testjvm212
       - if: ${{ !cancelled() }}
         run: sbt mima2_12
+      - if: ${{ !cancelled() && github.event_name == 'push' }}
+        run: sbt doc2_12
       - &testsem212
         if: ${{ !cancelled() }}
         run: sbt testsSemanticdb2_12
@@ -92,9 +94,6 @@ jobs:
         run: sbt testsJS3_lts/testFull
       - if: ${{ !cancelled() }}
         run: sbt download-scala-library
-      # the shortest worker of the gate, and it already builds the 2.13 rows scaladoc documents
-      - if: ${{ !cancelled() && github.event_name == 'push' }}
-        run: sbt doc
   
   pr-jvm33-sem213-other: # 3.3 parser and mima + 2.13 semanticdb + community + scalafmt
     runs-on: ubuntu-latest
@@ -105,6 +104,8 @@ jobs:
       - *testjvm3lts
       - if: ${{ !cancelled() }}
         run: sbt mima3_lts
+      - if: ${{ !cancelled() && github.event_name == 'push' }}
+        run: sbt doc3_lts
       - &testsem213
         if: ${{ !cancelled() }}
         run: sbt testsSemanticdb2_13
@@ -124,6 +125,8 @@ jobs:
         run: sbt testsJS2_12/testFull
       - if: ${{ !cancelled() }}
         run: sbt testsJS2_13/testFull
+      - if: ${{ !cancelled() && github.event_name == 'push' }}
+        run: sbt docJS2_13
 
   # ===== post-merge superset: deferred axes, added only on push to main =====
   post-native: # flaky Native leg — deferred off the PR gate, retried once
@@ -145,6 +148,8 @@ jobs:
         run: sbt testsNative3_lts/testFull || sbt testsNative3_lts/testFull
       - if: ${{ !cancelled() }}
         run: sbt testsNative3_next/testFull || sbt testsNative3_next/testFull
+      - if: ${{ !cancelled() && github.event_name == 'push' }}
+        run: sbt docNative3_lts
 
   post-other-scala: # what the gate leaves out: an older 2.x patch, a further Scala 3 row
     if: ${{ github.event_name == 'push' }}

--- a/build.sbt
+++ b/build.sbt
@@ -68,6 +68,21 @@ def mimaPublished = Command.single("mimaPublished") { (state, version) =>
   rows.map(ref => s"${ref.project}/mimaReportBinaryIssues").toList ::: state
 }
 
+/* Documents the rows a worker has already built, so scaladoc reuses their classes instead of
+ * compiling them again. A row whose doc no artifact carries is left out. */
+def docFor = Command.args("docFor", "<platform> <version>") { (state, args) =>
+  val Seq(prefix, version) = args
+  val extracted = Project.extract(state)
+  val rows = extracted.structure.allProjectRefs.filter(ref =>
+    extracted.getOpt(ref / scalaVersion).contains(version) &&
+      extracted.getOpt(ref / Compile / packageDoc / publishArtifact).contains(true) &&
+      // a platform names the Scala.js or Native major version too, as in sjs1 and native0.5
+      extracted.getOpt(ref / platform).exists(_.startsWith(prefix)),
+  ).map(_.project).sorted
+  state.log.info(s"doc for $prefix $version: ${rows.mkString(", ")}")
+  rows.map(row => s"$row/doc").toList ::: state
+}
+
 def helloContributor(): Unit = println(
   """|Welcome to the Scalameta build! You probably don't want to run `sbt test` since
      |that will take a long time to complete.  More likely, you want to run `tests/test`.
@@ -93,6 +108,11 @@ def rootSettings = Def.settings(
   addCommandAlias("mima2_13", "mimaPublished " + PublishedScala213),
   addCommandAlias("mima2_12", "mimaPublished " + PublishedScala212),
   addCommandAlias("mima3_lts", "mimaPublished " + Scala3Published),
+  commands += docFor,
+  addCommandAlias("doc2_12", "docFor jvm " + PublishedScala212),
+  addCommandAlias("docJS2_13", "docFor sjs " + PublishedScala213ForJS),
+  addCommandAlias("doc3_lts", "docFor jvm " + Scala3Published),
+  addCommandAlias("docNative3_lts", "docFor native " + Scala3Published),
   commands += Command.command("releaseSemanticdb") { s =>
     val rows = AllScala2Versions.flatMap(semanticdbRows(s))
     ("semanticdbShared2_13" +: rows).map(_ + "/publishSigned").toList ::: s


### PR DESCRIPTION
Previously, CI would run `sbt doc` which ended up compiling and running scaladoc for every version on every platform. This was both excessive and led to having a lopsided CI worker which took twice as long as the next longest one.

Let's instead build scaladoc for a subset of combinations, and do that right after testing the same exact combination, so we don't incur any extra compilation costs (exactly how we do with MIMA checks).