### PR TITLE
SBT: fix docs generation step

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -807,6 +807,9 @@ lazy val docs = project.in(file("scalameta-docs")).settings(
   mdocOut := (ThisBuild / baseDirectory).value / "website" / "target" / "docs",
   mimaPreviousArtifacts := Set.empty,
 ).enablePlugins(BuildInfoPlugin, DocusaurusPlugin)
+  /* mdoc drags in a released scalameta, so without this the examples compile
+   * against that release instead of the tree they document */
+  .dependsOn(scalameta.jvm(PublishedScala213))
 
 def fileOf = Def.task(fileConverter.value.toPath(_: xsbti.HashedVirtualFileRef).toFile)
 

--- a/docs/trees/guide.md
+++ b/docs/trees/guide.md
@@ -299,19 +299,16 @@ nodes . Imagine we have a list of type arguments that happens to be empty
 val typeArguments = List.empty[Type]
 ```
 
-If we directly splice the lists into a type application we get an error message
-"invariant failed (targClause should be non-empty)" referring to the `targClause`
-field of `Type.ApplyType` (with additional cryptic information showing specific
-checks performed):
+Splicing the empty list builds a `Term.ApplyType` whose `targClause` is empty,
+and nothing rejects it:
 
-```scala mdoc:crash
-q"function[..$typeArguments]()"
+```scala mdoc
+println(q"function[..$typeArguments]()".structure)
 ```
 
-The quasiquote above is equivalent to calling the normal constructor
-`Type.ApplyType(.., typeArguments)`. Scalameta trees perform strict runtime
-validation for invariants such as "type application arguments must be
-non-empty". To fix this problem, guard the splice against the length of the list
+It prints as `function()`, but it is not the tree `q"function()"` builds, so a
+pattern written for that one does not match. To fix this problem, guard the
+splice against the length of the list
 
 ```scala mdoc
 println(

--- a/docs/trees/guide.md
+++ b/docs/trees/guide.md
@@ -539,32 +539,30 @@ introduce infinite recursion in `.transform`
 q"a + b".transform {
   case name @ Term.Name.Initial("b") => q"function($name)"
 }.toString
-// [error] java.lang.StackOverflowError
-// at scala.meta.transversers.Api$XtensionCollectionLikeUI$transformer$2$.apply(Api.scala:10)
-// at scala.meta.transversers.Transformer.apply(Transformer.scala:4)
+// [error] java.lang.OutOfMemoryError: Java heap space
 ```
 
-The best solution to fix this problem is to implement a custom transformer to
-gain fine-grained control over the recursion.
+The rule matches `b` again inside its own result, `function(b)`. Write a rule
+that cannot match what it returns.
 
 ### Custom transformations
 
-Extend `Transformer` if you need to implement a custom tree transformation
+Extend `Transformer` and override `transformNode` if you need to implement a
+custom tree transformation
 
 ```scala mdoc:silent
 val transformer = new Transformer {
-  override def apply(tree: Tree): Tree = tree match {
-    case name @ Term.Name.Initial("b") => q"function($name)"
-    case node => super.apply(node)
+  override protected def transformNode(node: Tree): Tree = node match {
+    case Term.Name.Initial("b") => q"c"
+    case node => node
   }
 }
 ```
 
-By avoiding the call to `super.transform` in the first case, we prevent a stack
-overflow.
+`transform` applies it to every node of the tree.
 
 ```scala mdoc
 println(
-  transformer(q"a + b")
+  transformer.transform(q"a + b")
 )
 ```


### PR DESCRIPTION
- compile the docs against this build
- revise guide to refer to new `transformNode` instead of disabled `apply`