### PR TITLE
Transformer: add the replaceSubtree hook

### DIFF
--- a/docs/trees/guide.md
+++ b/docs/trees/guide.md
@@ -539,8 +539,9 @@ q"a + b".transform {
 // [error] java.lang.OutOfMemoryError: Java heap space
 ```
 
-The rule matches `b` again inside its own result, `function(b)`. Write a rule
-that cannot match what it returns.
+The rule matches `b` again inside its own result, `function(b)`. Either write a
+rule that cannot match what it returns, or override `replaceSubtree` to keep
+the result as it stands.
 
 ### Custom transformations
 
@@ -561,5 +562,24 @@ val transformer = new Transformer {
 ```scala mdoc
 println(
   transformer.transform(q"a + b")
+)
+```
+
+`replaceSubtree` runs first on every node. A tree it returns stands as the whole
+subtree, so the walk keeps it and does not descend into it; return `null` to
+leave the node to `transformNode`.
+
+```scala mdoc:silent
+val wrapper = new Transformer {
+  override protected def replaceSubtree(node: Tree): Tree = node match {
+    case name @ Term.Name.Initial("b") => q"function($name)"
+    case _ => null
+  }
+}
+```
+
+```scala mdoc
+println(
+  wrapper.transform(q"a + b")
 )
 ```

--- a/scalameta/transversers/shared/src/main/scala/scala/meta/transversers/TransformerBase.scala
+++ b/scalameta/transversers/shared/src/main/scala/scala/meta/transversers/TransformerBase.scala
@@ -4,13 +4,18 @@ package transversers
 /**
  * Base of the generated [[Transformer]].
  *
- * Override `transformNode` to map a node; `transform` applies it across the tree and rebuilds each
- * node through the generated (protected) `apply`, which pulls each transformed child via
- * `transformChild`.
+ * Override `transformNode` to map a node, or `replaceSubtree` to supply it together with everything
+ * under it; `transform` applies them across the tree and rebuilds each node through the generated
+ * (protected) `apply`, which pulls each transformed child via `transformChild`.
  */
 private[meta] abstract class TransformerBase {
 
   protected def transformNode(node: Tree): Tree = node
+
+  /* Runs before `transformNode` on every node. Return null to leave the node to `transformNode`,
+   * or the tree that stands for the whole subtree; the walk keeps that tree and does not descend
+   * into it, so a rule may return a tree that would match it again. */
+  protected def replaceSubtree(node: Tree): Tree = null
 
   protected def apply(tree: Tree): Tree
 
@@ -40,10 +45,12 @@ private[meta] abstract class TransformerBase {
       val childFrame = frame.nextChildFrame()
       if (childFrame ne null) stack = childFrame :: stack
       else {
-        pendingChildren = frame.children
-        pendingIndex = 0
-        ret = apply(frame.node) // generated dispatch; pulls children via transformChild
-        pendingChildren = null
+        if (frame.descend) {
+          pendingChildren = frame.children
+          pendingIndex = 0
+          ret = apply(frame.node) // generated dispatch; pulls children via transformChild
+          pendingChildren = null
+        } else ret = frame.node
         stack = stack.tail
       }
     }
@@ -54,21 +61,29 @@ private[meta] abstract class TransformerBase {
   // `children` from the result via `foreachChild` (reusing `apply`/`cursor`) and
   // resets `cursor`. During the walk the same `apply` overwrites each slot in place
   // with its transformed child; once `cursor` reaches the end the node is rebuilt.
-  private class Frame(val node: Tree) extends (Tree => Unit) {
+  // A frame that does not descend keeps no children and skips the rebuild.
+  private class Frame(val node: Tree, val descend: Boolean) extends (Tree => Unit) {
     private var cursor = 0
-    val children: Array[Tree] = {
-      val n = node.childrenCount
-      if (n == 0) TransformerBase.NoChildren else new Array[Tree](n)
-    }
+    val children: Array[Tree] =
+      if (!descend) TransformerBase.NoChildren
+      else {
+        val n = node.childrenCount
+        if (n == 0) TransformerBase.NoChildren else new Array[Tree](n)
+      }
     def apply(child: Tree): Unit = {
       children(cursor) = child
       cursor += 1
     }
-    node.foreachChild(this)
-    cursor = 0
+    if (descend) {
+      node.foreachChild(this)
+      cursor = 0
+    }
     def nextChildFrame(): Frame = if (cursor < children.length) frameOf(children(cursor)) else null
   }
-  private def frameOf(node: Tree): Frame = new Frame(transformNode(node))
+  private def frameOf(node: Tree): Frame = {
+    val subtree = replaceSubtree(node)
+    if (subtree eq null) new Frame(transformNode(node), true) else new Frame(subtree, false)
+  }
 
   // While `transform` rebuilds one node, holds that node's transformed children in
   // field order; `apply` reads them once each, in order, via `transformChild`.

--- a/tests/jvm/src/test/scala/scala/meta/tests/StackSafetySuite.scala
+++ b/tests/jvm/src/test/scala/scala/meta/tests/StackSafetySuite.scala
@@ -39,6 +39,20 @@ class StackSafetySuite extends FunSuite {
     assert(renamed ne tree) // the spine was actually rebuilt
   }
 
+  test("deeply nested tree - replaceSubtree") {
+    val tree = TestHelpers.deepTree(depth)
+    val transformer = new Transformer {
+      override protected def replaceSubtree(node: Tree): Tree = node match {
+        case Term.Name("x") => Term.Name("y")
+        case _ => null
+      }
+    }
+    // the leaf stops the walk, and the spine above it must still rebuild
+    def load() = transformer.transform(tree)
+    val renamed = load()
+    assert(renamed ne tree)
+  }
+
   // Unlike the others, this can't be captured upfront: before this fix its
   // failure is an OutOfMemoryError (the O(n^2) reparenting copies exhaust the
   // heap) that isn't cleanly catchable, so it is introduced as a positive test.

--- a/tests/shared/src/test/scala/scala/meta/tests/transversers/TransformerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/transversers/TransformerSuite.scala
@@ -59,6 +59,14 @@ class TransformerSuite extends TreeSuiteBase {
     assertEquals(afterTree.origin.inputOpt, beforeTree.origin.inputOpt)
   }
 
+  test("transform: a replacement with a matchable child") {
+    val tree = q"a".transform {
+      case Term.Name("a") => q"f(b)"
+      case Term.Name("b") => Term.Name("c")
+    }
+    assertEquals(tree.toString, "f(c)")
+  }
+
   test("#1200") {
     var i = 0
     val fn: PartialFunction[Tree, Tree] = {

--- a/tests/shared/src/test/scala/scala/meta/tests/transversers/TransformerSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/transversers/TransformerSuite.scala
@@ -67,6 +67,26 @@ class TransformerSuite extends TreeSuiteBase {
     assertEquals(tree.toString, "f(c)")
   }
 
+  test("replaceSubtree: a replacement with a matchable child") {
+    val transformer = new Transformer {
+      override protected def replaceSubtree(node: Tree): Tree = node match {
+        case Term.Name("a") => q"f(b)"
+        case _ => null
+      }
+    }
+    assertEquals(transformer.transform(q"a").toString, "f(b)")
+  }
+
+  test("replaceSubtree: a replacement that matches itself") {
+    val transformer = new Transformer {
+      override protected def replaceSubtree(node: Tree): Tree = node match {
+        case name @ Term.Name("b") => q"function($name)"
+        case _ => null
+      }
+    }
+    assertEquals(transformer.transform(q"a + b").toString, "a + function(b)")
+  }
+
   test("#1200") {
     var i = 0
     val fn: PartialFunction[Tree, Tree] = {


### PR DESCRIPTION
Overriding `apply` and not calling `super.apply` used to replace a node and leave its subtree alone. `apply` is protected since `transform` turned iterative, and the walk descends into whatever `transformNode` returns, so a rule that returns a tree matching itself never terminates. Now `replaceSubtree` supplies the whole subtree and the walk keeps it.
