### PR TITLE
Extensions: let the IDE import one Scala version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,21 @@ to your sbt file.
 PB.protocExecutable := file("/path/to/protoc")
 ```
 
+## IntelliJ
+
+IntelliJ imports the project for one Scala version, 2.13 by default, because it puts the sources
+that the matrix cells share into a single module: importing every cell would compile the Scala 2
+and the Scala 3 sources of a project together. To change that, set the properties below under
+`Settings -> Build, Execution, Deployment -> Build Tools -> sbt -> VM parameters` and reload the
+sbt project:
+
+- `-Dide.scala=X`: imports Scala version `X` instead. Name a binary version, `2.12`, `2.13` or
+  `3`. Ordinary projects build at one patch while the semanticdb rows build at every patch, so a
+  full version such as `2.13.18` selects the semanticdb row and leaves the rest out.
+- `-Dide.platform=Y`: if `Y` is empty, imports all platforms; otherwise, `Y` is a comma-separated
+  list of platforms to import, and `jvm` is implied, whether or not it is explicitly listed, while
+  `js` and `native` are optional.
+
 ## Testing
 
 The exact test command to run tests depends on what you are working on:

--- a/project/Extensions.scala
+++ b/project/Extensions.scala
@@ -243,6 +243,27 @@ object Extensions {
     },
   ).distinct
 
+  /* IntelliJ folds the source roots that matrix cells share into one module, so the whole matrix
+   * compiles scala-2 and scala-3 together. Only IntelliJ's importer reads `ide-skip-project`, so
+   * these properties change what the IDE sees and never what sbt builds. */
+  private val ideSkipProject = SettingKey[Boolean]("ide-skip-project")
+
+  private val ideScala = {
+    val prop = sys.props.getOrElse("ide.scala", "").trim
+    if (prop.isEmpty) CrossVersion.binaryScalaVersion(PublishedScala213) else prop
+  }
+
+  // the platforms to import besides the JVM, which the IDE always gets
+  private val idePlatforms = {
+    val prop = sys.props.getOrElse("ide.platform", "").trim
+    if (prop.isEmpty) Set.empty else prop.split("\\s*,\\s*").toSet + "jvm"
+  }
+
+  private def ideSkip(platform: String) = Seq(ideSkipProject := {
+    val versions = Set(scalaBinaryVersion.value, scalaVersion.value)
+    !versions(ideScala) || idePlatforms.nonEmpty && !idePlatforms(platform)
+  })
+
   implicit class ProjectMatrixExtensions(private val self: ProjectMatrix) extends AnyVal {
 
     def crossJvm(versions: Seq[String], ss: Def.SettingsDefinition*): ProjectMatrix = {
@@ -327,7 +348,7 @@ object Extensions {
         dir: String,
         platform: Seq[Setting[?]],
         ss: Seq[Def.SettingsDefinition],
-    ): Seq[Setting[?]] = platform ++ roots("shared", dir) ++ ss.flatMap(_.settings)
+    ): Seq[Setting[?]] = platform ++ roots("shared", dir) ++ ideSkip(dir) ++ ss.flatMap(_.settings)
 
     def jvmCompile(v: String) = self.jvm(v) / Compile
     def classDir(v: String) = Def.setting((jvmCompile(v) / classDirectory).value.getAbsolutePath)


### PR DESCRIPTION
The IDE imported every cell, and the result did not compile. Now it imports 2.13 on every platform: `-Dide.scala` picks the version and `-Dide.platform` picks the platforms besides the JVM.

`ide-skip-project` is IntelliJ's own key, so no plugin is needed. Every row is built by `rowSettings`, so that is where it attaches, and no row can be added without it.