### PR TITLE
Traverser: take one Iterable, not List and Seq

### DIFF
--- a/project/Mima.scala
+++ b/project/Mima.scala
@@ -66,6 +66,7 @@ object Mima {
   val apiCompatibilityExceptions: Seq[ProblemFilter] = Seq(
     exclude[DirectMissingMethodProblem]("transversers.Transformer.apply"),
     exclude[DirectMissingMethodProblem]("transversers.Traverser.apply"),
+    exclude[IncompatibleMethTypeProblem]("transversers.Traverser.apply"),
     // Tree
   )
 }

--- a/scalameta/common2/shared/src/main/scala/org/scalameta/internal/MacroHelpers.scala
+++ b/scalameta/common2/shared/src/main/scala/org/scalameta/internal/MacroHelpers.scala
@@ -71,6 +71,7 @@ trait MacroHelpers extends DebugFinder with MacroCompat with FreeLocalFinder wit
   lazy val ScalaRunTimeModule = hygienicRef(scala.runtime.ScalaRunTime)
   lazy val UnsupportedOperationException = hygienicRef[UnsupportedOperationException]
   lazy val IndexOutOfBoundsException = hygienicRef[IndexOutOfBoundsException]
+  lazy val IterableClass = tq"_root_.scala.Iterable"
   lazy val IteratorClass = tq"_root_.scala.collection.Iterator"
   lazy val ListClass = tq"_root_.scala.List"
   lazy val ListModule = q"_root_.scala.List"

--- a/scalameta/common2/shared/src/main/scala/scala/meta/internal/transversers/traverser.scala
+++ b/scalameta/common2/shared/src/main/scala/scala/meta/internal/transversers/traverser.scala
@@ -29,11 +29,7 @@ class TraverserMacros(val c: Context) extends TransverserMacros {
         case $NoneModule => // do nothing
       }
 
-      def apply(trees: $ListClass[$TreeClass]): $UnitClass = {
-        trees.foreach(apply(_))
-      }
-
-      def apply(trees: $SeqClass[$TreeClass]): $UnitClass = {
+      def apply(trees: $IterableClass[$TreeClass]): $UnitClass = {
         trees.foreach(apply(_))
       }
     """


### PR DESCRIPTION
The Scala 3 generator emits `apply(Option)` and `apply(Iterable)`, so the two builds published a different Traverser. A field typed `List` or `Seq` resolves against `Iterable` just as well.