### PR TITLE
CONTRIBUTING: name the test projects that exist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,19 +26,17 @@ PB.protocExecutable := file("/path/to/protoc")
 
 The exact test command to run tests depends on what you are working on:
 
-- `testsJVM/test`: run all parser tests
-- `testsSemanticdb/test`: run integration tests for semantic APIs.
+- `tests2_13/testFull`: run all parser tests
+- `testsSemanticdb2_13`: run integration tests for semantic APIs.
 
 Tips to make your edit/test/debug workflow as productive as possible:
 
-- Use `testOnly` to speedup your workflow. Running `testsJVM/test` may
+- Use `testOnly` to speedup your workflow. Running `tests2_13/testFull` may
   still be too slow if you want fast feedback while iterating on a small change.
-  It's recommended to use `testsJVM/testOnly *CUSTOM_SUITE` where `CUSTOM_SUITE`
+  It's recommended to use `tests2_13/testOnly *CUSTOM_SUITE` where `CUSTOM_SUITE`
   is the name of your test suite.
 - Use `testOnly *CUSTOM_SUITE -- -z "TEST_NAME"` to target an individual test case
-  from a test suite. Some test suites contains a lot of unit tests so it may still
-  be too slow to use `testOnly`. To target an individual slow test you must use
-  the `all` scope `testsJVM/all:testOnly *CUSTOM_SUITE -- -z "TEST_NAME"`.
+  from a test suite.
 - Use the sbt command `save-expect` to make `ExpectSuite` pass. This command
   writes to disk the output of the current behavior. The diff may be large,
   please review it thoroughly to ensure that the new expected behavior is correct.


### PR DESCRIPTION
The projectMatrix conversion renamed the test rows, so `testsJVM/test` and `testsSemanticdb/test` answer "Not a valid key". `test` is also the wrong task: it "executes the tests that either failed before, were not run or whose transitive dependencies changed", and `testFull` is the one that "executes all tests".

The `all` scope went with the conversion. No configuration by that name exists, so `testsJVM/all:testOnly` cannot resolve either, and the advice built on it is gone. What it introduced is already covered by the `-z` line above it.