### PR TITLE
Fix duplicate trailing comment ownership

### DIFF
--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -498,7 +498,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
                   if (begBuf ne null)
                     if (canEndStat(t) || body.is[Term.Block] || hadEOL && t.is[Comma])
                       begBuf.remove(0, pending)
-                  false
+                  t.isEmpty // cannot separate a leading comment from the tree
               }) idx -= 1
             if (begBuf eq null) None else asComments(begBuf)
           } else if (bodyIsBlock) None // braceless
@@ -542,7 +542,8 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
                   true
                 case _: HSpace => true
                 case _: Comma => tokens.findNotOrNull(_.is[HTrivia], idx + 1).is[AtEOL]
-                case _ => false
+                case null => false
+                case t => t.isEmpty // cannot separate the tree from a trailing comment
               }) idx += 1
             if (endBuf eq null) None else asComments(endBuf)
           } else if (bodyIsBlock) None // let the child own it

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -496,7 +496,7 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
                 case null => false
                 case t =>
                   if (begBuf ne null)
-                    if (t.isAny[Ident, CloseDelim] || body.is[Term.Block] || hadEOL && t.is[Comma])
+                    if (canEndStat(t) || body.is[Term.Block] || hadEOL && t.is[Comma])
                       begBuf.remove(0, pending)
                   false
               }) idx -= 1

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -495,8 +495,9 @@ class ScalametaParser(input: Input)(implicit dialect: Dialect, options: ParserOp
                 case _: HSpace => true
                 case null => false
                 case t =>
-                  if (t.isAny[Ident, CloseDelim] || body.is[Term.Block] || hadEOL && t.is[Comma])
-                    if (begBuf ne null) begBuf.remove(0, pending)
+                  if (begBuf ne null)
+                    if (t.isAny[Ident, CloseDelim] || body.is[Term.Block] || hadEOL && t.is[Comma])
+                      begBuf.remove(0, pending)
                   false
               }) idx -= 1
             if (begBuf eq null) None else asComments(begBuf)

--- a/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
+++ b/scalameta/parsers/shared/src/main/scala/scala/meta/internal/parsers/ScannerTokens.scala
@@ -212,7 +212,7 @@ final class ScannerTokens(val tokens: Tokens)(implicit dialect: Dialect) {
     case _ => true
   }
 
-  private def canEndStat(token: Token): Boolean = token match {
+  def canEndStat(token: Token): Boolean = token match {
     case _: Ident | _: KwGiven | _: Literal | _: Interpolation.End | _: Xml.End | _: KwReturn |
         _: KwThis | _: KwType | _: RightParen | _: RightBracket | _: RightBrace | _: Underscore |
         _: Ellipsis | _: Unquote => true

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/DeclSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/DeclSuite.scala
@@ -106,4 +106,13 @@ class DeclSuite extends ParseSuite {
   test("val x: (=> X)")(
     assertTree(templStat("val x: (=> X)"))(Decl.Val(Nil, List(patvar("x")), Type.ByName(pname("X")))),
   )
+
+  test("trailing comment on adjacent singleton type")(assertStatComments(
+    """|trait O {
+       |  def f: O.type // commentX
+       |  def g: Int
+       |}""".stripMargin,
+    "end // commentX",
+    "beg // commentX",
+  ))
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/DeclSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/DeclSuite.scala
@@ -113,6 +113,5 @@ class DeclSuite extends ParseSuite {
        |  def g: Int
        |}""".stripMargin,
     "end // commentX",
-    "beg // commentX",
   ))
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
@@ -55,6 +55,96 @@ class DefnSuite extends ParseSuite {
     Defn.Val(Nil, List(patvar("x")), Some("Int"), Term.Placeholder()),
   ))
 
+  test("trailing comment on adjacent literal definition") {
+    val code =
+      """|object O {
+         |  val x = 1 // commentX
+         |  val y = 2
+         |}""".stripMargin
+    code.parse[Source] match {
+      case x: Parsed.Error => fail(x.message)
+      case Parsed.Success(obtained) => obtained.stats match {
+          case (obj: Defn.Object) :: Nil => obj.templ.stats match {
+              case first :: second :: Nil =>
+                assert(first.endComment.exists(_.toString.contains("commentX")))
+                assert(
+                  second.begComment.exists(_.toString.contains("commentX")),
+                  s"adjacent definition duplicates the trailing comment: ${second.begComment}",
+                )
+              case x => fail(s"Expected two definitions: ${x.structure}")
+            }
+          case x => fail(s"Expected one object: ${x.structure}")
+        }
+    }
+  }
+
+  test("trailing comment on adjacent parenthesized definition") {
+    val code =
+      """|object O {
+         |  val x = List(1) // commentX
+         |  val y = 2
+         |}""".stripMargin
+    code.parse[Source] match {
+      case x: Parsed.Error => fail(x.message)
+      case Parsed.Success(obtained) => obtained.stats match {
+          case (obj: Defn.Object) :: Nil => obj.templ.stats match {
+              case first :: second :: Nil =>
+                assert(first.endComment.exists(_.toString.contains("commentX")))
+                assert(second.begComment.isEmpty, s"adjacent definition must not duplicate the trailing comment: ${second.begComment}")
+              case x => fail(s"Expected two definitions: ${x.structure}")
+            }
+          case x => fail(s"Expected one object: ${x.structure}")
+        }
+    }
+  }
+
+  test("trailing comment on adjacent interpolation")(assertStatComments(
+    """|object O {
+       |  val x = s"$y" // commentX
+       |  val z = 2
+       |}""".stripMargin,
+    "end // commentX",
+    "beg // commentX",
+  ))
+
+  test("trailing comment on adjacent xml literal")(assertStatComments(
+    """|object O {
+       |  val x = <a/> // commentX
+       |  val z = 2
+       |}""".stripMargin,
+    "beg // commentX",
+  ))
+
+  test("leading comment on xml argument")(assertStatComments(
+    """|object O {
+       |  val x = f(/* commentX */ <a/>)
+       |}""".stripMargin,
+  ))
+
+  test("leading comment on literal argument")(assertStatComments(
+    """|object O {
+       |  val x = f(/* commentX */ 1)
+       |}""".stripMargin,
+    "beg /* commentX */",
+  ))
+
+  test("trailing comment on adjacent self reference")(assertStatComments(
+    """|class O {
+       |  val x = this // commentX
+       |  val z = 2
+       |}""".stripMargin,
+    "end // commentX",
+    "beg // commentX",
+  ))
+
+  test("trailing comment on adjacent return")(assertStatComments(
+    """|object O {
+       |  def f: Unit = return // commentX
+       |  val z = 2
+       |}""".stripMargin,
+    "beg // commentX",
+  ))
+
   test("val (x: Int) = 2")(assertTree(templStat("val (x: Int) = 2"))(
     Defn.Val(Nil, Pat.Typed(patvar("x"), pname("Int")) :: Nil, None, int(2)),
   ))

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
@@ -67,10 +67,7 @@ class DefnSuite extends ParseSuite {
           case (obj: Defn.Object) :: Nil => obj.templ.stats match {
               case first :: second :: Nil =>
                 assert(first.endComment.exists(_.toString.contains("commentX")))
-                assert(
-                  second.begComment.exists(_.toString.contains("commentX")),
-                  s"adjacent definition duplicates the trailing comment: ${second.begComment}",
-                )
+                assert(second.begComment.isEmpty, s"adjacent definition must not duplicate the trailing comment: ${second.begComment}")
               case x => fail(s"Expected two definitions: ${x.structure}")
             }
           case x => fail(s"Expected one object: ${x.structure}")
@@ -104,7 +101,6 @@ class DefnSuite extends ParseSuite {
        |  val z = 2
        |}""".stripMargin,
     "end // commentX",
-    "beg // commentX",
   ))
 
   test("trailing comment on adjacent xml literal")(assertStatComments(
@@ -112,7 +108,6 @@ class DefnSuite extends ParseSuite {
        |  val x = <a/> // commentX
        |  val z = 2
        |}""".stripMargin,
-    "beg // commentX",
   ))
 
   test("leading comment on xml argument")(assertStatComments(
@@ -134,7 +129,6 @@ class DefnSuite extends ParseSuite {
        |  val z = 2
        |}""".stripMargin,
     "end // commentX",
-    "beg // commentX",
   ))
 
   test("trailing comment on adjacent return")(assertStatComments(
@@ -142,7 +136,7 @@ class DefnSuite extends ParseSuite {
        |  def f: Unit = return // commentX
        |  val z = 2
        |}""".stripMargin,
-    "beg // commentX",
+    "end // commentX",
   ))
 
   test("val (x: Int) = 2")(assertTree(templStat("val (x: Int) = 2"))(

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/DefnSuite.scala
@@ -108,12 +108,14 @@ class DefnSuite extends ParseSuite {
        |  val x = <a/> // commentX
        |  val z = 2
        |}""".stripMargin,
+    "end // commentX",
   ))
 
   test("leading comment on xml argument")(assertStatComments(
     """|object O {
        |  val x = f(/* commentX */ <a/>)
        |}""".stripMargin,
+    "beg /* commentX */",
   ))
 
   test("leading comment on literal argument")(assertStatComments(

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ImportSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ImportSuite.scala
@@ -176,6 +176,29 @@ class ImportSuite extends ParseSuite {
     }
   }
 
+  test("trailing comment on adjacent wildcard import") {
+    val code =
+      """|import c._ // commentC
+         |import b.B
+         |""".stripMargin
+    code.parse[Source] match {
+      case x: Parsed.Error => fail(x.message)
+      case Parsed.Success(obtained) => obtained.stats match {
+          case cImport :: bImport :: Nil =>
+            assert(cImport.endComment.isDefined, "wildcard import must keep its trailing comment")
+            assert(
+              cImport.endComment.get.toString.contains("commentC"),
+              s"wildcard trailing comment missing: ${cImport.endComment}",
+            )
+            assert(
+              bImport.begComment.exists(_.toString.contains("commentC")),
+              s"adjacent import duplicates the trailing comment: ${bImport.begComment}",
+            )
+          case x => fail(s"Expected two imports: ${obtained.structure}")
+        }
+    }
+  }
+
   test("import with detached comment") {
     val code =
       """|// detached comment before

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ImportSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ImportSuite.scala
@@ -191,8 +191,8 @@ class ImportSuite extends ParseSuite {
               s"wildcard trailing comment missing: ${cImport.endComment}",
             )
             assert(
-              bImport.begComment.exists(_.toString.contains("commentC")),
-              s"adjacent import duplicates the trailing comment: ${bImport.begComment}",
+              bImport.begComment.isEmpty,
+              s"adjacent import must not duplicate the trailing comment: ${bImport.begComment}",
             )
           case x => fail(s"Expected two imports: ${obtained.structure}")
         }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/ParseSuite.scala
@@ -84,6 +84,15 @@ abstract class ParseSuite extends TreeSuiteBase with CommonTrees {
   )(implicit loc: munit.Location, dialect: Dialect): Unit =
     checkParsedTree(code, _.entrypointStat(), syntax)(tree)
 
+  protected def assertStatComments(code: String, comments: String*)(implicit
+      loc: munit.Location,
+      dialect: Dialect,
+  ): Unit = {
+    val obtained = source(code).collect { case t if t.hasComments => t }
+      .flatMap(t => t.begComment.map(x => s"beg $x") ++ t.endComment.map(x => s"end $x")).distinct
+    assertEquals(obtained, comments.toList)
+  }
+
   protected def runTestError[T <: Tree](code: String, expected: String)(implicit
       parser: String => T,
       loc: munit.Location,

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExportImportSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExportImportSuite.scala
@@ -105,7 +105,6 @@ class ExportImportSuite extends BaseDottySuite {
        |import b.B
        |""".stripMargin,
     "end // commentC",
-    "beg // commentC",
   ))
 
 }

--- a/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExportImportSuite.scala
+++ b/tests/shared/src/test/scala/scala/meta/tests/parsers/dotty/ExportImportSuite.scala
@@ -100,4 +100,12 @@ class ExportImportSuite extends BaseDottySuite {
     runTestAssert[Stat](code, layout)(tree)
   }
 
+  test("trailing comment on adjacent given import")(assertStatComments(
+    """|import c.given // commentC
+       |import b.B
+       |""".stripMargin,
+    "end // commentC",
+    "beg // commentC",
+  ))
+
 }


### PR DESCRIPTION
Fixes https://github.com/scalacenter/scalafix/issues/2473

Reuse the parser's canonical `canEndStat` token predicate when attaching leading comments. This prevents trailing comments from being duplicated onto the following statement after wildcard imports and other terminal expressions.