### PR TITLE
Extensions: narrow the import with bspEnabled

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,20 +22,35 @@ to your sbt file.
 PB.protocExecutable := file("/path/to/protoc")
 ```
 
-## IntelliJ
+## Narrowing what an IDE imports
 
-IntelliJ imports the project for one Scala version, 2.13 by default, because it puts the sources
-that the matrix cells share into a single module: importing every cell would compile the Scala 2
-and the Scala 3 sources of a project together. To change that, set the properties below under
-`Settings -> Build, Execution, Deployment -> Build Tools -> sbt -> VM parameters` and reload the
-sbt project:
+sbt builds each project of this build once per Scala version and platform. Several of those rows
+use the same source directories. Two system properties control which rows an IDE imports: the
+build sets `bspEnabled := false` on the other rows, and sbt then leaves them out of the BSP
+workspace.
 
-- `-Dide.scala=X`: imports Scala version `X` instead. Name a binary version, `2.12`, `2.13` or
-  `3`. Ordinary projects build at one patch while the semanticdb rows build at every patch, so a
-  full version such as `2.13.18` selects the semanticdb row and leaves the rest out.
-- `-Dide.platform=Y`: if `Y` is empty, imports all platforms; otherwise, `Y` is a comma-separated
-  list of platforms to import, and `jvm` is implied, whether or not it is explicitly listed, while
-  `js` and `native` are optional.
+- `-Dide.scala=X` — sbt keeps only the rows for Scala version `X`.
+  - matches full or binary version. Ordinary projects build at one patch while the semanticdb rows
+    build at every patch, so a full version such as `2.13.18` selects the semanticdb row and
+    leaves the rest out.
+  - if unspecified or empty: keep all scala versions
+    - IntelliJ only: will be forced to `2.13`; see below why IntelliJ can't load multiple
+      versions.
+- `-Dide.platform=Y` — sbt keeps only the rows for the platforms in `Y`, a comma-separated list.
+  - matches `jvm`, `js`, or `native`
+  - if unspecified or empty: keep every platform
+  - the Scala.js and Native rows stay out either way, because `commonJsSettings` and
+    `nativeSettings` turn BSP off for them
+
+IntelliJ cannot import the whole matrix. It puts the sources that several rows use into one module,
+and then compiles the Scala 2 and the Scala 3 sources of a project together. It starts sbt with
+`-Didea.managed=true`. If you do not set `-Dide.scala`, that property selects 2.13. To choose
+another version, add `-Dide.scala=X` under `Settings -> Build, Execution, Deployment -> Build Tools
+-> sbt -> VM parameters`, then reload the sbt project.
+
+An sbt server uses the system properties from its own command line. It ignores a property that you
+pass to a later command. Run `sbt shutdown` before you test a change to these properties from the
+shell.
 
 ## Testing
 

--- a/project/Extensions.scala
+++ b/project/Extensions.scala
@@ -259,18 +259,25 @@ object Extensions {
     if (prop.isEmpty) Set.empty else prop.split("\\s*,\\s*").toSet + "jvm"
   }
 
-  private def ideSkip(platform: String) = Seq(ideSkipProject := {
-    val versions = Set(scalaBinaryVersion.value, scalaVersion.value)
-    !versions(ideScala) || idePlatforms.nonEmpty && !idePlatforms(platform)
-  })
+  // contributes nothing when it keeps a row, so it never overrides another setting
+  private def ideSkip(platform: String, version: Option[String]): Seq[Setting[?]] = {
+    val skipVersion = version
+      .exists(v => ideScala != v && ideScala != CrossVersion.binaryScalaVersion(v))
+    if (skipVersion || idePlatforms.nonEmpty && !idePlatforms(platform)) Seq(ideSkipProject := true)
+    else Nil
+  }
 
   implicit class ProjectMatrixExtensions(private val self: ProjectMatrix) extends AnyVal {
 
     def crossJvm(versions: Seq[String], ss: Def.SettingsDefinition*): ProjectMatrix = {
       val (scala2, scala3) = splitScala3(versions)
-      val settings = rowSettings("jvm", jvmPlatformSettings, ss)
-      val proj = self.defaultAxes(bareAxes *).jvmPlatform(scala2, settings)
-      scala3.foldLeft(proj) { case (m, (v, axis, ss)) => m.jvmPlatform(v, axis, settings ++ ss) }
+      // one row at a time, so each one knows the version it is built for
+      def settings(v: String) = rowSettings("jvm", Some(v), jvmPlatformSettings, ss)
+      val proj = scala2
+        .foldLeft(self.defaultAxes(bareAxes *))((m, v) => m.jvmPlatform(Seq(v), settings(v)))
+      scala3.foldLeft(proj) { case (m, (v, axis, ss)) =>
+        m.jvmPlatform(v, axis, settings(v.head) ++ ss)
+      }
     }
 
     /* semanticdb publishes one artifact per full Scala version, so each patch gets a row of its
@@ -284,7 +291,8 @@ object Extensions {
       /* customRow hands each row its own Project, so a row states the dependency for its own
        * version. A module published per binary version has one row a full-cross row can name. */
       val conv = (p: Project) =>
-        p.settings(rowSettings("jvm", jvmPlatformSettings, ss(v))).dependsOn(deps.map(_.jvm(pv)) *)
+        p.settings(rowSettings("jvm", Some(v), jvmPlatformSettings, ss(v)))
+          .dependsOn(deps.map(_.jvm(pv)) *)
       matrix.customRow(
         autoScalaLibrary = true,
         scalaVersions = Seq(v),
@@ -295,16 +303,22 @@ object Extensions {
 
     def crossJs(versions: Seq[String], ss: Def.SettingsDefinition*): ProjectMatrix = {
       val (scala2, scala3) = splitScala3(versions)
-      val settings = rowSettings("js", commonJsSettings, ss)
-      val proj = self.defaultAxes(bareAxes *).jsPlatform(jsScalaVersions(scala2), settings)
-      scala3.foldLeft(proj) { case (m, (v, axis, ss)) => m.jsPlatform(v, axis, settings ++ ss) }
+      def settings(v: String) = rowSettings("js", Some(v), commonJsSettings, ss)
+      val proj = jsScalaVersions(scala2)
+        .foldLeft(self.defaultAxes(bareAxes *))((m, v) => m.jsPlatform(Seq(v), settings(v)))
+      scala3.foldLeft(proj) { case (m, (v, axis, ss)) =>
+        m.jsPlatform(v, axis, settings(v.head) ++ ss)
+      }
     }
 
     def crossNative(versions: Seq[String], ss: Def.SettingsDefinition*): ProjectMatrix = {
       val (scala2, scala3) = splitScala3(versions)
-      val settings = rowSettings("native", nativeSettings, ss)
-      val proj = self.defaultAxes(bareAxes *).nativePlatform(nativeScalaVersions(scala2), settings)
-      scala3.foldLeft(proj) { case (m, (v, axis, ss)) => m.nativePlatform(v, axis, settings ++ ss) }
+      def settings(v: String) = rowSettings("native", Some(v), nativeSettings, ss)
+      val proj = nativeScalaVersions(scala2)
+        .foldLeft(self.defaultAxes(bareAxes *))((m, v) => m.nativePlatform(Seq(v), settings(v)))
+      scala3.foldLeft(proj) { case (m, (v, axis, ss)) =>
+        m.nativePlatform(v, axis, settings(v.head) ++ ss)
+      }
     }
 
     /** Every platform, nothing published. */
@@ -346,9 +360,11 @@ object Extensions {
 
     private def rowSettings(
         dir: String,
+        version: Option[String],
         platform: Seq[Setting[?]],
         ss: Seq[Def.SettingsDefinition],
-    ): Seq[Setting[?]] = platform ++ roots("shared", dir) ++ ideSkip(dir) ++ ss.flatMap(_.settings)
+    ): Seq[Setting[?]] = platform ++ roots("shared", dir) ++ ideSkip(dir, version) ++
+      ss.flatMap(_.settings)
 
     def jvmCompile(v: String) = self.jvm(v) / Compile
     def classDir(v: String) = Def.setting((jvmCompile(v) / classDirectory).value.getAbsolutePath)

--- a/project/Extensions.scala
+++ b/project/Extensions.scala
@@ -243,27 +243,28 @@ object Extensions {
     },
   ).distinct
 
-  /* IntelliJ folds the source roots that matrix cells share into one module, so the whole matrix
-   * compiles scala-2 and scala-3 together. Only IntelliJ's importer reads `ide-skip-project`, so
-   * these properties change what the IDE sees and never what sbt builds. */
-  private val ideSkipProject = SettingKey[Boolean]("ide-skip-project")
-
+  /* `bspEnabled := false` leaves a row out of the BSP workspace, so an IDE does not import it.
+   * IntelliJ can't load multiple versions, though, so force 2.13 if `ide.scala` is absent. */
   private val ideScala = {
     val prop = sys.props.getOrElse("ide.scala", "").trim
-    if (prop.isEmpty) CrossVersion.binaryScalaVersion(PublishedScala213) else prop
+    if (prop.nonEmpty) Some(prop)
+    // this looks like IntelliJ
+    else if (sys.props.contains("idea.managed"))
+      Some(CrossVersion.binaryScalaVersion(PublishedScala213))
+    else None
   }
 
-  // the platforms to import besides the JVM, which the IDE always gets
+  // an empty set is no filter, so every platform
   private val idePlatforms = {
     val prop = sys.props.getOrElse("ide.platform", "").trim
-    if (prop.isEmpty) Set.empty else prop.split("\\s*,\\s*").toSet + "jvm"
+    if (prop.isEmpty) Set.empty else prop.split("\\s*,\\s*").toSet
   }
 
   // contributes nothing when it keeps a row, so it never overrides another setting
   private def ideSkip(platform: String, version: Option[String]): Seq[Setting[?]] = {
     val skipVersion = version
-      .exists(v => ideScala != v && ideScala != CrossVersion.binaryScalaVersion(v))
-    if (skipVersion || idePlatforms.nonEmpty && !idePlatforms(platform)) Seq(ideSkipProject := true)
+      .exists(v => ideScala.exists(s => s != v && s != CrossVersion.binaryScalaVersion(v)))
+    if (skipVersion || idePlatforms.nonEmpty && !idePlatforms(platform)) Seq(bspEnabled := false)
     else Nil
   }
 


### PR DESCRIPTION
`ide-skip-project` is IntelliJ's own key, and the filter picked 2.13 whether or not anyone asked for it, so Metals and a command-line `sbt` saw a narrowed build they never asked to narrow.

sbt owns `bspEnabled`, so the build sets that instead. It picks a Scala version only when `-Dide.scala` is set, or when IntelliJ starts sbt with `-Didea.managed=true`. Everything else keeps every row.

`-Dide.platform` no longer adds `jvm` to the list it is given, so `-Dide.platform=js` imports the Scala.js rows alone.

*- Claude (on behalf of Albert)*
