### PR TITLE
CI: boot the sbt server in a step that retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,8 @@ jobs:
       # a cold boot downloads sbt and Scala; that failing is not a test failing
       - &sbt_bootup
         name: start the sbt server
-        run: sbt whoami
+        # the client can read a half-written active.json; a second one reaches the same server
+        run: sbt whoami || sbt whoami
         shell: bash
       - &testjvm212
         if: ${{ !cancelled() }}
@@ -70,6 +71,7 @@ jobs:
       - *checkout
       - *jdk
       - *sbt
+      - *sbt_bootup
       - *testjvm212
       - if: ${{ !cancelled() }}
         run: sbt mima2_12
@@ -87,6 +89,7 @@ jobs:
       - *checkout
       - *jdk
       - *sbt
+      - *sbt_bootup
       - *testjvm213
       - if: ${{ !cancelled() }}
         run: sbt mima2_13
@@ -101,6 +104,7 @@ jobs:
       - *checkout
       - *jdk
       - *sbt
+      - *sbt_bootup
       - *testjvm3lts
       - if: ${{ !cancelled() }}
         run: sbt mima3_lts
@@ -120,6 +124,7 @@ jobs:
       - *checkout
       - *jdk
       - *sbt
+      - *sbt_bootup
       - *testjvm3next
       - if: ${{ !cancelled() }}
         run: sbt testsJS2_12/testFull


### PR DESCRIPTION
The first sbt command of a job boots the server, and the client that boots it sometimes reads project/target/active.json while the server is still writing it. That command fails; the next one reaches the same server and runs. Four jobs met this in a test step, which reads as a test failure.

Every job now boots the server first, and that command runs twice if the first one loses the race. A test step is too expensive to retry this way.