### PR TITLE
ScaladocParser: read a fence wherever it appears

### DIFF
--- a/scalameta/trees/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
+++ b/scalameta/trees/shared/src/main/scala/scala/meta/internal/parsers/ScaladocParser.scala
@@ -27,6 +27,8 @@ object ScaladocParser {
 
   private def nl[$: P]: P0 = P("\n")
   private def nlOrEndPeek[$: P] = &(End | nl)
+  // a code block is a term, so one starting mid-line also ends the term before it
+  private def termEndPeek[$: P] = P(nlOrEndPeek | codeBlockPeek)
 
   private def space[$: P] = CharIn("\t\r \n")
   private def spacesMin[$: P](min: Int) = CharsWhileIn("\t\r \n", min)
@@ -57,20 +59,28 @@ object ScaladocParser {
   private def linkPrefix[$: P] = P("[[" ~ hspaces0)
   private def linkSuffix[$: P] = P(hspaces0 ~ "]]")
 
-  private def codeLineParser[$: P]: P[String] = P {
-    def codeLineEnd = P(nl | codeSuffix)
-    (!codeLineEnd ~ AnyChar).rep.!
-  }
+  private def codeLinePeek[$: P] = P((!(nl | codeSuffix) ~ AnyChar).rep)
+  private def codeLineParser[$: P]: P[String] = P(codeLinePeek.!)
 
-  private def codeExprParser[$: P]: P[CodeExpr] = P {
-    def pattern = codePrefix ~ hspaces0 ~ codeLineParser ~ codeSuffix
-    pattern.map(x => CodeExpr(x.trim))
-  }
+  // an expression, not a code block, if the fence closes on the line it opens
+  private def codeExprBody[$: P]: P[String] = P(codeLineParser ~ codeSuffix)
+  private def codeExprPeek[$: P] = P(&(codeExprBody))
+  // without a close, the fence and the code that follows it are words
+  private def codeClosePeek[$: P] = P(&((!codeSuffix ~ AnyChar).rep ~ codeSuffix))
+  // checks for a code block here without reading one
+  private def codeBlockPeek[$: P] = P(&(hspaces0 ~ codePrefix ~ !codeExprPeek ~ codeClosePeek))
+
+  private def codeBodyParser[$: P]: P[Seq[String]] =
+    P(hspaces0 ~ nl.? ~ codeLineParser.rep(1, sep = nl) ~ codeSuffix)
+
+  // the cut keeps a closed block's lines from being read as words
+  private def codeExprParser[$: P]: P[CodeExpr] =
+    P(codePrefix ~ (codeExprBody.map(x => CodeExpr(x.trim)) | codeClosePeek ~/ Fail))
 
   private def codeBlockParser[$: P]: P[CodeBlock] = P {
-    def code = codeLineParser.rep(1, sep = nl)
-    def pattern = hspaces0 ~ codePrefix ~ nl ~ code ~ codeSuffix
-    pattern.map(x => CodeBlock(if (x.last.nonEmpty) x else x.dropRight(1)))
+    def block = hspaces0 ~ codePrefix ~ !codeExprPeek ~ codeBodyParser
+    // a close on its own line leaves an empty last line
+    block.map(x => CodeBlock(if (x.last.isEmpty) x.dropRight(1) else x))
   }
 
   /*
@@ -145,10 +155,11 @@ object ScaladocParser {
     def end = P(nl ~/ nextPartParser(indent, mdOffset))
     def part: P[TextPart] =
       P(codeExprParser | mdCodeSpanParser | linkParser | enclosedJavaTagParser | wordParser)
-    (hspaces0 ~ part ~ (!end ~ (nl.? ~ hspaces0).! ~ part).rep(0)).map { case (part1, parts) =>
-      val partInfos = parts.map { case (spaces, part) => TextPartInfo(part, spaces.isEmpty) }
-      // the first part is NOT attached to a previous part, whatever it is
-      Text(TextPartInfo(part1) +: partInfos)
+    (hspaces0 ~ NoCut(part) ~ (!end ~ (nl.? ~ hspaces0).! ~ NoCut(part)).rep(0)).map {
+      case (part1, parts) =>
+        val partInfos = parts.map { case (spaces, part) => TextPartInfo(part, spaces.isEmpty) }
+        // the first part is NOT attached to a previous part, whatever it is
+        Text(TextPartInfo(part1) +: partInfos)
     }
   }
 
@@ -160,8 +171,10 @@ object ScaladocParser {
     def label = P((nl ~ !nextPartParser(indent)).? ~ hspaces0 ~ wordParser)
     // special case: @usecase takes a single code line, on the same line
     def labelInline = P(hspaces0 ~ (!nl ~ AnyChar).rep(1).!.map(Word))
-    def desc = P((textParser(indent).? ~ embeddedTermsParser()).map { case (x, terms) =>
-      x.fold(terms)(_ +: terms)
+    /* embeddedTermsParser requires a preceding newline, so a code block
+     * opening on the tag's own line has to be taken here */
+    def desc = P((textParser(indent).? ~ codeBlockParser.? ~ embeddedTermsParser()).map {
+      case (x, cb, terms) => x.toSeq ++ cb.toSeq ++ terms
     })
     hspaces0 ~ ("@" ~ labelParser).!.flatMap { tag =>
       val tagType = TagType.getTag(tag)
@@ -281,11 +294,12 @@ object ScaladocParser {
 
   private def termParser[$: P] = P {
     def leadingParser = // might not consume full line
-      tagParser(0)
+      tagParser(0) | codeBlockParser
     def completeParser = // will consume full line
       listBlockParser() | mdCodeBlockParser() | codeBlockParser | headingParser | tableParser |
         textParser(0) // keep at the end, this is the fallback
-    (nl | Start) ~ (leadingParser | completeParser ~ nlOrEndPeek) | textParser(0) // could be following an element leaving trailing text, e.g. tagParser
+    // a code block may also begin partway through a line, as may text after one
+    (nl | Start) ~ (leadingParser | completeParser ~ termEndPeek) | codeBlockParser | textParser(0)
   }
 
   private def embeddedTermsParser[$: P](indent: Int = 0, mdOffset: Int = 0): P[Seq[Term]] = P {

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
@@ -205,6 +205,109 @@ class ScaladocParserSuite extends FunSuite {
     assertScaladoc(comment, expected)
   }
 
+  test("talking about the fence marker") {
+    def words(x: String): Seq[TextPartInfo] = x.split(" ").toSeq.map(Word.apply)
+    def check(comment: String, terms: Term*): Unit =
+      assertEquals(parseString(comment), Option(Scaladoc(Seq(Paragraph(terms)))), comment)
+    def span(x: String) = MdCodeSpan(x, "`")
+
+    // backticks are how a mention keeps the marker out of the parse
+    check(
+      "/**\n * the `{{{` wiki block\n */",
+      Text(Seq(Word("the"), span("{{{"), Word("wiki"), Word("block"))),
+    )
+    check(
+      "/**\n * use `{{{` and `}}}` to fence\n */",
+      Text(Seq(Word("use"), span("{{{"), Word("and"), span("}}}"), Word("to"), Word("fence"))),
+    )
+    // a backslash does not escape, but the word it makes opens no fence
+    check("/**\n * the \\{{{ marker opens a block\n */", Text(words("the \\{{{ marker opens a block")))
+    check("/**\n * the {{{ marker opens a block\n */", Text(words("the {{{ marker opens a block")))
+    // naming both markers closes the fence, whatever the prose meant
+    check(
+      "/**\n * the {{{ marker is closed by }}} at the end\n */",
+      Text(Seq(Word("the"), CodeExpr("marker is closed by"), Word("at"), Word("the"), Word("end"))),
+    )
+    check(
+      "/**\n * the {{{ marker\n * pairs with the }}} marker\n */",
+      Text(words("the {{{ marker pairs with the }}} marker")),
+    )
+  }
+
+  test("code fence with no close") {
+    def words(x: String): Seq[TextPartInfo] = x.split(" ").toSeq.map(Word.apply)
+    def check(comment: String, terms: Term*): Unit =
+      assertEquals(parseString(comment), Option(Scaladoc(Seq(Paragraph(terms)))), comment)
+
+    check("/**\n * {{{ foo\n * bar\n */", Text(words("{{{ foo bar")))
+    check("/**\n * qux {{{ foo\n * bar\n */", Text(words("qux {{{ foo bar")))
+    check(
+      "/**\n * @example qux {{{ foo\n * bar\n */",
+      Tag(TagType.Example, None, Seq(Text(words("qux {{{ foo bar")))),
+    )
+  }
+
+  test("empty code fence") {
+    def check(comment: String, terms: Term*): Unit =
+      assertEquals(parseString(comment), Option(Scaladoc(Seq(Paragraph(terms)))), comment)
+    val empty: Seq[TextPartInfo] = Seq(CodeExpr(""))
+
+    check("/**\n * {{{}}}\n */", Text(empty))
+    check("/**\n * {{{ }}}\n */", Text(empty))
+    check("/**\n * qux {{{}}} baz\n */", Text(Seq(Word("qux"), CodeExpr(""), Word("baz"))))
+    check("/**\n * {{{\n * }}}\n */", CodeBlock(Nil))
+  }
+
+  test("code fence closed on the line below") {
+    def doc(lead: String, trail: String) = s"/**\n * $lead{{{ bar\n * }}}$trail\n */"
+    def words(x: String): Seq[TextPartInfo] = x.split(" ").toSeq.map(Word.apply)
+    def check(lead: String, trail: String, terms: Term*): Unit = {
+      val comment = doc(lead, trail)
+      assertEquals(parseString(comment), Option(Scaladoc(Seq(Paragraph(terms)))), comment)
+    }
+    def tag(terms: Term*) = Tag(TagType.Example, None, terms)
+
+    check("", "", Text(words("{{{ bar }}}")))
+    check("", " baz", Text(words("{{{ bar }}} baz")))
+    check("qux ", "", Text(words("qux {{{ bar }}}")))
+    check("qux ", " baz", Text(words("qux {{{ bar }}} baz")))
+    check("@example ", "", tag(Text(words("{{{ bar }}}"))))
+    check("@example ", " baz", tag(Text(words("{{{ bar }}} baz"))))
+  }
+
+  test("multiline code block by fence position") {
+    def doc(lead: String, open: String, trail: String) =
+      s"/**\n * $lead{{{$open\n * foo\n * }}}$trail\n */"
+    def words(x: String): Seq[TextPartInfo] = x.split(" ").toSeq.map(Word.apply)
+    def check(lead: String, open: String, trail: String, terms: Term*): Unit = {
+      val comment = doc(lead, open, trail)
+      assertEquals(parseString(comment), Option(Scaladoc(Seq(Paragraph(terms)))), comment)
+    }
+    def tag(x: String) = Tag(TagType.Example, None, Seq(Text(words(x))))
+
+    // only a bare fence alone on its line opens a code block
+    check("", "", "", CodeBlock(Seq(" foo")))
+    // and trailing text after the close discards the whole comment
+    assertEquals(parseString(doc("", "", " baz")), None)
+
+    check("", " bar", "", Text(words("{{{ bar foo }}}")))
+    check("", " bar", " baz", Text(words("{{{ bar foo }}} baz")))
+    check("qux ", "", "", Text(words("qux {{{ foo }}}")))
+    check("qux ", "", " baz", Text(words("qux {{{ foo }}} baz")))
+    check("qux ", " bar", "", Text(words("qux {{{ bar foo }}}")))
+    check("qux ", " bar", " baz", Text(words("qux {{{ bar foo }}} baz")))
+    check("@example ", "", "", tag("{{{ foo }}}"))
+    check("@example ", "", " baz", tag("{{{ foo }}} baz"))
+    check("@example ", " bar", "", tag("{{{ bar foo }}}"))
+    check("@example ", " bar", " baz", tag("{{{ bar foo }}} baz"))
+  }
+
+  test("single-line code expression stays in the text") {
+    val comment = "/**\n * qux {{{ bar }}} baz\n */"
+    val parts: Seq[TextPartInfo] = Seq(Word("qux"), CodeExpr("bar"), Word("baz"))
+    assertEquals(parseString(comment), Option(Scaladoc(Seq(Paragraph(Seq(Text(parts)))))))
+  }
+
   test("code blocks multiline") {
     val complexCodeBlock = // keep all newlines and leading spaces
       """|  ggmqwogmwogmqwomgq

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ScaladocParserSuite.scala
@@ -230,7 +230,9 @@ class ScaladocParserSuite extends FunSuite {
     )
     check(
       "/**\n * the {{{ marker\n * pairs with the }}} marker\n */",
-      Text(words("the {{{ marker pairs with the }}} marker")),
+      Text(Seq(Word("the"))),
+      CodeBlock(Seq("marker", " pairs with the")),
+      Text(Seq(Word("marker"))),
     )
   }
 
@@ -267,12 +269,16 @@ class ScaladocParserSuite extends FunSuite {
     }
     def tag(terms: Term*) = Tag(TagType.Example, None, terms)
 
-    check("", "", Text(words("{{{ bar }}}")))
-    check("", " baz", Text(words("{{{ bar }}} baz")))
-    check("qux ", "", Text(words("qux {{{ bar }}}")))
-    check("qux ", " baz", Text(words("qux {{{ bar }}} baz")))
-    check("@example ", "", tag(Text(words("{{{ bar }}}"))))
-    check("@example ", " baz", tag(Text(words("{{{ bar }}} baz"))))
+    val bar = CodeBlock(Seq("bar"))
+    val baz = Text(words("baz"))
+    val qux = Text(words("qux"))
+
+    check("", "", bar)
+    check("", " baz", bar, baz)
+    check("qux ", "", qux, bar)
+    check("qux ", " baz", qux, bar, baz)
+    check("@example ", "", tag(bar))
+    check("@example ", " baz", tag(bar), baz)
   }
 
   test("multiline code block by fence position") {
@@ -283,23 +289,24 @@ class ScaladocParserSuite extends FunSuite {
       val comment = doc(lead, open, trail)
       assertEquals(parseString(comment), Option(Scaladoc(Seq(Paragraph(terms)))), comment)
     }
-    def tag(x: String) = Tag(TagType.Example, None, Seq(Text(words(x))))
+    def tag(code: Seq[String]) = Tag(TagType.Example, None, Seq(CodeBlock(code)))
+    val foo = Seq(" foo")
+    val barFoo = Seq("bar", " foo")
+    val baz = Text(words("baz"))
+    val qux = Text(words("qux"))
 
-    // only a bare fence alone on its line opens a code block
-    check("", "", "", CodeBlock(Seq(" foo")))
-    // and trailing text after the close discards the whole comment
-    assertEquals(parseString(doc("", "", " baz")), None)
-
-    check("", " bar", "", Text(words("{{{ bar foo }}}")))
-    check("", " bar", " baz", Text(words("{{{ bar foo }}} baz")))
-    check("qux ", "", "", Text(words("qux {{{ foo }}}")))
-    check("qux ", "", " baz", Text(words("qux {{{ foo }}} baz")))
-    check("qux ", " bar", "", Text(words("qux {{{ bar foo }}}")))
-    check("qux ", " bar", " baz", Text(words("qux {{{ bar foo }}} baz")))
-    check("@example ", "", "", tag("{{{ foo }}}"))
-    check("@example ", "", " baz", tag("{{{ foo }}} baz"))
-    check("@example ", " bar", "", tag("{{{ bar foo }}}"))
-    check("@example ", " bar", " baz", tag("{{{ bar foo }}} baz"))
+    check("", "", "", CodeBlock(foo))
+    check("", "", " baz", CodeBlock(foo), baz)
+    check("", " bar", "", CodeBlock(barFoo))
+    check("", " bar", " baz", CodeBlock(barFoo), baz)
+    check("qux ", "", "", qux, CodeBlock(foo))
+    check("qux ", "", " baz", qux, CodeBlock(foo), baz)
+    check("qux ", " bar", "", qux, CodeBlock(barFoo))
+    check("qux ", " bar", " baz", qux, CodeBlock(barFoo), baz)
+    check("@example ", "", "", tag(foo))
+    check("@example ", "", " baz", tag(foo), baz)
+    check("@example ", " bar", "", tag(barFoo))
+    check("@example ", " bar", " baz", tag(barFoo), baz)
   }
 
   test("single-line code expression stays in the text") {


### PR DESCRIPTION
Only a bare fence alone on its line opened a code block, so the same `{{{` after a word or a tag was read as words, and text after the close discarded the comment. Now one fence body serves both readings: a fence that closes on the line it opens is an expression within the text, and any other is a block, which is a term and so ends the text before it. A fence that never closes stays words, because a cut behind it would fail the whole comment.