### PR TITLE
Transformer: drop the collection apply overloads

### DIFF
--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -64,6 +64,7 @@ object Mima {
     .exclude[A]("scala.meta." + metaType)
 
   val apiCompatibilityExceptions: Seq[ProblemFilter] = Seq(
+    exclude[DirectMissingMethodProblem]("transversers.Transformer.apply"),
     // Tree
   )
 }

--- a/scala3-tree-lifts/macro/src/main/scala/org/scalameta/adt/TransversersGenerate.scala
+++ b/scala3-tree-lifts/macro/src/main/scala/org/scalameta/adt/TransversersGenerate.scala
@@ -161,38 +161,6 @@ class TransversersGenerateMacros(val c: Context) extends GenerateHelper with Ast
 
     val footer =
       s"""|
-          |  def apply(treeopt: Option[scala.meta.Tree]): Option[scala.meta.Tree] = treeopt match {
-          |    case Some(tree) =>
-          |      val tree1 = apply(tree)
-          |      if (tree eq tree1) treeopt
-          |      else Some(tree1)
-          |    case None => None
-          |  }
-          |
-          |  def apply(trees: List[scala.meta.Tree]): List[scala.meta.Tree] = {
-          |    var same = true
-          |    val buf = List.newBuilder[scala.meta.Tree]
-          |    trees.foreach { tree =>
-          |      val tree1 = apply(tree)
-          |      if (tree ne tree1) same = false
-          |      buf += tree1
-          |    }
-          |    if (same) trees
-          |    else buf.result()
-          |  }
-          |
-          |  def apply(trees: Seq[scala.meta.Tree]): Seq[scala.meta.Tree] = {
-          |    var same = true
-          |    val buf = Seq.newBuilder[scala.meta.Tree]
-          |    trees.foreach { tree =>
-          |      val tree1 = apply(tree)
-          |      if (tree ne tree1) same = false
-          |      buf += tree1
-          |    }
-          |    if (same) trees
-          |    else buf.result()
-          |  }
-          |
           |  private def fail(field: String, from: scala.meta.Tree, to: scala.meta.Tree): Nothing = {
           |    import scala.meta.prettyprinters._
           |    val errorPrefix = "Invalid transformation of " + field + ": "

--- a/scalameta/common2/shared/src/main/scala/scala/meta/internal/transversers/transformer.scala
+++ b/scalameta/common2/shared/src/main/scala/scala/meta/internal/transversers/transformer.scala
@@ -94,39 +94,6 @@ class TransformerMacros(val c: Context) extends TransverserMacros {
 
   def generatedMethods(): Tree =
     q"""
-      def apply(treeopt: $OptionClass[$TreeClass]): $OptionClass[$TreeClass] = treeopt match {
-        case $SomeModule(tree) =>
-          val tree1 = apply(tree)
-          if (tree eq tree1) treeopt
-          else $SomeModule(tree1)
-        case $NoneModule =>
-          $NoneModule
-      }
-
-      def apply(trees: $ListClass[$TreeClass]): $ListClass[$TreeClass] = {
-        var same = true
-        val buf = $ListModule.newBuilder[$TreeClass]
-        trees.foreach { tree =>
-          val tree1 = apply(tree)
-          if (tree ne tree1) same = false
-          buf += tree1
-        }
-        if (same) trees
-        else buf.result()
-      }
-
-      def apply(trees: $SeqClass[$TreeClass]): $SeqClass[$TreeClass] = {
-        var same = true
-        val buf = $SeqModule.newBuilder[$TreeClass]
-        trees.foreach { tree =>
-          val tree1 = apply(tree)
-          if (tree ne tree1) same = false
-          buf += tree1
-        }
-        if (same) trees
-        else buf.result()
-      }
-
       private def fail(field: String, from: $TreeClass, to: $TreeClass): $NothingClass = {
         import scala.meta.prettyprinters._
         val errorPrefix = "Invalid transformation of " + field + ": "


### PR DESCRIPTION
`apply(Option)`, `apply(List)` and `apply(Seq)` mapped each element through the recursive `apply`, which now pulls children from the frame `transform` sets up. Outside `transform` there is no frame, so they threw for a node with children, and skipped `transformNode` for one without. Callers map the collection through `transform` instead.